### PR TITLE
Make error messages more visible when compiling manual.tex.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -110,7 +110,11 @@ manual.pdf: manual/manual.tex manual/manual.bib manual/parameters.tex \
 		pdflatex --interaction=batchmode manual.tex    && \
 		pdflatex --interaction=batchmode manual.tex)   && \
 	   mv manual/manual.pdf . || \
-	   (echo "Error compiling manual.pdf, check manual/manual.log" && false); \
+	   (echo                                                      && \
+	    echo "    Error: There were errors compiling manual.tex." && \
+	    echo "           Check manual/manual.log for details"     && \
+	    echo                                                      && \
+	    false); \
          else \
 	  echo "------------------------------------------------------" ; \
 	  echo "Can't find either 'pdflatex', 'bibtex' or 'makeindex'." ; \


### PR DESCRIPTION
See the message today on the mailing list. With this change, the output becomes a lot more visible:
```
[...]
This is makeindex, version 2.15 [TeX Live 2017] (kpathsea + Thai support).
Scanning input file prmindex.idx......done (2025 entries accepted, 0 rejected).
Sorting entries....................done (25273 comparisons).
Generating output file prmindex.ind.....done (1151 lines written, 0 warnings).
Output written in prmindex.ind.
Transcript written in prmindex.ilg.
This is makeindex, version 2.15 [TeX Live 2017] (kpathsea + Thai support).
Scanning input file prmindexfull.idx......done (2025 entries accepted, 0 rejected).
Sorting entries...................done (23968 comparisons).
Generating output file prmindexfull.ind......done (1860 lines written, 0 warnings).
Output written in prmindexfull.ind.
Transcript written in prmindexfull.ilg.

    Error: There were errors compiling manual.pdf.
           Check manual/manual.log for details

Makefile:101: recipe for target 'manual.pdf' failed
make: *** [manual.pdf] Error 1
```