### PR TITLE
New: Make thermodynamic table lookup into an EquationOfState

### DIFF
--- a/doc/modules/changes/20200829_bobmyhill
+++ b/doc/modules/changes/20200829_bobmyhill
@@ -1,0 +1,9 @@
+<li> New: ASPECT now has a ThermodynamicTableLookup
+equation of state plugin. This plugin allows material models
+to read in one or more PerpleX or HeFESTo table files,
+interpolate material properties at desired pressures and
+temperatures, and use the interpolated properties as
+material model outputs. The equation of state plugin is
+currently used in the Steinberger material model.
+<br>
+(Bob Myhill, 2020/08/29)

--- a/doc/modules/changes/20200829_bobmyhill
+++ b/doc/modules/changes/20200829_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: ASPECT now has a ThermodynamicTableLookup
+New: ASPECT now has a ThermodynamicTableLookup
 equation of state plugin. This plugin allows material models
 to read in one or more PerpleX or HeFESTo table files,
 interpolate material properties at desired pressures and

--- a/doc/modules/changes/20210708_bobmyhill
+++ b/doc/modules/changes/20210708_bobmyhill
@@ -1,9 +1,9 @@
 New: ASPECT now has a ThermodynamicTableLookup
 equation of state plugin. This plugin allows material models
-to read in one or more PerpleX or HeFESTo table files,
+to read in one or more Perple_X or HeFESTo table files,
 interpolate material properties at desired pressures and
 temperatures, and use the interpolated properties as
 material model outputs. The equation of state plugin is
 currently used in the Steinberger material model.
 <br>
-(Bob Myhill, 2020/08/29)
+(Bob Myhill, 2021/07/08)

--- a/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
+++ b/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
@@ -65,6 +65,10 @@ namespace aspect
            */
           bool is_compressible () const;
 
+          void fill_mass_and_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                                               std::vector<std::vector<double>> &mass_fractions,
+                                               std::vector<std::vector<double>> &volume_fractions) const;
+
           /**
           * Function to compute the thermodynamic properties in @p out given the
           * inputs in @p in over all evaluation points.
@@ -72,9 +76,15 @@ namespace aspect
           */
           void
           evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                   MaterialModel::MaterialModelOutputs<dim> &out,
-                   std::vector<std::vector<double>> &mass_fractions,
-                   std::vector<std::vector<double>> &volume_fractions) const;
+                   std::vector<MaterialModel::EquationOfStateOutputs<dim>> &eos_outputs) const;
+
+          /**
+          * Function to fill the seismic velocity and phase volume additional outputs
+          */
+          void
+          fill_additional_outputs(const MaterialModel::MaterialModelInputs<dim> &in,
+                                  const std::vector<std::vector<double>> &volume_fractions,
+                                  MaterialModel::MaterialModelOutputs<dim> &out) const;
 
           /**
            * Declare the parameters this class takes through input files.
@@ -95,7 +105,6 @@ namespace aspect
 
         private:
           bool has_background;
-          unsigned int first_composition_index;
 
           unsigned int n_material_lookups;
           bool use_bilinear_interpolation;
@@ -116,7 +125,7 @@ namespace aspect
 
           /**
            * The format of the provided material files. Currently we support
-           * the PERPLEX and HeFESTo data formats.
+           * the Perple_X and HeFESTo data formats.
            */
           enum formats
           {
@@ -143,46 +152,13 @@ namespace aspect
           */
           std::vector<std::vector<unsigned int>> unique_phase_indices;
 
-          void fill_mass_and_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                               std::vector<std::vector<double>> &mass_fractions,
-                                               std::vector<std::vector<double>> &volume_fractions) const;
-
-          void fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
-                                        const std::vector<double> &composite_densities,
-                                        const std::vector<std::vector<double>> &volume_fractions,
-                                        SeismicAdditionalOutputs<dim> *seismic_out) const;
-
-          /**
-          * This function uses the MaterialModelInputs &in to fill the output_values
-          * of the phase_volume_fractions_out output object with the volume
-          * fractions of each of the unique phases at each of the evaluation points.
-          * These volume fractions are obtained from the PerpleX-derived
-          * pressure-temperature lookup tables.
-          * The filled output_values object is a vector of vector<double>;
-          * the outer vector is expected to have a size that equals the number
-          * of unique phases, the inner vector is expected to have a size that
-          * equals the number of evaluation points.
-          */
-          void fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                            const std::vector<std::vector<double>> &volume_fractions,
-                                            NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const;
-
           /**
            * Compute the specific heat and thermal expansivity using the pressure
            * and temperature derivatives of the specific enthalpy.
            * This evaluation incorporates the effects of latent heat production.
            */
           void evaluate_thermal_enthalpy_derivatives(const MaterialModel::MaterialModelInputs<dim> &in,
-                                                     MaterialModel::MaterialModelOutputs<dim> &out) const;
-
-          /**
-           * Function to compute the thermodynamic properties in @p out given the
-           * inputs in @p in at a single evaluation point.
-           */
-          void
-          evaluate_at_single_point(const MaterialModel::MaterialModelInputs<dim> &in,
-                                   const unsigned int q,
-                                   MaterialModel::EquationOfStateOutputs<dim> &out) const;
+                                                     std::vector<MaterialModel::EquationOfStateOutputs<dim>> &eos_outputs) const;
 
           /**
            * Returns the cell-wise averaged enthalpy derivatives for the evaluate
@@ -197,6 +173,26 @@ namespace aspect
            */
           std::array<std::pair<double, unsigned int>,2>
           enthalpy_derivatives (const typename Interface<dim>::MaterialModelInputs &in) const;
+
+          void fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
+                                        const std::vector<double> &composite_densities,
+                                        const std::vector<std::vector<double>> &volume_fractions,
+                                        SeismicAdditionalOutputs<dim> *seismic_out) const;
+
+          /**
+          * This function uses the MaterialModelInputs &in to fill the output_values
+          * of the phase_volume_fractions_out output object with the volume
+          * fractions of each of the unique phases at each of the evaluation points.
+          * These volume fractions are obtained from the Perple_X-derived
+          * pressure-temperature lookup tables.
+          * The filled output_values object is a vector of vector<double>;
+          * the outer vector is expected to have a size that equals the number
+          * of unique phases, the inner vector is expected to have a size that
+          * equals the number of evaluation points.
+          */
+          void fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                                            const std::vector<std::vector<double>> &volume_fractions,
+                                            NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const;
       };
     }
   }

