### PR TITLE
fixed some typos in source code comments/doc strings

### DIFF
--- a/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.cc
+++ b/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.cc
@@ -8,7 +8,7 @@
   the Free Software Foundation; either version 2, or (at your option)
   any later version.
 
-  ASPEC is distributed in the hope that it will be useful,
+  ASPECT is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
+++ b/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
@@ -8,7 +8,7 @@
   the Free Software Foundation; either version 2, or (at your option)
   any later version.
 
-  ASPEC is distributed in the hope that it will be useful,
+  ASPECT is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
@@ -387,6 +387,3 @@ namespace aspect
     };
   }
 }
-
-
-

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -122,7 +122,7 @@ namespace aspect
                              "in weight fraction.");
           prm.declare_entry ("Max iteration", "30000",
                              Patterns::Integer (0),
-                             "The max iterations for nonliner core energy solver.");
+                             "The max iterations for nonlinear core energy solver.");
           prm.declare_entry ("Core heat capacity", "840.",
                              Patterns::Double (0.),
                              "Heat capacity of the core. "
@@ -405,7 +405,7 @@ namespace aspect
     {
       // Well solving the change in core-mantle boundary temperature T, inner core radius R, and
       //    light component (e.g. S, O, Si) composition X, the following relations has to be respected:
-      // 1. At the inner core boundary the adiabatic temperature should be equal to solidu temperature
+      // 1. At the inner core boundary the adiabatic temperature should be equal to solidus temperature
       // 2. The following energy production rate should be balanced in core:
       //    Heat flux at core-mantle boundary         Q
       //    Specific heat                             Qs*dT/dt
@@ -415,7 +415,7 @@ namespace aspect
       //    So that         Q+Qs*dT/dt+Qr+Qg*dR/dt*Ql*dR/dt=0
       // 3. The light component composition X depends on inner core radius (See function get_X() ),
       //    and core solidus may dependent on X as well
-      // This becomes a small nonliner problem. Directly iterate through the above three system doesn't
+      // This becomes a small nonlinear problem. Directly iterate through the above three system doesn't
       // converge well. Alternatively we solve the inner core radius by bisection method.
 
       int steps=1;
@@ -502,7 +502,7 @@ namespace aspect
     DynamicCore<dim>::get_Tc(double r) const
     {
       // Using all Q values from last step.
-      // Qs & Qr is constant, while Qg & Ql depends on inner core raidus Ri
+      // Qs & Qr is constant, while Qg & Ql depends on inner core radius Ri
       // TODO: Use mid-point value for Q values.
       return core_data.Ti - ( (core_data.Q + core_data.Qr + core_data.Q_OES) * core_data.dt
                               + (core_data.Qg + core_data.Ql)*(r-core_data.Ri)
@@ -755,7 +755,7 @@ namespace aspect
         global_CMB_area = Utilities::MPI::sum (local_CMB_area, this->get_mpi_communicator());
 
         // Using area averaged heat-flux density times core mantle boundary area to calculate total heat-flux on the 3D sphere.
-        // By doing this, using dyanmic core evolution with geometray other than 3D spherical shell becomes possible.
+        // By doing this, using dynamic core evolution with geometry other than 3D spherical shell becomes possible.
         double average_CMB_heatflux_density = global_CMB_flux / global_CMB_area;
         core_data.Q = average_CMB_heatflux_density * 4. * M_PI * Rc * Rc;
       }

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -65,7 +65,7 @@ namespace aspect
                             Patterns::List (Patterns::Double(0.)),
                             "List of heat production per unit volume values for "
                             "background and compositional fields, for a total of "
-                            "N+1 values, where the first value correponds to the "
+                            "N+1 values, where the first value corresponds to the "
                             "background material, and N is the number of compositional fields. "
                             "Units: \\si{\\watt\\per\\meter\\cubed}.");
           prm.declare_entry ("Use compositional field for heat production averaging", "1",

--- a/source/initial_composition/ascii_data_layered.cc
+++ b/source/initial_composition/ascii_data_layered.cc
@@ -103,7 +103,7 @@ namespace aspect
                                               "has to be `x', `y', `composition1', `composition2' etc. "
                                               "in a 2d model and `x', `y', `z', `composition1', "
                                               "`composition2' etc. in a 3d model; i.e. "
-                                              "the columns before the lcompositional field always contains "
+                                              "the columns before the compositional field always contains "
                                               "the position of the surface along the vertical direction. "
                                               "The first column needs to ascend first, "
                                               "followed by the second in order to assign the correct data "

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -518,7 +518,7 @@ namespace aspect
                                    "$A_i$ are prefactors, $n_i$ and $m_i$ are stress and grain size exponents "
                                    "$E_i$ are the activation energies and $V_i$ are the activation volumes. "
                                    "\n\n"
-                                   "This form of the viscosity equation is commonly used in geodynamic simulatons "
+                                   "This form of the viscosity equation is commonly used in geodynamic simulations "
                                    "See, for example, Billen and Hirth (2007), G3, 8, Q08012. Significantly, "
                                    "other studies may use slightly different forms of the viscosity equation "
                                    "leading to variations in how specific terms are defined or combined. For "

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -983,7 +983,7 @@ namespace aspect
           prm.declare_entry ("Phase transition temperatures", "",
                              Patterns::List (Patterns::Double (0.)),
                              "A list of temperatures where phase transitions occur. Higher or lower "
-                             "temperatures lead to phase transition ocurring in smaller or greater "
+                             "temperatures lead to phase transition occurring in smaller or greater "
                              "depths than given in Phase transition depths, depending on the "
                              "Clapeyron slope given in Phase transition Clapeyron slopes. "
                              "List must have the same number of entries as Phase transition depths. "
@@ -1108,7 +1108,7 @@ namespace aspect
           prm.declare_entry ("Diffusion creep grain size exponent", "3.",
                              Patterns::List (Patterns::Double (0.)),
                              "The diffusion creep grain size exponent $p_{diff}$ that determines the "
-                             "dependence of vescosity on grain size. "
+                             "dependence of viscosity on grain size. "
                              "Units: none.");
           prm.declare_entry ("Maximum temperature dependence of viscosity", "100.",
                              Patterns::Double (0.),

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -1087,7 +1087,7 @@ namespace aspect
                                    "the full finite strain tensor through particles."
                                    "When only the second invariant of the strain is tracked, one has the option to "
                                    "track the full strain or only the plastic strain. In the latter case, strain is only tracked "
-                                   "in case the material is plastically yielding, i.e. the viscous stess > yield stress. "
+                                   "in case the material is plastically yielding, i.e. the viscous stress > yield stress. "
                                    "\n\n"
                                    "Viscous stress may also be limited by a non-linear stress limiter "
                                    "that has a form similar to the Peierls creep mechanism. "

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -346,7 +346,7 @@ namespace aspect
 
       std::pair<double, std::pair<std::vector<double>,std::vector<double> > > SH_surface_dyna_topo_coes;
       std::pair<double, std::pair<std::vector<double>,std::vector<double> > > SH_CMB_dyna_topo_coes;
-      // Initialize the surface and CMB density contrasts with NaNs becasue they may be unused in case of no dynamic topography contribution.
+      // Initialize the surface and CMB density contrasts with NaNs because they may be unused in case of no dynamic topography contribution.
       double surface_delta_rho = numbers::signaling_nan<double>();
       double CMB_delta_rho = numbers::signaling_nan<double>();
       if (include_dynamic_topo_contribution == true)

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -8,7 +8,7 @@
   the Free Software Foundation; either version 2, or (at your option)
   any later version.
 
-  ASPEC is distributed in the hope that it will be useful,
+  ASPECT is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -628,7 +628,7 @@ namespace aspect
 
           prm.declare_entry ("Exclude output properties", "",
                              Patterns::Anything(),
-                             "A comma seperated list of strings which exclude all particle"
+                             "A comma separated list of strings which exclude all particle"
                              "property fields which contain these strings. If one of the "
                              "entries is 'all', only a id will be provided for every point.");
         }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -647,7 +647,7 @@ namespace aspect
     boundary_heat_flux->update();
 
     // If we do not want to prescribe Dirichlet boundary conditions on outflow boundaries,
-    // we update the boundary indicators of all faces that belong to ouflow boundaries
+    // we update the boundary indicators of all faces that belong to outflow boundaries
     // so that they are not in the list of fixed temperature boundary indicators any more.
     // We will undo this change in a later step, after the constraints have been set.
     // As long as we allow deal.II 8.5, we can not have boundary ids of more than 256,
@@ -1412,7 +1412,7 @@ namespace aspect
     // Set up the constraints for periodic boundary conditions:
 
     // Note: this has to happen _before_ we do hanging node constraints,
-    // because inconsistent contraints could be generated in parallel otherwise.
+    // because inconsistent constraints could be generated in parallel otherwise.
     {
       using periodic_boundary_set
         = std::set< std::pair< std::pair< types::boundary_id, types::boundary_id>, unsigned int> >;

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -1238,7 +1238,7 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::solve_single_advection_iterated_newton_stokes ()
   {
-    // First assemble and sove the temperature and compositional fields
+    // First assemble and solve the temperature and compositional fields
     assemble_and_solve_temperature();
     assemble_and_solve_composition();
 

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -811,7 +811,7 @@ namespace aspect
       {
         VectorizedArray<number> one_over_viscosity = (*viscosity)(cell, 0);
 
-        // The /= operator for VectorizedArray results in a foating point operation
+        // The /= operator for VectorizedArray results in a floating point operation
         // (divide by 0) since the (*viscosity)(cell) array is not completely filled.
         // Therefore, we need to divide each entry manually.
         const unsigned int n_components_filled = this->get_matrix_free()->n_components_filled(cell);
@@ -903,7 +903,7 @@ namespace aspect
       {
         VectorizedArray<number> one_over_viscosity = (*viscosity)(cell, 0);
 
-        // The /= operator for VectorizedArray results in a foating point operation
+        // The /= operator for VectorizedArray results in a floating point operation
         // (divide by 0) since the (*viscosity)(cell) array is not completely filled.
         // Therefore, we need to divide each entry manually.
         const unsigned int n_components_filled = this->get_matrix_free()->n_components_filled(cell);
@@ -1854,7 +1854,7 @@ namespace aspect
           throw SolverControl::NoConvergence(0,0);
 
         // Unlike with the expensive preconditioner which uses CG solves on both the
-        // velocity and pressure space, the cheap preonditioner only contains matrix-vector
+        // velocity and pressure space, the cheap preconditioner only contains matrix-vector
         // products and GMG v-cycle where the smoothers, transfer operators, and coarse
         // solvers are all defined to be linear operators which do not change from iteration
         // to iteration. Therefore we can use non-flexible Krylov methods like GMRES or IDR(s),

--- a/source/termination_criteria/end_walltime.cc
+++ b/source/termination_criteria/end_walltime.cc
@@ -26,7 +26,7 @@ namespace aspect
   namespace TerminationCriteria
   {
     // The start_walltime is made as static and initialized here to
-    // make sure it is initialized right way as the programe starts.
+    // make sure it is initialized right way as the program starts.
     template <int dim>
     std::time_t
     EndWalltime<dim>::start_walltime = std::time(nullptr);

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -347,7 +347,7 @@ namespace aspect
           const std::vector<std::string> split_parts = Utilities::split_string_list (*p, ':');
           AssertThrow (split_parts.size() == 2,
                        ExcMessage ("The format for "
-                                   "<Initial composition model/Volume of Fluid intialization method> "
+                                   "<Initial composition model/Volume of Fluid initialization method> "
                                    "volume of fluid initialization met "
                                    "requires that each entry " "has the form "
                                    "`<name of field> : <method>', but this "
@@ -365,7 +365,7 @@ namespace aspect
                        != names_of_compositional_fields.end(),
                        ExcMessage ("Name of field <" + key +
                                    "> appears in the parameter "
-                                   "<Initial composition model/Volume of Fluid intialization method>, but "
+                                   "<Initial composition model/Volume of Fluid initialization method>, but "
                                    "there is no field with this name."));
 
           const unsigned int compositional_field_index = std::distance(names_of_compositional_fields.begin(),
@@ -374,14 +374,14 @@ namespace aspect
           AssertThrow (compositional_field_methods[compositional_field_index]
                        == Parameters<dim>::AdvectionFieldMethod::volume_of_fluid,
                        ExcMessage ("The field <" + key + "> appears in the parameter "
-                                   "<Initial composition model/Volume of Fluid intialization method>, "
+                                   "<Initial composition model/Volume of Fluid initialization method>, "
                                    "but is not advected by a particle method."));
 
           AssertThrow (std::count(names_of_compositional_fields.begin(),
                                   names_of_compositional_fields.end(), key) == 1,
                        ExcMessage ("Name of field <" + key + "> appears more "
                                    "than once in the parameter "
-                                   "<Initial composition model/Volume of Fluid intialization type>."));
+                                   "<Initial composition model/Volume of fluid intialization type>."));
 
           // Get specification for how to treat initializing data
           const std::string value = split_parts[1];
@@ -413,7 +413,7 @@ namespace aspect
                 ExcMessage("Volume of Fluid Interface Tracking requires CFL < 1."));
 
     AssertThrow(!this->get_material_model().is_compressible(),
-                ExcMessage("Volume of Fluid Interface Tracking currently assumes incompressiblity."));
+                ExcMessage("Volume of Fluid Interface Tracking currently assumes incompressibility."));
 
     AssertThrow(dynamic_cast<const MappingCartesian<dim> *>(&(this->get_mapping())),
                 ExcMessage("Volume of Fluid Interface Tracking currently requires Cartesian Mappings"));

--- a/source/volume_of_fluid/utilities.cc
+++ b/source/volume_of_fluid/utilities.cc
@@ -53,7 +53,7 @@ namespace aspect
           {
             return 1.0;
           }
-        const double dtest = d / norm1; // Threshold value for changes in compuation behavior
+        const double dtest = d / norm1; // Threshold value for changes in computation behavior
         // Normalized parameter indicating the "slope" (positive and finite)
         // Chosen due to resulting in simple formulas
         // Equal to the absolute value of the smaller vector entry in the 1-norm normalized normal vector
@@ -362,7 +362,7 @@ namespace aspect
         // fpdx=\int pH(d-n\cdot x)dx$ for all polynomials $p$ less than or
         // equal to the given degree
         //
-        // The funcitons for the correct values were calculated and exported using sympy
+        // The functions for the correct values were calculated and exported using sympy
         if (d<-0.5*norm1)
           {
             for (unsigned int i =0; i < basis_count; ++i)
@@ -473,7 +473,7 @@ namespace aspect
         // fpdx=\int pH(d-n\cdot x)dx$ for all polynomials $p$ less than or
         // equal to the given degree
         //
-        // The funcitons for the correct values were calculated and exported using sympy
+        // The functions for the correct values were calculated and exported using sympy
         if (d<-0.5*norm1)
           {
             for (int i =0; i < basis_count; ++i)


### PR DESCRIPTION
Fixed some typos in source code comments and doc strings. 
I've purposefully avoided anything that changes how the code functions.