### PR TITLE
Fix changelog

### DIFF
--- a/doc/modules/changes/20200706_tjhei
+++ b/doc/modules/changes/20200706_tjhei
@@ -1,4 +1,4 @@
-<li> New: We now support the CMake option ASPECT_UNITY_BUILD (ON by default)
+New: We now support the CMake option ASPECT_UNITY_BUILD (ON by default)
 and a rewritten ASPECT_PRECOMPILE_HEADERS option (ON by default) if you use
 CMake 3.16 or newer. Both options combined can speed up compilation by more
 than 3x.

--- a/doc/modules/changes/20200727_tjhei
+++ b/doc/modules/changes/20200727_tjhei
@@ -1,3 +1,3 @@
-<li> New: ASPECT can now optionally link to the NetCDF library.
+New: ASPECT can now optionally link to the NetCDF library.
 <br>
 (Timo Heister, 2020/07/27)

--- a/doc/modules/changes/20200801_tjhei
+++ b/doc/modules/changes/20200801_tjhei
@@ -1,3 +1,3 @@
-<li> New: ASPECT now requires deal.II 9.2.0 or newer.
+New: ASPECT now requires deal.II 9.2.0 or newer.
 <br>
 (Timo Heister, 2020/08/01)

--- a/doc/modules/changes/20200802_tjhei
+++ b/doc/modules/changes/20200802_tjhei
@@ -1,4 +1,4 @@
-<li> New: Additional compiler flags can be set using the CMake variable
+New: Additional compiler flags can be set using the CMake variable
 ASPECT_ADDITIONAL_CXX_FLAGS.
 <br>
 (Timo Heister, 2020/08/02)

--- a/doc/modules/changes/20200803Bangerth
+++ b/doc/modules/changes/20200803Bangerth
@@ -1,4 +1,4 @@
-<li> New: ASPECT now supports the creation of visualization
+New: ASPECT now supports the creation of visualization
 postprocessors that only output data on the surface of a model. An
 example is the "surface stress" visualization postprocessor.
 <br>

--- a/doc/modules/changes/20200804_gassmoeller
+++ b/doc/modules/changes/20200804_gassmoeller
@@ -1,4 +1,4 @@
-<li> New: There is now a signal called post_nonlinear_solver that is triggered
+New: There is now a signal called post_nonlinear_solver that is triggered
 after the nonlinear solver has finished in a timestep and can be used to query
 information like the number of nonlinear iterations, the initial and final
 nonlinear residuals, and whether the solver succeeded.

--- a/doc/modules/changes/20200805_jdannberg
+++ b/doc/modules/changes/20200805_jdannberg
@@ -1,4 +1,4 @@
-<li> Fixed: The latent heat and latent heat melt material models now 
+Fixed: The latent heat and latent heat melt material models now 
 use the adiabatic temperature as the reference temperature for the 
 viscosity if adiabatic heating is switched on (and hence, the 
 geotherm is an adiabat rather than a constant temperature). 

--- a/doc/modules/changes/20200807_erinheilman
+++ b/doc/modules/changes/20200807_erinheilman
@@ -1,4 +1,4 @@
-<li> New: Added new rheology module, namespace MaterialModel::Rheology::FrankKamenetskii.
+New: Added new rheology module, namespace MaterialModel::Rheology::FrankKamenetskii.
 This new rheology computes the temperature dependent Frank Kamenetskii viscosity approximation.
 <br>
 (Erin Heilman, 2020/08/07)

--- a/doc/modules/changes/20200807_jdannberg
+++ b/doc/modules/changes/20200807_jdannberg
@@ -1,4 +1,4 @@
-<li> Fixed: The Newton solver schemes now correctly postprocess
+Fixed: The Newton solver schemes now correctly postprocess
 nonlinear iterations.
 <br>
 (Juliane Dannberg, 2020/08/07)

--- a/doc/modules/changes/20200810_jaustermann
+++ b/doc/modules/changes/20200810_jaustermann
@@ -1,3 +1,3 @@
-<li> New: The gravity model 'function' does now evaluate the time at each timestep and the function expression can therefore now be time dependent. 
+New: The gravity model 'function' does now evaluate the time at each timestep and the function expression can therefore now be time dependent. 
 <br>
 (Jacky Austermann, 2020/08/10)

--- a/doc/modules/changes/20200810_naliboff
+++ b/doc/modules/changes/20200810_naliboff
@@ -1,4 +1,4 @@
-<li> New: A rheology module for Peierls creep has been added
+New: A rheology module for Peierls creep has been added
 (namespace MaterialModel::Rheology::PeierlsCreep). This module 
 is used to define parameters for Peierls creep and compute an approximate
 viscosity, which is integrated in the visco_plastic material model.

--- a/doc/modules/changes/20200812_erinheilman
+++ b/doc/modules/changes/20200812_erinheilman
@@ -1,4 +1,4 @@
-<li> New: Added calculation for temperature-dependent strain healing in the strain 
+New: Added calculation for temperature-dependent strain healing in the strain 
 dependent rheology module.
 <br>
 (Erin Heilman, 2020/08/12)

--- a/doc/modules/changes/20200812_gassmoeller
+++ b/doc/modules/changes/20200812_gassmoeller
@@ -1,4 +1,4 @@
-<li> New: The 'mesh deformation' plugins can now prescribe an initial
+New: The 'mesh deformation' plugins can now prescribe an initial
 deformation to the mesh that acts as a starting point for deformations during
 the model run. This can be used to prescribe an initial topography and will
 replace the less general 'initial topography' plugin system in a future

