### PR TITLE
correct quotes type in lithosphere mask manual entry

### DIFF
--- a/source/initial_temperature/lithosphere_mask.cc
+++ b/source/initial_temperature/lithosphere_mask.cc
@@ -213,9 +213,9 @@ namespace aspect
                                               "lithosphere-asthenosphere boundary (specified by an ascii file "
                                               "or maximum lithosphere depth value). Below this the initial temperature is set as "
                                               "NaN.  Note the required format of the input data file: The first lines may "
-                                              "contain any number of comments if they begin with ‘#’, but one of these lines "
+                                              "contain any number of comments if they begin with '#', but one of these lines "
                                               "needs to contain the number of grid points in each dimension as for example"
-                                              "‘# POINTS: 3 3’. For a spherical model, the order of the data columns has to be"
+                                              "'# POINTS: 3 3'. For a spherical model, the order of the data columns has to be"
                                               "'phi', 'theta','depth (m)', where phi is the  azimuth angle and theta is the "
                                               "polar angle measured positive from the north pole. This plug-in can be combined "
                                               "with another using the 'replace if valid' operator. ")


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

The wrong type of quotes was used which led to such things as "exampleâĂŸ# POINTS: 3 3âĂŹ" in the manual. Corrected two instances of this in lithosphere mask.


### Before your first pull request:

* [x ] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [ x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

