### PR TITLE
Refactor rotation statistics postprocessor

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -134,6 +134,38 @@ namespace aspect
   };
 
   /**
+   * A data structure with all properties relevant to compute angular momentum and rotation.
+   */
+  template <int dim>
+  struct RotationProperties
+  {
+    RotationProperties()
+      :
+      scalar_moment_of_inertia(numbers::signaling_nan<double>()),
+      scalar_angular_momentum(numbers::signaling_nan<double>()),
+      scalar_rotation(numbers::signaling_nan<double>()),
+      tensor_moment_of_inertia(numbers::signaling_nan<SymmetricTensor<2,dim>>()),
+      tensor_angular_momentum(numbers::signaling_nan<Tensor<1,dim>>()),
+      tensor_rotation(numbers::signaling_nan<Tensor<1,dim>>())
+    {};
+
+    /**
+     * Scalar properties for the two-dimensional case
+     * with a fixed rotation axis (z).
+     */
+    double scalar_moment_of_inertia;
+    double scalar_angular_momentum;
+    double scalar_rotation;
+
+    /**
+     * Tensor properties for the three-dimensional case.
+     */
+    SymmetricTensor<2,dim> tensor_moment_of_inertia;
+    Tensor<1,dim> tensor_angular_momentum;
+    Tensor<1,dim> tensor_rotation;
+  };
+
+  /**
    * This is the main class of ASPECT. It implements the overall simulation
    * algorithm using the numerical methods discussed in the papers and manuals
    * that accompany ASPECT.
@@ -1422,6 +1454,22 @@ namespace aspect
        */
       void remove_nullspace(LinearAlgebra::BlockVector &relevant_dst,
                             LinearAlgebra::BlockVector &tmp_distributed_stokes);
+
+      /**
+       * Compute the angular momentum and other rotation properties
+       * of the velocities in the given solution vector.
+       *
+       * @param use_constant_density determines whether to use a constant
+       * density (which corresponds to computing a net rotation instead of net
+       * angular momentum).
+       * @param solution Solution vector to compute the properties for.
+       *
+       * This function is implemented in
+       * <code>source/simulator/nullspace.cc</code>.
+       */
+      RotationProperties<dim>
+      compute_net_angular_momentum(const bool use_constant_density,
+                                   const LinearAlgebra::BlockVector &solution) const;
 
       /**
        * Remove the angular momentum of the given vector

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -53,6 +53,7 @@ namespace aspect
   template <int dim> class Simulator;
   template <int dim> struct SimulatorSignals;
   template <int dim> class LateralAveraging;
+  template <int dim> struct RotationProperties;
 
   namespace GravityModel
   {
@@ -912,6 +913,19 @@ namespace aspect
        */
       const StokesMatrixFreeHandler<dim> &
       get_stokes_matrix_free () const;
+
+      /**
+       * Compute the angular momentum and other rotation properties
+       * of the velocities in the given solution vector.
+       *
+       * @param use_constant_density determines whether to use a constant
+       * density (which corresponds to computing a net rotation instead of net
+       * angular momentum).
+       * @param solution Solution vector to compute the properties for.
+       */
+      RotationProperties<dim>
+      compute_net_angular_momentum(const bool use_constant_density,
+                                   const LinearAlgebra::BlockVector &solution) const;
 
       /** @} */
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -742,6 +742,8 @@ namespace aspect
     return (simulator->stokes_matrix_free ? true : false);
   }
 
+
+
   template <int dim>
   const StokesMatrixFreeHandler<dim> &
   SimulatorAccess<dim>::get_stokes_matrix_free () const
@@ -749,6 +751,16 @@ namespace aspect
     Assert (simulator->stokes_matrix_free.get() != nullptr,
             ExcMessage("You can not call this function if the matrix-free Stokes solver is not used."));
     return *(simulator->stokes_matrix_free);
+  }
+
+
+
+  template <int dim>
+  RotationProperties<dim>
+  SimulatorAccess<dim>::compute_net_angular_momentum(const bool use_constant_density,
+                                                     const LinearAlgebra::BlockVector &solution) const
+  {
+    return simulator->compute_net_angular_momentum(use_constant_density, solution);
   }
 }
 


### PR DESCRIPTION
Similar to #3943, but this unifies the code used in the rotation statistics postprocessor with the similar code in nullspace removal. There should be no changes in behavior.