### PR TITLE
create and use is_defect_correction helper function.

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -80,6 +80,21 @@ namespace aspect
       };
     };
 
+    static
+    bool
+    is_defect_correction(const typename NonlinearSolver::Kind &input)
+    {
+      return input == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
+             input == NonlinearSolver::single_Advection_iterated_Newton_Stokes ||
+             input == NonlinearSolver::no_Advection_iterated_defect_correction_Stokes ||
+             input == NonlinearSolver::single_Advection_iterated_defect_correction_Stokes ||
+             input == NonlinearSolver::iterated_Advection_and_defect_correction_Stokes
+             ?
+             true
+             :
+             false;
+    }
+
     /**
      * @brief The NullspaceRemoval struct
      */

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -142,11 +142,7 @@ namespace aspect
     melt_handler (parameters.include_melt_transport ?
                   std_cxx14::make_unique<MeltHandler<dim>>(prm) :
                   nullptr),
-    newton_handler ((parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
-                     parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_Newton_Stokes ||
-                     parameters.nonlinear_solver == NonlinearSolver::no_Advection_iterated_defect_correction_Stokes ||
-                     parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_defect_correction_Stokes ||
-                     parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_defect_correction_Stokes) ?
+    newton_handler (Parameters<dim>::is_defect_correction(parameters.nonlinear_solver) ?
                     std_cxx14::make_unique<NewtonHandler<dim>>() :
                     nullptr),
     post_signal_creation(
@@ -233,11 +229,7 @@ namespace aspect
 
     rebuild_stokes_matrix (true),
     assemble_newton_stokes_matrix (true),
-    assemble_newton_stokes_system ((parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
-                                    parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_Newton_Stokes ||
-                                    parameters.nonlinear_solver == NonlinearSolver::no_Advection_iterated_defect_correction_Stokes ||
-                                    parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_defect_correction_Stokes ||
-                                    parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_defect_correction_Stokes)
+    assemble_newton_stokes_system (Parameters<dim>::is_defect_correction(parameters.nonlinear_solver)
                                    ?
                                    true
                                    :
@@ -388,11 +380,7 @@ namespace aspect
 
     // If the solver type is a Newton or defect correction type of solver, we need to set make sure
     // assemble_newton_stokes_system set to true.
-    if (parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_Newton_Stokes ||
-        parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_Newton_Stokes ||
-        parameters.nonlinear_solver == NonlinearSolver::no_Advection_iterated_defect_correction_Stokes ||
-        parameters.nonlinear_solver == NonlinearSolver::single_Advection_iterated_defect_correction_Stokes ||
-        parameters.nonlinear_solver == NonlinearSolver::iterated_Advection_and_defect_correction_Stokes)
+    if (Parameters<dim>::is_defect_correction(parameters.nonlinear_solver))
       {
         assemble_newton_stokes_system = true;
         newton_handler->initialize_simulator(*this);


### PR DESCRIPTION
follow up to #3112. This creates a helper function to centralize the question whether a type of nonlinear solver is a defect correction solver. 

I placed it close to the enum definition in parameters.h, but I am fine with putting it at an other location if there are strong opinions about it.