### PR TITLE
Update dockerfile

### DIFF
--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -1,6 +1,10 @@
-FROM tjhei/dealii:v9.0.1-full-v9.0.1-r5-gcc5
+FROM tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
+
+# we need a newer version of cmake to support unity builds:
+RUN cd $HOME/libs && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
+ENV PATH $HOME/libs/cmake-3.17.3-Linux-x86_64/bin:$PATH
 
 # Build aspect, replace git checkout command to create image for release
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 

--- a/contrib/docker/docker/build.sh
+++ b/contrib/docker/docker/build.sh
@@ -7,4 +7,4 @@
 # Note: This container is build from the developer version on Github, it does not use
 # the local ASPECT folder. Therefore local changes are not included in the container.
 
-docker build -t geodynamics/aspect .
+docker build --no-cache -t geodynamics/aspect .


### PR DESCRIPTION
We had a user request for an updated docker image including the bugfix of #3868, so I updated our docker image on https://hub.docker.com/repository/docker/geodynamics/aspect. Since we changed the deal.II requirement that requires a new base image (the same we use for CI). Also make sure to always use the newest master instead of using local caches when rebuilding the image.