### PR TITLE
Always rebuild Newton stokes matrix on first nonlinear iteration

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -440,7 +440,7 @@ namespace aspect
     // don't need to force assembly of the matrix.
     if (stokes_matrix_depends_on_solution()
         ||
-        (nonlinear_iteration == 0 && boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
+        nonlinear_iteration == 0)
       rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
     else if (parameters.enable_prescribed_dilation)
       // The dilation requires the Stokes matrix (which is on the rhs


### PR DESCRIPTION
In both pull request #3112 and #3787 I ran into the issue that the optimalizations in #3709 may have set some flags too strict. This pull request makes sure that the matrix is always rebuild on the first nonlinear iteration. We may be able to set it more strict again after #3112 and #3787 are merged and have a better idea of when exactly a rebuild (and of what) is needed.