### PR TITLE
ViscoPlastic rheology migrated into separate rheology module

### DIFF
--- a/doc/modules/changes/20201130_bobmyhill
+++ b/doc/modules/changes/20201130_bobmyhill
@@ -1,6 +1,7 @@
-<li> New: ASPECT's ViscoPlastic rheology has been migrated from the
+New: ASPECT's ViscoPlastic rheology has been migrated from the
 ViscoPlastic material model into its own rheology module. It is therefore
 accessible by not only the ViscoPlastic material model, but by other
-user-generated material models without needing a large amount of code duplication.
+user-generated material models as well, without needing a large amount
+of code duplication.
 <br>
 (Bob Myhill, 2020/11/30)

--- a/doc/modules/changes/20201130_bobmyhill
+++ b/doc/modules/changes/20201130_bobmyhill
@@ -1,0 +1,6 @@
+<li> New: ASPECT's ViscoPlastic rheology has been migrated from the
+ViscoPlastic material model into its own rheology module. It is therefore
+accessible by not only the ViscoPlastic material model, but by other
+user-generated material models without needing a large amount of code duplication.
+<br>
+(Bob Myhill, 2020/11/30)

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -108,16 +108,38 @@ namespace aspect
                             const std::shared_ptr<std::vector<unsigned int>> &expected_n_phases_per_composition =
                               std::shared_ptr<std::vector<unsigned int>>());
 
-          double min_strain_rate;
-          double ref_strain_rate;
-          double min_visc;
-          double max_visc;
+
+
           double ref_visc;
+          double min_strain_rate;
 
           /**
            * Enumeration for selecting which viscosity averaging scheme to use.
            */
           MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
+
+
+          Rheology::StrainDependent<dim> strain_rheology;
+          /*
+           * Input parameters for the drucker prager plasticity.
+           */
+          Rheology::DruckerPragerParameters drucker_prager_parameters;
+          /**
+           * Object for computing viscoelastic viscosities and stresses.
+           */
+          Rheology::Elasticity<dim> elastic_rheology;
+
+          /**
+           * Whether to include viscoelasticity in the constitutive formulation.
+           */
+          bool use_elasticity;
+
+
+        private:
+
+          double ref_strain_rate;
+          double min_visc;
+          double max_visc;
 
           /**
            * Enumeration for selecting which type of viscous flow law to use.
@@ -154,8 +176,6 @@ namespace aspect
            */
           double adiabatic_temperature_gradient_for_viscosity;
 
-          Rheology::StrainDependent<dim> strain_rheology;
-
           /**
            * Objects for computing viscous creep viscosities.
            */
@@ -184,22 +204,6 @@ namespace aspect
            * Objects for computing plastic stresses, viscosities, and additional outputs
            */
           Rheology::DruckerPrager<dim> drucker_prager_plasticity;
-
-          /*
-           * Input parameters for the drucker prager plasticity.
-           */
-          Rheology::DruckerPragerParameters drucker_prager_parameters;
-          /**
-           * Object for computing viscoelastic viscosities and stresses.
-           */
-          Rheology::Elasticity<dim> elastic_rheology;
-
-          /**
-           * Whether to include viscoelasticity in the constitutive formulation.
-           */
-          bool use_elasticity;
-
-          //private:
 
       };
     }

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -1,0 +1,183 @@
+/*
+  Copyright (C) 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_rheology_visco_plastic_h
+#define _aspect_material_model_rheology_visco_plastic_h
+
+#include <aspect/global.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/material_model/utilities.h>
+#include <aspect/material_model/rheology/strain_dependent.h>
+#include <aspect/material_model/rheology/diffusion_creep.h>
+#include <aspect/material_model/rheology/dislocation_creep.h>
+#include <aspect/material_model/rheology/frank_kamenetskii.h>
+#include <aspect/material_model/rheology/peierls_creep.h>
+#include <aspect/material_model/rheology/constant_viscosity_prefactors.h>
+#include <aspect/material_model/rheology/drucker_prager.h>
+#include <aspect/material_model/rheology/elasticity.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    namespace Rheology
+    {
+
+      template <int dim>
+      class ViscoPlastic : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Constructor.
+           */
+          ViscoPlastic();
+
+          /**
+           * This function calculates viscosities assuming that all the compositional fields
+           * experience the same strain rate (isostrain).
+           */
+          std::pair<std::vector<double>, std::vector<bool> >
+          calculate_isostrain_viscosities ( const MaterialModel::MaterialModelInputs<dim> &in,
+                                            const unsigned int i,
+                                            const std::vector<double> &volume_fractions,
+                                            const std::vector<double> &phase_function_values = std::vector<double>(),
+                                            const std::vector<unsigned int> &n_phases_per_composition =
+                                              std::vector<unsigned int>()) const;
+
+          /**
+           * Declare the parameters this function takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and will be checked against the parsed
+           * parameters.
+           */
+          void
+          parse_parameters (ParameterHandler &prm,
+                            const std::shared_ptr<std::vector<unsigned int>> &expected_n_phases_per_composition =
+                              std::shared_ptr<std::vector<unsigned int>>());
+
+          double min_strain_rate;
+          double ref_strain_rate;
+          double min_visc;
+          double max_visc;
+          double ref_visc;
+
+          /**
+           * Enumeration for selecting which viscosity averaging scheme to use.
+           */
+          MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
+
+          /**
+           * Enumeration for selecting which type of viscous flow law to use.
+           * Select between diffusion, dislocation or composite.
+           */
+          enum ViscosityScheme
+          {
+            diffusion,
+            dislocation,
+            frank_kamenetskii,
+            composite
+          } viscous_flow_law;
+
+          /**
+           * Enumeration for selecting which type of yield mechanism to use.
+           * Select between Drucker Prager and stress limiter.
+           */
+          enum YieldScheme
+          {
+            stress_limiter,
+            drucker_prager
+          } yield_mechanism;
+
+          /**
+           * Whether to allow negative pressures to be used in the computation
+           * of plastic yield stresses and viscosities. If false, the minimum
+           * pressure in the plasticity formulation will be set to zero.
+           */
+          bool allow_negative_pressures_in_plasticity;
+          std::vector<double> exponents_stress_limiter;
+
+          /**
+           * temperature gradient added to temperature used in the flow law.
+           */
+          double adiabatic_temperature_gradient_for_viscosity;
+
+          Rheology::StrainDependent<dim> strain_rheology;
+
+          /**
+           * Objects for computing viscous creep viscosities.
+           */
+          Rheology::DiffusionCreep<dim> diffusion_creep;
+          Rheology::DislocationCreep<dim> dislocation_creep;
+          std::unique_ptr<Rheology::FrankKamenetskii<dim> > frank_kamenetskii_rheology;
+
+          /**
+           * Whether to include peierls creep in the constitutive formulation.
+           */
+          bool use_peierls_creep;
+
+          /**
+           * Objects for computing peierls creep viscosities.
+           */
+          std::unique_ptr<Rheology::PeierlsCreep<dim> > peierls_creep;
+
+          /**
+           * Object for computing the viscosity multiplied by a constant prefactor.
+           * This multiplication step is done just prior to calculating the effective
+           * viscoelastic viscosity or plastic viscosity.
+           */
+          Rheology::ConstantViscosityPrefactors<dim> constant_viscosity_prefactors;
+
+          /*
+           * Objects for computing plastic stresses, viscosities, and additional outputs
+           */
+          Rheology::DruckerPrager<dim> drucker_prager_plasticity;
+
+          /*
+           * Input parameters for the drucker prager plasticity.
+           */
+          Rheology::DruckerPragerParameters drucker_prager_parameters;
+          /**
+           * Object for computing viscoelastic viscosities and stresses.
+           */
+          Rheology::Elasticity<dim> elastic_rheology;
+
+          /**
+           * Whether to include viscoelasticity in the constitutive formulation.
+           */
+          bool use_elasticity;
+
+          //private:
+
+      };
+    }
+  }
+}
+#endif

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -114,7 +114,6 @@ namespace aspect
                                              const std::vector<unsigned int> &n_phases_per_composition =
                                                std::vector<unsigned int>()) const;
 
-
           /**
            * A function that returns a ComponentMask that represents all compositional
            * fields that should be considered 'volumetric', that is representing a
@@ -160,7 +159,14 @@ namespace aspect
                                      const MaterialModel::MaterialModelInputs<dim> &in,
                                      MaterialModel::MaterialModelOutputs<dim> &out) const;
 
+          /**
+           * Reference viscosity used by material models using this rheology.
+           */
           double ref_visc;
+
+          /**
+           * Minimum strain rate used to stabilize the strain dependent rheology.
+           */
           double min_strain_rate;
 
           /**
@@ -168,7 +174,9 @@ namespace aspect
            */
           MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
