### PR TITLE
add new citation Negredo et al.

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -821,3 +821,17 @@ issn="2075-163X",
 doi="10.3390/min10110985",
 opturl="https://www.mdpi.com/2075-163X/10/11/985"
 }
+
+
+@ARTICLE{10.3389/feart.2020.533392,
+  AUTHOR={Negredo, A. M. and Mancilla, F. d. L. and Clemente, C. and Morales, J. and Fullea, J.},
+	TITLE={Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study},
+	JOURNAL={Frontiers in Earth Science},
+	VOLUME={8},
+	PAGES={435},
+	YEAR={2020},
+	URL={https://www.frontiersin.org/article/10.3389/feart.2020.533392},
+	DOI={10.3389/feart.2020.533392},      
+	ISSN={2296-6463},
+  ABSTRACT={Lithospheric tearing at slab edges is common in scenarios where retreating slabs face continental margins. Such tearing is often accommodated via subvertical STEP (Subduction-Transform Edge Propagator) faults that cut across the entire lithosphere and can result in sharp lateral thermal and rheological variations across the juxtaposed lithospheres. This setting favors the occurrence of continental delamination, i.e., the detachment between the crust and the lithospheric mantle. In order to evaluate this hypothesis, we have chosen a well-studied natural example recently imaged with unprecedented seismic resolution: the STEP fault under the central Betic orogen, at the northern edge of the Gibraltar Arc subduction system (westernmost Mediterranean Sea). The Gibraltar Arc subduction is the result of the fast westward roll-back of the Alboran slab and it is in its last evolutionary stage, where the oceanic lithosphere has been fully consumed and the continental lithosphere attached to it collides with the overriding plate. In this study we investigate by means of thermo-mechanical modeling the conditions for, and consequences of, delamination post-dating slab tearing in the central Betics. We consider a setup based on a STEP fault separating the orogenic Betic lithosphere and the adjacent thinned lithosphere of the overriding Alboran domain. Our model analysis indicates that delamination is very sensitive to the initial thermal and rheological conditions, transitioning from a stable to a very unstable and rapidly evolving regime. We find two clearly differentiated regimes according to the time at which the process becomes unstable: fast and slow delamination. Although the final state reached in both the fast and slow regimes is similar, the dynamic surface topography evolution is dramatically different. We suggest that given a weak enough Iberian lower crust the delaminating lithospheric mantle peels off the crust and adopts a geometry consistent with the imaged southward dipping Iberian lithosphere in the central Betics. The lack of spatial correspondence between the highest topography and the thickest crust, as well as the observed pattern of uplift/subsidence are properly reproduced by a model where relatively fast delamination (Reference Model) develops after slab tearing.}
+}


### PR DESCRIPTION
Adds new citation Negredo et al. 2020, Geodynamic Modeling of Edge-Delamination Driven by Subduction-Transform Edge Propagator Faults: The Westernmost Mediterranean Margin (Central Betic Orogen) Case Study, to publications citing ASPECT.