### PR TITLE
Prevent a warning in release mode of an unused variable in principle stress visualization

### DIFF
--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -96,9 +96,8 @@ namespace aspect
                             std::vector<Vector<double> > &computed_quantities) const
       {
         const unsigned int n_quadrature_points = input_data.solution_values.size();
-        const unsigned int n_output_components = dim*dim + dim;
         Assert (computed_quantities.size() == n_quadrature_points, ExcInternalError());
-        Assert (computed_quantities[0].size() == n_output_components, ExcInternalError());
+        Assert (computed_quantities[0].size() == dim*dim + dim, ExcInternalError());
         Assert (input_data.solution_values[0].size() == this->introspection().n_components,   ExcInternalError());
         Assert (input_data.solution_gradients[0].size() == this->introspection().n_components,  ExcInternalError());
 


### PR DESCRIPTION
Prevent a warning in release mode of an unused variable in principle stress visualization by removing the variable and using the computation directly in the assert.
