### PR TITLE
Simpler material model: remove reference_T

### DIFF
--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -76,7 +76,6 @@ namespace aspect
          */
 
       private:
-        double reference_T;
         double k_value;
 
         Rheology::ConstantViscosity constant_rheology;

--- a/source/material_model/simpler.cc
+++ b/source/material_model/simpler.cc
@@ -80,10 +80,6 @@ namespace aspect
         {
           EquationOfState::LinearizedIncompressible<dim>::declare_parameters (prm);
 
-          prm.declare_entry ("Reference temperature", "293.",
-                             Patterns::Double (0.),
-                             "The reference temperature $T_0$. The reference temperature is used "
-                             "in the density formula. Units: \\si{\\kelvin}.");
           prm.declare_entry ("Thermal conductivity", "4.7",
                              Patterns::Double (0.),
                              "The value of the thermal conductivity $k$. "
@@ -107,7 +103,6 @@ namespace aspect
         {
           equation_of_state.parse_parameters (prm);
 
-          reference_T                = prm.get_double ("Reference temperature");
           k_value                    = prm.get_double ("Thermal conductivity");
 
           constant_rheology.parse_parameters(prm);


### PR DESCRIPTION
The member "reference temperature" is unused inside Simpler (but it is
declared and used in the EquationOfState::LinearizedIncompressible EoS).
This means this change should be backwards-compatible.

