### PR TITLE
Remove some unnecessary 'typename's.

### DIFF
--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -80,7 +80,7 @@ namespace aspect
           /**
            * Interpolation functions to access the velocities.
            */
-          std::array<std::unique_ptr<typename Functions::InterpolatedUniformGridData<2> >, 2> velocities;
+          std::array<std::unique_ptr<Functions::InterpolatedUniformGridData<2>>, 2> velocities;
 
           /**
            * Distances between adjacent point in the Lat/Long grid

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -387,7 +387,7 @@ namespace aspect
           names_and_descriptions[std::get<0>(*p)] = std::get<1>(*p);;
 
         // then output it all
-        typename std::map<std::string,std::string>::const_iterator
+        std::map<std::string,std::string>::const_iterator
         p = names_and_descriptions.begin();
         while (true)
           {

--- a/include/aspect/volume_of_fluid/handler.h
+++ b/include/aspect/volume_of_fluid/handler.h
@@ -216,7 +216,7 @@ namespace aspect
        * held here as all access to the actual methods for composition
        * initialization is handled by the manager.
        */
-      std::vector<typename VolumeOfFluid::VolumeOfFluidInputType::Kind> initialization_data_type;
+      std::vector<VolumeOfFluid::VolumeOfFluidInputType::Kind> initialization_data_type;
 
       friend class Simulator<dim>;
   };

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -93,12 +93,18 @@ namespace aspect
         distributed_heat_flux_vector = 0.;
         heat_flux_vector = 0.;
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
-        typename HeatingModel::HeatingModelOutputs heating_out(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
+        typename MaterialModel::Interface<dim>::MaterialModelInputs
+        in(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
+        typename MaterialModel::Interface<dim>::MaterialModelOutputs
+        out(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
 
-        typename MaterialModel::Interface<dim>::MaterialModelInputs face_in(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs face_out(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
+        HeatingModel::HeatingModelOutputs
+        heating_out(fe_volume_values.n_quadrature_points, simulator_access.n_compositional_fields());
+
+        typename MaterialModel::Interface<dim>::MaterialModelInputs
+        face_in(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
+        typename MaterialModel::Interface<dim>::MaterialModelOutputs
+        face_out(fe_face_values.n_quadrature_points, simulator_access.n_compositional_fields());
 
         std::vector<double> old_temperatures (n_q_points);
         std::vector<double> old_old_temperatures (n_q_points);

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -401,10 +401,13 @@ namespace aspect
 
                   const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
                   const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];
-                  typename Newton::Parameters::Stabilization velocity_block_stabilization = this->get_newton_handler().parameters.velocity_block_stabilization;
+                  const Newton::Parameters::Stabilization velocity_block_stabilization
+                    = this->get_newton_handler().parameters.velocity_block_stabilization;
 
                   // use the spd factor when the stabilization is PD or SPD
-                  const double alpha =  (velocity_block_stabilization & Newton::Parameters::Stabilization::PD) != Newton::Parameters::Stabilization::none ?
+                  const double alpha =  (velocity_block_stabilization & Newton::Parameters::Stabilization::PD)
+                                        != Newton::Parameters::Stabilization::none
+                                        ?
                                         Utilities::compute_spd_factor<dim>(eta, strain_rate, viscosity_derivative_wrt_strain_rate,
                                                                            this->get_newton_handler().parameters.SPD_safety_factor)
                                         :
@@ -455,7 +458,8 @@ namespace aspect
 #if DEBUG
       if (scratch.rebuild_newton_stokes_matrix)
         {
-          if (this->get_newton_handler().parameters.velocity_block_stabilization == Newton::Parameters::Stabilization::SPD)
+          if (this->get_newton_handler().parameters.velocity_block_stabilization
+              == Newton::Parameters::Stabilization::SPD)
             {
               // regardless of whether we do or do not add the Newton
               // linearization terms, we ought to test whether the top-left

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2212,7 +2212,7 @@ namespace aspect
         // next make sure that all listed indicators are actually used by
         // this geometry
         for (unsigned int i=0; i<sizeof(boundary_indicator_lists)/sizeof(boundary_indicator_lists[0]); ++i)
-          for (typename std::set<types::boundary_id>::const_iterator
+          for (std::set<types::boundary_id>::const_iterator
                p = boundary_indicator_lists[i].begin();
                p != boundary_indicator_lists[i].end(); ++p)
             AssertThrow (all_boundary_indicators.find (*p)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1572,13 +1572,13 @@ namespace aspect
             nullspace_removal = typename NullspaceRemoval::Kind(
                                   nullspace_removal | NullspaceRemoval::net_translation_z);
           else if (nullspace_names[i]=="linear x momentum")
-            nullspace_removal = typename       NullspaceRemoval::Kind(
+            nullspace_removal = typename NullspaceRemoval::Kind(
                                   nullspace_removal | NullspaceRemoval::linear_momentum_x);
           else if (nullspace_names[i]=="linear y momentum")
-            nullspace_removal = typename       NullspaceRemoval::Kind(
+            nullspace_removal = typename NullspaceRemoval::Kind(
                                   nullspace_removal | NullspaceRemoval::linear_momentum_y);
           else if (nullspace_names[i]=="linear z momentum")
-            nullspace_removal = typename       NullspaceRemoval::Kind(
+            nullspace_removal = typename NullspaceRemoval::Kind(
                                   nullspace_removal | NullspaceRemoval::linear_momentum_z);
           else if (nullspace_names[i]=="linear momentum")
             nullspace_removal = typename NullspaceRemoval::Kind(

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3701,7 +3701,7 @@ namespace aspect
                      const unsigned int component_index,
                      const Quadrature<2> &quadrature,
                      const std::function<void(
-                       const typename DoFHandler<2>::active_cell_iterator &,
+                       const DoFHandler<2>::active_cell_iterator &,
                        const std::vector<Point<2> > &,
                        std::vector<double> &)> &function,
                      dealii::LinearAlgebra::distributed::Vector<double> &vec_result);
@@ -3712,7 +3712,7 @@ namespace aspect
                      const unsigned int component_index,
                      const Quadrature<3> &quadrature,
                      const std::function<void(
-                       const typename DoFHandler<3>::active_cell_iterator &,
+                       const DoFHandler<3>::active_cell_iterator &,
                        const std::vector<Point<3> > &,
                        std::vector<double> &)> &function,
                      dealii::LinearAlgebra::distributed::Vector<double> &vec_result);
@@ -3723,7 +3723,7 @@ namespace aspect
                      const unsigned int component_index,
                      const Quadrature<2> &quadrature,
                      const std::function<void(
-                       const typename DoFHandler<2>::active_cell_iterator &,
+                       const DoFHandler<2>::active_cell_iterator &,
                        const std::vector<Point<2> > &,
                        std::vector<double> &)> &function,
                      LinearAlgebra::BlockVector &vec_result);
@@ -3734,7 +3734,7 @@ namespace aspect
                      const unsigned int component_index,
                      const Quadrature<3> &quadrature,
                      const std::function<void(
-                       const typename DoFHandler<3>::active_cell_iterator &,
+                       const DoFHandler<3>::active_cell_iterator &,
                        const std::vector<Point<3> > &,
                        std::vector<double> &)> &function,
                      LinearAlgebra::BlockVector &vec_result);

--- a/source/volume_of_fluid/reconstruct.cc
+++ b/source/volume_of_fluid/reconstruct.cc
@@ -507,8 +507,10 @@ namespace aspect
     solution.block(blockidx) = initial_solution.block(blockidx);
   }
 
+
+
   template <>
-  void VolumeOfFluidHandler<3>::update_volume_of_fluid_composition (const typename Simulator<3>::AdvectionField &/*composition_field*/,
+  void VolumeOfFluidHandler<3>::update_volume_of_fluid_composition (const Simulator<3>::AdvectionField &/*composition_field*/,
                                                                     const VolumeOfFluidField<3> &/*volume_of_fluid_field*/,
                                                                     LinearAlgebra::BlockVector &/*solution*/)
   {


### PR DESCRIPTION
Not all `typename`s are actually necessary: It's only necessary when the references name is a type inside a template-argument dependent (outer) type. Remove a number of cases where that is not actually necessary.