-
+          /**
+           * Object for computing the strain dependence of the rheology model.
+           */
           Rheology::StrainDependent<dim> strain_rheology;
 
           /**
@@ -183,13 +191,22 @@ namespace aspect
 
 
         private:
+
+          /**
+           * Reference strain rate for the first time step.
+           */
           double ref_strain_rate;
+
+          /**
+           * Minimum and maximum viscosities used to improve the
+           * stability of the rheology model.
+           */
           double min_visc;
           double max_visc;
 
           /**
            * Enumeration for selecting which type of viscous flow law to use.
-           * Select between diffusion, dislocation or composite.
+           * Select between diffusion, dislocation, frank_kamenetskii or composite.
            */
           enum ViscosityScheme
           {
@@ -215,10 +232,15 @@ namespace aspect
            * pressure in the plasticity formulation will be set to zero.
            */
           bool allow_negative_pressures_in_plasticity;
+
+          /**
+           * List of exponents controlling the behaviour of the stress limiter
+           * yielding mechanism.
+           */
           std::vector<double> exponents_stress_limiter;
 
           /**
-           * temperature gradient added to temperature used in the flow law.
+           * Temperature gradient added to temperature used in the flow law.
            */
           double adiabatic_temperature_gradient_for_viscosity;
 
@@ -230,12 +252,12 @@ namespace aspect
           std::unique_ptr<Rheology::FrankKamenetskii<dim> > frank_kamenetskii_rheology;
 
           /**
-           * Whether to include peierls creep in the constitutive formulation.
+           * Whether to include Peierls creep in the constitutive formulation.
            */
           bool use_peierls_creep;
 
           /**
-           * Objects for computing peierls creep viscosities.
+           * Object for computing Peierls creep viscosities.
            */
           std::unique_ptr<Rheology::PeierlsCreep<dim> > peierls_creep;
 
@@ -247,9 +269,10 @@ namespace aspect
           Rheology::ConstantViscosityPrefactors<dim> constant_viscosity_prefactors;
 
           /*
-           * Objects for computing plastic stresses, viscosities, and additional outputs
+           * Object for computing plastic stresses, viscosities, and additional outputs
            */
           Rheology::DruckerPrager<dim> drucker_prager_plasticity;
+
           /*
            * Input parameters for the drucker prager plasticity.
            */

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -34,6 +34,8 @@
 #include <aspect/material_model/rheology/elasticity.h>
 #include <aspect/simulator_access.h>
 
+#include<deal.II/fe/component_mask.h>
+
 namespace aspect
 {
   namespace MaterialModel
@@ -63,6 +65,29 @@ namespace aspect
                                             const std::vector<double> &phase_function_values = std::vector<double>(),
                                             const std::vector<unsigned int> &n_phases_per_composition =
                                               std::vector<unsigned int>()) const;
+
+          /**
+           * A function that fills the viscosity derivatives in the
+           * MaterialModelOutputs object that is handed over, if they exist.
+           * Does nothing otherwise.
+           */
+          void compute_viscosity_derivatives(const unsigned int point_index,
+                                             const std::vector<double> &volume_fractions,
+                                             const std::vector<double> &composition_viscosities,
+                                             const MaterialModel::MaterialModelInputs<dim> &in,
+                                             MaterialModel::MaterialModelOutputs<dim> &out,
+                                             const std::vector<double> &phase_function_values = std::vector<double>(),
+                                             const std::vector<unsigned int> &n_phases_per_composition =
+                                               std::vector<unsigned int>()) const;
+
+
+          /**
+           * A function that returns a ComponentMask that represents all compositional
+           * fields that should be considered 'volumetric', that is representing a
+           * physical proportion of the material, e.g. volume fraction of peridotite
+           * (as opposed to non-volumetric quantities like the amount of finite-strain).
+           */
+          ComponentMask get_volumetric_composition_mask() const;
 
           /**
            * Declare the parameters this function takes through input files.

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -165,7 +165,7 @@ namespace aspect
           double ref_visc;
 
           /**
-           * Minimum strain rate used to stabilize the strain dependent rheology.
+           * Minimum strain rate used to stabilize the strain rate dependent rheology.
            */
           double min_strain_rate;
 
@@ -193,7 +193,8 @@ namespace aspect
         private:
 
           /**
-           * Reference strain rate for the first time step.
+           * Reference strain rate for the first non-linear iteration
+           * in the first time step.
            */
           double ref_strain_rate;
 

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -279,31 +279,6 @@ namespace aspect
       private:
 
         /**
-        * For some reason enums need to be copied...
-        */
-        /**
-         * Enumeration for selecting which type of viscous flow law to use.
-         * Select between diffusion, dislocation or composite.
-         */
-        enum ViscosityScheme
-        {
-          diffusion,
-          dislocation,
-          frank_kamenetskii,
-          composite
-        } viscous_flow_law;
-
-        /**
-         * Enumeration for selecting which type of yield mechanism to use.
-         * Select between Drucker Prager and stress limiter.
-         */
-        enum YieldScheme
-        {
-          stress_limiter,
-          drucker_prager
-        } yield_mechanism;
-
-        /**
          * Object for computing viscosities.
          */
         std::unique_ptr<Rheology::ViscoPlastic<dim>> rheology;

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -35,40 +35,6 @@ namespace aspect
     using namespace dealii;
 
     /**
-     * Additional output fields for the plastic parameters weakened (or hardened)
-     * by strain to be added to the MaterialModel::MaterialModelOutputs structure
-     * and filled in the MaterialModel::Interface::evaluate() function.
-     */
-    template <int dim>
-    class PlasticAdditionalOutputs : public NamedAdditionalMaterialOutputs<dim>
-    {
-      public:
-        PlasticAdditionalOutputs(const unsigned int n_points);
-
-        std::vector<double> get_nth_output(const unsigned int idx) const override;
-
-        /**
-         * Cohesions at the evaluation points passed to
-         * the instance of MaterialModel::Interface::evaluate() that fills
-         * the current object.
-         */
-        std::vector<double> cohesions;
-
-        /**
-         * Internal angles of friction at the evaluation points passed to
-         * the instance of MaterialModel::Interface::evaluate() that fills
-         * the current object.
-         */
-        std::vector<double> friction_angles;
-
-        /**
-         * The area where the viscous stress exceeds the plastic yield stress,
-         * and viscosity is rescaled back to the yield envelope.
-         */
-        std::vector<double> yielding;
-    };
-
-    /**
      * A material model combining viscous and plastic deformation, with
      * the option to also include viscoelastic deformation.
      *
@@ -283,18 +249,10 @@ namespace aspect
 
         std::vector<double> thermal_conductivities;
 
-        EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
-
         /**
-         * A function that fills the plastic additional output in the
-         * MaterialModelOutputs object that is handed over, if it exists.
-         * Does nothing otherwise.
+         * Object for computing the equation of state
          */
-        void fill_plastic_outputs (const unsigned int point_index,
-                                   const std::vector<double> &volume_fractions,
-                                   const bool plastic_yielding,
-                                   const MaterialModel::MaterialModelInputs<dim> &in,
-                                   MaterialModel::MaterialModelOutputs<dim> &out) const;
+        EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
 
         /**
          * Object that handles phase transitions.

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -331,27 +331,6 @@ namespace aspect
                                    MaterialModel::MaterialModelOutputs<dim> &out) const;
 
         /**
-         * A function that fills the viscosity derivatives in the
-         * MaterialModelOutputs object that is handed over, if they exist.
-         * Does nothing otherwise.
-         */
-        void compute_viscosity_derivatives(const unsigned int point_index,
-                                           const std::vector<double> &volume_fractions,
-                                           const std::vector<double> &composition_viscosities,
-                                           const MaterialModel::MaterialModelInputs<dim> &in,
-                                           MaterialModel::MaterialModelOutputs<dim> &out,
-                                           const std::vector<double> &phase_function_values = std::vector<double>()) const;
-
-
-        /**
-         * A function that returns a ComponentMask that represents all compositional
-         * fields that should be considered 'volumetric', that is representing a
-         * physical proportion of the material, e.g. volume fraction of peridotite
-         * (as opposed to non-volumetric quantities like the amount of finite-strain).
-         */
-        ComponentMask get_volumetric_composition_mask() const;
-
-        /**
          * Object that handles phase transitions.
          */
         MaterialUtilities::PhaseFunction<dim> phase_function;

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -192,8 +192,8 @@ namespace aspect
          * context, compressibility means whether we should solve the continuity
          * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
          * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
-        *
-        * This material model is incompressible.
+         *
+         * This material model is incompressible.
          */
         bool is_compressible () const override;
 
@@ -236,7 +236,15 @@ namespace aspect
       private:
 
         /**
-         * Object for computing viscosities.
+         * Pointer to the object used to compute the rheological properties.
+         * In this case, the rheology in question is visco(elasto)plastic. The
+         * object contains functions for parameter declaration and parsing,
+         * and further functions that calculate viscosity and viscosity
+         * derivatives. It also contains functions that creates and fills
+         * additional material model outputs, specifically plastic outputs.
+         * The rheology itself is a composite rheology, and so the object
+         * contains further objects and/or pointers to objects that provide
+         * functions and parameters for all subordinate rheologies.
          */
         std::unique_ptr<Rheology::ViscoPlastic<dim>> rheology;
 
@@ -250,7 +258,7 @@ namespace aspect
         std::vector<double> thermal_conductivities;
 
         /**
-         * Object for computing the equation of state
+         * Object for computing the equation of state.
          */
         EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
 

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -240,7 +240,7 @@ namespace aspect
          * In this case, the rheology in question is visco(elasto)plastic. The
          * object contains functions for parameter declaration and parsing,
          * and further functions that calculate viscosity and viscosity
-         * derivatives. It also contains functions that creates and fills
+         * derivatives. It also contains functions that create and fill
          * additional material model outputs, specifically plastic outputs.
          * The rheology itself is a composite rheology, and so the object
          * contains further objects and/or pointers to objects that provide

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -21,19 +21,10 @@
 #ifndef _aspect_material_model_visco_plastic_h
 #define _aspect_material_model_visco_plastic_h
 
+#include <aspect/simulator_access.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/equation_of_state/multicomponent_incompressible.h>
-#include <aspect/simulator_access.h>
 #include <aspect/material_model/rheology/visco_plastic.h>
-
-#include <aspect/material_model/rheology/strain_dependent.h>
-#include <aspect/material_model/rheology/diffusion_creep.h>
-#include <aspect/material_model/rheology/dislocation_creep.h>
-#include <aspect/material_model/rheology/frank_kamenetskii.h>
-#include <aspect/material_model/rheology/peierls_creep.h>
-#include <aspect/material_model/rheology/constant_viscosity_prefactors.h>
-#include <aspect/material_model/rheology/drucker_prager.h>
-#include <aspect/material_model/rheology/elasticity.h>
 
 #include<deal.II/fe/component_mask.h>
 

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -18,7 +18,6 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
 #include <aspect/material_model/rheology/visco_plastic.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
@@ -28,8 +27,6 @@
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/fe/fe_values.h>
-#include <deal.II/base/signaling_nan.h>
-
 
 namespace aspect
 {

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -1,0 +1,486 @@
+/*
+  Copyright (C) 2020 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/material_model/rheology/visco_plastic.h>
+#include <aspect/material_model/utilities.h>
+#include <aspect/utilities.h>
+
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/parameter_handler.h>
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace Rheology
+    {
+
+      template <int dim>
+      ViscoPlastic<dim>::ViscoPlastic ()
+      {}
+
+
+
+      template <int dim>
+      std::pair<std::vector<double>, std::vector<bool> >
+      ViscoPlastic<dim>::
+      calculate_isostrain_viscosities (const MaterialModel::MaterialModelInputs<dim> &in,
+                                       const unsigned int i,
+                                       const std::vector<double> &volume_fractions,
+                                       const std::vector<double> &phase_function_values,
+                                       const std::vector<unsigned int> &n_phases_per_composition) const
+      {
+
+        // Initialize or fill variables used to calculate viscosities
+        std::vector<bool> composition_yielding(volume_fractions.size(), false);
+        std::vector<double> composition_viscosities(volume_fractions.size(), numbers::signaling_nan<double>());
+
+        // Assemble stress tensor if elastic behavior is enabled
+        SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
+        if (use_elasticity == true)
+          {
+            for (unsigned int j=0; j < SymmetricTensor<2,dim>::n_independent_components; ++j)
+              stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(j)] = in.composition[i][j];
+          }
+
+        // The first time this function is called (first iteration of first time step)
+        // a specified "reference" strain rate is used as the returned value would
+        // otherwise be zero.
+        const bool use_reference_strainrate = (this->get_timestep_number() == 0) &&
+                                              (in.strain_rate[i].norm() <= std::numeric_limits<double>::min());
+
+        double edot_ii;
+        if (use_reference_strainrate)
+          edot_ii = ref_strain_rate;
+        else
+          // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
+          edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),
+                             min_strain_rate);
+
+        // Calculate viscosities for each of the individual compositional phases
+        for (unsigned int j=0; j < volume_fractions.size(); ++j)
+          {
+            // Step 1: viscous behavior
+
+            // Choice of activation volume depends on whether there is an adiabatic temperature
+            // gradient used when calculating the viscosity. This allows the same activation volume
+            // to be used in incompressible and compressible models.
+            const double temperature_for_viscosity = in.temperature[i] + adiabatic_temperature_gradient_for_viscosity*in.pressure[i];
+            AssertThrow(temperature_for_viscosity != 0, ExcMessage(
+                          "The temperature used in the calculation of the visco-plastic rheology is zero. "
+                          "This is not allowed, because this value is used to divide through. It is probably "
+                          "being caused by the temperature being zero somewhere in the model. The relevant "
+                          "values for debugging are: temperature (" + Utilities::to_string(in.temperature[i]) +
+                          "), adiabatic_temperature_gradient_for_viscosity ("
+                          + Utilities::to_string(adiabatic_temperature_gradient_for_viscosity) + ") and pressure ("
+                          + Utilities::to_string(in.pressure[i]) + ")."));
+
+            // Step 1a: compute viscosity from diffusion creep law
+            const double viscosity_diffusion = diffusion_creep.compute_viscosity(in.pressure[i], temperature_for_viscosity, j,
+                                                                                 phase_function_values,
+                                                                                 n_phases_per_composition);
+
+            // Step 1b: compute viscosity from dislocation creep law
+            const double viscosity_dislocation = dislocation_creep.compute_viscosity(edot_ii, in.pressure[i], temperature_for_viscosity, j,
+                                                                                     phase_function_values,
+                                                                                     n_phases_per_composition);
+
+            // Step 1c: select what form of viscosity to use (diffusion, dislocation, fk, or composite)
+            double viscosity_pre_yield = 0.0;
+            switch (viscous_flow_law)
+              {
+                case diffusion:
+                {
+                  viscosity_pre_yield = viscosity_diffusion;
+                  break;
+                }
+                case dislocation:
+                {
+                  viscosity_pre_yield = viscosity_dislocation;
+                  break;
+                }
+                case frank_kamenetskii:
+                {
+                  viscosity_pre_yield = frank_kamenetskii_rheology->compute_viscosity(in.temperature[i], j);
+                  break;
+                }
+                case composite:
+                {
+                  viscosity_pre_yield = (viscosity_diffusion * viscosity_dislocation)/
+                                        (viscosity_diffusion + viscosity_dislocation);
+                  break;
+                }
+                default:
+                {
+                  AssertThrow(false, ExcNotImplemented());
+                  break;
+                }
+              }
+
+            // Step 1d: compute viscosity from Peierls creep law and harmonically average with current viscosities
+            if (use_peierls_creep)
+              {
+                const double viscosity_peierls = peierls_creep->compute_viscosity(edot_ii, in.pressure[i], temperature_for_viscosity, j,
+                                                                                  phase_function_values,
+                                                                                  n_phases_per_composition);
+                viscosity_pre_yield = (viscosity_pre_yield * viscosity_peierls) / (viscosity_pre_yield + viscosity_peierls);
+              }
+
+            // Step 1e: multiply the viscosity by a constant (default value is 1)
+            viscosity_pre_yield = constant_viscosity_prefactors.compute_viscosity(viscosity_pre_yield, j);
+
+            // Step 2: calculate the viscous stress magnitude
+            // and strain rate. If requested compute visco-elastic contributions.
+            double current_edot_ii = edot_ii;
+
+            if (use_elasticity)
+              {
+                const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
+
+                if (use_reference_strainrate == true)
+                  current_edot_ii = ref_strain_rate;
+                else
+                  {
+                    const double viscoelastic_strain_rate_invariant = elastic_rheology.calculate_viscoelastic_strain_rate(in.strain_rate[i],
+                                                                      stress_old,
+                                                                      elastic_shear_moduli[j]);
+
+                    current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
+                                               min_strain_rate);
+                  }
+
+                // Step 2a: calculate viscoelastic (effective) viscosity
+                viscosity_pre_yield = elastic_rheology.calculate_viscoelastic_viscosity(viscosity_pre_yield,
+                                                                                        elastic_shear_moduli[j]);
+              }
+
+            // Step 2b: calculate current (viscous or viscous + elastic) stress magnitude
+            const double current_stress = 2. * viscosity_pre_yield * current_edot_ii;
+
+            // Step 3: strain weakening
+
+            // Step 3a: calculate strain weakening factors for the cohesion, friction, and pre-yield viscosity
+            // If no brittle and/or viscous strain weakening is applied, the factors are 1.
+            const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
+
+            // Step 3b: calculate weakened friction, cohesion, and pre-yield viscosity
+            const double current_cohesion = drucker_prager_parameters.cohesions[j] * weakening_factors[0];
+            const double current_friction = drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1];
+            viscosity_pre_yield *= weakening_factors[2];
+
+            // Step 4: plastic yielding
+
+            // Determine if the pressure used in Drucker Prager plasticity will be capped at 0 (default).
+            // This may be necessary in models without gravity and the dynamic stresses are much higher
+            // than the lithostatic pressure.
+
+            double pressure_for_plasticity = in.pressure[i];
+            if (allow_negative_pressures_in_plasticity == false)
+              pressure_for_plasticity = std::max(in.pressure[i],0.0);
+
+
+            // Step 4a: calculate Drucker-Prager yield stress
+            const double yield_stress = drucker_prager_plasticity.compute_yield_stress(current_cohesion,
+                                                                                       current_friction,
+                                                                                       pressure_for_plasticity,
+                                                                                       drucker_prager_parameters.max_yield_stress);
+
+            // Step 4b: select if yield viscosity is based on Drucker Prager or stress limiter rheology
+            double viscosity_yield = viscosity_pre_yield;
+            switch (yield_mechanism)
+              {
+                case stress_limiter:
+                {
+                  //Step 4b-1: always rescale the viscosity back to the yield surface
+                  const double viscosity_limiter = yield_stress / (2.0 * ref_strain_rate)
+                                                   * std::pow((edot_ii/ref_strain_rate),
+                                                              1./exponents_stress_limiter[j] - 1.0);
+                  viscosity_yield = 1. / ( 1./viscosity_limiter + 1./viscosity_pre_yield);
+                  break;
+                }
+                case drucker_prager:
+                {
+                  // Step 4b-2: if the current stress is greater than the yield stress,
+                  // rescale the viscosity back to yield surface
+                  if (current_stress >= yield_stress)
+                    {
+                      viscosity_yield = drucker_prager_plasticity.compute_viscosity(current_cohesion,
+                                                                                    current_friction,
+                                                                                    pressure_for_plasticity,
+                                                                                    current_edot_ii,
+                                                                                    drucker_prager_parameters.max_yield_stress,
+                                                                                    viscosity_pre_yield);
+                      composition_yielding[j] = true;
+                    }
+                  break;
+                }
+                default:
+                {
+                  AssertThrow(false, ExcNotImplemented());
+                  break;
+                }
+              }
+
+            // Step 5: limit the viscosity with specified minimum and maximum bounds
+            composition_viscosities[j] = std::min(std::max(viscosity_yield, min_visc), max_visc);
+          }
+        return std::make_pair (composition_viscosities, composition_yielding);
+      }
+
+
+
+      template <int dim>
+      void
+      ViscoPlastic<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        Rheology::StrainDependent<dim>::declare_parameters (prm);
+
+        Rheology::Elasticity<dim>::declare_parameters (prm);
+
+        // Reference and minimum/maximum values
+        prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double (0.),
+                           "Stabilizes strain dependent viscosity. Units: \\si{\\per\\second}.");
+        prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double (0.),
+                           "Reference strain rate for first time step. Units: \\si{\\per\\second}.");
+        prm.declare_entry ("Minimum viscosity", "1e17", Patterns::Double (0.),
+                           "Lower cutoff for effective viscosity. Units: \\si{\\pascal\\second}.");
+        prm.declare_entry ("Maximum viscosity", "1e28", Patterns::Double (0.),
+                           "Upper cutoff for effective viscosity. Units: \\si{\\pascal\\second}.");
+        prm.declare_entry ("Reference viscosity", "1e22", Patterns::Double (0.),
+                           "Reference viscosity for nondimensionalization. "
+                           "To understand how pressure scaling works, take a look at "
+                           "\\cite{KHB12}. In particular, the value of this parameter "
+                           "would not affect the solution computed by \\aspect{} if "
+                           "we could do arithmetic exactly; however, computers do "
+                           "arithmetic in finite precision, and consequently we need to "
+                           "scale quantities in ways so that their magnitudes are "
+                           "roughly the same. As explained in \\cite{KHB12}, we scale "
+                           "the pressure during some computations (never visible by "
+                           "users) by a factor that involves a reference viscosity. This "
+                           "parameter describes this reference viscosity."
+                           "\n\n"
+                           "For problems with a constant viscosity, you will generally want "
+                           "to choose the reference viscosity equal to the actual viscosity. "
+                           "For problems with a variable viscosity, the reference viscosity "
+                           "should be a value that adequately represents the order of "
+                           "magnitude of the viscosities that appear, such as an average "
+                           "value or the value one would use to compute a Rayleigh number."
+                           "\n\n"
+                           "Units: \\si{\\pascal\\second}.");
+
+        // Rheological parameters
+        prm.declare_entry ("Viscosity averaging scheme", "harmonic",
+                           Patterns::Selection("arithmetic|harmonic|geometric|maximum composition"),
+                           "When more than one compositional field is present at a point "
+                           "with different viscosities, we need to come up with an average "
+                           "viscosity at that point.  Select a weighted harmonic, arithmetic, "
+                           "geometric, or maximum composition.");
+        prm.declare_entry ("Viscous flow law", "composite",
+                           Patterns::Selection("diffusion|dislocation|frank kamenetskii|composite"),
+                           "Select what type of viscosity law to use between diffusion, "
+                           "dislocation, frank kamenetskii, and composite options. Soon there will be an option "
+                           "to select a specific flow law for each assigned composition ");
+        prm.declare_entry ("Yield mechanism", "drucker",
+                           Patterns::Selection("drucker|limiter"),
+                           "Select what type of yield mechanism to use between Drucker Prager "
+                           "and stress limiter options.");
+        prm.declare_entry ("Allow negative pressures in plasticity", "false",
+                           Patterns::Bool (),
+                           "Whether to allow negative pressures to be used in the computation "
+                           "of plastic yield stresses and viscosities. Setting this parameter "
+                           "to true may be advantageous in models without gravity where the "
+                           "dynamic stresses are much higher than the lithostatic pressure. "
+                           "If false, the minimum pressure in the plasticity formulation will "
+                           "be set to zero.");
+
+        // Diffusion creep parameters
+        Rheology::DiffusionCreep<dim>::declare_parameters(prm);
+
+        // Dislocation creep parameters
+        Rheology::DislocationCreep<dim>::declare_parameters(prm);
+
+        // Frank-Kamenetskii viscosity parameters
+        Rheology::FrankKamenetskii<dim>::declare_parameters(prm);
+
+        // Peierls creep parameters
+        Rheology::PeierlsCreep<dim>::declare_parameters(prm);
+
+        prm.declare_entry ("Include Peierls creep", "false",
+                           Patterns::Bool (),
+                           "Whether to include Peierls creep in the rheological formulation.");
+
+        // Constant viscosity prefactor parameters
+        Rheology::ConstantViscosityPrefactors<dim>::declare_parameters(prm);
+
+        // Drucker Prager plasticity parameters
+        Rheology::DruckerPrager<dim>::declare_parameters(prm);
+
+        // Stress limiter parameters
+        prm.declare_entry ("Stress limiter exponents", "1.0",
+                           Patterns::List(Patterns::Double (0.)),
+                           "List of stress limiter exponents, $n_{\\text{lim}}$, "
+                           "for background material and compositional fields, "
+                           "for a total of N+1 values, where N is the number of compositional fields. "
+                           "Units: none.");
+
+        // Temperature in viscosity laws to include an adiabat (note units of K/Pa)
+        prm.declare_entry ("Adiabat temperature gradient for viscosity", "0.0", Patterns::Double (0.),
+                           "Add an adiabatic temperature gradient to the temperature used in the flow law "
+                           "so that the activation volume is consistent with what one would use in a "
+                           "earth-like (compressible) model. Default is set so this is off. "
+                           "Note that this is a linear approximation of the real adiabatic gradient, which "
+                           "is okay for the upper mantle, but is not really accurate for the lower mantle. "
+                           "Using a pressure gradient of 32436 Pa/m, then a value of "
+                           "0.3 K/km = 0.0003 K/m = 9.24e-09 K/Pa gives an earth-like adiabat."
+                           "Units: \\si{\\kelvin\\per\\pascal}.");
+
+        prm.declare_entry ("Include viscoelasticity", "false",
+                           Patterns::Bool (),
+                           "Whether to include elastic effects in the rheological formulation.");
+      }
+
+
+
+      template <int dim>
+      void
+      ViscoPlastic<dim>::parse_parameters (ParameterHandler &prm,
+                                           const std::shared_ptr<std::vector<unsigned int>> &expected_n_phases_per_composition)
+      {
+
+        // increment by one for background:
+        const unsigned int n_fields = this->n_compositional_fields() + 1;
+
+        strain_rheology.initialize_simulator (this->get_simulator());
+        strain_rheology.parse_parameters(prm);
+
+        use_elasticity = prm.get_bool ("Include viscoelasticity");
+
+        if (use_elasticity)
+          {
+            elastic_rheology.initialize_simulator (this->get_simulator());
+            elastic_rheology.parse_parameters(prm);
+          }
+
+        // Reference and minimum/maximum values
+        min_strain_rate = prm.get_double("Minimum strain rate");
+        ref_strain_rate = prm.get_double("Reference strain rate");
+        min_visc = prm.get_double ("Minimum viscosity");
+        max_visc = prm.get_double ("Maximum viscosity");
+        ref_visc = prm.get_double ("Reference viscosity");
+
+        viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
+                              prm);
+
+        // Rheological parameters
+        if (prm.get ("Viscous flow law") == "composite")
+          viscous_flow_law = composite;
+        else if (prm.get ("Viscous flow law") == "diffusion")
+          viscous_flow_law = diffusion;
+        else if (prm.get ("Viscous flow law") == "dislocation")
+          viscous_flow_law = dislocation;
+        else if (prm.get ("Viscous flow law") == "frank kamenetskii")
+          viscous_flow_law = frank_kamenetskii;
+        else
+          AssertThrow(false, ExcMessage("Not a valid viscous flow law"));
+
+        // Rheological parameters
+        if (prm.get ("Yield mechanism") == "drucker")
+          yield_mechanism = drucker_prager;
+        else if (prm.get ("Yield mechanism") == "limiter")
+          yield_mechanism = stress_limiter;
+        else
+          AssertThrow(false, ExcMessage("Not a valid yield mechanism."));
+
+        AssertThrow(use_elasticity == false || yield_mechanism == drucker_prager,
+                    ExcMessage("Elastic behavior is only tested with the "
+                               "'drucker prager' plasticity option."));
+
+        allow_negative_pressures_in_plasticity = prm.get_bool ("Allow negative pressures in plasticity");
+
+        // Rheological parameters
+        // Diffusion creep parameters
+        diffusion_creep.initialize_simulator (this->get_simulator());
+        diffusion_creep.parse_parameters(prm, expected_n_phases_per_composition);
+
+        // Dislocation creep parameters
+        dislocation_creep.initialize_simulator (this->get_simulator());
+        dislocation_creep.parse_parameters(prm, expected_n_phases_per_composition);
+
+        // Frank Kamenetskii viscosity parameters
+        if (viscous_flow_law == frank_kamenetskii)
+          {
+            frank_kamenetskii_rheology = std_cxx14::make_unique<Rheology::FrankKamenetskii<dim>>();
+            frank_kamenetskii_rheology->initialize_simulator (this->get_simulator());
+            frank_kamenetskii_rheology->parse_parameters(prm);
+          }
+
+        // Peierls creep parameters
+        use_peierls_creep = prm.get_bool ("Include Peierls creep");
+        if (use_peierls_creep)
+          {
+            peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
+            peierls_creep->initialize_simulator (this->get_simulator());
+            peierls_creep->parse_parameters(prm);
+          }
+
+        // Constant viscosity prefactor parameters
+        constant_viscosity_prefactors.initialize_simulator (this->get_simulator());
+        constant_viscosity_prefactors.parse_parameters(prm);
+
+        // Plasticity parameters
+        drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(this->n_compositional_fields()+1,
+                                                                               prm);
+
+        // Stress limiter parameter
+        exponents_stress_limiter  = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Stress limiter exponents"))),
+                                                                            n_fields,
+                                                                            "Stress limiter exponents");
+
+        // Include an adiabat temperature gradient in flow laws
+        adiabatic_temperature_gradient_for_viscosity = prm.get_double("Adiabat temperature gradient for viscosity");
+        if (this->get_heating_model_manager().adiabatic_heating_enabled())
+          AssertThrow (adiabatic_temperature_gradient_for_viscosity == 0.0,
+                       ExcMessage("If adiabatic heating is enabled you should not add another adiabatic gradient"
+                                  "to the temperature for computing the viscosity, because the ambient"
+                                  "temperature profile already includes the adiabatic gradient."));
+
+      }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+#define INSTANTIATE(dim) \
+  namespace Rheology \
+  { \
+    template class ViscoPlastic<dim>; \
+  }
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+  }
+}

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -248,7 +248,6 @@ namespace aspect
             if (allow_negative_pressures_in_plasticity == false)
               pressure_for_plasticity = std::max(in.pressure[i],0.0);
 
-
             // Step 4a: calculate Drucker-Prager yield stress
             const double yield_stress = drucker_prager_plasticity.compute_yield_stress(current_cohesion,
                                                                                        current_friction,
@@ -398,7 +397,6 @@ namespace aspect
             if (viscosity_averaging == MaterialUtilities::maximum_composition)
               viscosity_averaging_p = 1000;
 
-
             derivatives->viscosity_derivative_wrt_strain_rate[i] =
               Utilities::derivative_of_weighted_p_norm_average(out.viscosities[i],
                                                                volume_fractions,
@@ -529,7 +527,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of compositional fields. "
                            "Units: none.");
 
-        // Temperature in viscosity laws to include an adiabat (note units of K/Pa)
+        // Temperature gradient in viscosity laws to include an adiabat (note units of K/Pa)
         prm.declare_entry ("Adiabat temperature gradient for viscosity", "0.0", Patterns::Double (0.),
                            "Add an adiabatic temperature gradient to the temperature used in the flow law "
                            "so that the activation volume is consistent with what one would use in a "
@@ -589,7 +587,6 @@ namespace aspect
         else
           AssertThrow(false, ExcMessage("Not a valid viscous flow law"));
 
-        // Rheological parameters
         if (prm.get ("Yield mechanism") == "drucker")
           yield_mechanism = drucker_prager;
         else if (prm.get ("Yield mechanism") == "limiter")
@@ -603,7 +600,6 @@ namespace aspect
 
         allow_negative_pressures_in_plasticity = prm.get_bool ("Allow negative pressures in plasticity");
 
-        // Rheological parameters
         // Diffusion creep parameters
         diffusion_creep.initialize_simulator (this->get_simulator());
         diffusion_creep.parse_parameters(prm, expected_n_phases_per_composition);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -67,7 +67,7 @@ namespace aspect
       const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(composition, get_volumetric_composition_mask());
 
       const std::pair<std::vector<double>, std::vector<bool> > calculate_viscosities =
-        calculate_isostrain_viscosities(in, i, volume_fractions, viscous_flow_law, yield_mechanism);
+        rheology->calculate_isostrain_viscosities(in, i, volume_fractions);
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(),volume_fractions.end());
       plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(),max_composition)];
@@ -126,8 +126,7 @@ namespace aspect
        */
 
       const std::pair<std::vector<double>, std::vector<bool>> calculate_viscosities =
-                                                             calculate_isostrain_viscosities(in, 0, volume_fractions, viscous_flow_law,
-                                                                 yield_mechanism, phase_function_values);
+                                                             rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
       const bool plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(), max_composition)];