--- a/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
+++ b/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
@@ -1,0 +1,248 @@
+/*
+  Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_equation_of_state_thermodynamic_table_lookup_h
+#define _aspect_material_model_equation_of_state_thermodynamic_table_lookup_h
+
+#include <aspect/material_model/interface.h>
+#include <aspect/simulator_access.h>
+#include <aspect/material_model/equation_of_state/interface.h>
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace EquationOfState
+    {
+      using namespace dealii;
+
+      /**
+       *
+       */
+      template <int dim>
+      class ThermodynamicTableLookup : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Initialization function. Loads the material data and sets up
+           * pointers.
+           */
+          void
+          initialize ();
+
+          /**
+           * Returns the number of lookups
+           */
+          virtual unsigned int number_of_lookups() const;
+
+          /**
+           * @name Physical parameters used in the basic equations
+           * @{
+           */
+
+          virtual double enthalpy (const double temperature,
+                                   const double pressure,
+                                   const std::vector<double> &compositional_fields,
+                                   const Point<dim> &position) const;
+
+          virtual double density (const double temperature,
+                                  const double pressure,
+                                  const std::vector<double> &compositional_fields,
+                                  const Point<dim> &position) const;
+
+          virtual double compressibility (const double temperature,
+                                          const double pressure,
+                                          const std::vector<double> &compositional_fields,
+                                          const Point<dim> &position) const;
+
+          virtual double specific_heat (const double temperature,
+                                        const double pressure,
+                                        const std::vector<double> &compositional_fields,
+                                        const Point<dim> &position) const;
+
+          virtual double thermal_expansion_coefficient (const double      temperature,
+                                                        const double      pressure,
+                                                        const std::vector<double> &compositional_fields,
+                                                        const Point<dim> &position) const;
+
+          virtual double seismic_Vp (const double      temperature,
+                                     const double      pressure,
+                                     const std::vector<double> &compositional_fields,
+                                     const Point<dim> &position) const;
+
+          virtual double seismic_Vs (const double      temperature,
+                                     const double      pressure,
+                                     const std::vector<double> &compositional_fields,
+                                     const Point<dim> &position) const;
+
+          void evaluate_enthalpy_dependent_properties(const MaterialModel::MaterialModelInputs<dim> &in,
+                                                      const unsigned int i,
+                                                      const double pressure,
+                                                      const double average_density,
+                                                      const double average_temperature,
+                                                      const std::array<std::pair<double, unsigned int>,2> dH,
+                                                      MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+          /**
+          * This function uses the MaterialModelInputs &in to fill the output_values
+          * of the phase_volume_fractions_out output object with the volume
+          * fractions of each of the unique phases at each of the evaluation points.
+          * These volume fractions are obtained from the PerpleX-derived
+          * pressure-temperature lookup tables.
+          * The filled output_values object is a vector of vector<double>;
+          * the outer vector is expected to have a size that equals the number
+          * of unique phases, the inner vector is expected to have a size that
+          * equals the number of evaluation points.
+          */
+          void fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                                            NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const;
+
+          /**
+           * Returns the cell-wise averaged enthalpy derivatives for the evaluate
+           * function and postprocessors. The function returns two pairs, the
+           * first one represents the temperature derivative, the second one the
+           * pressure derivative. The first member of each pair is the derivative,
+           * the second one the number of vertex combinations the function could
+           * use to compute the derivative. The second member is useful to handle
+           * the case no suitable combination of vertices could be found (e.g.
+           * if the temperature and pressure on all vertices of the current
+           * cell is identical.
+           */
+          std::array<std::pair<double, unsigned int>,2>
+          enthalpy_derivative (const typename Interface<dim>::MaterialModelInputs &in) const;
+          /**
+           * @}
+           */
+
+          /**
+           * @name Qualitative properties one can ask a material model
+           * @{
+           */
+
+          /**
+           * Return whether the model is compressible or not.  Incompressibility
+           * does not necessarily imply that the density is constant; rather, it
+           * may still depend on temperature or pressure. In the current
+           * context, compressibility means whether we should solve the continuity
+           * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
+           * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
+           */
+          bool is_compressible () const;
+          /**
+           * @}
+           */
+
+          /**
+           * @}
+           */
+
+          /**
+           * Function to compute the material properties in @p out given the
+           * inputs in @p in. If MaterialModelInputs.strain_rate has the length
+           * 0, then the viscosity does not need to be computed.
+           */
+          void
+          evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                   MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+          /**
+           * @name Functions used in dealing with run-time parameters
+           * @{
+           */
+          /**
+           * Declare the parameters this class takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           */
+          void
+          parse_parameters (ParameterHandler &prm);
+          /**
+           * @}
+           */
+
+          void
+          create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+
+        private:
+          unsigned int n_material_lookups;
+          bool use_bilinear_interpolation;
+          bool latent_heat;
+
+          /**
+           * Information about the location of data files.
+           */
+          std::string data_directory;
+          std::vector<std::string> material_file_names;
+          std::vector<std::string> derivatives_file_names;
+
+          /**
+           * Because of the nonlinear nature of this material model many
+           * parameters need to be kept within bounds to ensure stability of the
+           * solution. These bounds can be adjusted as input parameters.
+           */
+          double min_specific_heat;
+          double max_specific_heat;
+          double min_thermal_expansivity;
+          double max_thermal_expansivity;
+          unsigned int max_latent_heat_substeps;
+
+          /**
+           * The format of the provided material files. Currently we support
+           * the PERPLEX and HeFESTo data formats.
+           */
+          enum formats
+          {
+            perplex,
+            hefesto
+          } material_file_format;
+
+          /**
+           * List of pointers to objects that read and process data we get from
+           * material data files. There is one pointer/object per compositional
+           * field provided.
+           */
+          std::vector<std::unique_ptr<MaterialModel::MaterialUtilities::Lookup::MaterialLookup> > material_lookup;
+
+          /**
+          * Vector of strings containing the names of the unique phases in all the material lookups.
+          */
+          std::vector<std::string> unique_phase_names;
+
+          /**
+          * Vector of vector of unsigned ints which constitutes mappings
+          * between lookup phase name vectors and unique_phase_names.
+          * The element unique_phase_indices[i][j] contains the
+          * index of phase name j from lookup i as it is found in unique_phase_names.
+          */
+          std::vector<std::vector<unsigned int>> unique_phase_indices;
+
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2020 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2021 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -260,7 +260,6 @@ namespace aspect
          * Information about the location of data files.
          */
         std::string data_directory;
-        std::vector<std::string> material_file_names;
         std::string radial_viscosity_file_name;
         std::string lateral_viscosity_file_name;
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -219,14 +219,9 @@ namespace aspect
         EquationOfState::ThermodynamicTableLookup<dim> equation_of_state;
 
         /**
-         * Boolean describing whether to calculate material properties
-         * including latent heat effects.
-         */
-        bool latent_heat;
-
-
-        /**
-         * Boolean describing whether to use the lateral average temperature.
+         * Boolean describing whether to use the lateral average temperature
+         * for computing the viscosity, rather than the temperature
+         * on the reference adiabat.
          */
         bool use_lateral_average_temperature;
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -22,6 +22,7 @@
 #define _aspect_material_model_steinberger_h
 
 #include <aspect/material_model/interface.h>
+#include <aspect/material_model/equation_of_state/thermodynamic_table_lookup.h>
 
 #include <aspect/simulator_access.h>
 
@@ -147,44 +148,6 @@ namespace aspect
                                   const std::vector<double>    &compositional_fields,
                                   const SymmetricTensor<2,dim> &strain_rate,
                                   const Point<dim>             &position) const;
-
-        void fill_mass_and_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                             std::vector<std::vector<double>> &mass_fractions,
-                                             std::vector<std::vector<double>> &volume_fractions) const;
-
-        void fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
-                                      const std::vector<double> &composite_densities,
-                                      const std::vector<std::vector<double>> &volume_fractions,
-                                      SeismicAdditionalOutputs<dim> *seismic_out) const;
-
-        /**
-        * This function uses the MaterialModelInputs &in to fill the output_values
-        * of the phase_volume_fractions_out output object with the volume
-        * fractions of each of the unique phases at each of the evaluation points.
-        * These volume fractions are obtained from the PerpleX-derived
-        * pressure-temperature lookup tables.
-        * The filled output_values object is a vector of vector<double>;
-        * the outer vector is expected to have a size that equals the number
-        * of unique phases, the inner vector is expected to have a size that
-        * equals the number of evaluation points.
-        */
-        void fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                          const std::vector<std::vector<double>> &volume_fractions,
-                                          NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const;
-
-        /**
-         * Returns the cell-wise averaged enthalpy derivatives for the evaluate
-         * function and postprocessors. The function returns two pairs, the
-         * first one represents the temperature derivative, the second one the
-         * pressure derivative. The first member of each pair is the derivative,
-         * the second one the number of vertex combinations the function could
-         * use to compute the derivative. The second member is useful to handle
-         * the case no suitable combination of vertices could be found (e.g.
-         * if the temperature and pressure on all vertices of the current
-         * cell is identical.
-         */
-        std::array<std::pair<double, unsigned int>,2>
-        enthalpy_derivatives (const typename Interface<dim>::MaterialModelInputs &in) const;
         /**
          * @}
          */
@@ -250,11 +213,21 @@ namespace aspect
 
 
       private:
-        bool has_background;
-        unsigned int first_composition_index;
+        /**
+         * The thermodynamic lookup equation of state.
+         */
+        EquationOfState::ThermodynamicTableLookup<dim> equation_of_state;
 
-        bool interpolation;
+        /**
+         * Boolean describing whether to calculate material properties
+         * including latent heat effects.
+         */
         bool latent_heat;
