### PR TITLE
Also allow setting PERPLEX_DIR on the command line.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,8 @@ ENDIF()
 ADD_EXECUTABLE(${TARGET} ${TARGET_SRC})
 DEAL_II_SETUP_TARGET(${TARGET})
 
-FIND_PACKAGE(PerpleX QUIET HINTS ./contrib/perplex/install/ ../ ../../ $ENV{PERPLEX_DIR})
+FIND_PACKAGE(PerpleX QUIET
+  HINTS ./contrib/perplex/install/ ../ ../../ ${PERPLEX_DIR} $ENV{PERPLEX_DIR})
 IF(${PerpleX_FOUND})
   MESSAGE(STATUS "PerpleX found at ${PerpleX_INCLUDE_DIR}")
   INCLUDE_DIRECTORIES(${PerpleX_INCLUDE_DIR})


### PR DESCRIPTION
In what is probably a historical accident, our CMakeLists.txt file allows querying if
a user has set PERPLEX_DIR as an environment variable, but not on the command line
via
  -DPERPLEX_DIR=/where/I/installed/perplex
I suspect that that was not on purpose, and it is easily fixed. It also makes this
call to FIND_PACKAGE look more like the other calls to this command in this file.

/rebuild