### PR TITLE
Newton fail test fix

### DIFF
--- a/tests/prescribed_dilation_newton/screen-output
+++ b/tests/prescribed_dilation_newton/screen-output
@@ -13,13 +13,12 @@ Number of degrees of freedom: 948 (578+81+289)
       Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 441.548
 
    Skipping temperature solve because RHS is zero.
-   Solving Stokes system... 0+25 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.74883e-16, norm of the rhs: 1.65529e-13, newton_derivative_scaling_factor: 0
+   Nonlinear residual reduction has been very large (6.72207e-13); skipping Stokes solve
 
 
    Postprocessing:
      RMS, max velocity:        2.13 m/s, 4.82 m/s
-     Errors u_L2, p_L2:        1.794314e-04, 8.890805e-05
+     Errors u_L2, p_L2:        1.794314e-04, 8.890745e-05
      Writing graphical output: output-prescribed_dilation_newton/solution/solution-00000
 
 Number of active cells: 256 (on 5 levels)
@@ -34,13 +33,12 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 605.137
 
    Skipping temperature solve because RHS is zero.
-   Solving Stokes system... 0+27 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 6.09492e-16, norm of the rhs: 3.68826e-13, newton_derivative_scaling_factor: 0
+   Nonlinear residual reduction has been very large (5.45776e-13); skipping Stokes solve
 
 
    Postprocessing:
      RMS, max velocity:        2.13 m/s, 4.88 m/s
-     Errors u_L2, p_L2:        2.245433e-05, 5.961648e-06
+     Errors u_L2, p_L2:        2.245433e-05, 5.958839e-06
      Writing graphical output: output-prescribed_dilation_newton/solution/solution-00001
 
 Termination requested by criterion: end time

--- a/tests/sol_cx_newton_crash.cc
+++ b/tests/sol_cx_newton_crash.cc
@@ -1,0 +1,2 @@
+#include "../benchmarks/solcx/solcx.cc"
+

--- a/tests/sol_cx_newton_crash.prm
+++ b/tests/sol_cx_newton_crash.prm
@@ -1,0 +1,122 @@
+# A linear problem (copied from sol_cx_4) that crashes when "iterated Newton Stokes" is
+# used an the linear tolerance is reduced.
+
+set Dimension = 2
+
+
+set CFL number                             = 1.0
+
+set End time                               = 0
+
+
+set Resume computation                     = false
+
+set Start time                             = 0
+
+set Adiabatic surface temperature          = 0
+
+set Surface pressure                       = 0
+
+set Use years in output instead of seconds = false  # default: true
+
+set Nonlinear solver scheme                = single Advection, iterated Newton Stokes
+
+
+subsection Boundary temperature model
+  set List of model names = box
+
+end
+
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+
+  set Temperature polynomial degree           = 2
+
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+
+    set beta  = 0.078
+
+    set cR    = 0.5   # default: 0.11
+  end
+
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1
+
+    set Y extent = 1
+
+    set Z extent = 1
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+end
+
+
+subsection Initial temperature model
+  set Model name = perturbed box
+
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance                         = 1e-9
+  end
+end
+
+subsection Material model
+  set Model name = SolCxMaterial
+  set Material averaging = harmonic average only viscosity
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0                       # default: 2
+  set Initial global refinement          = 4                       # default: 2
+
+  set Strategy                           = density, temperature
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,2,3
+end
+
+
+subsection Postprocess
+  set List of postprocessors = SolCxPostprocessor
+
+  subsection Depth average
+    set Time between graphical output = 1e8
+  end
+
+  subsection Visualization
+    set Interpolate output = false
+    set Number of grouped files       = 0
+
+    set Output format                 = gnuplot
+
+    set Time between graphical output = 0   # default: 1e8
+  end
+end
+

--- a/tests/sol_cx_newton_crash/screen-output
+++ b/tests/sol_cx_newton_crash/screen-output
@@ -12,6 +12,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 50+0 iterations.
       Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 0.0172385
 
+   Nonlinear residual reduction has been very large (8.52861e-10); skipping Stokes solve
+
 
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.125999e-06, 1.101883e-01, 1.670011e-06, 1.106214e-01

--- a/tests/sol_cx_newton_crash/screen-output
+++ b/tests/sol_cx_newton_crash/screen-output
@@ -1,0 +1,22 @@
+
+Loading shared library <./libsol_cx_newton_crash.so>
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Initial Newton Stokes residual = 0.0172385, v = 0.0172385, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 50+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 0.0172385
+
+
+   Postprocessing:
+     Errors u_L1, p_L1, u_L2, p_L2: 1.125999e-06, 1.101883e-01, 1.670011e-06, 1.106214e-01
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/sol_cx_newton_crash/statistics
+++ b/tests/sol_cx_newton_crash/statistics
@@ -1,0 +1,12 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1 0 49 52 51 


### PR DESCRIPTION
This is a proposed fix for the problem found in #3705. I made a new pull request out of it to allow me to easily change the code.

In short, this introduces a test of whether the rhs has dropped more than 1e-8 (I could make this a parameter if desired).

While fixing this, I noticed that to get it working I had to enable rebuilding of the Newton stokes matrix every 0th nonlinear iteration. It doesn't seem to change anything for the other tests (as far as I could see locally) because they already did that due to their boundary conditions.