+
+
+        /**
+         * Boolean describing whether to use the lateral average temperature.
+         */
         bool use_lateral_average_temperature;
 
         /**
@@ -290,26 +263,6 @@ namespace aspect
         std::vector<std::string> material_file_names;
         std::string radial_viscosity_file_name;
         std::string lateral_viscosity_file_name;
-
-        /**
-         * List of pointers to objects that read and process data we get from
-         * Perplex files.
-         */
-        std::vector<std::unique_ptr<MaterialModel::MaterialUtilities::Lookup::PerplexReader> > material_lookup;
-
-        /**
-         * Vector of strings containing the names of the unique phases in all
-         * the material lookups.
-         */
-        std::vector<std::string> unique_phase_names;
-
-        /**
-         * Vector of vector of unsigned ints which constitutes mappings
-         * between lookup phase name vectors and unique_phase_names. The
-         * element unique_phase_indices[i][j] contains the index of phase name
-         * j from lookup i as it is found in unique_phase_names.
-         */
-        std::vector<std::vector<unsigned int>> unique_phase_indices;
 
         /**
          * Pointer to an object that reads and processes data for the lateral

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -1,0 +1,712 @@
+/*
+  Copyright (C) 2011 - 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/material_model/equation_of_state/thermodynamic_table_lookup.h>
+#include <aspect/utilities.h>
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace EquationOfState
+    {
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::initialize()
+      {
+        // This model allows the user to provide several PerpleX or HeFESTo
+        // P-T lookup files, each of which corresponds to a different material.
+        // The thermodynamic properties and stable mineral phases within each material
+        // will in general be different, and must be averaged in a reasonable way.
+
+        // In the following, we populate the material_lookups.
+        // We also populate the unique_phase_names vector, which is used to
+        // calculate the phase volumes if they are provided by the lookup.
+        // This equation of state adds the fraction volume fractions of
+        // minerals from different lookups which have the same phase name.
+        std::set<std::string> set_phase_volume_column_names;
+        n_material_lookups = material_file_names.size();
+
+        // Resize the unique_phase_indices object
+        unique_phase_indices.resize(n_material_lookups, std::vector<unsigned int>());
+
+        for (unsigned i = 0; i < n_material_lookups; i++)
+          {
+            if (material_file_format == perplex)
+              material_lookup
+              .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(data_directory+material_file_names[i],
+                         use_bilinear_interpolation,
+                         this->get_mpi_communicator()));
+            else if (material_file_format == hefesto)
+              material_lookup
+              .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::HeFESToReader>(data_directory+material_file_names[i],
+                         data_directory+derivatives_file_names[i],
+                         use_bilinear_interpolation,
+                         this->get_mpi_communicator()));
+            else
+              AssertThrow (false, ExcNotImplemented());
+
+            // Here we look up all of the column names and insert
+            // unique names into the unique_phase_names vector and
+            // filling the unique_phase_indices object.
+            std::vector<std::string> phase_volume_column_names = material_lookup[i]->phase_volume_column_names();
+            for (unsigned int j = 0; j < phase_volume_column_names.size(); j++)
+              {
+                // iterate over the present unique_phase_names object
+                // to find phase_volume_column_names[j].
+                std::vector<std::string>::iterator it = std::find(unique_phase_names.begin(),
+                                                                  unique_phase_names.end(),
+                                                                  phase_volume_column_names[j]);
+
+                // If phase_volume_column_names[j] already exists in unique_phase_names,
+                // std::distance finds its index. Otherwise, std::distance will return
+                // the size of the present object, which is the index where we are
+                // about to push the new name. Either way, this is the index we want
+                // to add to the unique_phase_indices[i] vector.
+                unsigned int i_unique = std::distance(unique_phase_names.begin(), it);
+                unique_phase_indices[i].push_back(i_unique);
+
+                // If phase_volume_column_names[j] did not already exist
+                // in unique_phase_names, we add it here.
+                if (it == unique_phase_names.end())
+                  unique_phase_names.push_back(phase_volume_column_names[j]);
+              }
+          }
+      }
+
+
+
+      template <int dim>
+      unsigned int
+      ThermodynamicTableLookup<dim>::number_of_lookups() const
+      {
+        return n_material_lookups;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      enthalpy (const double      temperature,
+                const double      pressure,
+                const std::vector<double> &compositional_fields,
+                const Point<dim> &/*position*/) const
+      {
+        double enthalpy = 0.0;
+
+        if (n_material_lookups == 1)
+          {
+            enthalpy = material_lookup[0]->enthalpy(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_enthalpy = material_lookup[0]->enthalpy(temperature,pressure);
+            enthalpy = background_enthalpy;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              enthalpy += compositional_fields[i] *
+                          (material_lookup[i+1]->enthalpy(temperature,pressure) - background_enthalpy);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; i++)
+              enthalpy += compositional_fields[i] * material_lookup[i]->enthalpy(temperature,pressure);
+          }
+        return enthalpy;
+      }
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      seismic_Vp (const double      temperature,
+                  const double      pressure,
+                  const std::vector<double> &compositional_fields,
+                  const Point<dim> &/*position*/) const
+      {
+        double vp = 0.0;
+
+        if (n_material_lookups == 1)
+          {
+            vp = material_lookup[0]->seismic_Vp(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_vp = material_lookup[0]->seismic_Vp(temperature,pressure);
+            vp = background_vp;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              vp += compositional_fields[i] *
+                    (material_lookup[i+1]->seismic_Vp(temperature,pressure) - background_vp);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; i++)
+              vp += compositional_fields[i] * material_lookup[i]->seismic_Vp(temperature,pressure);
+          }
+        return vp;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      seismic_Vs (const double      temperature,
+                  const double      pressure,
+                  const std::vector<double> &compositional_fields,
+                  const Point<dim> &/*position*/) const
+      {
+        double vs = 0.0;
+
+        if (n_material_lookups == 1)
+          {
+            vs = material_lookup[0]->seismic_Vs(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_vs = material_lookup[0]->seismic_Vs(temperature,pressure);
+            vs = background_vs;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              vs += compositional_fields[i] *
+                    (material_lookup[i+1]->seismic_Vs(temperature,pressure) - background_vs);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; i++)
+              vs += compositional_fields[i] * material_lookup[i]->seismic_Vs(temperature,pressure);
+          }
+        return vs;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      density (const double temperature,
+               const double pressure,
+               const std::vector<double> &compositional_fields, /*composition*/
+               const Point<dim> &) const
+      {
+        double rho = 0.0;
+        if (n_material_lookups == 1)
+          {
+            rho = material_lookup[0]->density(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_density = material_lookup[0]->density(temperature,pressure);
+            rho = background_density;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              rho += compositional_fields[i] *
+                     (material_lookup[i+1]->density(temperature,pressure) - background_density);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; ++i)
+              rho += compositional_fields[i] * material_lookup[i]->density(temperature,pressure);
+          }
+
+        return rho;
+      }
+
+
+
+      template <int dim>
+      bool
+      ThermodynamicTableLookup<dim>::
+      is_compressible () const
+      {
+        return true;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      compressibility (const double temperature,
+                       const double pressure,
+                       const std::vector<double> &compositional_fields,
+                       const Point<dim> &position) const
+      {
+        double dRhodp = 0.0;
+        if (n_material_lookups == 1)
+          {
+            dRhodp = material_lookup[0]->dRhodp(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_dRhodp = material_lookup[0]->dRhodp(temperature,pressure);
+            dRhodp = background_dRhodp;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              dRhodp += compositional_fields[i] *
+                        (material_lookup[i+1]->dRhodp(temperature,pressure) - background_dRhodp);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; i++)
+              dRhodp += compositional_fields[i] * material_lookup[i]->dRhodp(temperature,pressure);
+          }
+
+        const double rho = density(temperature,pressure,compositional_fields,position);
+        return (1/rho)*dRhodp;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      thermal_expansion_coefficient (const double      temperature,
+                                     const double      pressure,
+                                     const std::vector<double> &compositional_fields,
+                                     const Point<dim> &/*position*/) const
+      {
+        double alpha = 0.0;
+
+        if (n_material_lookups == 1)
+          {
+            alpha = material_lookup[0]->thermal_expansivity(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_alpha = material_lookup[0]->thermal_expansivity(temperature,pressure);
+            alpha = background_alpha;
+            for (unsigned int i = 0; i<compositional_fields.size(); ++i)
+              alpha += compositional_fields[i] *
+                       (material_lookup[i+1]->thermal_expansivity(temperature,pressure) - background_alpha);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; ++i)
+              alpha += compositional_fields[i] * material_lookup[i]->thermal_expansivity(temperature,pressure);
+          }
+
+        alpha = std::max(std::min(alpha,max_thermal_expansivity),min_thermal_expansivity);
+        return alpha;
+      }
+
+
+
+      template <int dim>
+      double
+      ThermodynamicTableLookup<dim>::
+      specific_heat (const double temperature,
+                     const double pressure,
+                     const std::vector<double> &compositional_fields,
+                     const Point<dim> &/*position*/) const
+      {
+        double cp = 0.0;
+
+        if (n_material_lookups == 1)
+          {
+            cp = material_lookup[0]->specific_heat(temperature,pressure);
+          }
+        else if (n_material_lookups == compositional_fields.size() + 1)
+          {
+            const double background_cp = material_lookup[0]->specific_heat(temperature,pressure);
+            cp = background_cp;
+            for (unsigned int i = 0; i < compositional_fields.size(); ++i)
+              cp += compositional_fields[i] *
+                    (material_lookup[i+1]->specific_heat(temperature,pressure) - background_cp);
+          }
+        else
+          {
+            for (unsigned i = 0; i < n_material_lookups; ++i)
+              cp += compositional_fields[i] * material_lookup[i]->specific_heat(temperature,pressure);
+          }
+
+        cp = std::max(std::min(cp,max_specific_heat),min_specific_heat);
+        return cp;
+      }
+
+
+
+      template <int dim>
+      std::array<std::pair<double, unsigned int>,2>
+      ThermodynamicTableLookup<dim>::
+      enthalpy_derivative (const typename Interface<dim>::MaterialModelInputs &in) const
+      {
+        std::array<std::pair<double, unsigned int>,2> derivative;
+
+        if (in.current_cell.state() == IteratorState::valid)
+          {
+            // get the pressures and temperatures at the vertices of the cell
+            const QTrapez<dim> quadrature_formula;
+            const unsigned int n_q_points = quadrature_formula.size();
+            FEValues<dim> fe_values (this->get_mapping(),
+                                     this->get_fe(),
+                                     quadrature_formula,
+                                     update_values);
+
+            std::vector<double> temperatures(n_q_points), pressures(n_q_points);
+            fe_values.reinit (in.current_cell);
+
+            fe_values[this->introspection().extractors.temperature]
+            .get_function_values (this->get_current_linearization_point(), temperatures);
+            fe_values[this->introspection().extractors.pressure]
+            .get_function_values (this->get_current_linearization_point(), pressures);
+
+            AssertThrow (n_material_lookups == 1,
+                         ExcMessage("This formalism is only implemented for one material "
+                                    "table."));
+
+            // We have to take into account here that the p,T spacing of the table of material properties
+            // we use might be on a finer grid than our model. Because of that we compute the enthalpy
+            // derivatives by using finite differences that average over the whole temperature and
+            // pressure range that is used in this cell. This way we should not miss any phase transformation.
+            derivative = material_lookup[0]->enthalpy_derivatives(temperatures,
+                                                                  pressures,
+                                                                  max_latent_heat_substeps);
+          }
+
+        return derivative;
+      }
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::
+      fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                                   NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const
+      {
+        // In the following function,
+        // the index i corresponds to the ith compositional field
+        // the index j corresponds to the jth phase in the lookup
+        // the index k corresponds to the kth evaluation point
+        std::vector<std::vector<double>> volume_fractions(unique_phase_names.size(), std::vector<double>(in.n_evaluation_points(), 0.));
+
+        if (n_material_lookups == 1)
+          {
+            // if there is only one lookup, unique_phase_names is in the same order as the lookup
+            for (unsigned int j = 0; j < unique_phase_indices[0].size(); j++)
+              {
+                for (unsigned int k = 0; k < in.n_evaluation_points(); k++)
+                  volume_fractions[j][k] = material_lookup[0]->phase_volume_fraction(j,in.temperature[k],in.pressure[k]);
+              }
+          }
+        else if (n_material_lookups == in.composition[0].size() + 1) // background field
+          {
+            // The first material lookup corresponds to a background composition
+            // We first look up the volume fractions corresponding to this background field
+            // (assuming the domain is filled 100% with this single composition)
+            std::vector<std::vector<double>> background_volume_fractions(unique_phase_names.size(),
+                                                                         std::vector<double>(in.n_evaluation_points(), 0.));
+
+            // We can now loop through the other material models
+            for (unsigned int i = 0; i < n_material_lookups; i++)
+              {
+                for (unsigned int j = 0; j < unique_phase_indices[i].size(); j++)
+                  {
+                    for (unsigned int k = 0; k < in.n_evaluation_points(); k++)
+                      if (i == 0)
+                        {
+                          background_volume_fractions[unique_phase_indices[0][j]][k] += material_lookup[0]->phase_volume_fraction(j,in.temperature[k],in.pressure[k]);
+                          volume_fractions[unique_phase_indices[0][j]][k] = background_volume_fractions[unique_phase_indices[0][j]][k];
+                        }
+                      else
+                        volume_fractions[unique_phase_indices[i][j]][k] += in.composition[k][i-1] * (material_lookup[i]->phase_volume_fraction(j,in.temperature[k],in.pressure[k]) - background_volume_fractions[unique_phase_indices[i][j]][k]);
+                  }
+              }
+          }
+        else if (n_material_lookups == in.composition[0].size())
+          {
+            for (unsigned i = 0; i < n_material_lookups; i++)
+              {
+                for (unsigned int j = 0; j < unique_phase_indices[i].size(); j++)
+                  {
+                    for (unsigned int k = 0; k < in.n_evaluation_points(); k++)
+                      volume_fractions[unique_phase_indices[i][j]][k] = in.composition[k][i] * material_lookup[i]->phase_volume_fraction(j,in.temperature[k],in.pressure[k]);
+                  }
+              }
+          }
+        else
+          {
+            AssertThrow (false,
+                         ExcMessage("The number of material lookups must be equal to "
+                                    "one, the number of compositional fields, or the number "
+                                    "of compositional fields plus one (if using a background field)."));
+          }
+        phase_volume_fractions_out->output_values = volume_fractions;
+      }
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::
+      evaluate_enthalpy_dependent_properties(const MaterialModel::MaterialModelInputs<dim> &in,
+                                             const unsigned int i,
+                                             const double pressure,
+                                             const double average_density,
+                                             const double average_temperature,
+                                             const std::array<std::pair<double, unsigned int>,2> dH,
+                                             MaterialModel::MaterialModelOutputs<dim> &out) const
+      {
+
+        if (this->get_adiabatic_conditions().is_initialized()
+            && (in.current_cell.state() == IteratorState::valid)
+            && (dH[0].second > 0)
+            && (dH[1].second > 0))
+          {
+            out.thermal_expansion_coefficients[i] = (1 - average_density * dH[1].first) / average_temperature;
+            out.specific_heat[i] = dH[0].first;
+          }
+        else
+          {
+            if (n_material_lookups == 1)
+              {
+                out.thermal_expansion_coefficients[i] = (1 - out.densities[i] * material_lookup[0]->dHdp(in.temperature[i],pressure)) / in.temperature[i];
+                out.specific_heat[i] = material_lookup[0]->dHdT(in.temperature[i],pressure);
+              }
+            else
+              {
+                ExcNotImplemented();
+              }
+          }
+
+        out.thermal_expansion_coefficients[i] = std::max(std::min(out.thermal_expansion_coefficients[i],max_thermal_expansivity),min_thermal_expansivity);
+        out.specific_heat[i] = std::max(std::min(out.specific_heat[i],max_specific_heat),min_specific_heat);
+
+      }
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::
+      evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+               MaterialModel::MaterialModelOutputs<dim> &out) const
+      {
+        double average_temperature(0.0);
+        double average_density(0.0);
+        std::array<std::pair<double, unsigned int>,2> dH;
+
+        if (latent_heat)
+          {
+            for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
+              {
+                average_temperature += in.temperature[i];
+                average_density += out.densities[i];
+              }
+            average_temperature /= in.n_evaluation_points();
+            average_density /= in.n_evaluation_points();
+            dH = enthalpy_derivative(in);
+          }
+
+        for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
+          {
+            // Use the adiabatic pressure instead of the real one, because of oscillations
+            const double pressure = (this->get_adiabatic_conditions().is_initialized())
+                                    ?
+                                    this->get_adiabatic_conditions().pressure(in.position[i])
+                                    :
+                                    in.pressure[i];
+
+            out.densities[i] = density(in.temperature[i], pressure, in.composition[i], in.position[i]);
+            out.compressibilities[i] = compressibility(in.temperature[i], pressure, in.composition[i], in.position[i]);
+
+            if (latent_heat)
+              {
+                /* We separate the calculation of specific heat and thermal expansivity,
+                 * because they depend on cell-wise averaged values
+                 */
+                evaluate_enthalpy_dependent_properties(in, i, pressure, average_density, average_temperature, dH, out);
+              }
+            else
+              {
+                out.thermal_expansion_coefficients[i] = thermal_expansion_coefficient(in.temperature[i], pressure, in.composition[i], in.position[i]);
+                out.specific_heat[i] = specific_heat(in.temperature[i], pressure, in.composition[i], in.position[i]);
+              }
+
+            // fill seismic velocities outputs if they exist
+            if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim> >())
+              {
+                seismic_out->vp[i] = seismic_Vp(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
+                seismic_out->vs[i] = seismic_Vs(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
+              }
+
+            // fill phase volume outputs if they exist
+            if (NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim> >())
+              fill_phase_volume_fractions(in, phase_volume_fractions_out);
+          }
+      }
+
+
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.declare_entry ("Data directory", "$ASPECT_SOURCE_DIR/data/material-model/steinberger/",
+                           Patterns::DirectoryName (),
+                           "The path to the model data. The path may also include the special "
+                           "text '$ASPECT_SOURCE_DIR' which will be interpreted as the path "
+                           "in which the ASPECT source files were located when ASPECT was "
+                           "compiled. This interpretation allows, for example, to reference "
+                           "files located in the `data/' subdirectory of ASPECT. ");
+        prm.declare_entry ("Material file names", "pyr-ringwood88.txt",
+                           Patterns::List (Patterns::Anything()),
+                           "The file names of the material data (material "
+                           "data is assumed to be in order with the ordering "
+                           "of the compositional fields). Note that there are "
+                           "three options on how many files need to be listed "
+                           "here: 1. If only one file is provided, it is used "
+                           "for the whole model domain, and compositional fields "
+                           "are ignored. 2. If there is one more file name than the "
+                           "number of compositional fields, then the first file is "
+                           "assumed to define a `background composition' that is "
+                           "modified by the compositional fields. If there are "
+                           "exactly as many files as compositional fields, the fields are "
+                           "assumed to represent the fractions of different materials "
+                           "and the average property is computed as a sum of "
+                           "the value of the compositional field times the "
+                           "material property of that field.");
+
+
+        prm.declare_entry ("Derivatives file names", "",
+                           Patterns::List (Patterns::Anything()),
+                           "The file names of the enthalpy derivatives data. "
+                           "List with as many components as active "
+                           "compositional fields (material data is assumed to "
+                           "be in order with the ordering of the fields). ");
+
+
+        prm.declare_entry ("Material file format", "perplex",
+                           Patterns::Selection ("perplex|hefesto"),
+                           "The material file format to be read in the property "
+                           "tables.");
+
+        prm.declare_entry ("Bilinear interpolation", "true",
+                           Patterns::Bool (),
+                           "Whether to use bilinear interpolation to compute "
+                           "material properties (slower but more accurate). ");
+        prm.declare_entry ("Latent heat", "false",
+                           Patterns::Bool (),
+                           "Whether to include latent heat effects in the "
+                           "calculation of thermal expansivity and specific heat. "
+                           "If true, ASPECT follows the approach of Nakagawa et al. 2009, "
+                           "using pressure and temperature derivatives of the enthalpy "
+                           "to calculate the thermal expansivity and specific heat. "
+                           "If false, ASPECT uses the thermal expansivity and "
+                           "specific heat values from the material properties table.");
+
+        prm.declare_entry ("Minimum specific heat", "500.",
+                           Patterns::Double (0.),
+                           "The minimum specific heat that is allowed in the whole model domain. "
+                           "Units: J/kg/K.");
+        prm.declare_entry ("Maximum specific heat", "6000.",
+                           Patterns::Double (0.),
+                           "The maximum specific heat that is allowed in the whole model domain. "
+                           "Units: J/kg/K.");
+        prm.declare_entry ("Minimum thermal expansivity", "1e-5",
+                           Patterns::Double (),
+                           "The minimum thermal expansivity that is allowed in the whole model domain. "
+                           "Units: 1/K.");
+        prm.declare_entry ("Maximum thermal expansivity", "1e-3",
+                           Patterns::Double (),
+                           "The maximum thermal expansivity that is allowed in the whole model domain. "
+                           "Units: 1/K.");
+
+        prm.declare_entry ("Maximum latent heat substeps", "1",
+                           Patterns::Integer (1),
+                           "The maximum number of substeps over the temperature pressure range "
+                           "to calculate the averaged enthalpy gradient over a cell.");
+      }
+
+
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        data_directory               = Utilities::expand_ASPECT_SOURCE_DIR(prm.get ("Data directory"));
+        material_file_names          = Utilities::split_string_list(prm.get ("Material file names"));
+        derivatives_file_names = Utilities::split_string_list(prm.get ("Derivatives file names"));
+        use_bilinear_interpolation   = prm.get_bool ("Bilinear interpolation");
+        latent_heat                  = prm.get_bool ("Latent heat");
+
+        min_specific_heat            = prm.get_double ("Minimum specific heat");
+        max_specific_heat            = prm.get_double ("Maximum specific heat");
+        min_thermal_expansivity      = prm.get_double ("Minimum thermal expansivity");
+        max_thermal_expansivity      = prm.get_double ("Maximum thermal expansivity");
+        max_latent_heat_substeps      = prm.get_integer ("Maximum latent heat substeps");
+
+        if (prm.get ("Material file format") == "perplex")
+          material_file_format = perplex;
+        else if (prm.get ("Material file format") == "hefesto")
+          material_file_format = hefesto;
+        else
+          AssertThrow (false, ExcNotImplemented());
+
+        // Do some error checking
+        AssertThrow ((material_file_names.size() == 1) ||
+                     (material_file_names.size() == this->n_compositional_fields()) ||
+                     (material_file_names.size() == this->n_compositional_fields() + 1),
+                     ExcMessage("This material model expects either one material data file, or as many files as compositional fields, "
+                                "or as many files as compositional fields plus one (in which case the first file "
+                                "is assumed to contain a background composition). This condition is not fulfilled. You "
+                                "prescribed " + Utilities::int_to_string(material_file_names.size()) + " material data files, but there are " +
+                                Utilities::int_to_string(this->n_compositional_fields()) + " compositional fields."));
+
+        if (latent_heat)
+          AssertThrow (material_file_names.size() == 1,
+                       ExcMessage("This formalism is currently only implemented for one material "
+                                  "table."));
+      }
+
+
+      template <int dim>
+      void
+      ThermodynamicTableLookup<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
+      {
+        if (out.template get_additional_output<NamedAdditionalMaterialOutputs<dim> >() == nullptr)
+          {
+            const unsigned int n_points = out.n_evaluation_points();
+            out.additional_outputs.push_back(
+              std_cxx14::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (unique_phase_names, n_points));
+          }
+
+        if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)
+          {
+            const unsigned int n_points = out.n_evaluation_points();
+            out.additional_outputs.push_back(
+              std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+          }
+      }
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace EquationOfState
+    {
+#define INSTANTIATE(dim) \
+  template class ThermodynamicTableLookup<dim>;
+
+      ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+    }
+  }
+}

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -391,6 +391,23 @@ namespace aspect
 
       template <int dim>
       void
