### PR TITLE
Use MappingQCache for curved cells if possible to speed up particle sort

### DIFF
--- a/doc/modules/changes/20210201_gassmoeller
+++ b/doc/modules/changes/20210201_gassmoeller
@@ -1,0 +1,7 @@
+Changed: ASPECT now uses a mapping caching strategy provided by deal.II for
+models with curved cells (spherical shells, chunk, sphere) as long as there is
+no mesh deformation. The new mapping drastically decreases the time for sorting
+particles, but has little influence (as far as we know) on other timings, and
+has no influence on the accuracy.
+<br>
+(Rene Gassmoeller, 2021/02/01)

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -436,6 +436,10 @@ namespace aspect
     geometry_model->create_coarse_mesh (triangulation);
     global_Omega_diameter = GridTools::diameter (triangulation);
 
+    // After creating the coarse mesh, initialize mapping cache if one is used
+    if (MappingQCache<dim> *map = dynamic_cast<MappingQCache<dim>*>(&(*mapping)))
+      map->initialize(triangulation,MappingQGeneric<dim>(4));
+
     for (const auto &p : parameters.prescribed_traction_boundary_indicators)
       {
         BoundaryTraction::Interface<dim> *bv

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -51,6 +51,7 @@
 
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/mapping_cartesian.h>
+#include <deal.II/fe/mapping_q_cache.h>
 
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/derivative_approximation.h>
@@ -106,7 +107,7 @@ namespace aspect
                                                  const InitialTopographyModel::Interface<dim> &initial_topography_model)
     {
       if (geometry_model.has_curved_elements())
-        return std_cxx14::make_unique<MappingQ<dim>>(4, true);
+        return std_cxx14::make_unique<MappingQCache<dim>>(4);
       if (Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(initial_topography_model))
         return std_cxx14::make_unique<MappingCartesian<dim>>();
 
@@ -1640,6 +1641,8 @@ namespace aspect
         mesh_deformation_trans->prepare_for_coarsening_and_refinement(x_fs_system);
 
       triangulation.execute_coarsening_and_refinement ();
+      if (MappingQCache<dim> *map = dynamic_cast<MappingQCache<dim>*>(&(*mapping)))
+        map->initialize(triangulation,MappingQGeneric<dim>(4));
     } // leave the timed section
 
     setup_dofs ();
@@ -1896,6 +1899,8 @@ namespace aspect
 
             mesh_refinement_manager.tag_additional_cells ();
             triangulation.execute_coarsening_and_refinement();
+            if (MappingQCache<dim> *map = dynamic_cast<MappingQCache<dim>*>(&(*mapping)))
+              map->initialize(triangulation,MappingQGeneric<dim>(4));
           }
 
         setup_dofs();

--- a/tests/hollow_sphere_gmg_project_q1/screen-output
+++ b/tests/hollow_sphere_gmg_project_q1/screen-output
@@ -10,11 +10,11 @@ Number of degrees of freedom: 4,030 (2,910+150+970)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.911907
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 6.19927e-09
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 5.96872e-09
 
 
    Postprocessing:
-     Pressure at top/bottom of domain:      -1.884e-07 Pa, 500 Pa
+     Pressure at top/bottom of domain:      -1.885e-07 Pa, 500 Pa
      Computing dynamic topography           
      Errors u_L1, p_L1, u_L2, p_L2 topo_L2: 1.675799e+00, 7.892602e+00, 9.120206e-01, 4.859899e+00, 8.407909e-03
 


### PR DESCRIPTION
I think this was suggested to me by one of the deal.II maintainers (maybe Martin?) a while ago, and I had a test branch for a while, but did not see much of a change for most applications so I never pursued it further. However, when looking at a particularly slow particle model in a sphere I realized that that is exactly the application getting the largest benefit from using a `MappingQCache` object instead of a `MappingQ` that we used before. The caching of mapping support points drastically speeds up particle sorting in curved geometries, because often there are dozens of particles in a cell, and in the current implementation we recompute the mapping support points for all of them when recomputing their reference locations. The improvement in 3D may be even larger.
The PR should not change test results.

@kchotalia: Please give this PR a try for your models.

Timing of the attached parameter file with 6 processes in release mode and deal.II dev 58ddbdaeab:

This PR:
```
+----------------------------------------------+------------+------------+
| Total wallclock time elapsed since start     |      92.4s |            |
|                                              |            |            |
| Section                          | no. calls |  wall time | % of total |
+----------------------------------+-----------+------------+------------+
| Assemble Stokes system           |       101 |      2.91s |       3.2% |
| Assemble temperature system      |       101 |      4.12s |       4.5% |
| Build Stokes preconditioner      |       101 |      4.74s |       5.1% |
| Build temperature preconditioner |       101 |     0.454s |      0.49% |
| Create snapshot                  |        10 |      1.45s |       1.6% |
| Initialization                   |         1 |      0.14s |      0.15% |
| Particles: Advect                |       202 |       7.7s |       8.3% |
| Particles: Generate              |         1 |     0.132s |      0.14% |
| Particles: Initialization        |         1 |  0.000119s |         0% |
| Particles: Initialize properties |         1 |    0.0663s |         0% |
| Particles: Interpolate           |       101 |      1.34s |       1.4% |
| Particles: Sort                  |       202 |      4.29s |       4.6% |
| Postprocessing                   |       101 |      22.9s |        25% |
| Refine mesh structure, part 1    |        33 |      3.99s |       4.3% |
| Refine mesh structure, part 2    |        33 |      4.84s |       5.2% |
| Setup dof systems                |        34 |     0.546s |      0.59% |
| Setup initial conditions         |         1 |      0.27s |      0.29% |
| Setup matrices                   |        34 |      1.64s |       1.8% |
| Solve Stokes system              |       101 |      27.7s |        30% |
| Solve temperature system         |       101 |     0.488s |      0.53% |
+----------------------------------+-----------+------------+------------+
```

Before:
```
+----------------------------------------------+------------+------------+
| Total wallclock time elapsed since start     |       161s |            |
|                                              |            |            |
| Section                          | no. calls |  wall time | % of total |
+----------------------------------+-----------+------------+------------+
| Assemble Stokes system           |       101 |      2.82s |       1.8% |
| Assemble temperature system      |       101 |       4.1s |       2.6% |
| Build Stokes preconditioner      |       101 |      4.48s |       2.8% |
| Build temperature preconditioner |       101 |      0.41s |      0.26% |
| Create snapshot                  |        10 |      1.21s |      0.75% |
| Initialization                   |         1 |     0.138s |         0% |
| Particles: Advect                |       202 |      6.56s |       4.1% |
| Particles: Generate              |         1 |     0.461s |      0.29% |
| Particles: Initialization        |         1 |  0.000131s |         0% |
| Particles: Initialize properties |         1 |    0.0386s |         0% |
| Particles: Interpolate           |       101 |      1.41s |      0.88% |
| Particles: Sort                  |       202 |        77s |        48% |
| Postprocessing                   |       101 |      21.9s |        14% |
| Refine mesh structure, part 1    |        33 |      3.82s |       2.4% |
| Refine mesh structure, part 2    |        33 |      4.79s |         3% |
| Setup dof systems                |        34 |     0.505s |      0.31% |
| Setup initial conditions         |         1 |     0.581s |      0.36% |
| Setup matrices                   |        34 |      1.47s |      0.91% |
| Solve Stokes system              |       101 |      25.5s |        16% |
| Solve temperature system         |       101 |     0.439s |      0.27% |
+----------------------------------+-----------+------------+------------+
```

[test.prm.txt](https://github.com/geodynamics/aspect/files/5907220/test.prm.txt)
