### PR TITLE
corrected geoid parameter typo

### DIFF
--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -931,7 +931,7 @@ namespace aspect
       {
         prm.enter_subsection("Geoid");
         {
-          prm.declare_entry("Include the contributon from dynamic topography", "true",
+          prm.declare_entry("Include the contribution from dynamic topography", "true",
                             Patterns::Bool(),
                             "Option to include the contribution from dynamic topography on geoid. The default is true.");
           prm.declare_entry("Maximum degree","20",
@@ -989,7 +989,7 @@ namespace aspect
       {
         prm.enter_subsection("Geoid");
         {
-          include_dynamic_topo_contribution = prm.get_bool ("Include the contributon from dynamic topography");
+          include_dynamic_topo_contribution = prm.get_bool ("Include the contribution from dynamic topography");
           max_degree = prm.get_integer ("Maximum degree");
           min_degree = prm.get_integer ("Minimum degree");
           output_in_lat_lon = prm.get_bool ("Output data in geographical coordinates");

--- a/tests/geoid.prm
+++ b/tests/geoid.prm
@@ -104,7 +104,7 @@ subsection Postprocess
     set Also output the spherical harmonic coefficients of surface dynamic topography contribution = true
     set Also output the spherical harmonic coefficients of CMB dynamic topography contribution = true
     set Also output the spherical harmonic coefficients of density anomaly contribution = true
-    set Include the contributon from dynamic topography = true
+    set Include the contribution from dynamic topography = true
 
     set Also output the gravity anomaly  = true
   end

--- a/tests/geoid_no_topo.prm
+++ b/tests/geoid_no_topo.prm
@@ -92,7 +92,7 @@ subsection Postprocess
     set Output data in geographical coordinates = true
     set Also output the spherical harmonic coefficients of geoid anomaly = true
     set Also output the spherical harmonic coefficients of density anomaly contribution = true
-    set Include the contributon from dynamic topography = false
+    set Include the contribution from dynamic topography = false
 
     set Also output the gravity anomaly  = true
   end

--- a/tests/geoid_visualization.prm
+++ b/tests/geoid_visualization.prm
@@ -100,7 +100,7 @@ subsection Postprocess
     set Also output the spherical harmonic coefficients of surface dynamic topography contribution = false
     set Also output the spherical harmonic coefficients of CMB dynamic topography contribution = false
     set Also output the spherical harmonic coefficients of density anomaly contribution = false
-    set Include the contributon from dynamic topography = true
+    set Include the contribution from dynamic topography = true
   end
 
   subsection Dynamic topography


### PR DESCRIPTION
The PR corrects a geoid parameter typo:
Include the contributon from dynamic topography -> Include the contribution from dynamic topography