### PR TITLE
add missing instantiation

### DIFF
--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -922,6 +922,16 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
+    namespace internal
+    {
+#define INSTANTIATE(dim) \
+  template class GPlatesLookup<dim>;
+
+      ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+    }
+
     ASPECT_REGISTER_BOUNDARY_VELOCITY_MODEL(GPlates,
                                             "gplates",
                                             "Implementation of a model in which the boundary "


### PR DESCRIPTION
internal::GPlatesLookup is used in boundary_velocity_residual_statistics
and clang correctly complains that we don't explicitly instantiate the
template class. Fix this.
