### PR TITLE
Introduce copy_particle_handler_function to particle world.

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -112,6 +112,18 @@ namespace aspect
         get_particle_handler() const;
 
         /**
+         * Copy the state of particle handler @p from_particle_handler into the
+         * particle handler @p to_particle_handler. This will copy
+         * all particles and properties and leave @p to_particle_handler
+         * as an identical copy of @p from_particle_handler, assuming it
+         * was set up by this particle world class. This means we assume
+         * @p from_particle_handler uses the same triangulation and
+         * particle properties as are used in this model.
+         */
+        void copy_particle_handler (const Particles::ParticleHandler<dim> &from_particle_handler,
+                                    Particles::ParticleHandler<dim> &to_particle_handler) const;
+
+        /**
          * Do initial logic for handling pre-refinement steps
          */
         void setup_initial_state ();
@@ -368,6 +380,14 @@ namespace aspect
         local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
                                const typename ParticleHandler<dim>::particle_iterator &end_particle);
+
+        /**
+         * This function registers the necessary functions to the
+         * @p signals that the @p particle_handler needs to know about.
+         */
+        void
+        connect_particle_handler_signals(aspect::SimulatorSignals<dim> &signals,
+                                         ParticleHandler<dim> &particle_handler) const;
     };
 
     /* -------------------------- inline and template functions ---------------------- */

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -118,7 +118,16 @@ namespace aspect
          * as an identical copy of @p from_particle_handler, assuming it
          * was set up by this particle world class. This means we assume
          * @p from_particle_handler uses the same triangulation and
-         * particle properties as are used in this model.
+         * particle properties as are used in this model. Existing
+         * particles in @p to_particle_handler are deleted.
+         *
+         * This function is expensive as it has to duplicate all data
+         * in @p from_particle_handler, and insert it into @p to_particle_handler,
+         * which may be a significant amount of data. However, it can
+         * be useful for example to save the state of a particle
+         * collection at a certain point in time and reset this
+         * state later under certain conditions, for example if
+         * a timestep has to be undone and repeated.
          */
         void copy_particle_handler (const Particles::ParticleHandler<dim> &from_particle_handler,
                                     Particles::ParticleHandler<dim> &to_particle_handler) const;

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -124,7 +124,7 @@ namespace aspect
          * This function is expensive as it has to duplicate all data
          * in @p from_particle_handler, and insert it into @p to_particle_handler,
          * which may be a significant amount of data. However, it can
-         * be useful for example to save the state of a particle
+         * be useful to save the state of a particle
          * collection at a certain point in time and reset this
          * state later under certain conditions, for example if
          * a timestep has to be undone and repeated.

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -134,7 +134,6 @@ namespace aspect
                                                    particle.get_reference_location(),
                                                    particle.get_id());
             new_particle.set_property_pool(to_particle_handler.get_property_pool());
-            new_particle.set_properties(particle.get_properties());
 
 #ifdef DEAL_II_WITH_CXX14
             new_particles.emplace_hint(new_particles.end(),
@@ -148,7 +147,13 @@ namespace aspect
           }
 
         to_particle_handler.insert_particles(new_particles);
