### PR TITLE
added new strain rate and derivative functions to diffusion and dislocation creep

### DIFF
--- a/doc/modules/changes/20200814b_bobmyhill
+++ b/doc/modules/changes/20200814b_bobmyhill
@@ -3,4 +3,4 @@ now have a new function to calculate the strain rate and
 first stress-derivative of the strain rate to facilitate
 the development of composite rheologies.
 <br>
-(Bob Myhill, 2020/08/14)
+(Bob Myhill, John Naliboff, Cedric Theulot, 2020/08/14)

--- a/doc/modules/changes/20200814b_bobmyhill
+++ b/doc/modules/changes/20200814b_bobmyhill
@@ -1,0 +1,6 @@
+<li> New: The diffusion and dislocation creep rheology modules
+now have a new function to calculate the strain rate and
+first stress-derivative of the strain rate to facilitate
+the development of composite rheologies.
+<br>
+(Bob Myhill, 2020/08/14)

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -23,6 +23,8 @@
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
+#include <aspect/material_model/rheology/diffusion_creep.h>
+#include <aspect/material_model/rheology/dislocation_creep.h>
 
 namespace aspect
 {
@@ -106,6 +108,11 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * Objects for computing viscous creep viscosities.
+         */
+        Rheology::DiffusionCreep<dim> diffusion_creep;
+        Rheology::DislocationCreep<dim> dislocation_creep;
 
         double reference_T;
 
@@ -136,18 +143,6 @@ namespace aspect
                                           const double &pressure,
                                           const double &temperature,
                                           const SymmetricTensor<2,dim> &strain_rate) const;