@@ -172,213 +171,6 @@ namespace aspect
 
 
     template <int dim>
-    std::pair<std::vector<double>, std::vector<bool> >
-    ViscoPlastic<dim>::
-    calculate_isostrain_viscosities (const MaterialModel::MaterialModelInputs<dim> &in,
-                                     const unsigned int i,
-                                     const std::vector<double> &volume_fractions,
-                                     const ViscosityScheme &viscous_type,
-                                     const YieldScheme &yield_type,
-                                     const std::vector<double> &phase_function_values) const
-    {
-      // Initialize or fill variables used to calculate viscosities
-      std::vector<bool> composition_yielding(volume_fractions.size(), false);
-      std::vector<double> composition_viscosities(volume_fractions.size(), numbers::signaling_nan<double>());
-
-      // Assemble stress tensor if elastic behavior is enabled
-      SymmetricTensor<2,dim> stress_old = numbers::signaling_nan<SymmetricTensor<2,dim>>();
-      if (use_elasticity == true)
-        {
-          for (unsigned int j=0; j < SymmetricTensor<2,dim>::n_independent_components; ++j)
-            stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(j)] = in.composition[i][j];
-        }
-
-      // The first time this function is called (first iteration of first time step)
-      // a specified "reference" strain rate is used as the returned value would
-      // otherwise be zero.
-      const bool use_reference_strainrate = (this->get_timestep_number() == 0) &&
-                                            (in.strain_rate[i].norm() <= std::numeric_limits<double>::min());
-
-      double edot_ii;
-      if (use_reference_strainrate)
-        edot_ii = ref_strain_rate;
-      else
-        // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
-        edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),
-                           min_strain_rate);
-
-      // Calculate viscosities for each of the individual compositional phases
-      for (unsigned int j=0; j < volume_fractions.size(); ++j)
-        {
-          // Step 1: viscous behavior
-
-          // Choice of activation volume depends on whether there is an adiabatic temperature
-          // gradient used when calculating the viscosity. This allows the same activation volume
-          // to be used in incompressible and compressible models.
-          const double temperature_for_viscosity = in.temperature[i] + adiabatic_temperature_gradient_for_viscosity*in.pressure[i];
-          AssertThrow(temperature_for_viscosity != 0, ExcMessage(
-                        "The temperature used in the calculation of the visco-plastic rheology is zero. "
-                        "This is not allowed, because this value is used to divide through. It is probably "
-                        "being caused by the temperature being zero somewhere in the model. The relevant "
-                        "values for debugging are: temperature (" + Utilities::to_string(in.temperature[i]) +
-                        "), adiabatic_temperature_gradient_for_viscosity ("
-                        + Utilities::to_string(adiabatic_temperature_gradient_for_viscosity) + ") and pressure ("
-                        + Utilities::to_string(in.pressure[i]) + ")."));
-
-          // Step 1a: compute viscosity from diffusion creep law
-          const double viscosity_diffusion = diffusion_creep.compute_viscosity(in.pressure[i], temperature_for_viscosity, j,
-                                                                               phase_function_values,
-                                                                               phase_function.n_phase_transitions_for_each_composition());
-
-          // Step 1b: compute viscosity from dislocation creep law
-          const double viscosity_dislocation = dislocation_creep.compute_viscosity(edot_ii, in.pressure[i], temperature_for_viscosity, j,
-                                                                                   phase_function_values,
-                                                                                   phase_function.n_phase_transitions_for_each_composition());
-
-          // Step 1c: select what form of viscosity to use (diffusion, dislocation, fk, or composite)
-          double viscosity_pre_yield = 0.0;
-          switch (viscous_type)
-            {
-              case diffusion:
-              {
-                viscosity_pre_yield = viscosity_diffusion;
-                break;
-              }
-              case dislocation:
-              {
-                viscosity_pre_yield = viscosity_dislocation;
-                break;
-              }
-              case frank_kamenetskii:
-              {
-                viscosity_pre_yield = frank_kamenetskii_rheology->compute_viscosity(in.temperature[i], j);
-                break;
-              }
-              case composite:
-              {
-                viscosity_pre_yield = (viscosity_diffusion * viscosity_dislocation)/
-                                      (viscosity_diffusion + viscosity_dislocation);
-                break;
-              }
-              default:
-              {
-                AssertThrow(false, ExcNotImplemented());
-                break;
-              }
-            }
-
-          // Step 1d: compute viscosity from Peierls creep law and harmonically average with current viscosities
-          if (use_peierls_creep)
-            {
-              const double viscosity_peierls = peierls_creep->compute_viscosity(edot_ii, in.pressure[i], temperature_for_viscosity, j,
-                                                                                phase_function_values,
-                                                                                phase_function.n_phase_transitions_for_each_composition());
-              viscosity_pre_yield = (viscosity_pre_yield * viscosity_peierls) / (viscosity_pre_yield + viscosity_peierls);
-            }
-
-          // Step 1e: multiply the viscosity by a constant (default value is 1)
-          viscosity_pre_yield = constant_viscosity_prefactors.compute_viscosity(viscosity_pre_yield, j);
-
-          // Step 2: calculate the viscous stress magnitude
-          // and strain rate. If requested compute visco-elastic contributions.
-          double current_edot_ii = edot_ii;
-
-          if (use_elasticity)
-            {
-              const std::vector<double> &elastic_shear_moduli = elastic_rheology.get_elastic_shear_moduli();
-
-              if (use_reference_strainrate == true)
-                current_edot_ii = ref_strain_rate;
-              else
-                {
-                  const double viscoelastic_strain_rate_invariant = elastic_rheology.calculate_viscoelastic_strain_rate(in.strain_rate[i],
-                                                                    stress_old,
-                                                                    elastic_shear_moduli[j]);
-
-                  current_edot_ii = std::max(viscoelastic_strain_rate_invariant,
-                                             min_strain_rate);
-                }
-
-              // Step 2a: calculate viscoelastic (effective) viscosity
-              viscosity_pre_yield = elastic_rheology.calculate_viscoelastic_viscosity(viscosity_pre_yield,
-                                                                                      elastic_shear_moduli[j]);
-            }
-
-          // Step 2b: calculate current (viscous or viscous + elastic) stress magnitude
-          const double current_stress = 2. * viscosity_pre_yield * current_edot_ii;
-
-          // Step 3: strain weakening
-
-          // Step 3a: calculate strain weakening factors for the cohesion, friction, and pre-yield viscosity
-          // If no brittle and/or viscous strain weakening is applied, the factors are 1.
-          const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
-
-          // Step 3b: calculate weakened friction, cohesion, and pre-yield viscosity
-          const double current_cohesion = drucker_prager_parameters.cohesions[j] * weakening_factors[0];
-          const double current_friction = drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1];
-          viscosity_pre_yield *= weakening_factors[2];
-
-          // Step 4: plastic yielding
-
-          // Determine if the pressure used in Drucker Prager plasticity will be capped at 0 (default).
-          // This may be necessary in models without gravity and the dynamic stresses are much higher
-          // than the lithostatic pressure.
-
-          double pressure_for_plasticity = in.pressure[i];
-          if (allow_negative_pressures_in_plasticity == false)
-            pressure_for_plasticity = std::max(in.pressure[i],0.0);
-
-
-          // Step 4a: calculate Drucker-Prager yield stress
-          const double yield_stress = drucker_prager_plasticity.compute_yield_stress(current_cohesion,
-                                                                                     current_friction,
-                                                                                     pressure_for_plasticity,
-                                                                                     drucker_prager_parameters.max_yield_stress);
-
-          // Step 4b: select if yield viscosity is based on Drucker Prager or stress limiter rheology
-          double viscosity_yield = viscosity_pre_yield;
-          switch (yield_type)
-            {
-              case stress_limiter:
-              {
-                //Step 4b-1: always rescale the viscosity back to the yield surface
-                const double viscosity_limiter = yield_stress / (2.0 * ref_strain_rate)
-                                                 * std::pow((edot_ii/ref_strain_rate),
-                                                            1./exponents_stress_limiter[j] - 1.0);
-                viscosity_yield = 1. / ( 1./viscosity_limiter + 1./viscosity_pre_yield);
-                break;
-              }
-              case drucker_prager:
-              {
-                // Step 4b-2: if the current stress is greater than the yield stress,
-                // rescale the viscosity back to yield surface
-                if (current_stress >= yield_stress)
-                  {
-                    viscosity_yield = drucker_prager_plasticity.compute_viscosity(current_cohesion,
-                                                                                  current_friction,
-                                                                                  pressure_for_plasticity,
-                                                                                  current_edot_ii,
-                                                                                  drucker_prager_parameters.max_yield_stress,
-                                                                                  viscosity_pre_yield);
-                    composition_yielding[j] = true;
-                  }
-                break;
-              }
-              default:
-              {
-                AssertThrow(false, ExcNotImplemented());
-                break;
-              }
-            }
-
-          // Step 5: limit the viscosity with specified minimum and maximum bounds
-          composition_viscosities[j] = std::min(std::max(viscosity_yield, min_visc), max_visc);
-        }
-      return std::make_pair (composition_viscosities, composition_yielding);
-    }
-
-
-    template <int dim>
     void
     ViscoPlastic<dim>::
     fill_plastic_outputs(const unsigned int i,
@@ -399,10 +191,10 @@ namespace aspect
           for (unsigned int j=0; j < volume_fractions.size(); ++j)
             {
               // Calculate the strain weakening factors and weakened values
-              const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
-              plastic_out->cohesions[i]   += volume_fractions[j] * (drucker_prager_parameters.cohesions[j] * weakening_factors[0]);
+              const std::array<double, 3> weakening_factors = rheology->strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
+              plastic_out->cohesions[i]   += volume_fractions[j] * (rheology->drucker_prager_parameters.cohesions[j] * weakening_factors[0]);
               // Also convert radians to degrees
-              plastic_out->friction_angles[i] += 180.0/numbers::PI * volume_fractions[j] * (drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1]);
+              plastic_out->friction_angles[i] += 180.0/numbers::PI * volume_fractions[j] * (rheology->drucker_prager_parameters.angles_internal_friction[j] * weakening_factors[1]);
             }
         }
     }
