### PR TITLE
Rename strain rate variable

### DIFF
--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -444,7 +444,7 @@ namespace aspect
              :
              directed_strain_rate);
 
-          const SymmetricTensor<2,dim> compressible_strain_rate =
+          const SymmetricTensor<2,dim> deviatoric_strain_rate =
             (this->get_material_model().is_compressible()
              ?
              material_model_inputs.strain_rate[q]
@@ -452,7 +452,7 @@ namespace aspect
              :
              material_model_inputs.strain_rate[q]);
 
-          heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
+          heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
           // If dislocation viscosities and boundary area work fractions are provided, reduce the
           // overall heating by this amount (which is assumed to increase surface energy)

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -47,7 +47,7 @@ namespace aspect
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
-          const SymmetricTensor<2,dim> compressible_strain_rate =
+          const SymmetricTensor<2,dim> deviatoric_strain_rate =
             (this->get_material_model().is_compressible()
              ?
              material_model_inputs.strain_rate[q]
@@ -57,9 +57,9 @@ namespace aspect
 
           const SymmetricTensor<2,dim> stress =
             2 * material_model_outputs.viscosities[q] *
-            compressible_strain_rate;
+            deviatoric_strain_rate;
 
-          heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
+          heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
           // If dislocation viscosities and boundary area work fractions are provided, reduce the
           // overall heating by this amount (which is assumed to increase surface energy)

--- a/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
+++ b/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
@@ -56,7 +56,7 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -73,7 +73,7 @@ namespace aspect
             //
             // note that the *compressive* stress is simply the
             // negative stress
-            const SymmetricTensor<2,dim> compressive_stress = -2*eta*compressible_strain_rate;
+            const SymmetricTensor<2,dim> compressive_stress = -2*eta*deviatoric_strain_rate;
 
             // then find a set of (dim-1) horizontal, unit-length, mutually orthogonal vectors
             const Tensor<1,dim> gravity = this->get_gravity_model().gravity_vector (in.position[q]);

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -112,7 +112,7 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3. * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -122,7 +122,7 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            SymmetricTensor<2,dim> stress = -2. * eta * compressible_strain_rate + in.pressure[q] * unit_symmetric_tensor<dim>();
+            SymmetricTensor<2,dim> stress = -2. * eta * deviatoric_strain_rate + in.pressure[q] * unit_symmetric_tensor<dim>();
 
             // Add elastic stresses if existent
             if (this->get_parameters().enable_elasticity == true)

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -64,7 +64,7 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -74,7 +74,7 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            const SymmetricTensor<2,dim> shear_stress = -2.*eta*compressible_strain_rate;
+            const SymmetricTensor<2,dim> shear_stress = -2.*eta*deviatoric_strain_rate;
 
             for (unsigned int d=0; d<dim; ++d)
               for (unsigned int e=0; e<dim; ++e)

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -58,14 +58,14 @@ namespace aspect
               grad_u[d] = input_data.solution_gradients[q][d];
 
             const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
                  :
                  strain_rate);
-            computed_quantities[q](0) = std::sqrt(compressible_strain_rate *
-                                                  compressible_strain_rate);
+            computed_quantities[q](0) = std::sqrt(deviatoric_strain_rate *
+                                                  deviatoric_strain_rate);
           }
 
         // average the values if requested

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -57,7 +57,7 @@ namespace aspect
               grad_u[d] = input_data.solution_gradients[q][d];
 
             const SymmetricTensor<2,dim> strain_rate = symmetrize(grad_u);
-            const Tensor<2,dim> compressible_strain_rate
+            const Tensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -67,7 +67,7 @@ namespace aspect
             for (unsigned int d=0; d<dim; ++d)
               for (unsigned int e=0; e<dim; ++e)
                 computed_quantities[q][Tensor<2,dim>::component_to_unrolled_index(TableIndices<2>(d,e))]
-                  = compressible_strain_rate[d][e];
+                  = deviatoric_strain_rate[d][e];
           }
 
         const auto &viz = this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Visualization<dim> >();

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -64,7 +64,7 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -74,7 +74,7 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            const SymmetricTensor<2,dim> stress = -2.*eta*compressible_strain_rate +
+            const SymmetricTensor<2,dim> stress = -2.*eta*deviatoric_strain_rate +
                                                   in.pressure[q] * unit_symmetric_tensor<dim>();
             for (unsigned int d=0; d<dim; ++d)
               for (unsigned int e=0; e<dim; ++e)

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -54,7 +54,7 @@ namespace aspect
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {
             const SymmetricTensor<2,dim> strain_rate = in.strain_rate[q];
-            const SymmetricTensor<2,dim> compressible_strain_rate
+            const SymmetricTensor<2,dim> deviatoric_strain_rate
               = (this->get_material_model().is_compressible()
                  ?
                  strain_rate - 1./3 * trace(strain_rate) * unit_symmetric_tensor<dim>()
@@ -64,7 +64,7 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            const SymmetricTensor<2,dim> stress = -2.*eta*compressible_strain_rate +
+            const SymmetricTensor<2,dim> stress = -2.*eta*deviatoric_strain_rate +
                                                   in.pressure[q] * unit_symmetric_tensor<dim>();
             for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
               computed_quantities[q](i) = stress[stress.unrolled_to_component_indices(i)];

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -546,7 +546,7 @@ namespace aspect
              :
              directed_strain_rate);
 
-          const SymmetricTensor<2,dim> compressible_strain_rate =
+          const SymmetricTensor<2,dim> deviatoric_strain_rate =
             (this->get_material_model().is_compressible()
              ?
              material_model_inputs.strain_rate[q]
@@ -554,7 +554,7 @@ namespace aspect
              :
              material_model_inputs.strain_rate[q]);
 
-          heating_model_outputs.heating_source_terms[q] = stress * compressible_strain_rate;
+          heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
           // If dislocation viscosities and boundary area work fractions are provided, reduce the
           // overall heating by this amount (which is assumed to increase surface energy)


### PR DESCRIPTION
Following the discussion in #3897, the deviatoric strain rate is represented with a variable named `compressible_strain_rate` in multiple locations. This PR changes those variable names to `deviatoric_strain_rate`. @bobmyhill 

* [X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