+      ThermodynamicTableLookup<dim>::fill_additional_outputs (const MaterialModel::MaterialModelInputs<dim> &in,
+                                                              const std::vector<std::vector<double>> &volume_fractions,
+                                                              MaterialModel::MaterialModelOutputs<dim> &out) const
+      {
+        // fill seismic velocity outputs if they exist
+        if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim> >())
+          fill_seismic_velocities(in, out.densities, volume_fractions, seismic_out);
+
+        // fill phase volume outputs if they exist
+        if (NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim> >())
+          fill_phase_volume_fractions(in, volume_fractions, phase_volume_fractions_out);
+      }
+
+
+
+      template <int dim>
+      void
       ThermodynamicTableLookup<dim>::declare_parameters (ParameterHandler &prm)
       {
         prm.declare_entry ("Data directory", "$ASPECT_SOURCE_DIR/data/material-model/steinberger/",
@@ -515,23 +532,6 @@ namespace aspect
           AssertThrow (n_material_lookups == 1,
                        ExcMessage("Isochemical latent heat calculations are only implemented for a single material lookup."));
 
-      }
-
-
-
-      template <int dim>
-      void
-      ThermodynamicTableLookup<dim>::fill_additional_outputs (const MaterialModel::MaterialModelInputs<dim> &in,
-                                                              const std::vector<std::vector<double>> &volume_fractions,
-                                                              MaterialModel::MaterialModelOutputs<dim> &out) const
-      {
-        // fill seismic velocity outputs if they exist
-        if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim> >())
-          fill_seismic_velocities(in, out.densities, volume_fractions, seismic_out);
-
-        // fill phase volume outputs if they exist
-        if (NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim> >())
-          fill_phase_volume_fractions(in, volume_fractions, phase_volume_fractions_out);
       }
 
 

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -262,11 +262,11 @@ namespace aspect
         std::array<std::pair<double, unsigned int>,2> derivative;
 
         // get the pressures and temperatures at the vertices of the cell
