### PR TITLE
Compute edot ii in a function

### DIFF
--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -119,15 +119,6 @@ namespace aspect
                                             const double shear_modulus) const;
 
           /**
-           * Calculate the square root of the second moment invariant for the deviatoric
-           * strain rate tensor, including viscoelastic stresses.
-           */
-          double
-          calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
-                                              const SymmetricTensor<2,dim> &stress,
-                                              const double shear_modulus) const;
-
-          /**
            * Compute the elastic time step.
            */
           double

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -460,31 +460,31 @@ namespace aspect
           std::shared_ptr<std::vector<unsigned int> > n_phase_transitions_per_composition;
       };
 
-    /**
-     * Computes the current_edot_ii and current_stress, with the option for
-     * viscous and viscoelastic contribution.
-     */
-    template <int dim>
-    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                    const std::vector<double> &composition,
-                                    const double ref_strain_rate,
-                                    const double min_strain_rate,
-                                    const SymmetricTensor<2,dim> &strain_rate,
-                                    const std::vector<double> &elastic_shear_moduli,
-                                    const bool use_elasticity,
-                                    const bool use_reference_strainrate,
-                                    const double dte);
+      /**
+       * Computes the current_edot_ii and current_stress, with the option for
+       * viscous and viscoelastic contribution.
+       */
+      template <int dim>
+      double compute_current_edot_ii (const unsigned int j,  // the volume fraction
+                                      const std::vector<double> &composition,
+                                      const double ref_strain_rate,
+                                      const double min_strain_rate,
+                                      const SymmetricTensor<2,dim> &strain_rate,
+                                      const std::vector<double> &elastic_shear_moduli,
+                                      const bool use_elasticity,
+                                      const bool use_reference_strainrate,
+                                      const double dte);
 
-    /**
-     * Calculate the square root of the second moment invariant for the deviatoric
-     * strain rate tensor, including viscoelastic stresses.
-     */
-    template <int dim>
-    double
-    calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
-                                        const SymmetricTensor<2,dim> &stress,
-                                        const double shear_modulus,
-                                        const double dte);
+      /**
+       * Calculate the square root of the second moment invariant for the deviatoric
+       * strain rate tensor, including viscoelastic stresses.
+       */
+      template <int dim>
+      double
+      calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
+                                          const SymmetricTensor<2,dim> &stress,
+                                          const double shear_modulus,
+                                          const double dte);
     }
   }
 }

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -465,12 +465,11 @@ namespace aspect
        * viscous and viscoelastic contribution.
        */
       template <int dim>
-      double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                      const std::vector<double> &composition,
+      double compute_current_edot_ii (const std::vector<double> &composition,
                                       const double ref_strain_rate,
                                       const double min_strain_rate,
                                       const SymmetricTensor<2,dim> &strain_rate,
-                                      const std::vector<double> &elastic_shear_moduli,
+                                      const double elastic_shear_module,
                                       const bool use_elasticity,
                                       const bool use_reference_strainrate,
                                       const double dte);

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -459,6 +459,32 @@ namespace aspect
            */
           std::shared_ptr<std::vector<unsigned int> > n_phase_transitions_per_composition;
       };
+
+    /**
+     * Computes the current_edot_ii and current_stress, with the option for
+     * viscous and viscoelastic contribution.
+     */
+    template <int dim>
+    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
+                                    const std::vector<double> &composition,
+                                    const double ref_strain_rate,
+                                    const double min_strain_rate,
+                                    const SymmetricTensor<2,dim> &strain_rate,
+                                    const std::vector<double> &elastic_shear_moduli,
+                                    const bool use_elasticity,
+                                    const bool use_reference_strainrate,
+                                    const double dte);
+
+    /**
+     * Calculate the square root of the second moment invariant for the deviatoric
+     * strain rate tensor, including viscoelastic stresses.
+     */
+    template <int dim>
+    double
+    calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
+                                        const SymmetricTensor<2,dim> &stress,
+                                        const double shear_modulus,
+                                        const double dte);
     }
   }
 }

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1258,8 +1258,9 @@ namespace aspect
                                     const double ref_strain_rate,
                                     const double min_strain_rate,
                                     const SymmetricTensor<2,dim> &strain_rate,
