### PR TITLE
Unify postprocessor sceen output

### DIFF
--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -491,7 +491,7 @@ namespace aspect
       // up the next time we need output:
       set_last_output_time (this->get_time());
       last_output_timestep = this->get_timestep_number();
-      return std::pair<std::string, std::string> ("gravity computation file:", filename);
+      return std::pair<std::string, std::string> ("Writing gravity output:", filename);
     }
 
 

--- a/tests/gravity_point_values_list/screen-output
+++ b/tests/gravity_point_values_list/screen-output
@@ -5,7 +5,7 @@ Number of degrees of freedom: 628 (450+28+150)
 *** Timestep 0:  t=0 years, dt=0 years
 
    Postprocessing:
-     gravity computation file: output-gravity_point_values_list/output_gravity/gravity-00000
+     Writing gravity output: output-gravity_point_values_list/output_gravity/gravity-00000
 
 Termination requested by criterion: end time
 

--- a/tests/gravity_point_values_map/screen-output
+++ b/tests/gravity_point_values_map/screen-output
@@ -5,7 +5,7 @@ Number of degrees of freedom: 628 (450+28+150)
 *** Timestep 0:  t=0 years, dt=0 years
 
    Postprocessing:
-     gravity computation file: output-gravity_point_values_map/output_gravity/gravity-00000
+     Writing gravity output: output-gravity_point_values_map/output_gravity/gravity-00000
 
 Termination requested by criterion: end time
 

--- a/tests/gravity_point_values_spiral/screen-output
+++ b/tests/gravity_point_values_spiral/screen-output
@@ -5,7 +5,7 @@ Number of degrees of freedom: 628 (450+28+150)
 *** Timestep 0:  t=0 years, dt=0 years
 
    Postprocessing:
-     gravity computation file: output-gravity_point_values_spiral/output_gravity/gravity-00000
+     Writing gravity output: output-gravity_point_values_spiral/output_gravity/gravity-00000
 
 Termination requested by criterion: end time
 


### PR DESCRIPTION
Found while looking through #3850. This unifies the screen output of the gravity point values postprocessor with the visualization, depth average, and geoid postprocessor.