@@ -442,7 +234,7 @@ namespace aspect
               // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
               // derivative
               const SymmetricTensor<2,dim> strain_rate_difference = in.strain_rate[i]
-                                                                    + std::max(std::fabs(in.strain_rate[i][strain_rate_indices]), min_strain_rate)
+                                                                    + std::max(std::fabs(in.strain_rate[i][strain_rate_indices]), rheology->min_strain_rate)
                                                                     * (component > dim-1 ? 0.5 : 1 )
                                                                     * finite_difference_accuracy
                                                                     * Utilities::nth_basis_for_symmetric_tensors<dim>(component);
@@ -450,9 +242,8 @@ namespace aspect
               in_derivatives.strain_rate[i] = strain_rate_difference;
 
               std::vector<double> eta_component =
-                calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                                viscous_flow_law, yield_mechanism,
-                                                phase_function_values).first;
+                rheology->calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
+                                                          phase_function_values, phase_function.n_phase_transitions_for_each_composition()).first;
 
               // For each composition of the independent component, compute the derivative.
               for (unsigned int composition_index = 0; composition_index < eta_component.size(); ++composition_index)
@@ -462,7 +253,7 @@ namespace aspect
                   if (viscosity_derivative != 0)
                     {
                       // when the difference is non-zero, divide by the difference.
-                      viscosity_derivative /= std::max(std::fabs(strain_rate_difference[strain_rate_indices]), min_strain_rate)
+                      viscosity_derivative /= std::max(std::fabs(strain_rate_difference[strain_rate_indices]), rheology->min_strain_rate)
                                               * finite_difference_accuracy;
                     }
                   composition_viscosities_derivatives[composition_index][strain_rate_indices] = viscosity_derivative;