-        to_particle_handler.update_cached_numbers();
+
+        auto from_particle = from_particle_handler.begin();
+        for (auto &particle : to_particle_handler)
+          {
+            particle.set_properties(from_particle->get_properties());
+            ++from_particle;
+          }
       }
 
       if (update_ghost_particles &&

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -133,7 +133,11 @@ namespace aspect
             Particles::Particle<dim> new_particle (particle.get_location(),
                                                    particle.get_reference_location(),
                                                    particle.get_id());
+
+#if !DEAL_II_VERSION_GTE(9,3,0)
             new_particle.set_property_pool(to_particle_handler.get_property_pool());
+            new_particle.set_properties(particle.get_properties());
+#endif
 
 #ifdef DEAL_II_WITH_CXX14
             new_particles.emplace_hint(new_particles.end(),
@@ -148,12 +152,15 @@ namespace aspect
 
         to_particle_handler.insert_particles(new_particles);
 
+#if DEAL_II_VERSION_GTE(9,3,0)
         auto from_particle = from_particle_handler.begin();
         for (auto &particle : to_particle_handler)
           {
             particle.set_properties(from_particle->get_properties());
             ++from_particle;
           }
+#endif
+
       }
 
       if (update_ghost_particles &&

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -108,6 +108,59 @@ namespace aspect
       return *particle_handler.get();
     }
 
+
+    template <int dim>
+    void
+    World<dim>::copy_particle_handler (const Particles::ParticleHandler<dim> &from_particle_handler,
+                                       Particles::ParticleHandler<dim> &to_particle_handler) const
+    {
+      {
+        TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Copy");
+
+        // initialize to_particle_handler
+        const unsigned int n_properties = property_manager->get_n_property_components();
+        to_particle_handler.clear();
+        to_particle_handler.initialize(this->get_triangulation(),
+                                       this->get_mapping(),
+                                       n_properties);
+
+        connect_particle_handler_signals(this->get_signals(),to_particle_handler);
+
+        std::multimap<typename Triangulation<dim>::active_cell_iterator, Particles::Particle<dim> > new_particles;
+
+        for (const auto &particle : from_particle_handler)
+          {
+            Particles::Particle<dim> new_particle (particle.get_location(),
+                                                   particle.get_reference_location(),
+                                                   particle.get_id());
+            new_particle.set_property_pool(to_particle_handler.get_property_pool());
+            new_particle.set_properties(particle.get_properties());
+
+#ifdef DEAL_II_WITH_CXX14
+            new_particles.emplace_hint(new_particles.end(),
+                                       particle.get_surrounding_cell(this->get_triangulation()),
+                                       std::move(new_particle));
+#else
+            new_particles.insert(new_particles.end(),
+                                 std::make_pair(particle.get_surrounding_cell(this->get_triangulation()),
+                                                std::move(new_particle)));
+#endif
+          }
+
+        to_particle_handler.insert_particles(new_particles);
+        to_particle_handler.update_cached_numbers();
+      }
+
+      if (update_ghost_particles &&
+          dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
+        {
+          TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Exchange ghosts");
+          to_particle_handler.exchange_ghost_particles();
+        }
+    }
+
+
+
     template <int dim>
     const Interpolator::Interface<dim> &
     World<dim>::get_interpolator() const
@@ -135,40 +188,50 @@ namespace aspect
         this->setup_initial_state();
       });
 
