### PR TITLE
[WIP] Add isostress and Voigt-Reuss-Hill averaging to CompositeViscoPlastic

### DIFF
--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -84,6 +84,22 @@ namespace aspect
                              const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
 
           /**
+           * Compute the viscosity based on the composite viscous creep law.
+           * If @p expected_n_phases_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
+           */
+          double
+          compute_isostress_viscosity (const double pressure,
+                                       const double temperature,
+                                       const std::vector<double> &volume_fractions,
+                                       const SymmetricTensor<2,dim> &strain_rate,
+                                       std::vector<double> &partial_strain_rates,
+                                       const std::vector<double> &phase_function_values = std::vector<double>(),
+                                       const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+
+          /**
            * Compute the compositional field viscosity
            * based on the composite viscous creep law.
            * If @p expected_n_phases_per_composition points to a vector of
@@ -119,6 +135,15 @@ namespace aspect
                                               const DruckerPragerParameters drucker_prager_parameters) const;
 
         private:
+
+          /**
+           * Enumeration for selecting which type of viscosity averaging to use.
+           */
+          enum ViscosityAveragingScheme
+          {
+            isostrain,
+            isostress
+          } viscosity_averaging_scheme;
 
           /**
            * Whether to use different deformation mechanisms

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -142,7 +142,8 @@ namespace aspect
           enum ViscosityAveragingScheme
           {
             isostrain,
-            isostress
+            isostress,
+            voigt_reuss_hill
           } viscosity_averaging_scheme;
 
           /**

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -120,11 +120,10 @@ namespace aspect
                   {
                     total_volume_fraction -= volume_fractions[composition];
                   }
-
-                viscosity /= total_volume_fraction;
-                for (unsigned int j=0; j < 5; ++j)
-                  partial_strain_rates[j] /= total_volume_fraction;
               }
+            viscosity /= total_volume_fraction;
+            for (unsigned int j=0; j < 5; ++j)
+              partial_strain_rates[j] /= total_volume_fraction;
           }
 
         // Final step for Voigt-Reuss-Hill averaging is to divide
@@ -220,21 +219,34 @@ namespace aspect
         while (std::abs(strain_rate_residual) > strain_rate_residual_threshold
                && stress_iteration < stress_max_iteration_number)
           {
-
+            double total_volume_fraction = 1.;
             std::pair<double, double> creep_edot_and_deriv = std::make_pair(0., 0.);
             for (unsigned int composition=0; composition < number_of_compositions; ++composition)
               {
-                creep_edot_and_deriv = (creep_edot_and_deriv
-                                        + volume_fractions[composition]
-                                        * compute_strain_rate_and_derivative (creep_stress,
-                                                                              pressure,
-                                                                              temperature,
-                                                                              composition,
-                                                                              diffusion_creep_parameters[composition],
-                                                                              dislocation_creep_parameters[composition],
-                                                                              peierls_creep_parameters[composition],
-                                                                              drucker_prager_parameters));
+                // Only include the contribution to the viscosity
+                // from a given composition if the volume fraction exceeds
+                // a certain (small) fraction.
+                if (volume_fractions[composition] > 2.*std::numeric_limits<double>::epsilon())
+                  {
+                    creep_edot_and_deriv = (creep_edot_and_deriv
+                                            + volume_fractions[composition]
+                                            * compute_strain_rate_and_derivative (creep_stress,
+                                                                                  pressure,
+                                                                                  temperature,
+                                                                                  composition,
+                                                                                  diffusion_creep_parameters[composition],
+                                                                                  dislocation_creep_parameters[composition],
+                                                                                  peierls_creep_parameters[composition],
+                                                                                  drucker_prager_parameters));
+                  }
+                else
+                  {
+                    total_volume_fraction -= volume_fractions[composition];
+                  }
               }
+
+            creep_edot_and_deriv = std::make_pair(creep_edot_and_deriv.first/total_volume_fraction,
+                                                  creep_edot_and_deriv.second/total_volume_fraction);
 
             const double strain_rate = creep_stress/(2.*max_viscosity) + (max_viscosity/(max_viscosity - min_viscosity))*creep_edot_and_deriv.first;
             strain_rate_deriv = 1./(2.*max_viscosity) + (max_viscosity/(max_viscosity - min_viscosity))*creep_edot_and_deriv.second;
@@ -277,34 +289,47 @@ namespace aspect
 
         // The components of partial_strain_rates must be provided in the order
         // dictated by make_strain_rate_additional_outputs_names
+        double total_volume_fraction = 1.;
         std::fill(partial_strain_rates.begin(), partial_strain_rates.end(), 0);
         for (unsigned int composition=0; composition < number_of_compositions; ++composition)
           {
-            if (use_diffusion_creep)
+            // Only include the contribution to the viscosity
+            // from a given composition if the volume fraction exceeds
+            // a certain (small) fraction.
+            if (volume_fractions[composition] > 2.*std::numeric_limits<double>::epsilon())
               {
-                const std::pair<double, double> diff_edot_and_deriv = diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, diffusion_creep_parameters[composition]);
-                partial_strain_rates[0] = volume_fractions[composition] * diff_edot_and_deriv.first;
-              }
+                if (use_diffusion_creep)
+                  {
+                    const std::pair<double, double> diff_edot_and_deriv = diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, diffusion_creep_parameters[composition]);
+                    partial_strain_rates[0] = volume_fractions[composition] * diff_edot_and_deriv.first;
+                  }
 
-            if (use_dislocation_creep)
+                if (use_dislocation_creep)
+                  {
+                    const std::pair<double, double> disl_edot_and_deriv = dislocation_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, dislocation_creep_parameters[composition]);
+                    partial_strain_rates[1] = volume_fractions[composition] * disl_edot_and_deriv.first;
+                  }
+
+                if (use_peierls_creep)
+                  {
+                    const std::pair<double, double> prls_edot_and_deriv = peierls_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, peierls_creep_parameters[composition]);
+                    partial_strain_rates[2] = volume_fractions[composition] * prls_edot_and_deriv.first;
+                  }
+
+                if (use_drucker_prager)
+                  {
+                    const std::pair<double, double> drpr_edot_and_deriv = drucker_prager->compute_strain_rate_and_derivative(creep_stress, pressure, composition, drucker_prager_parameters);
+                    partial_strain_rates[3] = volume_fractions[composition] * drpr_edot_and_deriv.first;
+                  }
+              }
+            else
               {
-                const std::pair<double, double> disl_edot_and_deriv = dislocation_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, dislocation_creep_parameters[composition]);
-                partial_strain_rates[1] = volume_fractions[composition] * disl_edot_and_deriv.first;
+                total_volume_fraction -= volume_fractions[composition];
               }
-
-            if (use_peierls_creep)
-              {
-                const std::pair<double, double> prls_edot_and_deriv = peierls_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, peierls_creep_parameters[composition]);
-                partial_strain_rates[2] = volume_fractions[composition] * prls_edot_and_deriv.first;
-              }
-
-            if (use_drucker_prager)
-              {
-                const std::pair<double, double> drpr_edot_and_deriv = drucker_prager->compute_strain_rate_and_derivative(creep_stress, pressure, composition, drucker_prager_parameters);
-                partial_strain_rates[3] = volume_fractions[composition] * drpr_edot_and_deriv.first;
-              }
-
           }
+
+        for (unsigned int j=0; j < 4; ++j)
+          partial_strain_rates[j] /= total_volume_fraction;
 
         partial_strain_rates[4] = total_stress/(2.*max_viscosity);
 


### PR DESCRIPTION
Yesterday evening, @naliboff and I discussed the possibility of implementing different averaging schemes with the CompositeViscoPlastic rheology model. The model as implemented in #3884 assumes isostrain (Voigt) averaging of material viscosities, which can result in very high viscosities.

As CompositeViscoPlastic decomposes the strains for each mechanism, isostress or Voigt-Reuss-Hill* averaging can both be implemented. The isostress averaging scheme is likely to be more efficient than isostrain, because isostrain averaging requires one stress inversion per material, whereas isostress averaging requires only one stress inversion in total.

This PR adds the option to choose between isostrain, isostress and Voigt-Reuss-Hill viscosity averaging schemes. Opened for discussion. PR #3884 should be merged before this is reviewed.

\* an arithmetic average of isostress and isostrain

* [ ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.