--- a/doc/modules/changes/20200812_naliboff
+++ b/doc/modules/changes/20200812_naliboff
@@ -1,4 +1,4 @@
-<li> New: Added a new particle property (ElasticStress) to store and advect
+New: Added a new particle property (ElasticStress) to store and advect
 elastic stresses. This particle property allows replacing compositional fields
 with particles in any model using viscoelasticity.
 <br>

--- a/doc/modules/changes/20200812_tjhei
+++ b/doc/modules/changes/20200812_tjhei
@@ -1,4 +1,4 @@
-<li> Improved: Data loading in AsciiDataLookup has been refactored to be more
+Improved: Data loading in AsciiDataLookup has been refactored to be more
 robust (errors in incorrect coordinate values are now being reported when
 detected) and data can be set directly without going through a text file by
 calling reinit() directly. This adds the possibility for other file formats in

--- a/doc/modules/changes/20200814_bobmyhill
+++ b/doc/modules/changes/20200814_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: The PerpleX Lookup module can now accept phase volume
+New: The PerpleX Lookup module can now accept phase volume
 fractions, for use in the material models or simply to visualize
 after the model runs. A python file is also provided in the
 contributions folder to allow users to easily create input files 

--- a/doc/modules/changes/20200814_tjhei
+++ b/doc/modules/changes/20200814_tjhei
@@ -1,4 +1,4 @@
-<li> New: A new class TimeStepping::Manager to control time stepping with a
+New: A new class TimeStepping::Manager to control time stepping with a
 plugin architecture has been added.
 <br>
 (Timo Heister, 2020/08/14)

--- a/doc/modules/changes/20200814b_bobmyhill
+++ b/doc/modules/changes/20200814b_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: The diffusion and dislocation creep rheology modules
+New: The diffusion and dislocation creep rheology modules
 now have a new function to calculate the strain rate and
 first stress-derivative of the strain rate to facilitate
 the development of composite rheologies.

--- a/doc/modules/changes/20200819_sac-bsa
+++ b/doc/modules/changes/20200819_sac-bsa
@@ -1,4 +1,4 @@
-<li> New: A new particle interpolator based upon quadratic least squares has
+New: A new particle interpolator based upon quadratic least squares has
 been added.
 <br>
 (Mack Gregory, 2020/08/19)

--- a/doc/modules/changes/20200820_gassmoeller
+++ b/doc/modules/changes/20200820_gassmoeller
@@ -1,3 +1,3 @@
-<li> New: ASPECT now has a new, reproducible logo.
+New: ASPECT now has a new, reproducible logo.
 <br>
 (Rene Gassmoeller, 2020/08/20)

--- a/doc/modules/changes/20200828_bobmyhill
+++ b/doc/modules/changes/20200828_bobmyhill
@@ -1,4 +1,4 @@
-<li> Changed: The steinberger material model now performs
+Changed: The steinberger material model now performs
 consistent averaging of material properties when multiple
 material lookups are used. Specifically, the density,
 thermal expansivity, compressibility and phase volume fractions

--- a/doc/modules/changes/20200829b_bobmyhill
+++ b/doc/modules/changes/20200829b_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: The rheology module for Peierls creep now includes a formulation
+New: The rheology module for Peierls creep now includes a formulation
 to compute the exact Peierls viscosity, using an internal Newton-Raphson
 iterative scheme. The module now also contains a function to calculate the
 strain rate and derivative as a function of stress

--- a/doc/modules/changes/20200903_naliboff
+++ b/doc/modules/changes/20200903_naliboff
@@ -1,4 +1,4 @@
-<li> New: Added a new benchmark that examines shortening of a
+New: Added a new benchmark that examines shortening of a
 visco-plastic or viscoelastic-plastic block in the absence of 
 gravity. The benchmark is modified from Exercise 13.2 in 
 Gerya 2019 (Introduction to Numerical Geodynamic Modeling).

--- a/doc/modules/changes/20200904_bobmyhill
+++ b/doc/modules/changes/20200904_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: The Peierls creep rheology can now accept different
+New: The Peierls creep rheology can now accept different
 parameter values for distinct phases in each compositional field.
 This unifies the functionality of the Peierls creep rheology
 with that of diffusion creep and dislocation creep.

--- a/doc/modules/changes/20201022_gassmoeller
+++ b/doc/modules/changes/20201022_gassmoeller
@@ -1,4 +1,4 @@
-<li> New: Added the functionality to compute averages in user defined depth
+New: Added the functionality to compute averages in user defined depth
 layers (e.g. lithosphere, asthenosphere, transition zone, lower mantle)
 to the depth average postprocessor and the lateral averaging plugin.
 <br>

--- a/doc/modules/changes/20201030_gassmoeller
+++ b/doc/modules/changes/20201030_gassmoeller
@@ -1,4 +1,4 @@
-<li> New: There is a new visualization postprocessor called 'principal stress',
+New: There is a new visualization postprocessor called 'principal stress',
 which outputs the principal stress values and directions at every point in the
 model. The postprocessor can either operate on the full stress tensor
 (including pressure) or on the trace-free deviatoric stress tensor.

--- a/doc/modules/changes/20201109_jdannberg
+++ b/doc/modules/changes/20201109_jdannberg
@@ -1,4 +1,4 @@
-<li> New: There is now a new property in the depth average postprocessor 
+New: There is now a new property in the depth average postprocessor 
 that averages the mass of a compositional field (rather than its volume, 
 as the "composition" property).
 <br>


### PR DESCRIPTION
We introduced a stray `<li>` in our changelog that got copied into many entries. See: https://aspect.geodynamics.org/doc/doxygen/changes_current.html.

This should fix the issue.