### PR TITLE
New: Add Peierls exact formulation

### DIFF
--- a/doc/modules/changes/20200829b_bobmyhill
+++ b/doc/modules/changes/20200829b_bobmyhill
@@ -1,0 +1,7 @@
+<li> New: The rheology module for Peierls creep now includes a formulation
+to compute the exact Peierls viscosity, using an internal Newton-Raphson
+iterative scheme. The module now also contains a function to calculate the
+strain rate and derivative as a function of stress
+for both the exact and approximate formulations.
+<br>
+(Bob Myhill, John Naliboff and Magali Billen, 2020/08/29)

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -108,6 +108,8 @@ namespace aspect
 
           /**
            * Compute the viscosity based on the selected Peierls creep flow law.
+           * This function uses either the compute_approximate_viscosity
+           * or the compute_exact_viscosity function.
            */
           double
           compute_viscosity (const double strain_rate,
@@ -138,6 +140,9 @@ namespace aspect
           /**
            * Compute the strain rate and first stress derivative
            * as a function of stress based on the selected Peierls creep law.
+           * This function uses either the
+           * compute_approximate_strain_rate_and_derivative
+           * or the compute_exact_strain_rate_and_derivative function.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -33,6 +33,26 @@ namespace aspect
     namespace Rheology
     {
       /**
+       * Data structure for Peierls creep parameters.
+       */
+      struct PeierlsCreepParameters
+      {
+        /**
+         * The Peierls creep prefactor, stress exponent, activation energy,
+         * activation volume, Peierls stress, glide parameters p and q
+         * and fitting parameter,
+         */
+        double prefactor;
+        double stress_exponent;
+        double activation_energy;
+        double activation_volume;
+        double peierls_stress;
+        double glide_parameter_p;
+        double glide_parameter_q;
+        double fitting_parameter;
+      };
+
+      /**
        * Peierls creep is a low temperature, high stress viscous deformation mechanism.
        * Crystal deformation occurs through dislocation glide, which requires high stresses.
        * It is considered an important deformation mechanism in the lithosphere and subducting
@@ -50,6 +70,12 @@ namespace aspect
           PeierlsCreep();
 
           /**
+           * Compute the creep parameters for the Peierls creep law.
+           */
+          const PeierlsCreepParameters
+          compute_creep_parameters (const unsigned int composition) const;
+
+          /**
            * Declare the parameters this function takes through input files.
            */
           static
@@ -63,6 +89,24 @@ namespace aspect
           parse_parameters (ParameterHandler &prm);
 
           /**
+           * Compute the viscosity based on the approximate Peierls creep flow law.
+           */
+          double
+          compute_approximate_viscosity (const double strain_rate,
+                                         const double pressure,
+                                         const double temperature,
+                                         const unsigned int composition) const;
+
+          /**
+           * Compute the viscosity based on the exact Peierls creep flow law.
+           */
+          double
+          compute_exact_viscosity (const double strain_rate,
+                                   const double pressure,
+                                   const double temperature,
+                                   const unsigned int composition) const;
+
+          /**
            * Compute the viscosity based on the selected Peierls creep flow law.
            */
           double
@@ -71,11 +115,43 @@ namespace aspect
                              const double temperature,
                              const unsigned int composition) const;
 