-  #if DEAL_II_VERSION_GTE(9,3,0)
+#if DEAL_II_VERSION_GTE(9,3,0)
         const QTrapezoid<dim> quadrature_formula;
-  #else
+#else
         const QTrapez<dim> quadrature_formula;
-  #endif
+#endif
 
         const unsigned int n_q_points = quadrature_formula.size();
         FEValues<dim> fe_values (this->get_mapping(),

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/material_model/equation_of_state/thermodynamic_table_lookup.h>
 #include <aspect/utilities.h>
+#include <aspect/simulator_access.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 
 namespace aspect

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -69,15 +69,15 @@ namespace aspect
             // unique names into the unique_phase_names vector and
             // filling the unique_phase_indices object.
             std::vector<std::string> phase_volume_column_names = material_lookup[i]->phase_volume_column_names();
-            for (unsigned int j = 0; j < phase_volume_column_names.size(); j++)
+            for (const auto &phase_volume_column_name : phase_volume_column_names)
               {
                 // iterate over the present unique_phase_names object
-                // to find phase_volume_column_names[j].
+                // to find phase_volume_column_name.
                 std::vector<std::string>::iterator it = std::find(unique_phase_names.begin(),
                                                                   unique_phase_names.end(),
-                                                                  phase_volume_column_names[j]);
+                                                                  phase_volume_column_name);
 
-                // If phase_volume_column_names[j] already exists in unique_phase_names,
+                // If phase_volume_column_name already exists in unique_phase_names,
                 // std::distance finds its index. Otherwise, std::distance will return
                 // the size of the present object, which is the index where we are
                 // about to push the new name. Either way, this is the index we want
@@ -85,10 +85,10 @@ namespace aspect
                 unsigned int i_unique = std::distance(unique_phase_names.begin(), it);
                 unique_phase_indices[i].push_back(i_unique);
 
-                // If phase_volume_column_names[j] did not already exist
+                // If phase_volume_column_name did not already exist
                 // in unique_phase_names, we add it here.
                 if (it == unique_phase_names.end())
-                  unique_phase_names.push_back(phase_volume_column_names[j]);
+                  unique_phase_names.push_back(phase_volume_column_name);
               }
           }
       }

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -348,35 +348,27 @@ namespace aspect
           equation_of_state.initialize_simulator (this->get_simulator());
           equation_of_state.parse_parameters(prm);
 
