### PR TITLE
rename viscosity argument to base_viscosity in ConstantViscosityPrefactors

### DIFF
--- a/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
@@ -64,7 +64,7 @@ namespace aspect
            * Compute the viscosity.
            */
           double
-          compute_viscosity (const double viscosity,
+          compute_viscosity (const double base_viscosity,
                              const unsigned int composition_index) const;
 
         private:
@@ -74,7 +74,7 @@ namespace aspect
            * The total number of prefactors will be equal to one
            * plus the number of compositional fields. The prefactor
            * for a given compositional field is multiplied with a
-           * viscosity value provided by the material model, which
+           * base_viscosity value provided by the material model, which
            * is then returned to the material model.
            */
           std::vector<double> constant_viscosity_prefactors;

--- a/source/material_model/rheology/constant_viscosity_prefactors.cc
+++ b/source/material_model/rheology/constant_viscosity_prefactors.cc
@@ -40,10 +40,10 @@ namespace aspect
 
       template <int dim>
       double
-      ConstantViscosityPrefactors<dim>::compute_viscosity (const double viscosity,
+      ConstantViscosityPrefactors<dim>::compute_viscosity (const double base_viscosity,
                                                            const unsigned int composition_index) const
       {
-        return viscosity * constant_viscosity_prefactors[composition_index];
+        return base_viscosity * constant_viscosity_prefactors[composition_index];
       }
 
 
@@ -92,4 +92,3 @@ namespace aspect
 #undef INSTANTIATE
   }
 }
-


### PR DESCRIPTION
The function compute_viscosity in the ConstantViscosityPrefactors rheology model takes an argument called viscosity as an argument. This was very confusing for my Winnie-the-Pooh-like brain. I think base_viscosity is clearer.