### PR TITLE
changed calculate_isostrain_viscosities from pair to structure

### DIFF
--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -76,6 +76,22 @@ namespace aspect
         std::vector<double> yielding;
     };
 
+    /**
+       * A data structure with the output of calculate_isostrain_viscosities.
+       */
+    struct IsostrainViscosities
+    {
+      /**
+       * The composition viscosity.
+       */
+      std::vector<double> composition_viscosities;
+
+      /**
+       * The composition yielding.
+       */
+      std::vector<bool> composition_yielding;
+    };
+
     namespace Rheology
     {
 
@@ -92,7 +108,7 @@ namespace aspect
            * This function calculates viscosities assuming that all the compositional fields
            * experience the same strain rate (isostrain).
            */
-          std::pair<std::vector<double>, std::vector<bool> >
+          IsostrainViscosities
           calculate_isostrain_viscosities ( const MaterialModel::MaterialModelInputs<dim> &in,
                                             const unsigned int i,
                                             const std::vector<double> &volume_fractions,

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -100,7 +100,7 @@ namespace aspect
                                        const std::vector<double> &phase_function_values,
                                        const std::vector<unsigned int> &n_phases_per_composition) const
       {
-      IsostrainViscosities output_parameters;
+        IsostrainViscosities output_parameters;
 
         // Initialize or fill variables used to calculate viscosities
         output_parameters.composition_yielding.resize(volume_fractions.size(), false);

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -111,8 +111,7 @@ namespace aspect
       /* The following returns whether or not the material is plastically yielding
        * as documented in evaluate.
        */
-      const IsostrainViscosities isostrain_viscosities =
-                                                             rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
+      const IsostrainViscosities isostrain_viscosities = rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
       const bool plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -54,11 +54,11 @@ namespace aspect
 
       const std::vector<double> volume_fractions = MaterialUtilities::compute_volume_fractions(composition, rheology->get_volumetric_composition_mask());
 
-      const std::pair<std::vector<double>, std::vector<bool> > calculate_viscosities =
+      const IsostrainViscosities isostrain_viscosities =
         rheology->calculate_isostrain_viscosities(in, i, volume_fractions);
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(),volume_fractions.end());
-      plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(),max_composition)];
+      plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(),max_composition)];
 
       return plastic_yielding;
     }
@@ -111,11 +111,11 @@ namespace aspect
       /* The following returns whether or not the material is plastically yielding
        * as documented in evaluate.
        */
-      const std::pair<std::vector<double>, std::vector<bool>> calculate_viscosities =
+      const IsostrainViscosities isostrain_viscosities =
                                                              rheology->calculate_isostrain_viscosities(in, 0, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
       std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(), volume_fractions.end());
-      const bool plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(), max_composition)];
+      const bool plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];
 
       return plastic_yielding;
     }
@@ -220,26 +220,26 @@ namespace aspect
               // isostrain amongst all compositions, allowing calculation of the viscosity ratio.
               // TODO: This is only consistent with viscosity averaging if the arithmetic averaging
               // scheme is chosen. It would be useful to have a function to calculate isostress viscosities.
-              const std::pair<std::vector<double>, std::vector<bool> > calculate_viscosities =
+              const IsostrainViscosities isostrain_viscosities =
                 rheology->calculate_isostrain_viscosities(in, i, volume_fractions, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
 
               // The isostrain condition implies that the viscosity averaging should be arithmetic (see above).
               // We have given the user freedom to apply alternative bounds, because in diffusion-dominated
               // creep (where n_diff=1) viscosities are stress and strain-rate independent, so the calculation
               // of compositional field viscosities is consistent with any averaging scheme.
-              out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, calculate_viscosities.first, rheology->viscosity_averaging);
+              out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, isostrain_viscosities.composition_viscosities, rheology->viscosity_averaging);
 
               // Decide based on the maximum composition if material is yielding.
               // This avoids for example division by zero for harmonic averaging (as plastic_yielding
               // holds values that are either 0 or 1), but might not be consistent with the viscosity
               // averaging chosen.
               std::vector<double>::const_iterator max_composition = std::max_element(volume_fractions.begin(),volume_fractions.end());
-              plastic_yielding = calculate_viscosities.second[std::distance(volume_fractions.begin(),max_composition)];
+              plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(),max_composition)];
 
               // Compute viscosity derivatives if they are requested
               if (MaterialModel::MaterialModelDerivatives<dim> *derivatives =
                     out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim> >())
-                rheology->compute_viscosity_derivatives(i, volume_fractions, calculate_viscosities.first, in, out, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
+                rheology->compute_viscosity_derivatives(i, volume_fractions, isostrain_viscosities.composition_viscosities, in, out, phase_function_values, phase_function.n_phase_transitions_for_each_composition());
             }
 
           // Now compute changes in the compositional fields (i.e. the accumulated strain).


### PR DESCRIPTION
As discussed with @anne-glerum @gassmoeller and @naliboff I changed calculate_isostrain_viscosities in visco_plastic.cc from being a pair into a structure, so that it is easier to return more parameters (e.g. current_edot_ii) needed in other functions. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