@@ -480,9 +271,8 @@ namespace aspect
           in_derivatives.strain_rate[i] = in.strain_rate[i];
 
           const std::vector<double> viscosity_difference =
-            calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                            viscous_flow_law, yield_mechanism,
-                                            phase_function_values).first;
+            rheology->calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
+                                                      phase_function_values, phase_function.n_phase_transitions_for_each_composition()).first;
 
           for (unsigned int composition_index = 0; composition_index < viscosity_difference.size(); ++composition_index)
             {
@@ -502,11 +292,11 @@ namespace aspect
             }
 
           double viscosity_averaging_p = 0; // Geometric
-          if (viscosity_averaging == MaterialUtilities::harmonic)
+          if (rheology->viscosity_averaging == MaterialUtilities::harmonic)
             viscosity_averaging_p = -1;
-          if (viscosity_averaging == MaterialUtilities::arithmetic)
+          if (rheology->viscosity_averaging == MaterialUtilities::arithmetic)
             viscosity_averaging_p = 1;
-          if (viscosity_averaging == MaterialUtilities::maximum_composition)
+          if (rheology->viscosity_averaging == MaterialUtilities::maximum_composition)
             viscosity_averaging_p = 1000;
 
 
@@ -532,9 +322,9 @@ namespace aspect
     get_volumetric_composition_mask() const
     {
       // Store which components to exclude during the volume fraction computation.
-      ComponentMask composition_mask = strain_rheology.get_strain_composition_mask();
+      ComponentMask composition_mask = rheology->strain_rheology.get_strain_composition_mask();
 
-      if (use_elasticity)
+      if (rheology->use_elasticity)
         {
           for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
             composition_mask.set(i,false);
@@ -644,14 +434,13 @@ namespace aspect
               // TODO: This is only consistent with viscosity averaging if the arithmetic averaging
               // scheme is chosen. It would be useful to have a function to calculate isostress viscosities.
               const std::pair<std::vector<double>, std::vector<bool> > calculate_viscosities =
-                calculate_isostrain_viscosities(in, i, volume_fractions, viscous_flow_law,
-                                                yield_mechanism, phase_function_values);
+                rheology->calculate_isostrain_viscosities(in, i, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
               // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
               // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
               // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
               // of compositional field viscosities is consistent with any averaging scheme.
-              out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, calculate_viscosities.first, viscosity_averaging);
+              out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, calculate_viscosities.first, rheology->viscosity_averaging);
 
               // Decide based on the maximum composition if material is yielding.
               // This avoids for example division by zero for harmonic averaging (as plastic_yielding
@@ -671,17 +460,17 @@ namespace aspect
             out.reaction_terms[i][c] = 0.0;
 
           // Calculate changes in strain invariants and update the reaction terms
-          strain_rheology.fill_reaction_outputs(in, i, min_strain_rate, plastic_yielding, out);
+          rheology->strain_rheology.fill_reaction_outputs(in, i, rheology->min_strain_rate, plastic_yielding, out);
 
           // Fill plastic outputs if they exist.
           fill_plastic_outputs(i,volume_fractions,plastic_yielding,in,out);
 
-          if (use_elasticity)
+          if (rheology->use_elasticity)
             {
               // Compute average elastic shear modulus
               average_elastic_shear_moduli[i] = MaterialUtilities::average_value(volume_fractions,
-                                                                                 elastic_rheology.get_elastic_shear_moduli(),
-                                                                                 viscosity_averaging);
+                                                                                 rheology->elastic_rheology.get_elastic_shear_moduli(),
+                                                                                 rheology->viscosity_averaging);
 
               // Fill the material properties that are part of the elastic additional outputs
               if (ElasticAdditionalOutputs<dim> *elastic_out = out.template get_additional_output<ElasticAdditionalOutputs<dim> >())
@@ -692,12 +481,12 @@ namespace aspect
         }
 
       // If we use the full strain tensor, compute the change in the individual tensor components.