-
-
-        std::vector<double> prefactors_diffusion;
-        std::vector<double> stress_exponents_diffusion;
-        std::vector<double> grain_size_exponents_diffusion;
-        std::vector<double> activation_energies_diffusion;
-        std::vector<double> activation_volumes_diffusion;
-
-        std::vector<double> prefactors_dislocation;
-        std::vector<double> stress_exponents_dislocation;
-        std::vector<double> activation_energies_dislocation;
-        std::vector<double> activation_volumes_dislocation;
 
     };
 

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -1,4 +1,4 @@
-/*
+first/*
   Copyright (C) 2019 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
@@ -83,8 +83,8 @@ namespace aspect
            * Compute the creep parameters for the diffusion creep law.
            * If @p expected_n_phases_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
-           * for each compositional field and viscosity will be fisrt computed on
-           * each phases and then averaged for each compositional field.
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           const DiffusionCreepParameters
           compute_creep_parameters (const unsigned int composition,
@@ -96,7 +96,7 @@ namespace aspect
            * If @p expected_n_phases_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
-           * each phases and then averaged for each compositional field.
+           * each phase and then averaged for each compositional field.
            */
           double
           compute_viscosity (const double pressure,

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -34,6 +34,22 @@ namespace aspect
 
     namespace Rheology
     {
+      /**
+       * Data structure for diffusion creep parameters.
+       */
+      struct DiffusionCreepParameters
+      {
+        /**
+         * The diffusion creep prefactor, activation energy, activation volume
+         * and grain size exponent.
+         */
+        double prefactor;
+        double activation_energy;
+        double activation_volume;
+        double stress_exponent;
+        double grain_size_exponent;
+      };
+
       template <int dim>
       class DiffusionCreep : public ::aspect::SimulatorAccess<dim>
       {
@@ -62,6 +78,19 @@ namespace aspect
                             const std::shared_ptr<std::vector<unsigned int>> &expected_n_phases_per_composition =
                               std::shared_ptr<std::vector<unsigned int>>());
 
+
+          /**
+           * Compute the creep parameters for the diffusion creep law.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be fisrt computed on
+           * each phases and then averaged for each compositional field.
+           */
+          const DiffusionCreepParameters
+          compute_creep_parameters (const unsigned int composition,
+                                    const std::vector<double> &phase_function_values = std::vector<double>(),
+                                    const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+
           /**
            * Compute the viscosity based on the diffusion creep law.
            * If @p expected_n_phases_per_composition points to a vector of
@@ -76,12 +105,31 @@ namespace aspect
                              const std::vector<double> &phase_function_values = std::vector<double>(),
                              const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
 
+          /**
+            * Compute the strain rate and first stress derivative
+            * as a function of stress based on the diffusion creep law.
+            * If @p expected_n_phases_per_composition points to a vector of
+            * unsigned integers this is considered the number of phase transitions
+            * for each compositional field and viscosity will be first computed on
+            * each phase and then averaged for each compositional field.
+            */
+          std::pair<double, double>
+          compute_strain_rate_and_derivative (const double stress,
+                                              const double pressure,
+                                              const double temperature,
+                                              const DiffusionCreepParameters creep_parameters) const;
+
         private:
 
           /**
            * List of diffusion creep prefactors A.
            */
           std::vector<double> prefactors_diffusion;
+
+          /**
+           * List of diffusion creep stress exponents n (usually = 1).
+           */
+          std::vector<double> stress_exponents_diffusion;
 
           /**
            * List of diffusion creep grain size exponents m.

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -1,4 +1,4 @@
-first/*
+/*
   Copyright (C) 2019 by the authors of the ASPECT code.
 
   This file is part of ASPECT.

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -80,7 +80,7 @@ namespace aspect
            * If @p expected_n_phases_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
-           * each phases and then averaged for each compositional field.
+           * each phase and then averaged for each compositional field.
            */
           const DislocationCreepParameters
           compute_creep_parameters (const unsigned int composition,

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -32,6 +32,21 @@ namespace aspect
 
     namespace Rheology
     {
+      /**
+       * Data structure for dislocation creep parameters.
+       */
+      struct DislocationCreepParameters
+      {
+        /**
+         * The dislocation creep prefactor, activation energy, activation volume
+         * and stress exponent.
+         */
+        double prefactor;
+        double activation_energy;
+        double activation_volume;
+        double stress_exponent;
+      };
+
       template <int dim>
       class DislocationCreep : public ::aspect::SimulatorAccess<dim>
       {
@@ -61,11 +76,23 @@ namespace aspect
                               std::shared_ptr<std::vector<unsigned int>>());
 
           /**
-           * Compute the viscosity based on the diffusion creep law.
+           * Compute the creep parameters for the dislocation creep law.
            * If @p expected_n_phases_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phases and then averaged for each compositional field.
+           */
+          const DislocationCreepParameters
+          compute_creep_parameters (const unsigned int composition,
+                                    const std::vector<double> &phase_function_values = std::vector<double>(),
+                                    const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+
+          /**
+           * Compute the viscosity based on the dislocation creep law.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           double
           compute_viscosity (const double strain_rate,
@@ -74,6 +101,20 @@ namespace aspect
                              const unsigned int composition,
                              const std::vector<double> &phase_function_values = std::vector<double>(),
                              const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+
+          /**
+           * Compute the strain rate and first stress derivative
+           * as a function of stress based on the dislocation creep law.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
+           */
+          std::pair<double, double>
+          compute_strain_rate_and_derivative (const double stress,
+                                              const double pressure,
+                                              const double temperature,
+                                              const DislocationCreepParameters creep_parameters) const;
 
         private:
 

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -38,6 +38,7 @@ namespace aspect
       {}
 
 
+
       template <int dim>
       const DiffusionCreepParameters
       DiffusionCreep<dim>::compute_creep_parameters (const unsigned int composition,
@@ -72,6 +73,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       double
       DiffusionCreep<dim>::compute_viscosity (const double pressure,
@@ -99,6 +101,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       std::pair<double, double>
       DiffusionCreep<dim>::compute_strain_rate_and_derivative (const double stress,
@@ -120,9 +123,9 @@ namespace aspect
 
         const double strain_rate_diffusion = stress * dstrain_rate_dstress_diffusion;
 
-        const std::pair<double, double> strain_rate_and_derivative (strain_rate_diffusion, dstrain_rate_dstress_diffusion);
-        return strain_rate_and_derivative;
+        return std::make_pair(strain_rate_diffusion, dstrain_rate_dstress_diffusion);
       }
+
 
 
       template <int dim>

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -37,6 +37,7 @@ namespace aspect
       {}
 
 
+
       template <int dim>
       const DislocationCreepParameters
       DislocationCreep<dim>::compute_creep_parameters (const unsigned int composition,
@@ -70,6 +71,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       double
       DislocationCreep<dim>::compute_viscosity (const double strain_rate,
@@ -96,6 +98,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       std::pair<double, double>
       DislocationCreep<dim>::compute_strain_rate_and_derivative (const double stress,
@@ -120,9 +123,9 @@ namespace aspect
                                                         std::exp(-(creep_parameters.activation_energy + pressure*creep_parameters.activation_volume)/
                                                                  (constants::gas_constant*temperature));
 
-        const std::pair<double, double> strain_rate_and_derivative (strain_rate_dislocation, dstrain_rate_dstress_dislocation);
-        return strain_rate_and_derivative;
+        return std::make_pair(strain_rate_dislocation, dstrain_rate_dstress_dislocation);
       }
+
 
 
       template <int dim>


### PR DESCRIPTION
This PR adds `strain rate(P, T, C, stress)` and `d(strain rate)/d(stress) (P, T, C, stress)` functions to diffusion and dislocation creep. These stress-dependent functions are needed for correct compositing (via a Newton-Raphson iteration). 

At the moment, diffusion_dislocation.cc contains these functions, but more composite rheologies are now being considered, and each of these will need the same functions.

Opened for comment, especially on the use of std::map<std::string, double> to store the creep parameters. The storage avoids repeated calculation of the creep parameters in compute_strain_rate_and_derivative(), but may slow down the code. If there's a more clean and efficient way to do this, I'll make a change. 