### PR TITLE
CI: switch to newer 9.2 deal.II image

### DIFF
--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM tjhei/dealii:v9.2.0-full-v9.2.0-r1-gcc5
+FROM tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 


### PR DESCRIPTION
The new image uses -O3 in debug mode as discussed in #3835.

related to #3630