-                                    bool use_elasticity,
-                                    bool use_reference_strainrate);
+                                    const std::vector<double> &elastic_shear_moduli,
+                                    const bool use_elasticity,
+                                    const bool use_reference_strainrate);
 
     /**
      * Calculate the square root of the second moment invariant for the deviatoric

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1249,32 +1249,6 @@ namespace aspect
                               const double SPD_safety_factor);
 
     /**
-     * Computes the current_edot_ii and current_stress, with the option for
-     * viscous and viscoelastic contribution.
-     */
-    template <int dim>
-    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                    const std::vector<double> &composition,
-                                    const double ref_strain_rate,
-                                    const double min_strain_rate,
-                                    const SymmetricTensor<2,dim> &strain_rate,
-                                    const std::vector<double> &elastic_shear_moduli,
-                                    const bool use_elasticity,
-                                    const bool use_reference_strainrate,
-                                    const double dte);
-
-    /**
-     * Calculate the square root of the second moment invariant for the deviatoric
-     * strain rate tensor, including viscoelastic stresses.
-     */
-    template <int dim>
-    double
-    calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
-                                        const SymmetricTensor<2,dim> &stress,
-                                        const double shear_modulus,
-                                        const double dte);
-
-    /**
      * Converts an array of size dim to a Point of size dim.
      */
     template <int dim>

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1249,6 +1249,19 @@ namespace aspect
                               const double SPD_safety_factor);
 
     /**
+     * Computes the current_edot_ii and current_stress, with the option for
+     * viscous and viscoelastic contribution.
+     */
+    template <int dim>
+    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
+                                                       const std::vector<double> &composition,
+                                                       const double ref_strain_rate,
+                                                       const double min_strain_rate,
+                                                       const double strain_rate,
+                                                       bool use_elasticity,
+                                                       bool use_reference_strainrate);
+
+    /**
      * Converts an array of size dim to a Point of size dim.
      */
     template <int dim>

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1254,12 +1254,21 @@ namespace aspect
      */
     template <int dim>
     double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                                       const std::vector<double> &composition,
-                                                       const double ref_strain_rate,
-                                                       const double min_strain_rate,
-                                                       const SymmetricTensor<2,dim> &strain_rate,
-                                                       bool use_elasticity,
-                                                       bool use_reference_strainrate);
+                                    const std::vector<double> &composition,
+                                    const double ref_strain_rate,
+                                    const double min_strain_rate,
+                                    const SymmetricTensor<2,dim> &strain_rate,
+                                    bool use_elasticity,
+                                    bool use_reference_strainrate);
+
+    /**
+     * Calculate the square root of the second moment invariant for the deviatoric
+     * strain rate tensor, including viscoelastic stresses.
+     */
+    double
+    calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
+                                        const SymmetricTensor<2,dim> &stress,
+                                        const double shear_modulus) const;
 
     /**
      * Converts an array of size dim to a Point of size dim.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1271,7 +1271,8 @@ namespace aspect
     double
     calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
                                         const SymmetricTensor<2,dim> &stress,
-                                        const double shear_modulus);
+                                        const double shear_modulus,
+                                        const double dte);
 
     /**
      * Converts an array of size dim to a Point of size dim.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1266,6 +1266,7 @@ namespace aspect
      * Calculate the square root of the second moment invariant for the deviatoric
      * strain rate tensor, including viscoelastic stresses.
      */
+    template <int dim>
     double
     calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
                                         const SymmetricTensor<2,dim> &stress,

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1260,7 +1260,8 @@ namespace aspect
                                     const SymmetricTensor<2,dim> &strain_rate,
                                     const std::vector<double> &elastic_shear_moduli,
                                     const bool use_elasticity,
