### PR TITLE
Fix grammar.

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -501,7 +501,7 @@ namespace aspect
         catch (...)
           {
             // start the solve over again and try with a stabilized version
-            pcout << "Solve failed and catched, try again with stabilisation" << std::endl;
+            pcout << "failed, trying again with stabilization" << std::endl;
             newton_handler->parameters.preconditioner_stabilization = Newton::Parameters::Stabilization::SPD;
             newton_handler->parameters.velocity_block_stabilization = Newton::Parameters::Stabilization::SPD;
 
@@ -574,7 +574,6 @@ namespace aspect
 
         pcout << "      Relative nonlinear residual (total Newton system) after nonlinear iteration " << nonlinear_iteration+1
               << ": " << dcr.stokes_residuals.first/dcr.initial_residual << ", norm of the rhs: " << dcr.stokes_residuals.first << std::endl;
-
       }
     else
       {

--- a/tests/spiegelman_fail_test/screen-output
+++ b/tests/spiegelman_fail_test/screen-output
@@ -24,7 +24,7 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... Solve failed and catched, try again with stabilisation
+   Solving Stokes system... failed, trying again with stabilization
    The linear solver tolerance is set to 0.758936
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+9 iterations.


### PR DESCRIPTION
Found while looking at #3787. The proper past tense of "catch" is "caught", but I think we don't need that word at all.