### PR TITLE
refactor set_default_assemblers to fix the Newton solver for heatflow boundaries

### DIFF
--- a/doc/modules/changes/20201021_mfraters
+++ b/doc/modules/changes/20201021_mfraters
@@ -1,0 +1,4 @@
+Fix: Fixed heatflow boundaries for the Newton solver and refactor the
+code so it is more maintainable in the future.
+<br>
+(Menno Fraters, 2020/10/21)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1031,14 +1031,25 @@ namespace aspect
       /**
        * Determine, based on the run-time parameters of the current simulation,
        * which functions need to be called in order to assemble linear systems,
-       * matrices, and right hand side vectors. This function handles the
-       * default operation mode of ASPECT, i.e. without considering two-phase
-       * flow, or Newton solvers.
+       * matrices, and right hand side vectors for the advection. This function
+       * is used by both the default full Stokes solver and the Newton solvers,
+       * but not by the two-phase flow solver.
        *
        * This function is implemented in
        * <code>source/simulator/assembly.cc</code>.
        */
-      void set_default_assemblers ();
+      void set_advection_assemblers ();
+
+      /**
+       * Determine, based on the run-time parameters of the current simulation,
+       * which functions need to be called in order to assemble linear systems,
+       * matrices, and right hand side vectors for the default full Stokes solver
+       * i.e. without considering two-phase flow, or Newton solvers.
+       *
+       * This function is implemented in
+       * <code>source/simulator/assembly.cc</code>.
+       */
+      void set_stokes_assemblers ();
 
       /**
        * Initiate the assembly of the preconditioner for the Stokes system.

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -120,7 +120,7 @@ namespace aspect
   template <int dim>
   void
   Simulator<dim>::
-  set_default_assemblers()
+  set_stokes_assemblers()
   {
     assemblers->stokes_preconditioner.push_back(std_cxx14::make_unique<aspect::Assemblers::StokesPreconditioner<dim> >());
     assemblers->stokes_system.push_back(std_cxx14::make_unique<aspect::Assemblers::StokesIncompressibleTerms<dim> >());
@@ -189,6 +189,13 @@ namespace aspect
       assemblers->stokes_system.push_back(
         std_cxx14::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim> >());
 
+  }
+
+  template <int dim>
+  void
+  Simulator<dim>::
+  set_advection_assemblers()
+  {
     assemblers->advection_system.push_back(
       std_cxx14::make_unique<aspect::Assemblers::AdvectionSystem<dim> >());
 
@@ -257,7 +264,8 @@ namespace aspect
     if (!parameters.include_melt_transport
         && !assemble_newton_stokes_system)
       {
-        set_default_assemblers();
+        set_advection_assemblers();
+        set_stokes_assemblers();
       }
     else if (parameters.include_melt_transport
              && !assemble_newton_stokes_system)
@@ -267,6 +275,7 @@ namespace aspect
     else if (!parameters.include_melt_transport
              && assemble_newton_stokes_system)
       {
+        set_advection_assemblers();
         newton_handler->set_assemblers(*assemblers);
       }
     else if (parameters.include_melt_transport

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -99,34 +99,6 @@ namespace aspect
     if (this->pressure_rhs_needs_compatibility_modification())
       assemblers.stokes_system.push_back(
         std_cxx14::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim> >());
-
-    assemblers.advection_system.push_back(
-      std_cxx14::make_unique<aspect::Assemblers::AdvectionSystem<dim> >());
-
-    if (this->get_parameters().use_discontinuous_temperature_discretization ||
-        this->get_parameters().use_discontinuous_composition_discretization)
-      {
-        assemblers.advection_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim> >());
-
-        assemblers.advection_system_on_interior_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemInteriorFace<dim> >());
-      }
-
-    if (this->get_parameters().use_discontinuous_temperature_discretization)
-      {
-        assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
-        assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
-      }
-
-    if (this->get_parameters().use_discontinuous_composition_discretization)
-      {
-        for (unsigned int i = 1; i<=this->introspection().n_compositional_fields; ++i)
-          {
-            assemblers.advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;
-            assemblers.advection_system_assembler_on_face_properties[i].need_face_finite_element_evaluation = true;
-          }
-      }
   }
 
 


### PR DESCRIPTION
A slight refactoring of the code which should fix the problem with the heatflow boundaries and make it more future proof. 

followup to #3868. Fixes #3869.