-                                    const bool use_reference_strainrate);
+                                    const bool use_reference_strainrate,
+                                    const double dte);
 
     /**
      * Calculate the square root of the second moment invariant for the deviatoric

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1257,7 +1257,7 @@ namespace aspect
                                                        const std::vector<double> &composition,
                                                        const double ref_strain_rate,
                                                        const double min_strain_rate,
-                                                       const double strain_rate,
+                                                       const SymmetricTensor<2,dim> &strain_rate,
                                                        bool use_elasticity,
                                                        bool use_reference_strainrate);
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1269,7 +1269,7 @@ namespace aspect
     double
     calculate_viscoelastic_strain_rate (const SymmetricTensor<2,dim> &strain_rate,
                                         const SymmetricTensor<2,dim> &stress,
-                                        const double shear_modulus) const;
+                                        const double shear_modulus);
 
     /**
      * Converts an array of size dim to a Point of size dim.

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -355,21 +355,6 @@ namespace aspect
         const double dte = elastic_timestep();
         return ( viscosity * dte ) / ( dte + ( viscosity / elastic_shear_modulus ) );
       }
-
-
-
-      template <int dim>
-      double
-      Elasticity<dim>::
-      calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
-                                         const SymmetricTensor<2,dim> &stress,
-                                         const double shear_modulus) const
-      {
-        const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
-                                            (shear_modulus * elastic_timestep());
-
-        return std::sqrt(std::fabs(second_invariant(edot)));
-      }
     }
   }
 }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1018,6 +1018,80 @@ namespace aspect
       }
 
 
+    template <int dim>
+    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
+                                    const std::vector<double> &composition,
+                                    const double ref_strain_rate,
+                                    const double min_strain_rate,
+                                    const SymmetricTensor<2,dim> &strain_rate,
+                                    const std::vector<double> &elastic_shear_moduli,
+                                    const bool use_elasticity,
+                                    const bool use_reference_strainrate,
+                                    const double dte)
+    {
+      // Assemble stress tensor if elastic behavior is enabled
+      SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
+      if (use_elasticity == true)
+        {
+          for (unsigned int q=0; q < SymmetricTensor<2,dim>::n_independent_components; ++q)
+            stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
+        }
+
+      double edot_ii;
+      if (use_reference_strainrate)
+        edot_ii = ref_strain_rate;
+      else
+        // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
+        edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
+                           min_strain_rate);
+
+      // Step 2: calculate the viscous stress magnitude
+      // and strain rate. If requested compute visco-elastic contribution
+      double current_edot_ii = numbers::signaling_nan<double>();
+
+      if (use_elasticity == false)
+        {
+          current_edot_ii = edot_ii;
+        }
+      else
+        {
+          if (use_reference_strainrate == true)
+            current_edot_ii = ref_strain_rate;
+          else
+            {
+              const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
+                                                                stress_old,
+                                                                elastic_shear_moduli[j],
+                                                                dte);
+
+              current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
+                                         min_strain_rate);
+            }
+
+          // The viscoelastic strain rate is divided by 2 here as the Drucker Prager
+          // viscosity calculation below assumes stress = 2 * viscosity * strain_rate_invariant,
+          // whereas the combined viscoelastic + viscous stresses already include the
+          // 2x factor (see computation of edot inside elastic_rheology).
+          current_edot_ii /= 2.;
+        }
+
+      return current_edot_ii;
+    }
+
+    template <int dim>
+    double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
+                                              const SymmetricTensor<2,dim> &stress,
+                                              const double shear_modulus,
+                                              const double dte)
+    {
+      const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
+                                          (shear_modulus * dte);
+
+      return std::sqrt(std::fabs(second_invariant(edot)));
+    }
+
+
+
 
       template <int dim>
       void
@@ -1165,6 +1239,25 @@ namespace aspect
       ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+
+    template double compute_current_edot_ii (const unsigned int j,
+                                             const std::vector<double> &composition,
+                                             const double ref_strain_rate,
+                                             const double min_strain_rate,
+                                             const SymmetricTensor<2,2> &strain_rate,
+                                             const std::vector<double> &elastic_shear_moduli,
+                                             const bool use_elasticity,
+                                             const bool use_reference_strainrate,
+                                             const double dte);
+    template double compute_current_edot_ii (const unsigned int j,
+                                             const std::vector<double> &composition,
+                                             const double ref_strain_rate,
+                                             const double min_strain_rate,
+                                             const SymmetricTensor<2,3> &strain_rate,
+                                             const std::vector<double> &elastic_shear_moduli,
+                                             const bool use_elasticity,
+                                             const bool use_reference_strainrate,
+                                             const double dte);
     }
   }
 }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1019,12 +1019,11 @@ namespace aspect
 
 
       template <int dim>
-      double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                      const std::vector<double> &composition,
+      double compute_current_edot_ii (const std::vector<double> &composition,
                                       const double ref_strain_rate,
                                       const double min_strain_rate,
                                       const SymmetricTensor<2,dim> &strain_rate,
-                                      const std::vector<double> &elastic_shear_moduli,
+                                      const double elastic_shear_module,
                                       const bool use_elasticity,
                                       const bool use_reference_strainrate,
                                       const double dte)
@@ -1061,7 +1060,7 @@ namespace aspect
               {
                 const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
                                                                   stress_old,
-                                                                  elastic_shear_moduli[j],
+                                                                  elastic_shear_module,
                                                                   dte);
 
                 current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
@@ -1240,21 +1239,19 @@ namespace aspect
 
 #undef INSTANTIATE
 
-      template double compute_current_edot_ii (const unsigned int j,
-                                               const std::vector<double> &composition,
+      template double compute_current_edot_ii (const std::vector<double> &composition,
                                                const double ref_strain_rate,
                                                const double min_strain_rate,
                                                const SymmetricTensor<2,2> &strain_rate,
-                                               const std::vector<double> &elastic_shear_moduli,
+                                               const double elastic_shear_module,
                                                const bool use_elasticity,
                                                const bool use_reference_strainrate,
                                                const double dte);
-      template double compute_current_edot_ii (const unsigned int j,
-                                               const std::vector<double> &composition,
+      template double compute_current_edot_ii (const std::vector<double> &composition,
                                                const double ref_strain_rate,
                                                const double min_strain_rate,
                                                const SymmetricTensor<2,3> &strain_rate,
-                                               const std::vector<double> &elastic_shear_moduli,
+                                               const double elastic_shear_module,
                                                const bool use_elasticity,
                                                const bool use_reference_strainrate,
                                                const double dte);

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1018,77 +1018,77 @@ namespace aspect
       }
 
 
-    template <int dim>
-    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                    const std::vector<double> &composition,
-                                    const double ref_strain_rate,
-                                    const double min_strain_rate,
-                                    const SymmetricTensor<2,dim> &strain_rate,
-                                    const std::vector<double> &elastic_shear_moduli,
-                                    const bool use_elasticity,
-                                    const bool use_reference_strainrate,
-                                    const double dte)
-    {
-      // Assemble stress tensor if elastic behavior is enabled
-      SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
-      if (use_elasticity == true)
-        {
-          for (unsigned int q=0; q < SymmetricTensor<2,dim>::n_independent_components; ++q)
-            stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
-        }
+      template <int dim>
+      double compute_current_edot_ii (const unsigned int j,  // the volume fraction
+                                      const std::vector<double> &composition,
+                                      const double ref_strain_rate,
+                                      const double min_strain_rate,
+                                      const SymmetricTensor<2,dim> &strain_rate,
+                                      const std::vector<double> &elastic_shear_moduli,
+                                      const bool use_elasticity,
+                                      const bool use_reference_strainrate,
+                                      const double dte)
+      {
+        // Assemble stress tensor if elastic behavior is enabled
+        SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
+        if (use_elasticity == true)
+          {
+            for (unsigned int q=0; q < SymmetricTensor<2,dim>::n_independent_components; ++q)
+              stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
+          }
 
-      double edot_ii;
-      if (use_reference_strainrate)
-        edot_ii = ref_strain_rate;
-      else
-        // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
-        edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
-                           min_strain_rate);
+        double edot_ii;
+        if (use_reference_strainrate)
+          edot_ii = ref_strain_rate;
+        else
+          // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
+          edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
+                             min_strain_rate);
 
-      // Step 2: calculate the viscous stress magnitude
-      // and strain rate. If requested compute visco-elastic contribution
-      double current_edot_ii = numbers::signaling_nan<double>();
+        // Step 2: calculate the viscous stress magnitude
+        // and strain rate. If requested compute visco-elastic contribution
+        double current_edot_ii = numbers::signaling_nan<double>();
 
-      if (use_elasticity == false)
-        {
-          current_edot_ii = edot_ii;
-        }
-      else
-        {
-          if (use_reference_strainrate == true)
-            current_edot_ii = ref_strain_rate;
-          else
-            {
-              const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
-                                                                stress_old,
-                                                                elastic_shear_moduli[j],
-                                                                dte);
+        if (use_elasticity == false)
+          {
+            current_edot_ii = edot_ii;
+          }
+        else
+          {
+            if (use_reference_strainrate == true)
+              current_edot_ii = ref_strain_rate;
+            else
+              {
+                const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
+                                                                  stress_old,
+                                                                  elastic_shear_moduli[j],
+                                                                  dte);
 
-              current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
-                                         min_strain_rate);
-            }
+                current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
+                                           min_strain_rate);
+              }
 
-          // The viscoelastic strain rate is divided by 2 here as the Drucker Prager
-          // viscosity calculation below assumes stress = 2 * viscosity * strain_rate_invariant,
-          // whereas the combined viscoelastic + viscous stresses already include the
-          // 2x factor (see computation of edot inside elastic_rheology).
-          current_edot_ii /= 2.;
-        }
+            // The viscoelastic strain rate is divided by 2 here as the Drucker Prager
+            // viscosity calculation below assumes stress = 2 * viscosity * strain_rate_invariant,
+            // whereas the combined viscoelastic + viscous stresses already include the
+            // 2x factor (see computation of edot inside elastic_rheology).
+            current_edot_ii /= 2.;
+          }
 
-      return current_edot_ii;
-    }
+        return current_edot_ii;
+      }
 
-    template <int dim>
-    double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
-                                              const SymmetricTensor<2,dim> &stress,
-                                              const double shear_modulus,
-                                              const double dte)
-    {
-      const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
-                                          (shear_modulus * dte);
+      template <int dim>
+      double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
+                                                const SymmetricTensor<2,dim> &stress,
+                                                const double shear_modulus,
+                                                const double dte)
+      {
+        const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
+                                            (shear_modulus * dte);
 
-      return std::sqrt(std::fabs(second_invariant(edot)));
-    }
+        return std::sqrt(std::fabs(second_invariant(edot)));
+      }
 
 
 
@@ -1240,24 +1240,24 @@ namespace aspect
 
 #undef INSTANTIATE
 
-    template double compute_current_edot_ii (const unsigned int j,
-                                             const std::vector<double> &composition,
-                                             const double ref_strain_rate,
-                                             const double min_strain_rate,
-                                             const SymmetricTensor<2,2> &strain_rate,
-                                             const std::vector<double> &elastic_shear_moduli,
-                                             const bool use_elasticity,
-                                             const bool use_reference_strainrate,
-                                             const double dte);
-    template double compute_current_edot_ii (const unsigned int j,
-                                             const std::vector<double> &composition,
-                                             const double ref_strain_rate,
-                                             const double min_strain_rate,
-                                             const SymmetricTensor<2,3> &strain_rate,
-                                             const std::vector<double> &elastic_shear_moduli,
-                                             const bool use_elasticity,
-                                             const bool use_reference_strainrate,
-                                             const double dte);
+      template double compute_current_edot_ii (const unsigned int j,
+                                               const std::vector<double> &composition,
+                                               const double ref_strain_rate,
+                                               const double min_strain_rate,
+                                               const SymmetricTensor<2,2> &strain_rate,
+                                               const std::vector<double> &elastic_shear_moduli,
+                                               const bool use_elasticity,
+                                               const bool use_reference_strainrate,
+                                               const double dte);
+      template double compute_current_edot_ii (const unsigned int j,
+                                               const std::vector<double> &composition,
+                                               const double ref_strain_rate,
+                                               const double min_strain_rate,
+                                               const SymmetricTensor<2,3> &strain_rate,
+                                               const std::vector<double> &elastic_shear_moduli,
+                                               const bool use_elasticity,
+                                               const bool use_reference_strainrate,
+                                               const double dte);
     }
   }
 }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -274,14 +274,14 @@ namespace aspect
           const double dte = elastic_rheology.elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
           const double current_edot_ii = MaterialUtilities::compute_current_edot_ii(j,
-                                                                            in.composition[i],
-                                                                            ref_strain_rate,
-                                                                            min_strain_rate,
-                                                                            in.strain_rate[i],
-                                                                            elastic_shear_moduli,
-                                                                            use_elasticity,
-                                                                            use_reference_strainrate,
-                                                                            dte);
+                                                                                    in.composition[i],
+                                                                                    ref_strain_rate,
+                                                                                    min_strain_rate,
+                                                                                    in.strain_rate[i],
+                                                                                    elastic_shear_moduli,
+                                                                                    use_elasticity,
+                                                                                    use_reference_strainrate,
+                                                                                    dte);
 
 
           double current_stress = numbers::signaling_nan<double>();

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -279,6 +279,8 @@ namespace aspect
                                                                             use_elasticity,
                                                                             use_reference_strainrate);
 
+          
+          double current_stress = numbers::signaling_nan<double>();
           if (use_elasticity == false)
             current_stress = 2. * viscosity_pre_yield * current_edot_ii;
           else

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -271,6 +271,7 @@ namespace aspect
 
           // Step 2: calculate the viscous stress magnitude
           // and strain rate. If requested compute visco-elastic contributions.
+          const double dte = elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
           const double current_edot_ii = Utilities::compute_current_edot_ii(j,
                                                                             composition,
@@ -279,7 +280,8 @@ namespace aspect
                                                                             strain_rate,
                                                                             elastic_shear_moduli,
                                                                             use_elasticity,
-                                                                            use_reference_strainrate);
+                                                                            use_reference_strainrate,
+                                                                            dte);
 
 
           double current_stress = numbers::signaling_nan<double>();

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -273,12 +273,11 @@ namespace aspect
           // and strain rate. If requested compute visco-elastic contributions.
           const double dte = elastic_rheology.elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
-          const double current_edot_ii = MaterialUtilities::compute_current_edot_ii(j,
-                                                                                    in.composition[i],
+          const double current_edot_ii = MaterialUtilities::compute_current_edot_ii(in.composition[i],
                                                                                     ref_strain_rate,
                                                                                     min_strain_rate,
                                                                                     in.strain_rate[i],
-                                                                                    elastic_shear_moduli,
+                                                                                    elastic_shear_moduli[j],
                                                                                     use_elasticity,
                                                                                     use_reference_strainrate,
                                                                                     dte);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -271,11 +271,13 @@ namespace aspect
 
           // Step 2: calculate the viscous stress magnitude
           // and strain rate. If requested compute visco-elastic contributions.
+          const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
           const double current_edot_ii = Utilities::compute_current_edot_ii(j,
                                                                             composition,
                                                                             ref_strain_rate,
                                                                             min_strain_rate,
                                                                             strain_rate,
+                                                                            elastic_shear_moduli,
                                                                             use_elasticity,
                                                                             use_reference_strainrate);
 
@@ -287,7 +289,6 @@ namespace aspect
             {
               if (use_reference_strainrate == false)
                 {
-                  const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
                   // Step 2a: calculate viscoelastic (effective) viscosity
                   viscosity_pre_yield = elastic_rheology.calculate_viscoelastic_viscosity(viscosity_pre_yield,
                                                                                           elastic_shear_moduli[j]);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -279,7 +279,7 @@ namespace aspect
                                                                             use_elasticity,
                                                                             use_reference_strainrate);
 
-          
+
           double current_stress = numbers::signaling_nan<double>();
           if (use_elasticity == false)
             current_stress = 2. * viscosity_pre_yield * current_edot_ii;

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -274,10 +274,10 @@ namespace aspect
           const double dte = elastic_rheology.elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
           const double current_edot_ii = Utilities::compute_current_edot_ii(j,
-                                                                            composition,
+                                                                            in.composition[i],
                                                                             ref_strain_rate,
                                                                             min_strain_rate,
-                                                                            strain_rate,
+                                                                            in.strain_rate[i],
                                                                             elastic_shear_moduli,
                                                                             use_elasticity,
                                                                             use_reference_strainrate,

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -271,7 +271,7 @@ namespace aspect
 
           // Step 2: calculate the viscous stress magnitude
           // and strain rate. If requested compute visco-elastic contributions.
-          const double dte = elastic_timestep();
+          const double dte = elastic_rheology.elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
           const double current_edot_ii = Utilities::compute_current_edot_ii(j,
                                                                             composition,

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -273,7 +273,7 @@ namespace aspect
           // and strain rate. If requested compute visco-elastic contributions.
           const double dte = elastic_rheology.elastic_timestep();
           const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
-          const double current_edot_ii = Utilities::compute_current_edot_ii(j,
+          const double current_edot_ii = MaterialUtilities::compute_current_edot_ii(j,
                                                                             in.composition[i],
                                                                             ref_strain_rate,
                                                                             min_strain_rate,

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3232,7 +3232,7 @@ namespace aspect
                                                        const std::vector<double> &composition,
                                                        const double ref_strain_rate,
                                                        const double min_strain_rate,
-                                                       const double strain_rate,
+                                                       const SymmetricTensor<2,dim> &strain_rate,
                                                        bool use_elasticity,
                                                        bool use_reference_strainrate)
     {
@@ -3255,7 +3255,6 @@ namespace aspect
       // Step 2: calculate the viscous stress magnitude
       // and strain rate. If requested compute visco-elastic contribution
       double current_edot_ii = numbers::signaling_nan<double>();
-      double current_stress = numbers::signaling_nan<double>();
 
       if (use_elasticity == false)
         {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3291,7 +3291,7 @@ namespace aspect
     double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
                                               const SymmetricTensor<2,dim> &stress,
                                               const double shear_modulus,
-                                              const double dte) 
+                                              const double dte)
     {
       const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
                                           (shear_modulus * dte);
@@ -3810,5 +3810,24 @@ namespace aspect
                        const std::vector<Point<3> > &,
                        std::vector<double> &)> &function,
                      LinearAlgebra::BlockVector &vec_result);
+
+    template double compute_current_edot_ii (const unsigned int j,
+                                             const std::vector<double> &composition,
+                                             const double ref_strain_rate,
+                                             const double min_strain_rate,
+                                             const SymmetricTensor<2,2> &strain_rate,
+                                             const std::vector<double> &elastic_shear_moduli,
+                                             const bool use_elasticity,
+                                             const bool use_reference_strainrate,
+                                             const double dte);
+    template double compute_current_edot_ii (const unsigned int j,
+                                             const std::vector<double> &composition,
+                                             const double ref_strain_rate,
+                                             const double min_strain_rate,
+                                             const SymmetricTensor<2,3> &strain_rate,
+                                             const std::vector<double> &elastic_shear_moduli,
+                                             const bool use_elasticity,
+                                             const bool use_reference_strainrate,
+                                             const double dte);
   }
 }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3235,7 +3235,8 @@ namespace aspect
                                     const SymmetricTensor<2,dim> &strain_rate,
                                     const std::vector<double> &elastic_shear_moduli,
                                     const bool use_elasticity,
-                                    const bool use_reference_strainrate)
+                                    const bool use_reference_strainrate,
+                                    const double dte)
     {
       // Assemble stress tensor if elastic behavior is enabled
       SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
@@ -3269,7 +3270,8 @@ namespace aspect
             {
               const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
                                                                 stress_old,
-                                                                elastic_shear_moduli[j]);
+                                                                elastic_shear_moduli[j],
+                                                                dte);
 
               current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
                                          min_strain_rate);
@@ -3288,10 +3290,11 @@ namespace aspect
     template <int dim>
     double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
                                               const SymmetricTensor<2,dim> &stress,
-                                              const double shear_modulus) 
+                                              const double shear_modulus,
+                                              const double dte) 
     {
       const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
-                                          (shear_modulus * elastic_timestep());
+                                          (shear_modulus * dte);
 
       return std::sqrt(std::fabs(second_invariant(edot)));
     }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3229,12 +3229,12 @@ namespace aspect
 
     template <int dim>
     double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                                       const std::vector<double> &composition,
-                                                       const double ref_strain_rate,
-                                                       const double min_strain_rate,
-                                                       const SymmetricTensor<2,dim> &strain_rate,
-                                                       bool use_elasticity,
-                                                       bool use_reference_strainrate)
+                                    const std::vector<double> &composition,
+                                    const double ref_strain_rate,
+                                    const double min_strain_rate,
+                                    const SymmetricTensor<2,dim> &strain_rate,
+                                    bool use_elasticity,
+                                    bool use_reference_strainrate)
     {
       // Assemble stress tensor if elastic behavior is enabled
       SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
@@ -3268,7 +3268,7 @@ namespace aspect
             current_edot_ii = ref_strain_rate;
           else
             {
-              const double viscoelastic_strain_rate_invariant = elastic_rheology.calculate_viscoelastic_strain_rate(strain_rate,
+              const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
                                                                 stress_old,
                                                                 elastic_shear_moduli[j]);
 
@@ -3286,6 +3286,16 @@ namespace aspect
       return current_edot_ii;
     }
 
+    template <int dim>
+    double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
+                                              const SymmetricTensor<2,dim> &stress,
+                                              const double shear_modulus) const
+    {
+      const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
+                                          (shear_modulus * elastic_timestep());
+
+      return std::sqrt(std::fabs(second_invariant(edot)));
+    }
 
 
     template <int dim>

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3226,80 +3226,6 @@ namespace aspect
         return std::max(0.0, SPD_safety_factor * ((2.0 * eta) / denom));
     }
 
-
-    template <int dim>
-    double compute_current_edot_ii (const unsigned int j,  // the volume fraction
-                                    const std::vector<double> &composition,
-                                    const double ref_strain_rate,
-                                    const double min_strain_rate,
-                                    const SymmetricTensor<2,dim> &strain_rate,
-                                    const std::vector<double> &elastic_shear_moduli,
-                                    const bool use_elasticity,
-                                    const bool use_reference_strainrate,
-                                    const double dte)
-    {
-      // Assemble stress tensor if elastic behavior is enabled
-      SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
-      if (use_elasticity == true)
-        {
-          for (unsigned int q=0; q < SymmetricTensor<2,dim>::n_independent_components; ++q)
-            stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
-        }
-
-      double edot_ii;
-      if (use_reference_strainrate)
-        edot_ii = ref_strain_rate;
-      else
-        // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
-        edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
-                           min_strain_rate);
-
-      // Step 2: calculate the viscous stress magnitude
-      // and strain rate. If requested compute visco-elastic contribution
-      double current_edot_ii = numbers::signaling_nan<double>();
-
-      if (use_elasticity == false)
-        {
-          current_edot_ii = edot_ii;
-        }
-      else
-        {
-          if (use_reference_strainrate == true)
-            current_edot_ii = ref_strain_rate;
-          else
-            {
-              const double viscoelastic_strain_rate_invariant = calculate_viscoelastic_strain_rate(strain_rate,
-                                                                stress_old,
-                                                                elastic_shear_moduli[j],
-                                                                dte);
-
-              current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
-                                         min_strain_rate);
-            }
-
-          // The viscoelastic strain rate is divided by 2 here as the Drucker Prager
-          // viscosity calculation below assumes stress = 2 * viscosity * strain_rate_invariant,
-          // whereas the combined viscoelastic + viscous stresses already include the
-          // 2x factor (see computation of edot inside elastic_rheology).
-          current_edot_ii /= 2.;
-        }
-
-      return current_edot_ii;
-    }
-
-    template <int dim>
-    double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
-                                              const SymmetricTensor<2,dim> &stress,
-                                              const double shear_modulus,
-                                              const double dte)
-    {
-      const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
-                                          (shear_modulus * dte);
-
-      return std::sqrt(std::fabs(second_invariant(edot)));
-    }
-
-
     template <int dim>
     Point<dim> convert_array_to_point(const std::array<double,dim> &array)
     {
@@ -3810,24 +3736,5 @@ namespace aspect
                        const std::vector<Point<3> > &,
                        std::vector<double> &)> &function,
                      LinearAlgebra::BlockVector &vec_result);
-
-    template double compute_current_edot_ii (const unsigned int j,
-                                             const std::vector<double> &composition,
-                                             const double ref_strain_rate,
-                                             const double min_strain_rate,
-                                             const SymmetricTensor<2,2> &strain_rate,
-                                             const std::vector<double> &elastic_shear_moduli,
-                                             const bool use_elasticity,
-                                             const bool use_reference_strainrate,
-                                             const double dte);
-    template double compute_current_edot_ii (const unsigned int j,
-                                             const std::vector<double> &composition,
-                                             const double ref_strain_rate,
-                                             const double min_strain_rate,
-                                             const SymmetricTensor<2,3> &strain_rate,
-                                             const std::vector<double> &elastic_shear_moduli,
-                                             const bool use_elasticity,
-                                             const bool use_reference_strainrate,
-                                             const double dte);
   }
 }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3288,7 +3288,7 @@ namespace aspect
     template <int dim>
     double calculate_viscoelastic_strain_rate(const SymmetricTensor<2,dim> &strain_rate,
                                               const SymmetricTensor<2,dim> &stress,
-                                              const double shear_modulus) const
+                                              const double shear_modulus) 
     {
       const SymmetricTensor<2,dim> edot = 2. * (deviator(strain_rate)) + stress /
                                           (shear_modulus * elastic_timestep());

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3233,8 +3233,9 @@ namespace aspect
                                     const double ref_strain_rate,
                                     const double min_strain_rate,
                                     const SymmetricTensor<2,dim> &strain_rate,
-                                    bool use_elasticity,
-                                    bool use_reference_strainrate)
+                                    const std::vector<double> &elastic_shear_moduli,
+                                    const bool use_elasticity,
+                                    const bool use_reference_strainrate)
     {
       // Assemble stress tensor if elastic behavior is enabled
       SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
@@ -3262,8 +3263,6 @@ namespace aspect
         }
       else
         {
-          const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
-
           if (use_reference_strainrate == true)
             current_edot_ii = ref_strain_rate;
           else


### PR DESCRIPTION
I moved the computation of the current_edot_ii from visco_plastic into function inside utilities.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