+          /**
+           * Compute the strain rate and first stress derivative
+           * as a function of stress based on the approximate Peierls creep law.
+           */
+          std::pair<double, double>
+          compute_approximate_strain_rate_and_derivative (const double stress,
+                                                          const double pressure,
+                                                          const double temperature,
+                                                          const PeierlsCreepParameters creep_parameters) const;
+
+          /**
+           * Compute the strain rate and first stress derivative
+           * as a function of stress based on the exact Peierls creep law.
+           */
+          std::pair<double, double>
+          compute_exact_strain_rate_and_derivative (const double stress,
+                                                    const double pressure,
+                                                    const double temperature,
+                                                    const PeierlsCreepParameters creep_parameters) const;
+
+          /**
+           * Compute the strain rate and first stress derivative
+           * as a function of stress based on the selected Peierls creep law.
+           */
+          std::pair<double, double>
+          compute_strain_rate_and_derivative (const double stress,
+                                              const double pressure,
+                                              const double temperature,
+                                              const PeierlsCreepParameters creep_parameters) const;
+
         private:
           /**
            * Enumeration for selecting which type of Peierls creep flow law to use.
-           * Currently, the only available option directly calculates the viscosity
-           * using an approximation where the strain rate, rather than stress is used.
+           * The options are currently "exact" (which requires a Newton-Raphson iteration
+           * in compute_viscosity) and "viscosity_approximation", which
+           * uses a simplified expression where the strain rate has a power law dependence
+           * on the stress (so that the equation can be directly inverted for viscosity).
            * This approximation requires specifying one fitting parameter (gamma) to
            * obtain the best fit in the expected stress range for a given problem
            * (gamma = stress / peierls_stress). The derivation for this approximation
@@ -84,7 +160,8 @@ namespace aspect
            */
           enum PeierlsCreepScheme
           {
-            viscosity_approximation
+            viscosity_approximation,
+            exact
           } peierls_creep_flow_law;
 
           /**
@@ -128,6 +205,13 @@ namespace aspect
            * to dislocation glide (q).
            */
           std::vector<double> glide_parameters_q;
+
+          /**
+           * Parameters governing the iteration for the exact
+           * Peierls viscosity.
+           */
+          double strain_rate_residual_threshold;
+          unsigned int stress_max_iteration_number;
 
       };
     }

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -38,6 +38,134 @@ namespace aspect
 
 
 