-      strain_rheology.compute_finite_strain_reaction_terms(in, out);
+      rheology->strain_rheology.compute_finite_strain_reaction_terms(in, out);
 
-      if (use_elasticity)
+      if (rheology->use_elasticity)
         {
-          elastic_rheology.fill_elastic_force_outputs(in, average_elastic_shear_moduli, out);
-          elastic_rheology.fill_reaction_outputs(in, average_elastic_shear_moduli, out);
+          rheology->elastic_rheology.fill_elastic_force_outputs(in, average_elastic_shear_moduli, out);
+          rheology->elastic_rheology.fill_reaction_outputs(in, average_elastic_shear_moduli, out);
         }
     }
 
@@ -706,7 +495,7 @@ namespace aspect
     ViscoPlastic<dim>::
     reference_viscosity () const
     {
-      return ref_visc;
+      return rheology->ref_visc;
     }
 
     template <int dim>
@@ -721,7 +510,7 @@ namespace aspect
     double ViscoPlastic<dim>::
     get_min_strain_rate () const
     {
-      return min_strain_rate;
+      return rheology->min_strain_rate;
     }
 
     template <int dim>
@@ -736,40 +525,7 @@ namespace aspect
 
           EquationOfState::MulticomponentIncompressible<dim>::declare_parameters (prm);
 
