### PR TITLE
Add visco plastic composition mask

### DIFF
--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -279,6 +279,12 @@ namespace aspect
            */
           Rheology::DruckerPragerParameters drucker_prager_parameters;
 
+          /**
+           * A list of user set component masks, which are compositional field names which
+           * need to be ignored by this plugin.
+           */
+          ComponentMask user_component_masks;
+
       };
     }
   }

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -429,6 +429,8 @@ namespace aspect
               composition_mask.set(i,false);
           }
 
+        composition_mask = composition_mask & user_component_masks;
+
         return composition_mask;
       }
 
@@ -497,6 +499,15 @@ namespace aspect
                            "dynamic stresses are much higher than the lithostatic pressure. "
                            "If false, the minimum pressure in the plasticity formulation will "
                            "be set to zero.");
+        prm.declare_entry ("List of compositional field names to use", "",
+                           Patterns::Anything (),
+                           "Indicate which compositional field are used by the visco plastic "
+                           "rheology model by listing the names of the fields. If left empty "
+                           "all compositional fields will be used. Compositional fields not "
+                           "listed with receive a volume fraction of 0. This means that you "
+                           "still need to provide resonable values for prefactors, activation "
+                           "energies, etc. for them.");
+
 
         // Diffusion creep parameters
         Rheology::DiffusionCreep<dim>::declare_parameters(prm);
@@ -646,6 +657,17 @@ namespace aspect
                        ExcMessage("If adiabatic heating is enabled you should not add another adiabatic gradient"
                                   "to the temperature for computing the viscosity, because the ambient"
                                   "temperature profile already includes the adiabatic gradient."));
+
+        std::vector<std::string> component_masks_string = Utilities::split_string_list(prm.get("List of compositional field names to use"));
+        user_component_masks = component_masks_string.size() == 0
+                               ?
+                               ComponentMask(this->n_compositional_fields(),true)
+                               :
+                               ComponentMask(this->n_compositional_fields(),false);
+        for (auto &&mask : component_masks_string)
+          {
+            user_component_masks.set(this->introspection().compositional_index_for_name(mask), true);
+          }
 
       }
 

--- a/tests/visco_plastic_mask.prm
+++ b/tests/visco_plastic_mask.prm
@@ -1,0 +1,73 @@
+include $ASPECT_SOURCE_DIR/tests/visco_plastic_complex.prm
+
+# Compositional fields used to track finite strain
+subsection Compositional fields
+  set Number of fields = 3
+  set Names of fields = plastic_strain, crust, water
+  set Compositional field methods = field, field, static
+  set List of normalized fields = 0,
+end
+
+# Initial composition model
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = 0; if(y>=70.e3, 1, 0);800;
+  end
+end
+
+# Boundary composition specification
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+# Material model (values for background material, strain fields and crust)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    # compositional masking
+    set List of compositional field names to use = crust
+
+    # Reference values and viscosity averaging
+    set Minimum strain rate = 1.e-20
+    set Reference strain rate = 1.e-16
+    set Minimum viscosity = 1e18
+    set Maximum viscosity = 1e28
+    set Reference viscosity = 1e22
+    set Viscosity averaging scheme = harmonic
+
+    # Thermodynamic properties
+    set Thermal diffusivities = 1.474747e-6,1.474747e-6,1.190476e-6,1.0
+    set Heat capacities = 750.
+    set Densities = 3300,3300,2800,0.
+    set Thermal expansivities = 0.
+
+    # Viscous flow laws
+    # Background: Dry olive (Hirth & Kohlstedt 2004), Crust: Wet quartzite (Rutter & Brodie 2004)
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 6.52e-16,6.52e-16,8.57e-28,1.0
+    set Stress exponents for dislocation creep = 3.5,3.5,4.0,1.0
+    set Activation energies for dislocation creep = 530.e3,530.e3,223.e3,1.0
+    set Activation volumes for dislocation creep = 18.e-6,18.e-6,0.,0.
+
+    # Yielding mechanism and values
+    set Yield mechanism = limiter
+    set Stress limiter exponents = 10, 10, 10, 2
+    set Angles of internal friction = 0.,0.,0.,0.
+    set Cohesions = 1.e6,1.e6,1.e6,1.0
+
+    # Strain weakening
+    set Strain weakening mechanism = plastic weakening with plastic strain only
+    set Start plasticity strain weakening intervals = 0.
+    set End plasticity strain weakening intervals = 1.0
+    set Cohesion strain weakening factors = 0.5
+    set Friction strain weakening factors = 0.5
+
+  end
+end
+
+# Postprocess
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics
+end

--- a/tests/visco_plastic_mask/screen-output
+++ b/tests/visco_plastic_mask/screen-output
@@ -1,0 +1,24 @@
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 2,767 (882+121+441+441+441+441)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Skipping plastic_strain composition solve because RHS is zero.
+   Solving crust system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+11 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000692 m/year
+     Mass fluxes through boundary parts: 1.57e+05 kg/yr, 1.57e+05 kg/yr, -1.65e+05 kg/yr, -1.4e+05 kg/yr
+
+
+
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
This pull request adds the option for the user to mask compositional fields from use in the volume fraction calculation in the visco plastic material/rheology model (setting the volume fraction to zero). This is useful for for example the cpo code, since it requires a water compositional field which should not be used by the visco plastic plugin.

I have added a test which shows that the result has not changed by adding the extra composition compared to `visco_plastic_complex` (only extra degree's of freedoms).