-          // Some error checking
+          // Assign background field and do some error checking
+          if (equation_of_state.number_of_lookups() == this->n_compositional_fields() + 1)
+            {
+              prm.set("Background material", "true");
+            }
+          else
+            {
+              AssertThrow ((equation_of_state.number_of_lookups() == this->n_compositional_fields()),
+                           ExcMessage("The Steinberger material model assumes that all compositional "
+                                      "fields correspond to mass fractions of materials. There must either be "
+                                      "the same number of material lookup files as compositional fields, "
+                                      "or one additional file (if a background field is used)."));
+
+              prm.set("Background material", "false");
+            }
+
           AssertThrow (prm.get_integer ("Index of first mass fraction compositional field") == 0,
                        ExcMessage("The Steinberger material model currently assumes that all the "
                                   "compositional fields correspond to materials with PerpleX lookup tables. "
                                   "Therefore the 'Index of first mass fraction compositional field' "
                                   "parameter must be equal to zero. "));
-
-          if (prm.get_bool ("Background material"))
-            {
-              AssertThrow ((equation_of_state.number_of_lookups() == this->n_compositional_fields() + 1),
-                           ExcMessage("You have specified that a background material field exists, "
-                                      "and the Steinberger material model assumes that all compositional "
-                                      "fields correspond to mass fractions of materials. "
-                                      "You must therefore specify one more material file name "
-                                      "than the number of compositional fields.  You have prescribed "
-                                      + Utilities::int_to_string(equation_of_state.number_of_lookups())
-                                      + " material data files, but there are "
-                                      + Utilities::int_to_string(this->n_compositional_fields())
-                                      + " compositional fields."));
-            }
-          else
-            {
-              AssertThrow ((equation_of_state.number_of_lookups() == this->n_compositional_fields()),
-                           ExcMessage("You have specified that no background material field exists, "
-                                      "and the Steinberger material model assumes that all compositional "
-                                      "fields correspond to mass fractions of materials. "
-                                      "You must therefore specify the same number of material file names "
-                                      "as the number of compositional fields."));
-            }
 
           prm.leave_subsection();
         }

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2011 - 2020 by the authors of the ASPECT code.
+  Copyright (C) 2011 - 2021 by the authors of the ASPECT code.
 
   This file is part of ASPECT.
 
@@ -224,7 +224,6 @@ namespace aspect
     Steinberger<dim>::evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                                MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-
       std::vector<EquationOfStateOutputs<dim>> eos_outputs (in.n_evaluation_points(), equation_of_state.number_of_lookups());
 
       std::vector<std::vector<double>> mass_fractions;
@@ -371,11 +370,13 @@ namespace aspect
             }
           else
             {
-              AssertThrow ((equation_of_state.number_of_lookups() == this->n_compositional_fields()),
+              AssertThrow ((equation_of_state.number_of_lookups() == 1) ||
+                           (equation_of_state.number_of_lookups() == this->n_compositional_fields()),
                            ExcMessage("The Steinberger material model assumes that all compositional "
                                       "fields correspond to mass fractions of materials. There must either be "
-                                      "the same number of material lookup files as compositional fields, "
-                                      "or one additional file (if a background field is used)."));
+                                      "one material lookup file, the same number of material lookup files "
+                                      "as compositional fields, or one additional file "
+                                      "(if a background field is used)."));
 
               prm.set("Background material", "false");
             }

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -132,49 +132,7 @@ namespace aspect
     void
     Steinberger<dim>::initialize()
     {
-      // This model allows the user to provide several PerpleX P-T lookup files,
-      // each of which corresponds to a different material.
-      // The thermodynamic properties and stable mineral phases within each material
-      // will in general be different, and must be averaged in a reasonable way.
-
-      // In the following, we populate the unique_phase_names vector.
-      // We do this because we are choosing in this material model to combine
-      // minerals with different compositions but which are the same phase.
-      std::set<std::string> set_phase_volume_column_names;
-      for (unsigned i = 0; i < material_file_names.size(); i++)
-        {
-          material_lookup.push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>
-                                    (data_directory+material_file_names[i],interpolation,this->get_mpi_communicator()));
-
-          // Resize the unique_phase_indices object
-          unique_phase_indices.resize(material_file_names.size(), std::vector<unsigned int>());
-
-          // Here we look up all of the column names and insert
-          // unique names into the unique_phase_names vector and
-          // filling the unique_phase_indices object.
-          std::vector<std::string> phase_volume_column_names = material_lookup[i]->phase_volume_column_names();
-          for (const auto &phase_volume_column_name : phase_volume_column_names)
-            {
-              // iterate over the present unique_phase_names object
-              // to find phase_volume_column_names[j].
-              std::vector<std::string>::iterator it = std::find(unique_phase_names.begin(),
-                                                                unique_phase_names.end(),
-                                                                phase_volume_column_name);
-
-              // If phase_volume_column_names[j] already exists in unique_phase_names,
-              // std::distance finds its index. Otherwise, std::distance will return
-              // the size of the present object, which is the index where we are
-              // about to push the new name. Either way, this is the index we want
-              // to add to the unique_phase_indices[i] vector.
-              unsigned int i_unique = std::distance(unique_phase_names.begin(), it);
-              unique_phase_indices[i].push_back(i_unique);
-
-              // If phase_volume_column_names[j] did not already exist
-              // in unique_phase_names, we add it here.
-              if (it == unique_phase_names.end())
-                unique_phase_names.push_back(phase_volume_column_name);
-            }
-        }
+      equation_of_state.initialize();
 
       lateral_viscosity_lookup
         = std_cxx14::make_unique<internal::LateralViscosityLookup>(data_directory+lateral_viscosity_file_name,
@@ -252,137 +210,6 @@ namespace aspect
 
 
     template <int dim>
-    void
-    Steinberger<dim>::
-    fill_mass_and_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                    std::vector<std::vector<double>> &mass_fractions,
-                                    std::vector<std::vector<double>> &volume_fractions) const
-    {
-      // Resize mass and volume fraction vectors
-      mass_fractions.resize(in.n_evaluation_points(), std::vector<double>(material_lookup.size(), 1.));
-      volume_fractions.resize(in.n_evaluation_points(), std::vector<double>(material_lookup.size(), 1.));
-
-      if (material_lookup.size() > 1)
-        {
-          for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
-            {
-              double summed_volumes = 0.;
-
-              if (has_background)
-                {
-                  mass_fractions[i][0] = 1.;
-                  for (unsigned int j=1; j<material_lookup.size(); ++j)
-                    {
-                      const double mass_fraction = in.composition[i][first_composition_index+j-1];
-                      mass_fractions[i][j] = mass_fraction;
-                      mass_fractions[i][0] -= mass_fraction;
-                      volume_fractions[i][j] = mass_fraction/material_lookup[j]->density(in.temperature[i],in.pressure[i]);
-                      summed_volumes += volume_fractions[i][j];
-                    }
-                  volume_fractions[i][0] = mass_fractions[i][0]/material_lookup[0]->density(in.temperature[i],in.pressure[i]);
-                  summed_volumes += volume_fractions[i][0];
-
-                }
-              else
-                {
-                  for (unsigned int j=0; j<material_lookup.size(); ++j)
-                    {
-                      const double mass_fraction = in.composition[i][first_composition_index+j];
-                      mass_fractions[i][j] = mass_fraction;
-                      volume_fractions[i][j] = mass_fraction/material_lookup[j]->density(in.temperature[i],in.pressure[i]);
-                      summed_volumes += volume_fractions[i][j];
-                    }
-                }
-
-              for (unsigned int j=0; j<material_lookup.size(); ++j)
-                volume_fractions[i][j] /= summed_volumes;
-
-            }
-        }
-    }
-
-
-
-    template <int dim>
-    void
-    Steinberger<dim>::
-    fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
-                             const std::vector<double> &composite_densities,
-                             const std::vector<std::vector<double>> &volume_fractions,
-                             SeismicAdditionalOutputs<dim> *seismic_out) const
-    {
-      // This function returns the Voigt-Reuss-Hill averages of the
-      // seismic velocities of the different materials.
-
-      // Now we calculate the averaged moduli.
-      // mu = rho*Vs^2; K_s = rho*Vp^2 - 4./3.*mu
-      // The Voigt average is an arithmetic volumetric average,
-      // while the Reuss average is a harmonic volumetric average.
-
-      for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
-        {
-          if (material_lookup.size() == 1)
-            {
-              seismic_out->vs[i] = material_lookup[0]->seismic_Vs(in.temperature[i],in.pressure[i]);
-              seismic_out->vp[i] = material_lookup[0]->seismic_Vp(in.temperature[i],in.pressure[i]);
-            }
-          else
-            {
-              double k_voigt = 0.;
-              double mu_voigt = 0.;
-              double invk_reuss = 0.;
-              double invmu_reuss = 0.;
-
-              for (unsigned int j = 0; j < material_lookup.size(); ++j)
-                {
-                  const double mu = material_lookup[j]->density(in.temperature[i],in.pressure[i])*std::pow(material_lookup[j]->seismic_Vs(in.temperature[i],in.pressure[i]), 2.);
-                  const double k =  material_lookup[j]->density(in.temperature[i],in.pressure[i])*std::pow(material_lookup[j]->seismic_Vp(in.temperature[i],in.pressure[i]), 2.) - 4./3.*mu;
-
-                  k_voigt += volume_fractions[i][j] * k;
-                  mu_voigt += volume_fractions[i][j] * mu;
-                  invk_reuss += volume_fractions[i][j] / k;
-                  invmu_reuss += volume_fractions[i][j] / mu;
-                }
-
-              const double k_VRH = (k_voigt + 1./invk_reuss)/2.;
-              const double mu_VRH = (mu_voigt + 1./invmu_reuss)/2.;
-              seismic_out->vp[i] = std::sqrt((k_VRH + 4./3.*mu_VRH)/composite_densities[i]);
-              seismic_out->vs[i] = std::sqrt(mu_VRH/composite_densities[i]);
-            }
-        }
-    }
-
-
-
-    template <int dim>
-    void
-    Steinberger<dim>::
-    fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                 const std::vector<std::vector<double>> &volume_fractions,
-                                 NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const
-    {
-      // Each call to material_lookup[j]->phase_volume_fraction(k,temperature,pressure)
-      // returns the volume fraction of the kth phase which is present in that material lookup
-      // at the requested temperature and pressure.
-      // The total volume fraction of each phase at each evaluation point is equal to
-      // sum_j (volume_fraction_of_material_j * phase_volume_fraction_in_material_j).
-      // In the following function,
-      // the index i corresponds to the ith evaluation point
-      // the index j corresponds to the jth compositional field
-      // the index k corresponds to the kth phase in the lookup
-      std::vector<std::vector<double>> phase_volume_fractions(unique_phase_names.size(),
-                                                              std::vector<double>(in.n_evaluation_points(), 0.));
-      for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
-        for (unsigned j = 0; j < material_lookup.size(); ++j)
-          for (unsigned int k = 0; k < unique_phase_indices[j].size(); ++k)
-            phase_volume_fractions[unique_phase_indices[j][k]][i] += volume_fractions[i][j] * material_lookup[j]->phase_volume_fraction(k,in.temperature[i],in.pressure[i]);
-
-      phase_volume_fractions_out->output_values = phase_volume_fractions;
-    }
-
-
-
-    template <int dim>
     bool
     Steinberger<dim>::
     is_compressible () const
