### PR TITLE
fix melt migration with heat flux boundaries

### DIFF
--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -24,6 +24,7 @@
 #include <aspect/utilities.h>
 #include <aspect/citation_info.h>
 #include <aspect/mesh_deformation/interface.h>
+#include <aspect/simulator/assemblers/advection.h>
 #include <deal.II/base/signaling_nan.h>
 
 #include <deal.II/dofs/dof_tools.h>
@@ -1673,7 +1674,13 @@ namespace aspect
     assemblers.advection_system.push_back(
       std_cxx14::make_unique<Assemblers::MeltAdvectionSystem<dim> > ());
 
-
+    if (this->get_parameters().fixed_heat_flux_boundary_indicators.size() != 0)
+      {
+        assemblers.advection_system_on_boundary_face.push_back(
+          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim> >());
+        assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
+        assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
+      }
   }
 
 

--- a/tests/melt_boundary_heat_flux.cc
+++ b/tests/melt_boundary_heat_flux.cc
@@ -1,0 +1,1 @@
+#include "rising_melt_blob.cc"

--- a/tests/melt_boundary_heat_flux.prm
+++ b/tests/melt_boundary_heat_flux.prm
@@ -1,0 +1,143 @@
+#########################################################
+# This is a test to see if the heat flux boundary 
+# conditions work together with melt migration.
+
+############### Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 5000
+set Use years in output instead of seconds = true
+set Adiabatic surface temperature          = 1600 
+set Nonlinear solver scheme                = iterated Advection and Stokes
+set Max nonlinear iterations               = 50  
+set CFL number                             = 0.2
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+
+############### Parameters describing the model
+# Let us here choose again a box domain 
+# where we fix the temperature at the bottom and top,
+# allow free slip along the boundaries
+# and include melt migration.
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 200000
+    set Y extent = 100000
+    set X repetitions = 2
+  end
+end
+
+
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary heat flux model
+  set Fixed heat flux boundary indicators   = 2, 3
+
+  set Model name = function
+  
+  subsection Function
+    set Variable names = x,z
+    set Function expression = if(z<50000, -1,1)
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1, 2, 3
+end
+
+subsection Melt settings
+  set Include melt transport = true
+end
+
+############### Compositional fields
+# We want to use two compositional fields, the porosity and
+# an additional field, to check if the melting rate functionality 
+# has the same effect as the reaction term for the other 
+# compositional fields. As the porosity field is advected by
+# a different mechanism, slight differences between the fields
+# are expected. 
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+
+# We then choose a vertical gravity model and describe the
+# initial temperature with a vertical gradient. 
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = adiabatic
+  subsection Adiabatic
+    set Age top boundary layer      = 1e6
+    subsection Function
+      set Function expression       = 0;0
+    end
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = pi=3.1415926,x0=100000,y0=50000,c=10000
+    set Function expression = 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c)); 0.2 * exp(-((x-x0)*(x-x0)+(y-y0)*(y-y0))/(2*c*c))
+  end
+end
+
+
+subsection Material model
+  set Model name = melting rate
+end
+
+
+# The final part of this input file describes how many times the
+# mesh is refined and what to do with the solution once computed
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+end
+
+subsection Postprocess
+
+  set List of postprocessors = composition statistics, visualization, temperature statistics, heat flux statistics
+
+  subsection Visualization
+    set Interpolate output = false
+
+    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+
+    subsection Melt material properties
+      set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    set Number of grouped files       = 0
+
+    set Output format                 = vtu
+
+    set Time between graphical output = 0
+
+  end
+
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Use direct solver for Stokes system = false
+  end
+end

