### PR TITLE
world builder: disable unity builds temporarily

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ if(ASPECT_WITH_WORLD_BUILDER)
     # do not include ASPECT's dependencies at all.
     SET_PROPERTY(SOURCE ${_source_file} PROPERTY COTIRE_EXCLUDED TRUE )
     SET_PROPERTY(SOURCE ${_source_file} PROPERTY SKIP_PRECOMPILE_HEADERS TRUE )
+    # Temporarily disable world builder unity builds:
+    SET_PROPERTY(SOURCE ${_source_file} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE )
   ENDFOREACH()
 
   SET_PROPERTY(SOURCE "${CMAKE_BINARY_DIR}/world_builder_config.cc" PROPERTY COTIRE_EXCLUDED TRUE )


### PR DESCRIPTION
Let's disable the world builder unity builds for now as this is causing various problems for people.

Grouping world builder and ASPECT files into the same .cxx is the wrong approach.