### PR TITLE
van Leer limiter for LLS particle interpolation

### DIFF
--- a/include/aspect/particle/interpolator/linear_least_squares_van_leer.h
+++ b/include/aspect/particle/interpolator/linear_least_squares_van_leer.h
@@ -1,0 +1,94 @@
+/*
+ Copyright (C) 2020-2021 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_interpolator_linear_least_squares_van_leer_h
+#define _aspect_particle_interpolator_linear_least_squares_van_leer_h
+
+#include <aspect/particle/interpolator/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      /**
+       * Evaluate the properties of all particles of the given cell
+       * using a least squares projection onto the set of bilinear
+       * (or, in 3d, trilinear) functions.
+       *
+       * @ingroup ParticleInterpolators
+       */
+      template <int dim>
+      class LinearLeastSquaresVanLeer : public Interface<dim>, public aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Return the cell-wise evaluated properties of the bilinear least squares function at the positions.
+           */
+          std::vector<std::vector<double> >
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim> > &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+
+          // avoid -Woverloaded-virtual:
+          using Interface<dim>::properties_at_points;
+
+          /**
+           * Declare the parameters this class takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           */
+          void
+          parse_parameters (ParameterHandler &prm) override;
+
+        private:
+          /**
+           * Variables related to a limiting scheme that prevents overshoot and
+           * undershoot of interpolated particle properties based on global max
+           * and global min for each property.
+           */
+          bool use_global_min_max_limiter;
+
+          /**
+           * For each interpolated particle property, a global max and global
+           * min are stored as elements of vectors.
+           */
+          ComponentMask use_limiter;
+
+          /**
+           * For each interpolated particle property, a global max and global
+           * min are stored as elements of vectors.
+           */
+          std::vector<double> global_minimum_particle_properties;
+          std::vector<double> global_maximum_particle_properties;
+      };
+    }
+  }
+}
+
+#endif