--- a/tests/melt_boundary_heat_flux/screen-output
+++ b/tests/melt_boundary_heat_flux/screen-output
@@ -1,0 +1,133 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libmelt_boundary_heat_flux.so>
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 512 (on 5 levels)
+Number of degrees of freedom: 17,673 (4,290+2,097+4,290+561+2,145+2,145+2,145)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 22+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63669e-16, 1.54902e-16, 1.54902e-16, 0.168632
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.168632
+
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Solving peridotite system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.63669e-16, 1.54902e-16, 1.54902e-16, 5.58899e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.58899e-08
+
+
+   Postprocessing:
+     Compositions min/max/mass:          1.438e-28/0.2/1.257e+08 // 1.438e-28/0.2/1.257e+08
+     Writing graphical output:           output-melt_boundary_heat_flux/solution/solution-00000
+     Temperature min/avg/max:            1600 K, 1600 K, 1600 K
+     Heat fluxes through boundary parts: 0 W, 0 W, -2e+05 W, 2e+05 W
+
+*** Timestep 1:  t=3443.45 years, dt=3443.45 years
+   Solving temperature system... 8 iterations.
+   Solving porosity system ... 10 iterations.
+   Solving peridotite system ... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00141713, 0.0308629, 0.00391777, 0.0163796
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0308629
+
+   Solving temperature system... 5 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.37033e-07, 0.00209112, 0.000128711, 0.000678497
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00209112
+
+   Solving temperature system... 3 iterations.
+   Solving porosity system ... 8 iterations.
+   Solving peridotite system ... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.36391e-09, 0.000130762, 5.48326e-06, 2.60101e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000130762
+
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 5 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 6+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.73064e-11, 1.22713e-05, 4.86712e-07, 3.63059e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.22713e-05
+
+   Solving temperature system... 1 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 4 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.10243e-12, 9.10844e-07, 2.62983e-08, 2.35847e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.10844e-07
+
+
+   Postprocessing:
+     Compositions min/max/mass:          -1.979e-06/0.1989/1.257e+08 // -5.063e-10/0.199/1.256e+08
+     Writing graphical output:           output-melt_boundary_heat_flux/solution/solution-00001
+     Temperature min/avg/max:            1563 K, 1600 K, 1637 K
+     Heat fluxes through boundary parts: 0 W, 0 W, -2e+05 W, 2e+05 W
+
+*** Timestep 2:  t=5000 years, dt=1556.55 years
+   Solving temperature system... 7 iterations.
+   Solving porosity system ... 9 iterations.
+   Solving peridotite system ... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.96053e-05, 0.000855117, 0.0010344, 0.00127379
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00127379
+
+   Solving temperature system... 3 iterations.
+   Solving porosity system ... 7 iterations.
+   Solving peridotite system ... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 6+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.38391e-09, 2.28568e-05, 1.17575e-06, 1.00623e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.28568e-05
+
+   Solving temperature system... 1 iterations.
+   Solving porosity system ... 6 iterations.
+   Solving peridotite system ... 4 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+   Solving fluid velocity system... 12 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.56765e-12, 6.14835e-07, 3.74647e-08, 2.6496e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 6.14835e-07
+
+
+   Postprocessing:
+     Compositions min/max/mass:          -3.228e-06/0.1986/1.257e+08 // -7.95e-10/0.1989/1.256e+08
+     Writing graphical output:           output-melt_boundary_heat_flux/solution/solution-00002
+     Temperature min/avg/max:            1548 K, 1600 K, 1652 K
+     Heat fluxes through boundary parts: 0 W, 0 W, -2e+05 W, 2e+05 W
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/melt_boundary_heat_flux/statistics
+++ b/tests/melt_boundary_heat_flux/statistics
@@ -1,0 +1,31 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Minimal value for composition porosity
+# 16: Maximal value for composition porosity
+# 17: Global mass for composition porosity
+# 18: Minimal value for composition peridotite
+# 19: Maximal value for composition peridotite
+# 20: Global mass for composition peridotite
+# 21: Visualization file name
+# 22: Minimal temperature (K)
+# 23: Average temperature (K)
+# 24: Maximal temperature (K)
+# 25: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 26: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 27: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 28: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 512 4851 2145 4290 2  0  0  0 20 23  815  1.43755635e-28 2.00000000e-01 1.25663632e+08  1.43755635e-28 2.00000000e-01 1.25663632e+08 output-melt_boundary_heat_flux/solution/solution-00000 1.60000000e+03 1.60000000e+03 1.60000000e+03 0.00000000e+00 0.00000000e+00 -2.00000000e+05 2.00000000e+05 
+1 3.443450186487e+03 3.443450186487e+03 512 4851 2145 4290 5 19 40 31 45 55 1993 -1.97927640e-06 1.98851293e-01 1.25663384e+08 -5.06312576e-10 1.99028023e-01 1.25646684e+08 output-melt_boundary_heat_flux/solution/solution-00001 1.56349861e+03 1.60000040e+03 1.63652496e+03 0.00000000e+00 0.00000000e+00 -2.00000000e+05 2.00000000e+05 
+2 5.000000000000e+03 1.556549813513e+03 512 4851 2145 4290 3 11 22 19 20 26  924 -3.22770043e-06 1.98577801e-01 1.25663236e+08 -7.95042218e-10 1.98902040e-01 1.25636401e+08 output-melt_boundary_heat_flux/solution/solution-00002 1.54757428e+03 1.60000064e+03 1.65246294e+03 0.00000000e+00 0.00000000e+00 -2.00000000e+05 2.00000000e+05 


### PR DESCRIPTION
This fixes a bug described on the forum (https://community.geodynamics.org/t/melt-production-migration/1498/6?u=jdannberg). 
Basically, the melt migration routine calls its own set_assemblers function, so it didn't include the assembler for the heat flux boundary conditions. 

I think the same fix will have to be done for the Newton assembly as well. @MFraters, this wouldn't cause any problems for the assembler, since it is only an assembler for the temperature equation, correct?

* [x ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