+      /**
+       * Compute the creep parameters for the Peierls creep law.
+       */
+      template <int dim>
+      const PeierlsCreepParameters
+      PeierlsCreep<dim>::compute_creep_parameters (const unsigned int composition) const
+      {
+        PeierlsCreepParameters creep_parameters;
+        creep_parameters.prefactor = prefactors[composition];
+        creep_parameters.stress_exponent = stress_exponents[composition];
+        creep_parameters.activation_energy = activation_energies[composition];
+        creep_parameters.activation_volume = activation_volumes[composition];
+        creep_parameters.peierls_stress = peierls_stresses[composition];
+        creep_parameters.glide_parameter_p = glide_parameters_p[composition];
+        creep_parameters.glide_parameter_q = glide_parameters_q[composition];
+        creep_parameters.fitting_parameter = fitting_parameters[composition];
+        return creep_parameters;
+      }
+
+
+
+      template <int dim>
+      double
+      PeierlsCreep<dim>::compute_approximate_viscosity (const double strain_rate,
+                                                        const double pressure,
+                                                        const double temperature,
+                                                        const unsigned int composition) const
+      {
+        /**
+         * An approximation of the Peierls creep formulation, where stress is replaced with strain rate
+         * (second invariant) when calculating viscosity. This substitution requires a fitting parameter (gamma),
+         * which describes the relationship between stress and the Peierls stress (gamma = stress/stress_peierls).
+         * Details of this derivation can be found in the following document:
+         * https://ucdavis.app.box.com/s/cl5mwhkjeabol4otrdukfcdwfvg9me4w/file/705438695737
+         * The formulation for the viscosity is:
+         *   stress_term * arrhenius_term * strain_rate_term, where
+         * stress_term      = (0.5 * gamma * sigma_p) / (A * ((gamma * sigma_p)^n)^(1/(s+n)))
+         * arrhenius_term   = exp(( (E + P * V) / (R * T)) * (1 - gamma^p)^q / (s + n) )
+         * strain_rate_term = edot_ii^(1 / (s + n) - 1)
+         * Above,
+         * s = ((E + P * V) / (R * T)) * p * q * (1 - gamma^p)^(q-1) * (gamma^p)
+         * sigma_p is the Peierls stress
+         * gamma is the Peierls creep fitting parameter
+         * p is the first Peierls glide parameter
+         * q is the second Peierls creep glide parameter
+         * A is the Peierls prefactor term (1/s 1/Pa^2)
+         * n is the Peierls stress exponent
+         * E is the Peierls activation energy (J/mol)
+         * V is the Peierls activation volume (m^3/mol). However, to date V has always been set to 0.
+         * edot_ii is the second invariant of the deviatoric strain rate (1/s)
+         * T is temperature (K)
+         * R is the gas constant
+         */
+
+        const PeierlsCreepParameters p = compute_creep_parameters(composition);
+
+        const double s = ( (p.activation_energy + pressure * p.activation_volume) / (constants::gas_constant * temperature)) *
+                         p.glide_parameter_p * p.glide_parameter_q *
+                         std::pow((1. - std::pow(p.fitting_parameter, p.glide_parameter_p)),(p.glide_parameter_q - 1.)) *
+                         std::pow(p.fitting_parameter, p.glide_parameter_p);
+
+        const double stress_term = 0.5 * (p.fitting_parameter * p.peierls_stress) /
+                                   std::pow((p.prefactor * std::pow(p.fitting_parameter * p.peierls_stress,p.stress_exponent)),( 1. / (s + p.stress_exponent)));
+
+        const double arrhenius_term = std::exp( ((p.activation_energy + pressure * p.activation_volume) / (constants::gas_constant * temperature)) *
+                                                (std::pow((1. - std::pow(p.fitting_parameter,p.glide_parameter_p)),p.glide_parameter_q)) /
+                                                (s + p.stress_exponent) );
+
+        const double strain_rate_term = std::pow(strain_rate, (1. / (s + p.stress_exponent)) - 1.);
+
+        return stress_term * arrhenius_term * strain_rate_term;
+      }
+
+
+
+      template <int dim>
+      double
+      PeierlsCreep<dim>::compute_exact_viscosity (const double strain_rate,
+                                                  const double pressure,
+                                                  const double temperature,
+                                                  const unsigned int composition) const
+      {
+        /**
+         * A generalised Peierls creep formulation. The Peierls creep expression
+         * for the strain rate has multiple stress-dependent terms, and cannot be
+         * directly inverted to find an expression for viscosity in terms of
+         * strain rate. For this reason, a Newton Raphson iteration is required,
+         * which can be quite expensive.
+         * The equation for the strain rate is given in
+         * compute_exact_strain_rate_and_derivative.
+         */
+        const PeierlsCreepParameters p = compute_creep_parameters(composition);
+
+        // The generalized Peierls creep flow law cannot be expressed as viscosity in
+        // terms of strain rate, because there are multiple stress-dependent terms
+        // in the strain rate expression.
+        // We use Newton's method to find the second invariant of the stress tensor.
+
+        // Create a starting guess for the stress using
+        // the approximate form of the viscosity expression
+        double viscosity = compute_approximate_viscosity(strain_rate, pressure, temperature, composition);
+        double stress_ii = 2.*viscosity*strain_rate;
+        double strain_rate_residual = 2.*strain_rate_residual_threshold;
+
+        double strain_rate_deriv = 0;
+        unsigned int stress_iteration = 0;
+        while (std::abs(strain_rate_residual) > strain_rate_residual_threshold
+               && stress_iteration < stress_max_iteration_number)
+          {
+            const std::pair<double, double> edot_and_deriv = compute_exact_strain_rate_and_derivative(stress_ii, pressure, temperature, p);
+
+            strain_rate_residual = edot_and_deriv.first - strain_rate;
+            strain_rate_deriv = edot_and_deriv.second;
+
+            // If the strain rate derivative is zero, we catch it below.
+            if (strain_rate_deriv>std::numeric_limits<double>::min())
+              stress_ii -= strain_rate_residual/strain_rate_deriv;
+
+            stress_iteration += 1;
+          }
+
+        viscosity = 0.5*stress_ii/strain_rate;
+
+        return viscosity;
+      }
+
+
+
       template <int dim>
       double
       PeierlsCreep<dim>::compute_viscosity (const double strain_rate,
@@ -45,54 +173,18 @@ namespace aspect
                                             const double temperature,
                                             const unsigned int composition) const
       {
-        const unsigned int c = composition;
-
         double viscosity = 0.0;
 
         switch (peierls_creep_flow_law)
           {
             case viscosity_approximation:
             {
-              /**
-               * An approximation of the Peierls creep formulation, where stress is replaced with strain rate
-               * (second invariant) when calculating viscosity. This substitution requires a fitting parameter (gamma),
-               * which describes the relationship between stress and the Peierls stress (gamma = stress/stress_peierls).
-               * Details of this derivation can be found in the following document:
-               * https://ucdavis.app.box.com/s/cl5mwhkjeabol4otrdukfcdwfvg9me4w/file/705438695737
-               * The formulation for the viscosity is:
-               *   stress_term * arrhenius_term * strain_rate_term, where
-               * stress_term      = (0.5 * gamma * sigma_p) / (A * ((gamma * sigma_p)^n)^(1/(s+n)))
-               * arrhenius_term   = exp(( (E + P * V) / (R * T)) * (1 - gamma^p)^q / (s + n) )
-               * strain_rate_term = edot_ii^(1 / (s + n) - 1)
-               * Above,
-               * s = ((E + P * V) / (R * T)) * p * q * (1 - gamma^p)^(q-1) * (gamma^p)
-               * sigma_p is the Peierls stress
-               * gamma is the Peierls creep fitting parameter
-               * p is the first Peierls glide parameter
-               * q is the second Peierls creep glide parameter
-               * A is the Peierls prefactor term (1/s 1/Pa^2)
-               * n is the Peierls stress exponent
-               * E is the Peierls activation energy (J/mol)
-               * V is the Peierls activation volume (m^3/mol). However, to date V has always been set to 0.
-               * edot_ii is the second invariant of the deviatoric strain rate (1/s)
-               * T is temperature (K)
-               * R is the gas constant
-               */
-              const double s = ( (activation_energies[c] + pressure * activation_volumes[c]) / (constants::gas_constant * temperature)) *
-                               glide_parameters_p[c] * glide_parameters_q[c] *
-                               std::pow((1. - std::pow(fitting_parameters[c], glide_parameters_p[c])),(glide_parameters_q[c] - 1.)) *
-                               std::pow(fitting_parameters[c], glide_parameters_p[c]);
-
-              const double stress_term = 0.5 * (fitting_parameters[c] * peierls_stresses[c]) /
-                                         std::pow((prefactors[c] * std::pow(fitting_parameters[c] * peierls_stresses[c],stress_exponents[c])),( 1. / (s + stress_exponents[c])));
-
-              const double arrhenius_term = std::exp( ((activation_energies[c] + pressure * activation_volumes[c]) / (constants::gas_constant * temperature)) *
-                                                      (std::pow((1. - std::pow(fitting_parameters[c],glide_parameters_p[c])),glide_parameters_q[c])) /
-                                                      (s + stress_exponents[c]) );
-
-              const double strain_rate_term = std::pow(strain_rate, (1. / (s + stress_exponents[c])) - 1.);
-
-              viscosity = stress_term * arrhenius_term * strain_rate_term;
+              viscosity = compute_approximate_viscosity(strain_rate, pressure, temperature, composition);
+              break;
+            }
+            case exact:
+            {
+              viscosity = compute_exact_viscosity(strain_rate, pressure, temperature, composition);
               break;
             }
             default:
@@ -108,14 +200,123 @@ namespace aspect
 
 
       template <int dim>
+      std::pair<double, double>
+      PeierlsCreep<dim>::compute_approximate_strain_rate_and_derivative (const double stress,
+                                                                         const double pressure,
+                                                                         const double temperature,
+                                                                         const PeierlsCreepParameters creep_parameters) const
+      {
+        /**
+        * b = (E+P*V)/(R*T)
+        * c = std::pow(gamma, p)
+        * d = std::pow(1. - c, q)
+        * s = b*p*q*c*d/(1. - c)
+        * arrhenius = std::exp(-b*d)
+        *
+        * edot_ii = A * std::pow(stress, s + n) * std::pow(gamma*peierls_stress, -s) * arrhenius
+        * deriv = edot_ii / stress * (s + n)
+        */
+        const PeierlsCreepParameters p = creep_parameters;
+
+        const double b = (p.activation_energy + pressure*p.activation_volume)/(constants::gas_constant * temperature);
+        const double c = std::pow(p.fitting_parameter, p.glide_parameter_p);
+        const double d = std::pow(1. - c, p.glide_parameter_q);
+        const double s = b*p.glide_parameter_p*p.glide_parameter_q*c*d/(1. - c);
+        const double arrhenius = std::exp(-b*d);
+
+        const double edot_ii = p.prefactor * std::pow(stress, s + p.stress_exponent) * std::pow(p.fitting_parameter*p.peierls_stress, -s) * arrhenius;
+        const double deriv = edot_ii / stress * (s + p.stress_exponent);
+
+        return std::make_pair(edot_ii, deriv);
+      }
+
+
+
+      template <int dim>
+      std::pair<double, double>
+      PeierlsCreep<dim>::compute_exact_strain_rate_and_derivative (const double stress,
+                                                                   const double pressure,
+                                                                   const double temperature,
+                                                                   const PeierlsCreepParameters creep_parameters) const
+      {
+        /**
+        * b = (E+P*V)/(R*T)
+        * c = std::pow(stress/peierls_stress, p)
+        * d = std::pow(1 - c, q)
+        * s = b*p*q*c*d/(1 - c)
+        * arrhenius = std::exp(-b*d)
+        *
+        * edot_ii = A * std::pow(stress, n) * arrhenius
+        * deriv = edot_ii / stress * (s + n)
+        */
+        const PeierlsCreepParameters p = creep_parameters;
+
+        const double b = (p.activation_energy + pressure*p.activation_volume)/(constants::gas_constant * temperature);
+        const double c = std::pow(stress/p.peierls_stress, p.glide_parameter_p);
+        const double d = std::pow(1. - c, p.glide_parameter_q);
+        const double s = b*p.glide_parameter_p*p.glide_parameter_q*c*d/(1. - c);
+        const double arrhenius = std::exp(-b*d);
+
+        const double edot_ii = p.prefactor * std::pow(stress, p.stress_exponent) * arrhenius;
+        const double deriv = edot_ii / stress * (s + p.stress_exponent);
+
+        return std::make_pair(edot_ii, deriv);
+      }
+
+
+
+      template <int dim>
+      std::pair<double, double>
+      PeierlsCreep<dim>::compute_strain_rate_and_derivative (const double stress,
+                                                             const double pressure,
+                                                             const double temperature,
+                                                             const PeierlsCreepParameters creep_parameters) const
+      {
+        std::pair<double, double> strain_rate_and_deriv;
+
+        switch (peierls_creep_flow_law)
+          {
+            case viscosity_approximation:
+            {
+              strain_rate_and_deriv = compute_approximate_strain_rate_and_derivative(stress, pressure, temperature, creep_parameters);
+              break;
+            }
+            case exact:
+            {
+              strain_rate_and_deriv = compute_exact_strain_rate_and_derivative(stress, pressure, temperature, creep_parameters);
+              break;
+            }
+            default:
+            {
+              AssertThrow(false, ExcNotImplemented());
+              break;
+            }
+          }
+        return strain_rate_and_deriv;
+      }
+
+
+
+      template <int dim>
       void
       PeierlsCreep<dim>::declare_parameters (ParameterHandler &prm)
       {
         prm.declare_entry ("Peierls creep flow law", "viscosity approximation",
-                           Patterns::Selection("viscosity approximation"),
+                           Patterns::Selection("viscosity approximation|exact"),
                            "Select what type of Peierls creep flow law to use. Currently, the "
-                           "only available option is an approximation to Peierls creep, which "
-                           "uses the strain rate invariant, rather than stress, as an input. ");
+                           "available options are 'exact', which uses a Newton-Raphson iteration "
+                           "to find the stress and then compute viscosity, and 'viscosity approximation', "
+                           "in which viscosity is an explicit function of the strain rate invariant, "
+                           "rather than stress. ");
+
+        // Viscosity iteration parameters
+        prm.declare_entry ("Peierls strain rate residual tolerance", "1e-22", Patterns::Double(0.),
+                           "Tolerance for correct Peierls creep strain rate.");
+        prm.declare_entry ("Maximum Peierls strain rate iterations", "40", Patterns::Integer(0),
+                           "Maximum number of iterations to find the correct "
+                           "Peierls strain rate.");
+
+        // Rheological parameters
         prm.declare_entry ("Prefactors for Peierls creep", "1.4e-19",
                            Patterns::List(Patterns::Double(0.)),
                            "List of viscosity prefactors, $A$, for background material and compositional fields, "
@@ -174,9 +375,16 @@ namespace aspect
 
         if (prm.get ("Peierls creep flow law") == "viscosity approximation")
           peierls_creep_flow_law = viscosity_approximation;
+        else if (prm.get ("Peierls creep flow law") == "exact")
+          peierls_creep_flow_law = exact;
         else
           AssertThrow(false, ExcMessage("Not a valid Peierls creep flow law"));
 
+        // Iteration parameters
+        strain_rate_residual_threshold = prm.get_double ("Peierls strain rate residual tolerance");
+        stress_max_iteration_number = prm.get_integer ("Maximum Peierls strain rate iterations");
+
+        // Rheological parameters
         prefactors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Prefactors for Peierls creep"))),
                                                              n_fields,
                                                              "Prefactors for Peierls creep");

--- a/tests/visco_plastic_peierls_mei_exact.prm
+++ b/tests/visco_plastic_peierls_mei_exact.prm
@@ -1,0 +1,115 @@
+# A test for the exact Peierls creep flow law
+# with the visco_plastic material model.
+# Following the general Peierls creep flow law of Mei
+# et al. 2010 and assuming a stress of 900e6 Pa, the
+# exact viscosity is calculated in python through:
+#  import numpy as np
+#  A    = 1.4e-7/np.power(1e6,2) # Peierls creep prefactor 1/s 1/Pa^2
+#  R    = 8.314   # gas constant [J/mol*K]
+#  T    = 1073    # temperature [K]
+#  sig  = 1000e6  # stress [Pa]
+#  sigp = 5.9e9   # Peierls creep stress [Pa]
+#  E    = 320e3   # Peierls creeep activation energy [J/mol]
+#  V    = 0       # Peierls creep activation volume
+#  P    = 0       # Pressure (Pa)
+#  n    = 2       # Peierls creep stress exponent
+#  p    = 0.5     # First slide parameter
+#  q    = 1       # Second glide parameter
+#
+#  Strain rate invariant:
+#    edot_ii = A*np.power(sig,n)*np.exp(-(E/(R*T))*np.power( (1-np.power((sig/sigp),p) ),q) )
+#            = 9.576747017313619e-11
+#
+#  Viscosity:
+#    visc = 0.5*sig/edot_ii = 5.22097951523685e+18
+#
+# The material model should return this viscosity.
+# The strain rate invariant (edot_ii) above is manually set in the material
+# model subsection.
+
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Surface pressure                       = 3.e9
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+# No boundary-driven deformation, but the strain-rate used by the material
+# model is set in the material model section through the parameters
+# "Reference strain rate" and "Minimum strain rate".
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, top, left, right
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set List of model names = initial temperature
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1073
+  end
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Reference strain rate                     = 9.576747017313619e-11
+    set Minimum strain rate                       = 9.576747017313619e-11
+    # dislocation creep parameters
+    # These values produce such a sufficiently high viscosity that the
+    # composite viscosity between the diffusion and dislocation creep
+    # is effectively equal to the Peierls creep viscosity.
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep          = 1.e-50
+    set Stress exponents for dislocation creep    = 1.0
+    set Activation energies for dislocation creep = 0
+    set Activation volumes for dislocation creep  = 0
+    # Peierls creep parameters
+    set Include Peierls creep                     = true
+    set Peierls creep flow law                    = exact
+    set Prefactors for Peierls creep              = 1.4e-19
+    set Activation energies for Peierls creep     = 320.e3
+    set Activation volumes for Peierls creep      = 0.
+    set Peierls stresses                          = 5.9e9
+    set Stress exponents for Peierls creep        = 2.0
+    set Peierls fitting parameters                = 0.15
+    set Peierls glide parameters p                = 0.5
+    set Peierls glide parameters q                = 1.0
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = material statistics
+end

--- a/tests/visco_plastic_peierls_mei_exact.prm
+++ b/tests/visco_plastic_peierls_mei_exact.prm
@@ -98,6 +98,8 @@ subsection Material model
     set Peierls fitting parameters                = 0.15
     set Peierls glide parameters p                = 0.5
     set Peierls glide parameters q                = 1.0
+    set Peierls strain rate residual tolerance = 1e-22
+    set Maximum Peierls strain rate iterations = 40
   end
 end
 

--- a/tests/visco_plastic_peierls_mei_exact/screen-output
+++ b/tests/visco_plastic_peierls_mei_exact/screen-output
@@ -1,0 +1,53 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.3.0-pre (add_peierls_exact, d92e78fad)
+--     . using deal.II 9.2.0
+--     .       with 32 bit indices and vectorization level 1 (128 bits)
+--     . using Trilinos 12.18.1
+--     . using p4est 2.2.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.3.0-pre&sha=d92e78fad&src=code
+-----------------------------------------------------------------------------
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,444 (882+121+441)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 20+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     Average density / Average viscosity / Total mass:  3210 kg/m^3, 5.22e+18 Pa s, 3.21e+13 kg
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start     |      1.02s |            |
+|                                              |            |            |
+| Section                          | no. calls |  wall time | % of total |
++----------------------------------+-----------+------------+------------+
+| Assemble Stokes system           |         1 |    0.0651s |       6.4% |
+| Assemble temperature system      |         1 |    0.0819s |         8% |
+| Build Stokes preconditioner      |         1 |    0.0616s |       6.1% |
+| Build temperature preconditioner |         1 |   0.00106s |       0.1% |
+| Initialization                   |         1 |     0.665s |        65% |
+| Postprocessing                   |         1 |    0.0335s |       3.3% |
+| Setup dof systems                |         1 |    0.0331s |       3.3% |
+| Setup initial conditions         |         1 |    0.0258s |       2.5% |
+| Setup matrices                   |         1 |    0.0207s |         2% |
+| Solve Stokes system              |         1 |    0.0134s |       1.3% |
+| Solve temperature system         |         1 |  0.000845s |         0% |
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.3.0-pre&sha=d92e78fad&src=code
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_peierls_mei_exact/statistics
+++ b/tests/visco_plastic_peierls_mei_exact/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Average density (kg/m^3)
+# 13: Average viscosity (Pa s)
+# 14: Total mass (kg)
+0 0.000000000000e+00 0.000000000000e+00 100 1003 441 1 0 19 21 20 3.20991000e+03 5.22032696e+18 3.20991000e+13 


### PR DESCRIPTION
This PR adds the exact formulation for Peierls creep to the Peierls creep rheology module, along with the associated strain rate and derivative functions.
It also adds a new test using the analytical calculations by @mibillen and @naliboff.

Based on #3723.
