### PR TITLE
Remove assert natural coordinates

### DIFF
--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -257,12 +257,6 @@ namespace aspect
 
           use_natural_coordinates = prm.get_bool("Use natural coordinates");
 
-          if (use_natural_coordinates)
-            AssertThrow (!Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>>(this->get_geometry_model()) &&
-                         !Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>>(this->get_geometry_model()),
-                         ExcMessage ("This postprocessor can not be used if the geometry "
-                                     "is a sphere or spherical shell, because these geometries have not implemented natural coordinates."));
-
           // Convert the vector of coordinate arrays in Cartesian or natural
           // coordinates to a vector of Point<dim> of Cartesian coordinates.
           evaluation_points_cartesian.resize(evaluation_points.size());

--- a/tests/point_value_natural_coordinates_shell.prm
+++ b/tests/point_value_natural_coordinates_shell.prm
@@ -1,0 +1,102 @@
+# A test for the point values postprocessor
+# using natural coordinates
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 1613.0
+set Surface pressure                       = 0
+set Nonlinear solver scheme                = single Advection, single Stokes
+
+
+subsection Boundary temperature model
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 1613.0
+    set Outer temperature = 1613.0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 9.81
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell 
+    set Inner radius  = 3481000
+    set Outer radius  = 6371000
+    set Opening angle = 90
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1613 # default: 293
+    set Thermal conductivity          = 1e-6 # default: 4.7
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1e22    # default: 5e24
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function 
+    set Variable names      = x,y
+    set Function expression = if((sqrt((x-3483208.)^2+(y-3483208.)^2)<5e5) , 1800.0, 1613.0)
+  end
+end
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 2, 3
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = 1
+end
+
+subsection Heating model
+  set List of model names = shear heating
+end
+
+subsection Postprocess
+  set List of postprocessors = point values
+
+  subsection Point values
+    # Get values at 45 degrees longitude and 1 and 1445 km depth.
+    # The former should give a temperature of 1613 K and the latter
+    # of 1800 K.
+    set Evaluation points = 6370e3, 0.7854; \
+                            4926e3, 0.7854 
+    set Use natural coordinates = true
+  end
+
+end
+

--- a/tests/point_value_natural_coordinates_shell/point_values.txt
+++ b/tests/point_value_natural_coordinates_shell/point_values.txt
@@ -1,0 +1,4 @@
+# <time> <evaluation_point_x> <evaluation_point_y> <velocity_x> <velocity_y> <pressure> <temperature>
+0 4.50426e+06 4.50428e+06 1.99509e-07 2.0055e-07 6.07507e+07 1613
+0 3.4832e+06 3.48321e+06 0.0180459 0.018046 4.67758e+10 1800
+

--- a/tests/point_value_natural_coordinates_shell/screen-output
+++ b/tests/point_value_natural_coordinates_shell/screen-output
@@ -1,0 +1,16 @@
+
+Number of active cells: 768 (on 5 levels)
+Number of degrees of freedom: 10,436 (6,402+833+3,201)
+
+*** Timestep 0:  t=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 44+0 iterations.
+
+   Postprocessing:
+     Writing point values: output-point_value_natural_coordinates_shell/point_values.txt
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
As natural coordinates conversions have been implemented in the spherical geometries, this assert can be removed from the point values postprocessor.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