-          Rheology::StrainDependent<dim>::declare_parameters (prm);
-
-          Rheology::Elasticity<dim>::declare_parameters (prm);
-
-          // Reference and minimum/maximum values
-          prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double (0.),
-                             "Stabilizes strain dependent viscosity. Units: \\si{\\per\\second}.");
-          prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double (0.),
-                             "Reference strain rate for first time step. Units: \\si{\\per\\second}.");
-          prm.declare_entry ("Minimum viscosity", "1e17", Patterns::Double (0.),
-                             "Lower cutoff for effective viscosity. Units: \\si{\\pascal\\second}.");
-          prm.declare_entry ("Maximum viscosity", "1e28", Patterns::Double (0.),
-                             "Upper cutoff for effective viscosity. Units: \\si{\\pascal\\second}.");
-          prm.declare_entry ("Reference viscosity", "1e22", Patterns::Double (0.),
-                             "Reference viscosity for nondimensionalization. "
-                             "To understand how pressure scaling works, take a look at "
-                             "\\cite{KHB12}. In particular, the value of this parameter "
-                             "would not affect the solution computed by \\aspect{} if "
-                             "we could do arithmetic exactly; however, computers do "
-                             "arithmetic in finite precision, and consequently we need to "
-                             "scale quantities in ways so that their magnitudes are "
-                             "roughly the same. As explained in \\cite{KHB12}, we scale "
-                             "the pressure during some computations (never visible by "
-                             "users) by a factor that involves a reference viscosity. This "
-                             "parameter describes this reference viscosity."
-                             "\n\n"
-                             "For problems with a constant viscosity, you will generally want "
-                             "to choose the reference viscosity equal to the actual viscosity. "
-                             "For problems with a variable viscosity, the reference viscosity "
-                             "should be a value that adequately represents the order of "
-                             "magnitude of the viscosities that appear, such as an average "
-                             "value or the value one would use to compute a Rayleigh number."
-                             "\n\n"
-                             "Units: \\si{\\pascal\\second}.");
+          Rheology::ViscoPlastic<dim>::declare_parameters(prm);
 
           // Equation of state parameters
           prm.declare_entry ("Thermal diffusivities", "0.8e-6",
@@ -789,76 +545,6 @@ namespace aspect
                              "for a total of N+1 values, where N is the number of compositional fields. "
                              "If only one value is given, then all use the same value. "
                              "Units: \\si{\\watt\\per\\meter\\per\\kelvin}.");
