### PR TITLE
change parameters.cc asserts to assertthrows when dealing with user input.

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1627,9 +1627,9 @@ namespace aspect
       use_discontinuous_composition_discretization
         = prm.get_bool("Use discontinuous composition discretization");
 
-      Assert(use_discontinuous_composition_discretization == true || composition_degree > 0,
-             ExcMessage("Using a composition polynomial degree of 0 (cell-wise constant composition) "
-                        "is only supported if a discontinuous composition discretization is selected."));
+      AssertThrow(use_discontinuous_composition_discretization == true || composition_degree > 0,
+                  ExcMessage("Using a composition polynomial degree of 0 (cell-wise constant composition) "
+                             "is only supported if a discontinuous composition discretization is selected."));
 
       prm.enter_subsection ("Stabilization parameters");
       {
@@ -1730,19 +1730,19 @@ namespace aspect
       // check that the names use only allowed characters, are not empty strings and are unique
       for (unsigned int i=0; i<names_of_compositional_fields.size(); ++i)
         {
-          Assert (names_of_compositional_fields[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
-                                                                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                                     "0123456789_") == std::string::npos,
-                  ExcMessage("Invalid character in field " + names_of_compositional_fields[i] + ". "
-                             "Names of compositional fields should consist of a "
-                             "combination of letters, numbers and underscores."));
-          Assert (names_of_compositional_fields[i].size() > 0,
-                  ExcMessage("Invalid name of field " + names_of_compositional_fields[i] + ". "
-                             "Names of compositional fields need to be non-empty."));
+          AssertThrow (names_of_compositional_fields[i].find_first_not_of("abcdefghijklmnopqrstuvwxyz"
+                                                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                                          "0123456789_") == std::string::npos,
+                       ExcMessage("Invalid character in field " + names_of_compositional_fields[i] + ". "
+                                  "Names of compositional fields should consist of a "
+                                  "combination of letters, numbers and underscores."));
+          AssertThrow (names_of_compositional_fields[i].size() > 0,
+                       ExcMessage("Invalid name of field " + names_of_compositional_fields[i] + ". "
+                                  "Names of compositional fields need to be non-empty."));
           for (unsigned int j=0; j<i; ++j)
-            Assert (names_of_compositional_fields[i] != names_of_compositional_fields[j],
-                    ExcMessage("Names of compositional fields have to be unique! " + names_of_compositional_fields[i] +
-                               " is used more than once."));
+            AssertThrow (names_of_compositional_fields[i] != names_of_compositional_fields[j],
+                         ExcMessage("Names of compositional fields have to be unique! " + names_of_compositional_fields[i] +
+                                    " is used more than once."));
         }
 
       // default names if list is empty


### PR DESCRIPTION
I noticed some asserts which I think should be also active in release mode since they check user input.