### PR TITLE
Refactor viscoelastic viscosity

### DIFF
--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -358,8 +358,8 @@ namespace aspect
       calculate_viscoelastic_viscosity (const double viscosity,
                                         const double elastic_shear_modulus) const
       {
-        const double dte = elastic_timestep();
-        return ( viscosity * dte ) / ( dte + ( viscosity / elastic_shear_modulus ) );
+        const double elastic_viscosity = elastic_shear_modulus*elastic_timestep();
+        return 1. / (1./elastic_viscosity + 1./viscosity);
       }
 
 


### PR DESCRIPTION
This PR ensures that the Elasticity<dim>:: calculate_viscoelastic_viscosity outputs the correct value even when the viscous viscosity is infinite.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).