+      connect_particle_handler_signals(signals,*particle_handler);
+
+      signals.post_refinement_load_user_data.connect(
+        [&] (typename parallel::distributed::Triangulation<dim> &)
+      {
+        this->apply_particle_per_cell_bounds();
+      });
+
+      signals.post_resume_load_user_data.connect(
+        [&] (typename parallel::distributed::Triangulation<dim> &)
+      {
+        this->apply_particle_per_cell_bounds();
+      });
+    }
+
+
+
+    template <int dim>
+    void
+    World<dim>::connect_particle_handler_signals(aspect::SimulatorSignals<dim> &signals,
+                                                 ParticleHandler<dim> &particle_handler_) const
+    {
       signals.pre_refinement_store_user_data.connect(
         [&] (typename parallel::distributed::Triangulation<dim> &)
       {
-        particle_handler->register_store_callback_function();
+        particle_handler_.register_store_callback_function();
       });
 
       signals.post_refinement_load_user_data.connect(
         [&] (typename parallel::distributed::Triangulation<dim> &)
       {
-        particle_handler->register_load_callback_function(false);
+        particle_handler_.register_load_callback_function(false);
       });
 
       signals.pre_checkpoint_store_user_data.connect(
         [&] (typename parallel::distributed::Triangulation<dim> &)
       {
-        particle_handler->register_store_callback_function();
+        particle_handler_.register_store_callback_function();
       });
 
       signals.post_resume_load_user_data.connect(
         [&] (typename parallel::distributed::Triangulation<dim> &)
       {
-        particle_handler->register_load_callback_function(true);
-      });
-
-      signals.post_refinement_load_user_data.connect(
-        [&] (typename parallel::distributed::Triangulation<dim> &)
-      {
-        this->apply_particle_per_cell_bounds();
-      });
-
-      signals.post_resume_load_user_data.connect(
-        [&] (typename parallel::distributed::Triangulation<dim> &)
-      {
-        this->apply_particle_per_cell_bounds();
+        particle_handler_.register_load_callback_function(true);
       });
 
       if (update_ghost_particles &&
@@ -176,7 +239,7 @@ namespace aspect
         {
           auto lambda = [&] (typename parallel::distributed::Triangulation<dim> &)
           {
-            particle_handler->exchange_ghost_particles();
+            particle_handler_.exchange_ghost_particles();
           };
           signals.post_refinement_load_user_data.connect(lambda);
           signals.post_resume_load_user_data.connect(lambda);

--- a/tests/particle_handler_copy.cc
+++ b/tests/particle_handler_copy.cc
@@ -1,0 +1,84 @@
+/*
+  Copyright (C) 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/simulator_signals.h>
+#include <aspect/particle/world.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include <iostream>
+
+using namespace aspect;
+
+template <int dim>
+void duplicate_particle_handler(const SimulatorAccess<dim> &simulator_access,
+                                const bool,
+                                const unsigned int,
+                                const SolverControl &)
+{
+  const auto &particle_world = simulator_access.get_particle_world();
+  dealii::Particles::ParticleHandler<dim> particle_handler;
+  std::cout << "duplicating particle handler" << std::endl;
+
+  particle_world.copy_particle_handler(particle_world.get_particle_handler(),
+                                       particle_handler);
+
+  auto copied_particle = particle_handler.begin();
+  for (const auto &particle: particle_world.get_particle_handler())
+    {
+      std::cout << "Original position: " << particle.get_location()
+                << ". Copied position: " << copied_particle->get_location() << std::endl;
+      std::cout << "Original properties: " << particle.get_properties()[0]
+                << ". Copied properties: " << copied_particle->get_properties()[0] << std::endl;
+      ++copied_particle;
+    }
+
+  particle_handler.begin()->get_properties()[0] = 3.14;
+
+  std::cout << "resetting changed particle handler" << std::endl;
+
+  auto &non_const_particle_handler = const_cast<dealii::Particles::ParticleHandler<dim> &>(particle_world.get_particle_handler());
+
+  particle_world.copy_particle_handler(particle_handler,
+                                       non_const_particle_handler);
+
+  copied_particle = particle_handler.begin();
+  for (const auto &particle: particle_world.get_particle_handler())
+    {
+      std::cout << "Original position: " << particle.get_location()
+                << ". Copied position: " << copied_particle->get_location() << std::endl;
+      std::cout << "Original properties: " << particle.get_properties()[0]
+                << ". Copied properties: " << copied_particle->get_properties()[0] << std::endl;
+      ++copied_particle;
+    }
+}
+
+
+template <int dim>
+void signal_connector (SimulatorSignals<dim> &signals)
+{
+  std::cout << "Connecting signals" << std::endl;
+  signals.post_advection_solver.connect (&duplicate_particle_handler<dim>);
+}
+
+
+ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                  signal_connector<3>)
+

--- a/tests/particle_handler_copy.prm
+++ b/tests/particle_handler_copy.prm
@@ -1,0 +1,93 @@
+# A test for the Particle::World::copy_particle_handler
+# function that copies the particle handler (and all contained
+# particles), modifies one of them, and then resets the
+# the particles every time the composition system is solved.
+ 
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = bottom, top
+  set Tangential velocity boundary indicators = left, right
+end
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = box
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,particles
+
+  subsection Particles
+    set Number of particles = 10
+    set Time between data output = 70
+    set Data output format = vtu
+    set List of particle properties = velocity
+
+    set Particle generator name = uniform box
+
+    subsection Generator
+      subsection Uniform box
+        set Minimum x = 0.3
+        set Maximum x = 0.5
+        set Minimum y = 0.1
+        set Maximum y = 0.3
+      end
+    end
+  end
+end

--- a/tests/particle_handler_copy/screen-output
+++ b/tests/particle_handler_copy/screen-output
@@ -1,0 +1,184 @@
+
+Loading shared library <./libparticle_handler_copy.so>
+
+Connecting signals
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 seconds
+   Skipping temperature solve because RHS is zero.
+duplicating particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: 0. Copied properties: 0
+resetting changed particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: 0. Copied properties: 0
+   Solving C_1 system ... duplicating particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: 0. Copied properties: 0
+resetting changed particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: 0. Copied properties: 0
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: 0. Copied properties: 0
+0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.000181 m/s, 0.000404 m/s
+     Compositions min/max/mass: 0/1/0.1825
+     Writing particle output:   output-particle_handler_copy/particles/particles-00000
+
+*** Timestep 1:  t=70 seconds
+   Skipping temperature solve because RHS is zero.
+duplicating particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: -0.000348228. Copied properties: -0.000348228
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: -0.000380139. Copied properties: -0.000380139
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: -0.0002879. Copied properties: -0.0002879
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: -0.000309201. Copied properties: -0.000309201
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: -4.9609e-05. Copied properties: -4.9609e-05
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: -6.17923e-05. Copied properties: -6.17923e-05
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: -0.00036835. Copied properties: -0.00036835
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: -0.000291888. Copied properties: -0.000291888
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: -6.5404e-05. Copied properties: -6.5404e-05
+resetting changed particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: -0.000380139. Copied properties: -0.000380139
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: -0.0002879. Copied properties: -0.0002879
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: -0.000309201. Copied properties: -0.000309201
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: -4.9609e-05. Copied properties: -4.9609e-05
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: -6.17923e-05. Copied properties: -6.17923e-05
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: -0.00036835. Copied properties: -0.00036835
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: -0.000291888. Copied properties: -0.000291888
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: -6.5404e-05. Copied properties: -6.5404e-05
+   Solving C_1 system ... duplicating particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: -0.000380139. Copied properties: -0.000380139
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: -0.0002879. Copied properties: -0.0002879
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: -0.000309201. Copied properties: -0.000309201
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: -4.9609e-05. Copied properties: -4.9609e-05
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: -6.17923e-05. Copied properties: -6.17923e-05
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: -0.00036835. Copied properties: -0.00036835
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: -0.000291888. Copied properties: -0.000291888
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: -6.5404e-05. Copied properties: -6.5404e-05
+resetting changed particle handler
+Original position: 0.3 0.1. Copied position: 0.3 0.1
+Original properties: 3.14. Copied properties: 3.14
+Original position: 0.4 0.1. Copied position: 0.4 0.1
+Original properties: -0.000380139. Copied properties: -0.000380139
+Original position: 0.3 0.2. Copied position: 0.3 0.2
+Original properties: -0.0002879. Copied properties: -0.0002879
+Original position: 0.4 0.2. Copied position: 0.4 0.2
+Original properties: -0.000309201. Copied properties: -0.000309201
+Original position: 0.3 0.3. Copied position: 0.3 0.3
+Original properties: -4.9609e-05. Copied properties: -4.9609e-05
+Original position: 0.4 0.3. Copied position: 0.4 0.3
+Original properties: -6.17923e-05. Copied properties: -6.17923e-05
+Original position: 0.5 0.1. Copied position: 0.5 0.1
+Original properties: -0.00036835. Copied properties: -0.00036835
+Original position: 0.5 0.2. Copied position: 0.5 0.2
+Original properties: -0.000291888. Copied properties: -0.000291888
+Original position: 0.5 0.3. Copied position: 0.5 0.3
+Original properties: -6.5404e-05. Copied properties: -6.5404e-05
+14 iterations.
+   Solving Stokes system... 35+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.000327 m/s, 0.000727 m/s
+     Compositions min/max/mass: -0.001642/1.001/0.1825
+     Writing particle output:   output-particle_handler_copy/particles/particles-00001
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
This is the function I promised @anne-glerum for #3760 to work. The test case does something very similar to what is needed there, it creates a new particle handler as a copy of the existing one and afterwards copies the new particle handler back into the existing one (thus overwriting the particles in the existing handler). @tjhei: I decided to register all signals to the copy as well, i.e. the particles of the copied handler will be shipped around in case the triangulation is refined or repartitioned. I did not attach the the signal that actually modifies the set of stored particles (the ones that enforce the particle per cell limit). Is this what you need as well? 