-
-          // Rheological parameters
-          prm.declare_entry ("Viscosity averaging scheme", "harmonic",
-                             Patterns::Selection("arithmetic|harmonic|geometric|maximum composition"),
-                             "When more than one compositional field is present at a point "
-                             "with different viscosities, we need to come up with an average "
-                             "viscosity at that point.  Select a weighted harmonic, arithmetic, "
-                             "geometric, or maximum composition.");
-          prm.declare_entry ("Viscous flow law", "composite",
-                             Patterns::Selection("diffusion|dislocation|frank kamenetskii|composite"),
-                             "Select what type of viscosity law to use between diffusion, "
-                             "dislocation, frank kamenetskii, and composite options. Soon there will be an option "
-                             "to select a specific flow law for each assigned composition ");
-          prm.declare_entry ("Yield mechanism", "drucker",
-                             Patterns::Selection("drucker|limiter"),
-                             "Select what type of yield mechanism to use between Drucker Prager "
-                             "and stress limiter options.");
-          prm.declare_entry ("Allow negative pressures in plasticity", "false",
-                             Patterns::Bool (),
-                             "Whether to allow negative pressures to be used in the computation "
-                             "of plastic yield stresses and viscosities. Setting this parameter "
-                             "to true may be advantageous in models without gravity where the "
-                             "dynamic stresses are much higher than the lithostatic pressure. "
-                             "If false, the minimum pressure in the plasticity formulation will "
-                             "be set to zero.");
-
-          // Diffusion creep parameters
-          Rheology::DiffusionCreep<dim>::declare_parameters(prm);
-
-          // Dislocation creep parameters
-          Rheology::DislocationCreep<dim>::declare_parameters(prm);
-
-          // Frank-Kamenetskii viscosity parameters
-          Rheology::FrankKamenetskii<dim>::declare_parameters(prm);
-
-          // Peierls creep parameters
-          Rheology::PeierlsCreep<dim>::declare_parameters(prm);
-
-          prm.declare_entry ("Include Peierls creep", "false",
-                             Patterns::Bool (),
-                             "Whether to include Peierls creep in the rheological formulation.");
-
-          // Constant viscosity prefactor parameters
-          Rheology::ConstantViscosityPrefactors<dim>::declare_parameters(prm);
-
-          // Drucker Prager plasticity parameters
-          Rheology::DruckerPrager<dim>::declare_parameters(prm);
-
-          // Stress limiter parameters
-          prm.declare_entry ("Stress limiter exponents", "1.0",
-                             Patterns::List(Patterns::Double (0.)),
-                             "List of stress limiter exponents, $n_{\\text{lim}}$, "
-                             "for background material and compositional fields, "
-                             "for a total of N+1 values, where N is the number of compositional fields. "
-                             "Units: none.");
-
-          // Temperature in viscosity laws to include an adiabat (note units of K/Pa)
-          prm.declare_entry ("Adiabat temperature gradient for viscosity", "0.0", Patterns::Double (0.),
-                             "Add an adiabatic temperature gradient to the temperature used in the flow law "
-                             "so that the activation volume is consistent with what one would use in a "
-                             "earth-like (compressible) model. Default is set so this is off. "
-                             "Note that this is a linear approximation of the real adiabatic gradient, which "
-                             "is okay for the upper mantle, but is not really accurate for the lower mantle. "
-                             "Using a pressure gradient of 32436 Pa/m, then a value of "
-                             "0.3 K/km = 0.0003 K/m = 9.24e-09 K/Pa gives an earth-like adiabat."
-                             "Units: \\si{\\kelvin\\per\\pascal}.");
-
-          prm.declare_entry ("Include viscoelasticity", "false",
-                             Patterns::Bool (),
-                             "Whether to include elastic effects in the rheological formulation.");
         }
         prm.leave_subsection();
       }
@@ -895,23 +581,6 @@ namespace aspect
           equation_of_state.parse_parameters (prm,
                                               std::make_shared<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
 
-          strain_rheology.initialize_simulator (this->get_simulator());
-          strain_rheology.parse_parameters(prm);
-
-          use_elasticity = prm.get_bool ("Include viscoelasticity");
-
-          if (use_elasticity)
-            {
-              elastic_rheology.initialize_simulator (this->get_simulator());
-              elastic_rheology.parse_parameters(prm);
-            }
-
-          // Reference and minimum/maximum values
-          min_strain_rate = prm.get_double("Minimum strain rate");
-          ref_strain_rate = prm.get_double("Reference strain rate");
-          min_visc = prm.get_double ("Minimum viscosity");
-          max_visc = prm.get_double ("Maximum viscosity");
-          ref_visc = prm.get_double ("Reference viscosity");
 
           thermal_diffusivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal diffusivities"))),
                                                                           n_fields,
@@ -923,83 +592,9 @@ namespace aspect
                                                                            n_fields,
                                                                            "Thermal conductivities");
 
-
-          viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
-                                prm);
-
-          // Rheological parameters
-          if (prm.get ("Viscous flow law") == "composite")
-            viscous_flow_law = composite;
-          else if (prm.get ("Viscous flow law") == "diffusion")
-            viscous_flow_law = diffusion;
-          else if (prm.get ("Viscous flow law") == "dislocation")
-            viscous_flow_law = dislocation;
-          else if (prm.get ("Viscous flow law") == "frank kamenetskii")
-            viscous_flow_law = frank_kamenetskii;
-          else
-            AssertThrow(false, ExcMessage("Not a valid viscous flow law"));
-
-          // Rheological parameters
-          if (prm.get ("Yield mechanism") == "drucker")
-            yield_mechanism = drucker_prager;
-          else if (prm.get ("Yield mechanism") == "limiter")
-            yield_mechanism = stress_limiter;
-          else
-            AssertThrow(false, ExcMessage("Not a valid yield mechanism."));
-
-          AssertThrow(use_elasticity == false || yield_mechanism == drucker_prager,
-                      ExcMessage("Elastic behavior is only tested with the "
-                                 "'drucker prager' plasticity option."));
-
-          allow_negative_pressures_in_plasticity = prm.get_bool ("Allow negative pressures in plasticity");
-
-          // Rheological parameters
-          // Diffusion creep parameters
-          diffusion_creep.initialize_simulator (this->get_simulator());
-          diffusion_creep.parse_parameters(prm, std::make_shared<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
-
-          // Dislocation creep parameters
-          dislocation_creep.initialize_simulator (this->get_simulator());
-          dislocation_creep.parse_parameters(prm, std::make_shared<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
-
-          // Frank Kamenetskii viscosity parameters
-          if (viscous_flow_law == frank_kamenetskii)
-            {
-              frank_kamenetskii_rheology = std_cxx14::make_unique<Rheology::FrankKamenetskii<dim>>();
-              frank_kamenetskii_rheology->initialize_simulator (this->get_simulator());
-              frank_kamenetskii_rheology->parse_parameters(prm);
-            }
-
-          // Peierls creep parameters
-          use_peierls_creep = prm.get_bool ("Include Peierls creep");
-          if (use_peierls_creep)
-            {
-              peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
-              peierls_creep->initialize_simulator (this->get_simulator());
-              peierls_creep->parse_parameters(prm);
-            }
-
-          // Constant viscosity prefactor parameters
-          constant_viscosity_prefactors.initialize_simulator (this->get_simulator());
-          constant_viscosity_prefactors.parse_parameters(prm);
-
-          // Plasticity parameters
-          drucker_prager_parameters = drucker_prager_plasticity.parse_parameters(this->n_compositional_fields()+1,
-                                                                                 prm);
-
-          // Stress limiter parameter
-          exponents_stress_limiter  = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Stress limiter exponents"))),
-                                                                              n_fields,
-                                                                              "Stress limiter exponents");
-
-          // Include an adiabat temperature gradient in flow laws
-          adiabatic_temperature_gradient_for_viscosity = prm.get_double("Adiabat temperature gradient for viscosity");
-          if (this->get_heating_model_manager().adiabatic_heating_enabled())
-            AssertThrow (adiabatic_temperature_gradient_for_viscosity == 0.0,
-                         ExcMessage("If adiabatic heating is enabled you should not add another adiabatic gradient"
-                                    "to the temperature for computing the viscosity, because the ambient"
-                                    "temperature profile already includes the adiabatic gradient."));
-
+          rheology = std_cxx14::make_unique<Rheology::ViscoPlastic<dim>>();
+          rheology->initialize_simulator (this->get_simulator());
+          rheology->parse_parameters(prm, std::make_shared<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
 
         }
         prm.leave_subsection();
@@ -1024,8 +619,8 @@ namespace aspect
           out.additional_outputs.push_back(
             std_cxx14::make_unique<MaterialModel::PlasticAdditionalOutputs<dim>> (n_points));
         }
-      if (use_elasticity)
-        elastic_rheology.create_elastic_outputs(out);
+      if (rheology->use_elasticity)
+        rheology->elastic_rheology.create_elastic_outputs(out);
     }
 
   }


### PR DESCRIPTION
This PR splits the rheological parts of the ViscoPlastic material model into a new Rheology model.
The intention is to make it easier for users to use the viscoplastic rheology in their own material models while using a different equation of state. 

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