@@ -393,58 +220,15 @@ namespace aspect
 
 
     template <int dim>
-    std::array<std::pair<double, unsigned int>,2>
-    Steinberger<dim>::
-    enthalpy_derivatives (const typename Interface<dim>::MaterialModelInputs &in) const
-    {
-      // We have to take into account here that the p,T spacing of the table of material properties
-      // we use might be on a finer grid than our model. Because of that we compute the enthalpy
-      // derivatives by using finite differences that average over the whole temperature and
-      // pressure range that is used in this cell. This way we should not miss any phase transformation.
-      std::array<std::pair<double, unsigned int>,2> derivative;
-
-      // get the pressures and temperatures at the vertices of the cell
-#if DEAL_II_VERSION_GTE(9,3,0)
-      const QTrapezoid<dim> quadrature_formula;
-#else
-      const QTrapez<dim> quadrature_formula;
-#endif
-
-      const unsigned int n_q_points = quadrature_formula.size();
-      FEValues<dim> fe_values (this->get_mapping(),
-                               this->get_fe(),
-                               quadrature_formula,
-                               update_values);
-
-      std::vector<double> temperatures(n_q_points), pressures(n_q_points);
-      fe_values.reinit (in.current_cell);
-
-      fe_values[this->introspection().extractors.temperature]
-      .get_function_values (this->get_current_linearization_point(), temperatures);
-      fe_values[this->introspection().extractors.pressure]
-      .get_function_values (this->get_current_linearization_point(), pressures);
-
-      // compute the averaged enthalpy derivatives for all temperatures and
-      // pressures in this cell. The 1 means we only do one substep for this
-      // computation (see documentation of the called function for more
-      // information.
-      derivative = material_lookup[0]->enthalpy_derivatives(temperatures,
-                                                            pressures,
-                                                            1);
-
-      return derivative;
-    }
-
-
-
-    template <int dim>
     void
     Steinberger<dim>::evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                                MaterialModel::MaterialModelOutputs<dim> &out) const
     {
+      EquationOfStateOutputs<dim> eos_outputs (equation_of_state.number_of_lookups());
+
       std::vector<std::vector<double>> mass_fractions;
       std::vector<std::vector<double>> volume_fractions;
-      fill_mass_and_volume_fractions (in, mass_fractions, volume_fractions);
+      equation_of_state.fill_mass_and_volume_fractions (in, mass_fractions, volume_fractions);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
@@ -452,106 +236,37 @@ namespace aspect
             out.viscosities[i] = viscosity(in.temperature[i], in.pressure[i], in.composition[i], in.strain_rate[i], in.position[i]);
 
           out.thermal_conductivities[i] = thermal_conductivity_value;
-          out.entropy_derivative_pressure[i]    = 0;
-          out.entropy_derivative_temperature[i] = 0;
           for (unsigned int c=0; c<in.composition[i].size(); ++c)
             out.reaction_terms[i][c]            = 0;
 
-          // The following lines take the appropriate averages of the
-          // thermodynamic material properties
-          std::vector<double> specific_heats(material_lookup.size());
-          std::vector<double> densities(material_lookup.size());
-          std::vector<double> compressibilities(material_lookup.size());
-          std::vector<double> thermal_expansivities(material_lookup.size());
-
-          for (unsigned int j=0; j<material_lookup.size(); ++j)
-            {
-              densities[j] = material_lookup[j]->density(in.temperature[i],in.pressure[i]);
-              compressibilities[j] = material_lookup[j]->dRhodp(in.temperature[i],in.pressure[i])/densities[j];
-
-              if (!latent_heat)
-                {
-                  thermal_expansivities[j] = material_lookup[j]->thermal_expansivity(in.temperature[i],in.pressure[i]);
-                  specific_heats[j] = material_lookup[j]->specific_heat(in.temperature[i],in.pressure[i]);
-                }
-            }
+          // Evaluate the equation of state properties at the current evaluation point
+          equation_of_state.evaluate(in, i, eos_outputs);
 
           // The density and isothermal compressibility are both volume-averaged
-          out.densities[i] = MaterialUtilities::average_value(volume_fractions[i], densities, MaterialUtilities::arithmetic);
-          out.compressibilities[i] = MaterialUtilities::average_value(volume_fractions[i], compressibilities, MaterialUtilities::arithmetic);
+          out.densities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs.densities, MaterialUtilities::arithmetic);
+          out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs.compressibilities, MaterialUtilities::arithmetic);
+          out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs.entropy_derivative_pressure, MaterialUtilities::arithmetic);
+          out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs.entropy_derivative_temperature, MaterialUtilities::arithmetic);
 
           if (!latent_heat)
             {
               // Specific heat is measured per unit mass, so it is mass averaged.
               // Thermal expansivity is volume averaged.
-              out.specific_heat[i] = MaterialUtilities::average_value(mass_fractions[i], specific_heats, MaterialUtilities::arithmetic);
-              out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value(volume_fractions[i], thermal_expansivities, MaterialUtilities::arithmetic);
+              out.specific_heat[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs.specific_heat_capacities, MaterialUtilities::arithmetic);
+              out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs.thermal_expansion_coefficients, MaterialUtilities::arithmetic);
             }
         }
 
