### PR TITLE
Use -O3 for tester

### DIFF
--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -4,7 +4,7 @@ pipeline {
   agent {
     // first build a docker image for running the tests from the repo
     docker {
-      image 'geodynamics/aspect-tester:optimized'
+      image 'geodynamics/aspect-tester:o1'
       // We mount /repos into the docker image. This allows us to cache
       // the git repo by setting "advanced clone behaviors". If the
       // directory does not exist, this will be ignored.

--- a/Jenkinsfile.cig
+++ b/Jenkinsfile.cig
@@ -3,8 +3,8 @@
 pipeline {
   agent {
     // first build a docker image for running the tests from the repo
-    dockerfile {
-      dir 'contrib/ci'
+    docker {
+      image 'geodynamics/aspect-tester:optimized'
       // We mount /repos into the docker image. This allows us to cache
       // the git repo by setting "advanced clone behaviors". If the
       // directory does not exist, this will be ignored.

--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -14,7 +14,3 @@ RUN cd / && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmak
 ENV PATH /cmake-3.17.3-Linux-x86_64/bin:$PATH
 
 USER dealii
-
-ENV DEAL_II_VERSION v9.2.0
-
-RUN cd dealii-${DEAL_II_VERSION}-src && mkdir build && cd build && cmake -DDEAL_II_CXX_FLAGS_DEBUG='-O3' -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=~/dealii-${DEAL_II_VERSION} -DCMAKE_BUILD_TYPE=Debug -GNinja ../ && ninja install && cp summary.log ~/dealii-${DEAL_II_VERSION}/summary.log && cd .. && rm -rf build

--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -14,3 +14,7 @@ RUN cd / && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmak
 ENV PATH /cmake-3.17.3-Linux-x86_64/bin:$PATH
 
 USER dealii
+
+ENV DEAL_II_VERSION v9.2.0
+
+RUN cd dealii-${DEAL_II_VERSION}-src && mkdir build && cd build && cmake -DDEAL_II_CXX_FLAGS_DEBUG='-O3' -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=~/dealii-${DEAL_II_VERSION} -DCMAKE_BUILD_TYPE=Debug -GNinja ../ && ninja install && cp summary.log ~/dealii-${DEAL_II_VERSION}/summary.log && cd .. && rm -rf build

--- a/contrib/ci/Dockerfile.optimized
+++ b/contrib/ci/Dockerfile.optimized
@@ -6,4 +6,4 @@ USER dealii
 
 ENV DEAL_II_VERSION v9.2.0
 
-RUN cd dealii-${DEAL_II_VERSION}-src && mkdir build && cd build && cmake -DDEAL_II_CXX_FLAGS_DEBUG='-O3' -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=~/dealii-${DEAL_II_VERSION} -DCMAKE_BUILD_TYPE=Debug -GNinja ../ && ninja install && cp summary.log ~/dealii-${DEAL_II_VERSION}/summary.log && cd .. && rm -rf build
+RUN rm -rf ~/dealii-${DEAL_II_VERSION} && cd dealii-${DEAL_II_VERSION}-src && mkdir build && cd build && cmake -DDEAL_II_CXX_FLAGS_DEBUG='-O1' -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=~/dealii-${DEAL_II_VERSION} -DCMAKE_BUILD_TYPE=Debug -GNinja ../ && ninja install && cp summary.log ~/dealii-${DEAL_II_VERSION}/summary.log && cd .. && rm -rf build

--- a/contrib/ci/Dockerfile.optimized
+++ b/contrib/ci/Dockerfile.optimized
@@ -1,0 +1,9 @@
+FROM geodynamics/aspect-tester:latest
+
+LABEL maintainer <rene.gassmoeller@mailbox.org>
+
+USER dealii
+
+ENV DEAL_II_VERSION v9.2.0
+
+RUN cd dealii-${DEAL_II_VERSION}-src && mkdir build && cd build && cmake -DDEAL_II_CXX_FLAGS_DEBUG='-O3' -DDEAL_II_WITH_MPI=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=~/dealii-${DEAL_II_VERSION} -DCMAKE_BUILD_TYPE=Debug -GNinja ../ && ninja install && cp summary.log ~/dealii-${DEAL_II_VERSION}/summary.log && cd .. && rm -rf build

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -7,4 +7,4 @@
 
 docker build -t geodynamics/aspect-tester:latest .
 
-docker build -t geodynamics/aspect-tester:optimized -f Dockerfile.optimized .
+docker build -t geodynamics/aspect-tester:o1 -f Dockerfile.optimized .

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -5,4 +5,6 @@
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 
-docker build -t geodynamics/aspect-tester .
+docker build -t geodynamics/aspect-tester:latest .
+
+docker build -t geodynamics/aspect-tester:optimized -f Dockerfile.optimized .


### PR DESCRIPTION
This is an experiment to address #3630. This will likely take a long time on the testers the first time it is run, because they have to compile deal.II to build the image. I hope this falls outside the timeout limit, but lets see. Otherwise we could change the deal.II base image (or derive another image from the deal.II base image and precompile there outside the testers).