### PR TITLE
Make all captions italics.

### DIFF
--- a/cookbooks/van-keken-vof/doc/van-keken-vof.tex
+++ b/cookbooks/van-keken-vof/doc/van-keken-vof.tex
@@ -19,7 +19,7 @@ in a neighborhood of the interface, rather than in the entire computational doma
 \begin{figure}
    \centering
 \includegraphics[width=0.5\textwidth]{cookbooks/van-keken-vof/doc/rms_vel_comparison.png}
-   \caption{Evolution of the root mean square velocity as a function of time for computations 
+   \caption{\it Evolution of the root mean square velocity as a function of time for computations 
     of the van Keken problem made with the VOF interface tracking algorithm with five 
     different global mesh refinements.
     Since the VOF initial conditions are discontinuous, the above results should really be 

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2764,7 +2764,7 @@ guide users to an informed decision about the best option for their purpose.
     Modifying ASPECT        & Possible & Possible & Possible \\
     Configuring dependencies & Possible & No   & No \\ \hline
   \end{tabular}
-  \caption{Features of the different installation options of \aspect{}.}
+  \caption{\it Features of the different installation options of \aspect{}.}
   \label{tab:install-options}
 \end{table}
 
@@ -5477,7 +5477,7 @@ it is possible to produce many interesting flow fields such as the ones visualiz
   ~
   \subfigure[]{
     \includegraphics[width=.48\textwidth]{cookbooks/prescribed_velocity/doc/circle.png}}
-    \caption{Examples of flows with prescribed internal velocities, as described in Section \ref{sec:prescribed-velocities}.}
+    \caption{\it Examples of flows with prescribed internal velocities, as described in Section \ref{sec:prescribed-velocities}.}
     \label{fig:prescribed-velocity}
 \end{figure}
 
@@ -5509,7 +5509,7 @@ Figure~\ref{fig:smoothing}.
   ~
   \subfigure[]{
     \includegraphics[width=.48\textwidth]{cookbooks/shell_simple_2d_smoothing/doc/without_smoothing.png}}
-    \caption{Artificial viscosity smoothing: Example of the output of two similar runs.  The run on the left has the artificial viscosity smoothing turned on and the run on the right does not, as described in Section \ref{sec:artificial-viscosity-smoothing}.}
+    \caption{\it Artificial viscosity smoothing: Example of the output of two similar runs.  The run on the left has the artificial viscosity smoothing turned on and the run on the right does not, as described in Section \ref{sec:artificial-viscosity-smoothing}.}
     \label{fig:smoothing}
 \end{figure}
 
@@ -5553,7 +5553,7 @@ properties are read in from the subsection \texttt{Simple model}.
 \begin{figure}
     \centering
     \includegraphics[width=0.75\textwidth]{cookbooks/finite_strain/doc/finite_strain.pdf}
-    \caption{Accumulated finite strain in an example convection model, as described in Section
+    \caption{\it Accumulated finite strain in an example convection model, as described in Section
              \ref{sec:finite-strain} at a time of 67.6~Ma. Top panel: Temperature distribution. Bottom panel:
              Natural strain distribution. Additional black crosses are the scaled eigenvectors of the
              stretching tensor $\mathbf L$, showing the direction of stretching and compression.}
@@ -5629,7 +5629,7 @@ have already been assigned to each path (Figure~\ref{fig:jelly-picture}).
 \begin{figure}[tb]
     \centering
     \includegraphics[width=0.2\textwidth]{cookbooks/geomio/doc/jellyfish.pdf}
-    \caption{Vector drawing of a jellyfish.}
+    \caption{\it Vector drawing of a jellyfish.}
     \label{fig:jelly-picture}
 \end{figure}
 \note{The page of your drawing in Inkscape should already have the extents (in px) that you later want to use in your model (in m).}
@@ -5648,7 +5648,7 @@ You can plot the \texttt{Phase} variable in MATLAB to see if the drawing was rea
 \begin{figure}[tb]
     \centering
     \includegraphics[width=0.45\textwidth]{cookbooks/geomio/doc/jelly.png}
-    \caption{Plot of the \texttt{Phase} variable in MATLAB.}
+    \caption{\it Plot of the \texttt{Phase} variable in MATLAB.}
     \label{fig:jelly-plot}
 \end{figure}
 Finally, we want to write output in a format that can be read in by \aspect{}'s \texttt{ascii data} compositional
@@ -5666,7 +5666,7 @@ boundaries between the different phases (Figure~\ref{fig:jelly-paraview}).
 \begin{figure}[tb]
     \centering
     \includegraphics[width=0.55\textwidth]{cookbooks/geomio/doc/jelly-paraview.pdf}
-    \caption{\aspect{} model output of the jellyfish and corresponding mesh in ParaView.}
+    \caption{\it \aspect{} model output of the jellyfish and corresponding mesh in ParaView.}
     \label{fig:jelly-paraview}
 \end{figure}
 
@@ -6702,7 +6702,7 @@ Three main areas can be distinguished: the stable area, the plume convection are
 \begin{figure}[h]
 \begin{center}
 \includegraphics[height=0.57\textwidth]{cookbooks/inner_core_convection/doc/Diagstab.pdf}
-	\caption{Stability diagram for convection in a sphere with phase change at its outer boundary. The stability curves for the first unstable mode (l=1) and the translation are obtained from \cite{Deguen2013}. Each dot (no convection) and triangle (blue: translation, yellow: plume convection) is one model run done with ASPECT. The highest the Ra and P are, the more refinement is required (see text).}
+	\caption{\it Stability diagram for convection in a sphere with phase change at its outer boundary. The stability curves for the first unstable mode (l=1) and the translation are obtained from \cite{Deguen2013}. Each dot (no convection) and triangle (blue: translation, yellow: plume convection) is one model run done with ASPECT. The highest the Ra and P are, the more refinement is required (see text).}
     \label{fig:diagramme-regime}
 \end{center}
 \end{figure}
@@ -6731,7 +6731,7 @@ $Ra=10^5, \mathcal{P}=0.01$ (translation), $Ra=10, \mathcal{P}=30$ (no convectio
     \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/no_convection.png}
     \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/translation.png}
     \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/convection.png}
-    \caption{Convection regimes in the inner core for different values of $Ra$ and $\mathcal{P}$. From left to right: no convection, translation, plume convection; the 2D slices at the top are with the default temperature scale for all panels, while in the second row an adaptive scale is used. The bottom row features slightly different model parameters (that are still in the same regime as the models in the respective panels above) and also shows the velocity as arrows.}
+    \caption{\it Convection regimes in the inner core for different values of $Ra$ and $\mathcal{P}$. From left to right: no convection, translation, plume convection; the 2D slices at the top are with the default temperature scale for all panels, while in the second row an adaptive scale is used. The bottom row features slightly different model parameters (that are still in the same regime as the models in the respective panels above) and also shows the velocity as arrows.}
     \label{fig:inner-core-regimes}
        \end{center}
 \end{figure}
@@ -6759,7 +6759,7 @@ Both trends are shown in Figure~\ref{fig:inner-core-trends} and can be compared 
     \includegraphics[width=0.49\textwidth]{cookbooks/inner_core_convection/doc/translation_over_Ra_P.pdf}
     \hfill
     \includegraphics[width=0.49\textwidth]{cookbooks/inner_core_convection/doc/translation_over_P.pdf}
-    \caption{Translation rate (approximated by the average of the velocity component in the direction of translation),
+    \caption{\it Translation rate (approximated by the average of the velocity component in the direction of translation),
     normalized to the low $\mathcal{P}$
     limit estimate given in \cite{Deguen2013}, as a function of $\frac{Ra}{\mathcal{P}}$ for $\mathcal{P}=10^{-2}$
     (left) and as a function of $\mathcal{P}$ for $Ra=10^5$ (right).
@@ -6806,7 +6806,7 @@ In the first few tens of millions of years, this models evolves similarly to the
 \begin{figure}
     \centering
     \includegraphics[width=0.9\textwidth]{cookbooks/global_melt/doc/model_evolution.pdf}
-    \caption{Evolution of the model without (left) and with (right) melt migration.}
+    \caption{\it Evolution of the model without (left) and with (right) melt migration.}
     \label{fig:global-melt}
 \end{figure}
 
@@ -6891,7 +6891,7 @@ The complete input file is located at \url{cookbooks/mid_ocean_ridge.prm}.
 \begin{figure}
     \centering
     \includegraphics[width=0.5\textwidth]{cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.pdf}
-    \caption{Mid-ocean ridge model after 8 million years. The top panel shows the depletion
+    \caption{\it Mid-ocean ridge model after 8 million years. The top panel shows the depletion
              and porosity fields (with the characteristic triangular melting region),
              the bottom panel shows the temperature distribution and the melt velocity, indicated
              by the arrows.}
@@ -6916,7 +6916,7 @@ A vertical profile at a distance of 80 km from the ridge axis showing this compo
 \begin{figure}
     \centering
     \includegraphics[width=0.35\textwidth]{cookbooks/mid_ocean_ridge/doc/depletion_profile.pdf}
-    \caption{Vertical profile through the model domain at a distance of 80 km from the ridge axis
+    \caption{\it Vertical profile through the model domain at a distance of 80 km from the ridge axis
              at the end of the model run, showing the distribution of depletion and enrichment as
              indicated by the peridotite field.}
     \label{fig:mid-ocean-ridge-profile}
@@ -6937,7 +6937,7 @@ Of course it is also possible to combine both methods for refining the mesh.
 \begin{figure}
     \centering
     \includegraphics[width=0.6\textwidth]{cookbooks/mid_ocean_ridge/doc/refinement.pdf}
-    \caption{Mesh after a time of 3.6 million years for a model using the composition threshold
+    \caption{\it Mesh after a time of 3.6 million years for a model using the composition threshold
              refinement strategy (left) and the compaction length refinement strategy (right)
              Background colors indicate the melt velocity. Its sharp gradients at the interface
              between regions with and without melt can only be resolved using the compaction
@@ -7090,7 +7090,7 @@ We use bisection to determine $Ra_c$ for specific choices of the domain geometry
  \includegraphics[width=0.49\textwidth]{cookbooks/benchmarks/onset-of-convection/doc/racr.png}
  \hfill
  \includegraphics[width=0.49\textwidth]{cookbooks/benchmarks/onset-of-convection/doc/racr_error.png}
- \caption{Left: Comparison of numerically-determined and theoretical values for $Ra_c$. Red circles indicate numerical simulations unstable to convection, black circles indicate simulations that are stable. The green dashed curve indicates the theoretical prediction. Right: Relative error in determination of $Ra_c$. The dashed red line indicates the error tolerance used in bisection procedure.}
+ \caption{\it Left: Comparison of numerically-determined and theoretical values for $Ra_c$. Red circles indicate numerical simulations unstable to convection, black circles indicate simulations that are stable. The green dashed curve indicates the theoretical prediction. Right: Relative error in determination of $Ra_c$. The dashed red line indicates the error tolerance used in bisection procedure.}
  \label{fig:onset-1}
 \end{figure}
 
@@ -7446,14 +7446,14 @@ as explained by linear stability analysis \cite{wesc92,ramb81}.
     \includegraphics[width=0.48\textwidth]{cookbooks/polydiapirism/doc/diapirs0005.png}
     \includegraphics[width=0.48\textwidth]{cookbooks/polydiapirism/doc/diapirs0010.png}
     \includegraphics[width=0.48\textwidth]{cookbooks/polydiapirism/doc/diapirs0015.png}
-    \caption{Polydiapirism benchmark: Density field at $t=0,25,50,75\si{s}$.}
+    \caption{\it Polydiapirism benchmark: Density field at $t=0,25,50,75\si{s}$.}
     \label{fig:polydiapirs_density}
 \end{figure}
 
 \begin{figure}
     \centering
     \includegraphics[width=0.75\textwidth]{cookbooks/polydiapirism/doc/vrms.pdf}
-    \caption{Polydiapirism benchmark: Root mean square velocity as a function of time}
+    \caption{\it Polydiapirism benchmark: Root mean square velocity as a function of time}
     \label{fig:polydiapirs_vrms}
 \end{figure}
 
@@ -7861,7 +7861,7 @@ Expected analytical solutions at two locations are summarised in Table~\ref{tab:
 Figure~\ref{fig:burstedde-benchmark} shows that the analytical solution is indeed retrieved by the model.
 
 \begin{table}[h!]
-\caption{Analytical solutions \label{tab:burstedde-table}}
+\caption{\it Analytical solutions \label{tab:burstedde-table}}
 \centering
 \begin{tabular}{l|c|c}
 Quantity & $\mathbf{r} = (0,0,0)$ & $\mathbf{r} = (1,1,1)$ \\ \hline
@@ -7884,7 +7884,7 @@ $|\mathbf{u}|$ & $0$ &  $14.177$ \\
   ~
   \subfigure[]{
     \includegraphics[width=0.48\textwidth]{cookbooks/benchmarks/burstedde/doc/velocity_z.png}}
-  \caption{Burstedde benchmark: Results for the 3D polynomial Stokes benchmark, obtained with a resolution of $16\times 16$ elements, with $\beta = 10$.}\label{fig:burstedde-benchmark}
+  \caption{\it Burstedde benchmark: Results for the 3D polynomial Stokes benchmark, obtained with a resolution of $16\times 16$ elements, with $\beta = 10$.}\label{fig:burstedde-benchmark}
 \end{figure}
 
 The convergence of the numerical error of this benchmark has been analysed by
@@ -7897,7 +7897,7 @@ $Q_1$ elements for the pressure.
 \begin{figure}[tbp]
   \centering
   \includegraphics[width=\textwidth]{cookbooks/benchmarks/burstedde/doc/errors.pdf}
-  \caption{Burstedde benchmark: Error convergence for the 3D polynomial Stokes
+  \caption{\it Burstedde benchmark: Error convergence for the 3D polynomial Stokes
     benchmark.
     \label{errors}}
 \end{figure}
@@ -7923,7 +7923,7 @@ boundary conditions are imposed at the top and bottom.
 \begin{figure}
 \centering
 \includegraphics[width=0.6\linewidth]{cookbooks/benchmarks/slab_detachment/doc/drawing.png}
-\caption{Slab detachment benchmark: Initial geometry
+\caption{\it Slab detachment benchmark: Initial geometry
 \label{fig:slab_detachment_setup}}
 \end{figure}
 
@@ -7949,7 +7949,7 @@ and the effect of viscosity and material averaging was explored in \cite{gltf18}
 \begin{figure}
 \centering
 \includegraphics[width=0.85\textwidth]{cookbooks/benchmarks/slab_detachment/doc/results.png}
-\caption{Slab detachment benchmark: a,b) velocity and strain rate fields at $t=0$.
+\caption{\it Slab detachment benchmark: a,b) velocity and strain rate fields at $t=0$.
 c,d,e) and f,g,h) time evolution of the viscosity and slab composition fields at $t=0, 6, 12\text{Myr}$.
 \label{fig:slab_detachment_evolution}}
 \end{figure}
@@ -8000,14 +8000,14 @@ and a second-order convergence rate for the pressure.
 \includegraphics[width=.3\textwidth]{cookbooks/benchmarks/hollow_sphere/doc/vel.png}
 \includegraphics[width=.3\textwidth]{cookbooks/benchmarks/hollow_sphere/doc/vel2.png}
 \includegraphics[width=.3\textwidth]{cookbooks/benchmarks/hollow_sphere/doc/pressure.png}
-\caption{Velocity and pressure fields for the hollow sphere benchmark.}
+\caption{\it Velocity and pressure fields for the hollow sphere benchmark.}
 \label{fig:hollow-sphere-vp}
 \end{figure}
 
 \begin{figure}
 \centering
 \includegraphics[width=.7\textwidth]{cookbooks/benchmarks/hollow_sphere/doc/errors_hollowsphere.pdf}
-\caption{Velocity and pressure errors in the $L_2$-norm as a function of the mesh size.}
+\caption{\it Velocity and pressure errors in the $L_2$-norm as a function of the mesh size.}
 \label{fig:hollow-sphere-errors}
 \end{figure}
 
@@ -8047,7 +8047,7 @@ as shown in Fig.~\ref{fig:annulus-vp}.
 \includegraphics[width=.9\textwidth]{cookbooks/benchmarks/annulus/doc/pressures.png}
 \includegraphics[width=.9\textwidth]{cookbooks/benchmarks/annulus/doc/density.png}
 \includegraphics[width=.9\textwidth]{cookbooks/benchmarks/annulus/doc/velocities2.png}
-\caption{Pressure, density and velocity fields for $k=0,1,2,3$ for the 2D annulus benchmark.}
+\caption{\it Pressure, density and velocity fields for $k=0,1,2,3$ for the 2D annulus benchmark.}
 \label{fig:annulus-vp}
 \end{figure}
 
@@ -8059,7 +8059,7 @@ and a second-order convergence rate for the pressure.
 \begin{figure}
 \centering
 \includegraphics[width=.7\textwidth]{cookbooks/benchmarks/annulus/doc/errors_annulus.pdf}
-\caption{Velocity and pressure errors in the $L_2$-norm as a function of the mesh size for the 2D annulus benchmark.}
+\caption{\it Velocity and pressure errors in the $L_2$-norm as a function of the mesh size for the 2D annulus benchmark.}
 \label{fig:annulus-errors}
 \end{figure}
 
@@ -8668,7 +8668,7 @@ plumes. This is nicely reflected in the visualizations.
   \hfill
   \subfigure[Case 2.3]{\includegraphics[width=0.23\textwidth]{cookbooks/benchmarks/davies_et_al/doc/case23_final.png}}
   \hfill
-  \caption{Davies et al.~benchmarks: Final steady state temperature fields for
+  \caption{\it Davies et al.~benchmarks: Final steady state temperature fields for
     the 2D cylindrical benchmark cases.}
   \label{fig:davies-2DcylinderFSS}
 \end{figure}
@@ -8689,7 +8689,7 @@ different models used after that.
   \hfill
   \subfigure[Case 2.3]{\includegraphics[width=0.48\textwidth]{cookbooks/benchmarks/davies_et_al/doc/Case23Vrms.png}}
   \hfill
-  \caption{Davies et al.~benchmarks: $V_{\text{rms}}$ for 2D Cylindrical Cases. Large jumps occur when transitioning from case 2.1 to cases 2.2 and 2.3 due to the instantaneous change of parameter settings.}
+  \caption{\it Davies et al.~benchmarks: $V_{\text{rms}}$ for 2D Cylindrical Cases. Large jumps occur when transitioning from case 2.1 to cases 2.2 and 2.3 due to the instantaneous change of parameter settings.}
   \label{fig:davies-2DcylinderVrms}
 \end{figure}
 
@@ -9181,7 +9181,7 @@ $L_2$ norm, as expected when using the $Q_2\times Q_1$ element.
   ~
   \subfigure[]{
     \includegraphics[width=0.31\textwidth]{cookbooks/benchmarks/doneahuerta/doc/vel.png}}
-  \caption{Donea \& Huerta benchmark: Results for the 2D polynomial Stokes benchmark,
+  \caption{\it Donea \& Huerta benchmark: Results for the 2D polynomial Stokes benchmark,
 obtained with a resolution of $32\times 32$ elements. (a) Gravity field, (b) pressure field,
 (c) velocity field. }\label{fig:doneahuerta-benchmark}
 \end{figure}
@@ -9205,13 +9205,13 @@ Both benchmarks have the identical setup in the temperature and a compositional 
 \begin{figure}[t!]
   \centering
     \includegraphics[width=\textwidth]{cookbooks/benchmarks/advection/doc/drop.png}%
-  \caption{Dropping box benchmark at final time. Left: entropy viscosity. Right: SUPG.}\label{fig:benchmark-drop}
+  \caption{\it Dropping box benchmark at final time. Left: entropy viscosity. Right: SUPG.}\label{fig:benchmark-drop}
 \end{figure}
 
 \begin{figure}[t!]
   \centering
     \includegraphics[width=\textwidth]{cookbooks/benchmarks/advection/doc/rotate_shape.png}%
-  \caption{Rotating shapes benchmark at final time: Left: reference. Middle: Entropy viscosity. Right: SUPG.}\label{fig:benchmark-rotate-shape}
+  \caption{\it Rotating shapes benchmark at final time: Left: reference. Middle: Entropy viscosity. Right: SUPG.}\label{fig:benchmark-rotate-shape}
 \end{figure}
 
 


### PR DESCRIPTION
We're generally quite consistent in making figure and table captions italics,
but a few have slipped our attention. Fix this.