-      // The second derivatives of the thermodynamic potentials (compressibility, thermal expansivity, specific heat)
-      // are dependent not only on the phases present in the assemblage at the given temperature and pressure,
-      // but also on any reactions between phases in the assemblage. PerpleX and HeFESTo output only "static" properties
-      // (properties not including any reaction effects), and so do not capture the latent heat of reaction.
-
-      // In this material model, we always use a compressibility which includes the effects of reaction,
-      // but we allow the user the option to switch on or off thermal (latent heat) effects.
-      // If the latent_heat bool is set to true, thermal expansivity and specific heat are calculated from
-      // the change in enthalpy with pressure and temperature.
-
-      // There are alternative ways to capture the latent heat effect (by preprocessing the P-T table, for example),
-      // which may be a more appropriate approach in some cases, but the latent heat should always be considered if
-      // thermodynamic self-consistency is intended.
-
-      // The affected properties are computed using the partial derivatives of the enthalpy
-      // with respect to pressure and temperature:
-      // thermal expansivity = (1 - rho * (dH/dp)_T) / T
-      // specific heat capacity = (dH/dT)_P
-      // where the subscript indicates the natural variable which is held constant.
       if (latent_heat)
-        {
-          double average_temperature(0.0);
-          double average_density(0.0);
-          std::array<std::pair<double, unsigned int>,2> dH;
-
-          for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
-            {
-              average_temperature += in.temperature[i];
-              average_density += out.densities[i];
-            }
-          average_temperature /= in.n_evaluation_points();
-          average_density /= in.n_evaluation_points();
-
-          if (in.current_cell.state() == IteratorState::valid)
-            dH = enthalpy_derivatives(in);
-
-          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
-            {
-              // Use the adiabatic pressure instead of the real one,
-              // to stabilize against pressure oscillations in phase transitions
-              const double pressure = this->get_adiabatic_conditions().pressure(in.position[i]);
-
-              if ((in.current_cell.state() == IteratorState::valid)
-                  && (dH[0].second > 0) && (dH[1].second > 0))
-                {
-                  out.thermal_expansion_coefficients[i] = (1 - average_density * dH[1].first) / average_temperature;
-                  out.specific_heat[i] = dH[0].first;
-                }
-              else
-                {
-                  out.thermal_expansion_coefficients[i] = (1 - out.densities[i] * material_lookup[0]->dHdp(in.temperature[i],pressure)) / in.temperature[i];
-                  out.specific_heat[i] = material_lookup[0]->dHdT(in.temperature[i],pressure);
-                }
-            }
-        }
+        equation_of_state.evaluate_using_enthalpy_derivatives(in, out);
 
       // fill seismic velocity outputs if they exist
       if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim> >())
-        fill_seismic_velocities(in, out.densities, volume_fractions, seismic_out);
+        equation_of_state.fill_seismic_velocities(in, out.densities, volume_fractions, seismic_out);
 
       // fill phase volume outputs if they exist
       if (NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim> >())
-        fill_phase_volume_fractions(in, volume_fractions, phase_volume_fractions_out);
+        equation_of_state.fill_phase_volume_fractions(in, volume_fractions, phase_volume_fractions_out);
     }
 
 
@@ -571,23 +286,6 @@ namespace aspect
                              "in which the ASPECT source files were located when ASPECT was "
                              "compiled. This interpretation allows, for example, to reference "
                              "files located in the `data/' subdirectory of ASPECT. ");
-          prm.declare_entry ("Material file names", "pyr-ringwood88.txt",
-                             Patterns::List (Patterns::Anything()),
-                             "The file names of the material data (material "
-                             "data is assumed to be in order with the ordering "
-                             "of the compositional fields). Note that there are "
-                             "three options on how many files need to be listed "
-                             "here: 1. If only one file is provided, it is used "
-                             "for the whole model domain, and compositional fields "
-                             "are ignored. 2. If there is one more file name than the "
-                             "number of compositional fields, then the first file is "
-                             "assumed to define a `background composition' that is "
-                             "modified by the compositional fields. If there are "
-                             "exactly as many files as compositional fields, the fields are "
-                             "assumed to represent the mass fractions of different materials "
-                             "and the average property is computed as a sum of "
-                             "the value of the compositional field times the "
-                             "material property of that field.");
           prm.declare_entry ("Radial viscosity file name", "radial-visc.txt",
                              Patterns::Anything (),
                              "The file name of the radial viscosity data. ");
@@ -604,15 +302,6 @@ namespace aspect
           prm.declare_entry ("Number lateral average bands", "10",
                              Patterns::Integer (1),
                              "Number of bands to compute laterally averaged temperature within.");
-          prm.declare_entry ("Bilinear interpolation", "true",
-                             Patterns::Bool (),
-                             "Whether to use bilinear interpolation to compute "
-                             "material properties (slower but more accurate). ");
-          prm.declare_entry ("Latent heat", "false",
-                             Patterns::Bool (),
-                             "Whether to include latent heat effects in the "
-                             "calculation of thermal expansivity and specific heat. "
-                             "Following the approach of Nakagawa et al. 2009. ");
           prm.declare_entry ("Reference viscosity", "1e23",
                              Patterns::Double (0.),
                              "The reference viscosity that is used for pressure scaling. "
@@ -652,6 +341,10 @@ namespace aspect
                              Patterns::Double (0.),
                              "The value of the thermal conductivity $k$. "
                              "Units: \\si{\\watt\\per\\meter\\per\\kelvin}.");
+
+          // Table lookup parameters
+          EquationOfState::ThermodynamicTableLookup<dim>::declare_parameters(prm);
+
           prm.leave_subsection();
         }
         prm.leave_subsection();
@@ -675,13 +368,30 @@ namespace aspect
           lateral_viscosity_file_name  = prm.get ("Lateral viscosity file name");
           use_lateral_average_temperature = prm.get_bool ("Use lateral average temperature for viscosity");
           n_lateral_slices = prm.get_integer("Number lateral average bands");
-          interpolation        = prm.get_bool ("Bilinear interpolation");
           latent_heat          = prm.get_bool ("Latent heat");
           reference_eta        = prm.get_double ("Reference viscosity");
           min_eta              = prm.get_double ("Minimum viscosity");
           max_eta              = prm.get_double ("Maximum viscosity");
           max_lateral_eta_variation    = prm.get_double ("Maximum lateral viscosity variation");
           thermal_conductivity_value = prm.get_double ("Thermal conductivity");
+
+
+          // Parse the table lookup parameters
+
+          // The Steinberger material model currently assumes that all the
+          // compositional fields correspond to materials with
+          // PerpleX lookup tables.
+          // Therefore the first composition index is hard-coded as zero and
+          // a background field exists if the number of files is one greater
+          // then the number of compositional fields.
+          prm.set("Material file format", "perplex");
+          prm.set("Index of first mass fraction compositional field", "0");
+          if (material_file_names.size() == this->n_compositional_fields() + 1)
+            prm.set("Background material", "true");
+          else
+            prm.set("Background material", "false");
+          equation_of_state.initialize_simulator (this->get_simulator());
+          equation_of_state.parse_parameters(prm);
 
           prm.leave_subsection();
         }
@@ -696,21 +406,6 @@ namespace aspect
                                 "is assumed to contain a background composition). This condition is not fulfilled. You "
                                 "prescribed " + Utilities::int_to_string(material_file_names.size()) + " material data files, but there are " +
                                 Utilities::int_to_string(this->n_compositional_fields()) + " compositional fields."));
-
-        // The Steinberger material model currently assumes that all the
-        // compositional fields correspond to materials with lookup tables.
-        // Therefore the first composition index is hard-coded as zero.
-        // If more compositional fields are needed, this parameter allows
-        // the user to declare the first compositional index which
-        // corresponds to a lookup.
-        first_composition_index = 0;
-
-        // Define whether there is a background compositional field
-        has_background = (material_file_names.size() == this->n_compositional_fields() + 1);
-
-        if (latent_heat)
-          AssertThrow (material_file_names.size() == 1,
-                       ExcMessage("Isochemical latent heat calculations are only implemented for a single material lookup."));
 
         // Declare dependencies on solution variables
         this->model_dependence.viscosity = NonlinearDependence::temperature;
@@ -731,7 +426,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (unique_phase_names, n_points));
+            std_cxx14::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (equation_of_state.unique_phase_names_list(), n_points));
         }
 
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == nullptr)


### PR DESCRIPTION
This PR makes a new EquationOfState plugin called ThermodynamicTableLookup. This can be used by both the Steinberger and GrainSize Material models, removing two almost identical chunks of code from those models. It will also make it easier for new material models to use the table lookup.

To make this PR as easy to read as possible, I will modify the GrainSize material model in a separate PR.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