--- a/source/particle/interpolator/linear_least_squares_van_leer.cc
+++ b/source/particle/interpolator/linear_least_squares_van_leer.cc
@@ -1,0 +1,348 @@
+/*
+  Copyright (C) 2020-2021 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#include <aspect/particle/interpolator/linear_least_squares_van_leer.h>
+#include <aspect/particle/interpolator/cell_average.h>
+#include <aspect/postprocess/particles.h>
+#include <aspect/simulator.h>
+
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/lac/full_matrix.templates.h>
+
+#include <boost/lexical_cast.hpp>
+
+dealii::ComponentMask parse_bool_list(const std::vector<std::string> &list)
+{
+  std::vector<bool> temp;
+  for (const auto &value : list)
+    {
+      if (value == "yes" || value == "true")
+        {
+          temp.push_back(true);
+        }
+      else if (value == "no" || value == "false")
+        {
+          temp.push_back(false);
+        }
+      else
+        {
+          AssertThrow(false, dealii::StandardExceptions::ExcNotImplemented());
+        }
+    }
+  return dealii::ComponentMask(temp);
+}
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      template <int dim>
+      std::vector<std::vector<double> >
+      LinearLeastSquaresVanLeer<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                           const std::vector<Point<dim> > &positions,
+                                                           const ComponentMask &selected_properties,
+                                                           const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      {
+        const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
+
+        const unsigned int property_index = selected_properties.first_selected_component(selected_properties.size());
+
+        AssertThrow(property_index != numbers::invalid_unsigned_int,
+                    ExcMessage("Internal error: the particle property interpolator was "
+                               "called without a specified component to interpolate."));
+
+        const Point<dim> approximated_cell_midpoint = std::accumulate (positions.begin(), positions.end(), Point<dim>())
+                                                      / static_cast<double> (positions.size());
+
+        typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
+
+        if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
+          {
+            // We can not simply use one of the points as input for find_active_cell_around_point
+            // because for vertices of mesh cells we might end up getting ghost_cells as return value
+            // instead of the local active cell. So make sure we are well in the inside of a cell.
+            Assert(positions.size() > 0,
+                   ExcMessage("The particle property interpolator was not given any "
+                              "positions to evaluate the particle cell_properties at."));
+
+
+            found_cell =
+              (GridTools::find_active_cell_around_point<> (this->get_mapping(),
+                                                           this->get_triangulation(),
+                                                           approximated_cell_midpoint)).first;
+          }
+        else
+          found_cell = cell;
+        Point<dim> midpoint = found_cell->vertex(0);
+        midpoint[0] += found_cell->extent_in_direction(0)/2;
+        midpoint[1] += found_cell->extent_in_direction(1)/2;
+        if (dim == 3)
+          midpoint[2] += found_cell->extent_in_direction(2)/2;
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range =
+          particle_handler.particles_in_cell(found_cell);
+
+        std::vector<std::vector<double> > cell_properties(positions.size(),
+                                                          std::vector<double>(n_particle_properties,
+                                                                              numbers::signaling_nan<double>()));
+
+        const unsigned int n_particles = std::distance(particle_range.begin(), particle_range.end());
+
+        AssertThrow(n_particles != 0,
+                    ExcMessage("At least one cell contained no particles. The 'linear'"
+                               "interpolation scheme does not support this case. "));
+
+
+        // Noticed that the size of matrix A is n_particles x matrix_dimension
+        // which usually is not a square matrix. Therefore, we find the
+        // least squares solution of Ax=r by solving the "normal" equations
+        // (A^TA) x = A^Tr.
+        const unsigned int matrix_dimension = (dim == 2) ? 3 : 4;
+        dealii::LAPACKFullMatrix<double> A(n_particles, matrix_dimension);
+        std::vector<Vector<double>> r(n_particle_properties, Vector<double>(n_particles));
+        for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
+          if (selected_properties[property_index])
+            r[property_index] = 0;
+        unsigned int positions_index = 0;
+        for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
+             particle != particle_range.end(); ++particle, ++positions_index)
+          {
+            const auto particle_property_value = particle->get_properties();
+            for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
+              if (selected_properties[property_index])
+                r[property_index][positions_index] = particle_property_value[property_index];
+
+            Tensor<1, dim, double> relative_particle_position = particle->get_location() - midpoint;
+            relative_particle_position[0] /= found_cell->extent_in_direction(0);
+            relative_particle_position[1] /= found_cell->extent_in_direction(1);
+            if (dim == 3)
+              relative_particle_position[2] /= found_cell->extent_in_direction(2);
+            A(positions_index, 0) = 1;
+            A(positions_index, 1) = relative_particle_position[0];
+            A(positions_index, 2) = relative_particle_position[1];
+            if (dim == 3)
+              A(positions_index, 3) = relative_particle_position[2];
+          }
+        dealii::LAPACKFullMatrix<double> B(matrix_dimension, matrix_dimension);
+
+        std::vector<Vector<double>> c_ATr(n_particle_properties, Vector<double>(matrix_dimension));
+        std::vector<Vector<double>> c(n_particle_properties, Vector<double>(matrix_dimension));
+
+        constexpr double threshold = 1e-15;
+        unsigned int index_positions = 0;
+
+        // Form the matrix B=A^TA and right hand side A^Tr of the normal equation.
+        A.Tmmult(B, A, false);
+        dealii::LAPACKFullMatrix<double> B_inverse(B);
+        B_inverse.compute_inverse_svd(threshold);
+        CellAverage<dim> cell_average_interpolator;
+        bool edge_case = false;
+        for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
+          {
+            if (selected_properties[property_index])
+              {
+                A.Tvmult(c_ATr[property_index],r[property_index]);
+                B_inverse.vmult(c[property_index], c_ATr[property_index]);
+                const double current_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, found_cell)[0][property_index];
+                c[property_index][0] = current_cell_average;
+                // The limiter must ensure that the following conditions are
+                // satisfied in order to work properly
+                // 1) The neighbors on each side are not boundaries of the
+                //    model
+                // 2) The cell iterator returned is valid
+                // 3) The cell iterator returned is active and not a ghost cell
+
+                if (!use_limiter[property_index])
+                  continue;
+                if (!(found_cell->at_boundary(0) || found_cell->at_boundary(1)) &&
+                    (found_cell->neighbor(0).state() == dealii::IteratorState::valid && found_cell->neighbor(0)->is_active() &&
+                     found_cell->neighbor(1).state() == dealii::IteratorState::valid && found_cell->neighbor(1)->is_active() &&
+                     !found_cell->neighbor(0)->is_artificial() && !found_cell->neighbor(1)->is_artificial()))
+                  {
+                    const auto &left_cell = found_cell->neighbor(0);
+                    const auto &right_cell = found_cell->neighbor(1);
+                    const double left_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, left_cell)[0][property_index];
+                    const double right_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, right_cell)[0][property_index];
+                    double c_one = c[property_index][1];
+                    double left_difference = (current_cell_average - left_cell_average) / found_cell->extent_in_direction(0);
+                    double right_difference = (right_cell_average - current_cell_average) / found_cell->extent_in_direction(0);
+                    double phi = left_difference * right_difference;
+                    double theta = std::min(2*std::abs(left_difference), std::min(std::abs(c_one)/2, 2*std::abs(right_difference)));
+                    double van_leer_difference =  ((phi > 0) ? std::copysign(1, c_one)*theta : 0);
+                    c[property_index][1] = van_leer_difference;
+                  }
+                else
+                  {
+                    edge_case = true;
+                  }
+                if (!(found_cell->at_boundary(2) || found_cell->at_boundary(3)) &&
+                    (found_cell->neighbor(2).state() == dealii::IteratorState::valid && found_cell->neighbor(2)->is_active() &&
+                     found_cell->neighbor(3).state() == dealii::IteratorState::valid && found_cell->neighbor(3)->is_active() &&
+                     !found_cell->neighbor(2)->is_artificial() && !found_cell->neighbor(3)->is_artificial()))
+                  {
+                    const auto &front_cell = found_cell->neighbor(2);
+                    const auto &back_cell = found_cell->neighbor(3);
+                    const double front_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, front_cell)[0][property_index];
+                    const double back_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, back_cell)[0][property_index];
+                    double c_two = c[property_index][2];
+                    double front_difference = (current_cell_average - front_cell_average) / found_cell->extent_in_direction(1);
+                    double right_difference = (back_cell_average - current_cell_average) / found_cell->extent_in_direction(1);
+                    double phi = front_difference * right_difference;
+                    double theta = std::min(2*std::abs(front_difference), std::min(std::abs(c_two)/2, 2*std::abs(right_difference)));
+                    double van_leer_difference =  ((phi > 0) ? std::copysign(1, c_two)*theta : 0);
+                    c[property_index][2] = van_leer_difference;
+                  }
+                else
+                  {
+                    edge_case = true;
+                  }
+                if (dim == 3 && !(found_cell->at_boundary(4) || found_cell->at_boundary(5)) &&
+                    (found_cell->neighbor(4).state() == dealii::IteratorState::valid && found_cell->neighbor(4)->is_active() &&
+                     found_cell->neighbor(5).state() == dealii::IteratorState::valid && found_cell->neighbor(5)->is_active() &&
+                     !found_cell->neighbor(4)->is_artificial() && !found_cell->neighbor(5)->is_artificial()))
+                  {
+                    const auto &lower_cell = found_cell->neighbor(4);
+                    const auto &upper_cell = found_cell->neighbor(5);
+                    const double lower_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, lower_cell)[0][property_index];
+                    const double upper_cell_average = cell_average_interpolator.properties_at_points(particle_handler, positions, selected_properties, upper_cell)[0][property_index];
+                    double c_three = c[property_index][3];
+                    double left_difference = (current_cell_average - lower_cell_average) / found_cell->extent_in_direction(2);
+                    double right_difference = (upper_cell_average - current_cell_average) / found_cell->extent_in_direction(2);
+                    double phi = left_difference * right_difference;
+                    double theta = std::min(2*std::abs(left_difference), std::min(std::abs(c_three)/2, 2*std::abs(right_difference)));
+                    double van_leer_difference =  ((phi > 0) ? std::copysign(1, c_three)*theta : 0);
+                    c[property_index][3] = van_leer_difference;
+                  }
+                else if (dim == 3)
+                  {
+                    edge_case = true;
+                  }
+
+              }
+          }
+        for (typename std::vector<Point<dim>>::const_iterator itr = positions.begin(); itr != positions.end(); ++itr, ++index_positions)
+          {
+            Tensor<1, dim, double> relative_support_point_location = *itr - midpoint;
+            relative_support_point_location[0] /= found_cell->extent_in_direction(0);
+            relative_support_point_location[1] /= found_cell->extent_in_direction(1);
+            if (dim == 3)
+              relative_support_point_location[2] /= found_cell->extent_in_direction(2);
+            for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
+              {
+                double interpolated_value = c[property_index][0] +
+                                            c[property_index][1] * relative_support_point_location[0] +
+                                            c[property_index][2] * relative_support_point_location[1];
+                if (dim == 3)
+                  {
+                    interpolated_value += c[property_index][3] * relative_support_point_location[2];
+                  }
+                if (edge_case && use_limiter[property_index])
+                  {
+                    interpolated_value = std::min(interpolated_value, global_maximum_particle_properties[property_index]);
+                    interpolated_value = std::max(interpolated_value, global_minimum_particle_properties[property_index]);
+                  }
+                cell_properties[index_positions][property_index] = interpolated_value;
+              }
+          }
+        return cell_properties;
+      }
+
+
+
+      template <int dim>
+      void
+      LinearLeastSquaresVanLeer<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
+        prm.enter_subsection("Interpolator");
+        prm.enter_subsection("Linear least squares van Leer");
+        prm.declare_entry("Use limiter for properties",
+                          "true",
+                          Patterns::List(Patterns::Bool()),
+                          "Enable or disable the Van Leer limiter for each particle property");
+        prm.declare_entry("Global particle property maximum",
+                          boost::lexical_cast<std::string>(std::numeric_limits<double>::max()),
+                          Patterns::List(Patterns::Double()),
+                          "The maximum global particle property that is used as a limiter only at boundaries of the model in the van leer limiter.");
+        prm.declare_entry("Global particle property minimum",
+                          boost::lexical_cast<std::string>(std::numeric_limits<double>::min()),
+                          Patterns::List(Patterns::Double()),
+                          "The minimum global particle property that is used as a limiter only at the boundaries of the model in the van leer limiter.");
+
+        prm.leave_subsection();
+        prm.leave_subsection();
+        prm.leave_subsection();
+        prm.leave_subsection();
+      }
+
+
+
+      template <int dim>
+      void
+      LinearLeastSquaresVanLeer<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
+        prm.enter_subsection("Interpolator");
+        prm.enter_subsection("Linear least squares van Leer");
+        use_limiter = parse_bool_list(Utilities::split_string_list(prm.get("Use limiter for properties")));
+        global_maximum_particle_properties = Utilities::string_to_double(Utilities::split_string_list(prm.get("Global particle property maximum")));
+        global_minimum_particle_properties = Utilities::string_to_double(Utilities::split_string_list(prm.get("Global particle property minimum")));
+
+        const Postprocess::Particles<dim> &particle_postprocessor = this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim> >();
+        const unsigned int n_property_components = particle_postprocessor.get_particle_world().get_property_manager().get_n_property_components();
+        AssertThrow(use_limiter.size() == n_property_components, ExcMessage("Make sure that the size of the list 'Use limiter for properties' is correct."));
+        AssertThrow(global_minimum_particle_properties.size() == n_property_components,
+                    ExcMessage("Make sure that the size of list 'Global minimum particle property' "
+                               "is equivalent to the number of particle properties."));
+
+        AssertThrow(global_maximum_particle_properties.size() == n_property_components,
+                    ExcMessage("Make sure that the size of list 'Global maximum particle property' "
+                               "is equivalent to the number of particle properties."));
+
+        prm.leave_subsection();
+        prm.leave_subsection();
+        prm.leave_subsection();
+        prm.leave_subsection();
+      }
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      ASPECT_REGISTER_PARTICLE_INTERPOLATOR(LinearLeastSquaresVanLeer,
+                                            "linear least squares van leer limiter",
+                                            "Interpolates particle properties onto a vector of points using a "
+                                            "linear least squares method and then limits using a van leer slope limiter "
+                                            "Note that deal.II must be configured with BLAS and LAPACK to "
+                                            "support this operation.")
+    }
+  }
+}

--- a/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam.prm
+++ b/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam.prm
@@ -1,0 +1,52 @@
+# This test checks whether the viscoelastic bending beam benchmark
+# run successfully. In particular, this benchmark is a good test to 
+# ensure that a model using active particles to track both viscoelastic 
+# stresses and lithologies, which affect material properties, works.
+
+include $ASPECT_SOURCE_DIR/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm 
+
+set End time         = 2e3
+set Output directory = particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam
+subsection Mesh refinement
+  set Initial global refinement = 0
+end
+# Significantly reduce resolution 
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 15
+    set Y repetitions = 10
+  end
+end
+
+# Compositional field names and methods
+subsection Compositional fields
+  set Number of fields = 4
+  set Compositional field methods =           particles,           particles,           particles,         particles
+  set Names of fields             =           stress_xx,           stress_yy,           stress_xy,              beam
+  set Mapped particle properties  = stress_xx:stress_xx, stress_yy:stress_yy, stress_xy:stress_xy, beam:initial beam
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = basic statistics, composition statistics, particles
+  subsection Particles
+    set Number of particles = 4.5e3
+    set Minimum particles per cell  = 25
+    set Maximum particles per cell  = 35
+    set Load balancing strategy     = remove and add particles
+    set List of particle properties = initial composition, elastic stress
+    set Interpolation scheme        = linear least squares van leer limiter
+    set Update ghost particles      = true
+    set Particle generator name     = random uniform
+    set Data output format          = none
+    subsection Interpolator
+      subsection Linear least squares van Leer
+        set Use limiter for properties = false, false, false, true, false, false, false
+        set Global particle property maximum = 1, 1, 1, 1, 1, 1, 1
+        set Global particle property minimum = 0, 0, 0, 0, 0, 0, 0
+      end
+    end
+  end
+end
+

--- a/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam/screen-output
+++ b/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam/screen-output
@@ -1,0 +1,35 @@
+
+Number of active cells: 150 (on 1 levels)
+Number of degrees of freedom: 7,054 (1,302+176+176+1,350+1,350+1,350+1,350)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 45+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass:    0/0/0 // 0/0/0 // 0/0/0 // 0/1/2.25e+06
+     Number of advected particles: 4506
+
+*** Timestep 1:  t=1000 years, dt=1000 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass:    0/0/0 // 0/0/0 // 0/0/0 // 0/1/2.25e+06
+     Number of advected particles: 4504
+
+*** Timestep 2:  t=2000 years, dt=1000 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass:    -1.328e+07/1.181e+07/-9.491e+11 // -1.181e+07/1.328e+07/9.491e+11 // -3.895e+06/1.3e+06/-3.734e+12 // 0/1/2.234e+06
+     Number of advected particles: 4502
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam/statistics
+++ b/tests/particle_interpolator_linear_least_squares_van_leer_viscoelastic_bending_beam/statistics
@@ -1,0 +1,27 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Minimal value for composition stress_xx
+# 13: Maximal value for composition stress_xx
+# 14: Global mass for composition stress_xx
+# 15: Minimal value for composition stress_yy
+# 16: Maximal value for composition stress_yy
+# 17: Global mass for composition stress_yy
+# 18: Minimal value for composition stress_xy
+# 19: Maximal value for composition stress_xy
+# 20: Global mass for composition stress_xy
+# 21: Minimal value for composition beam
+# 22: Maximal value for composition beam
+# 23: Global mass for composition beam
+# 24: Number of advected particles
+0 0.000000000000e+00 0.000000000000e+00 150 1478 176 5400 0 44 46 135  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00 1.00000000e+00 2.25000000e+06 4506 
+1 1.000000000000e+03 1.000000000000e+03 150 1478 176 5400 0  1  3   9  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00 1.00000000e+00 2.25000000e+06 4504 
+2 2.000000000000e+03 1.000000000000e+03 150 1478 176 5400 0 36 38 109 -1.32805935e+07 1.18066284e+07 -9.49102830e+11 -1.18066284e+07 1.32805935e+07 9.49102830e+11 -3.89542291e+06 1.30019614e+06 -3.73380534e+12 0.00000000e+00 1.00000000e+00 2.23382272e+06 4502 


### PR DESCRIPTION
*Describe what you did in this PR and why you did it.*
We(@egpuckett and I) have implemented a van Leer limiter for the (bi) linear least squares particle interpolation algorithm. This ensures that the initial maximum and minimum values of the particle property will be automatically maintained with out degrading the accuracy of linear least squares algorithm. For example: if the particle property is an indicator function such as the initial beam property of the viscoelastic bending beam benchmark, which is constrained to be in [0, 1], will remain within the interval [0, 1] for the entire computation. Note that with the van Leer limiter on, chopping is done only at the boundaries of the model. Also note that we wrote a function parse_bool_list (at the top of linear_least_squares_van_leer.cc), which we suspect may duplicate existing functionality, but we couldn't find such a function.


### For all pull requests:
* [X] I have followed the instructions for indenting my code.
### For new features/models or changes of existing features:
 * [X] I have tested my new feature locally to ensure it is correct.
 * [X] I have created a testcase for the new feature/benchmark in the tests/
directory.
* [ ] I have added a changelog entry in the doc/modules/changes directory
that will inform other users of my change.
