### PR TITLE
Add assert and maximum to viscosity computation

### DIFF
--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -101,10 +101,12 @@ namespace aspect
                 ExcMessage ("Negative diffusion viscosity detected. This is unphysical and should not happen. "
                             "Check for negative parameters."));
 
-        // For low temperatures viscosities can become extremely large. These viscosities are physically meaningless
-        // (in composite rheologies other deformation mechanisms will take over), but they can provoke
-        // floating-point overflow errors. Since viscosities of diffusion and dislocation creep are often
-        // multiplied, we constrain each to be smaller than std::sqrt(max_double).
+        // Creep viscosities become extremely large at low
+        // temperatures and can therefore provoke floating-point overflow errors. In
+        // real rocks, other deformation mechanisms become dominant at low temperatures,
+        // so these high viscosities are never achieved. It is therefore both reasonable
+        // and desirable to require the single-mechanism viscosity to be smaller than
+        // std::sqrt(max_double).
         viscosity_diffusion = std::min(viscosity_diffusion, std::sqrt(std::numeric_limits<double>::max()));
 
         return viscosity_diffusion;

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -91,11 +91,21 @@ namespace aspect
         // A: prefactor,
         // d: grain size, m: grain size exponent, E: activation energy, P: pressure,
         // V; activation volume, R: gas constant, T: temperature.
-        const double viscosity_diffusion = 0.5 / p.prefactor *
-                                           std::exp((p.activation_energy +
-                                                     pressure*p.activation_volume)/
-                                                    (constants::gas_constant*temperature)) *
-                                           std::pow(grain_size, p.grain_size_exponent);
+        double viscosity_diffusion = 0.5 / p.prefactor *
+                                     std::exp((p.activation_energy +
+                                               pressure*p.activation_volume)/
+                                              (constants::gas_constant*temperature)) *
+                                     std::pow(grain_size, p.grain_size_exponent);
+
+        Assert (viscosity_diffusion > 0.0,
+                ExcMessage ("Negative diffusion viscosity detected. This is unphysical and should not happen. "
+                            "Check for negative parameters."));
+
+        // For low temperatures viscosities can become extremely large. These viscosities are physically meaningless
+        // (in composite rheologies other deformation mechanisms will take over), but they can provoke
+        // floating-point overflow errors. Since viscosities of diffusion and dislocation creep are often
+        // multiplied, we constrain each to be smaller than std::sqrt(max_double).
+        viscosity_diffusion = std::min(viscosity_diffusion, std::sqrt(std::numeric_limits<double>::max()));
 
         return viscosity_diffusion;
       }

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -99,10 +99,12 @@ namespace aspect
                 ExcMessage ("Negative dislocation viscosity detected. This is unphysical and should not happen. "
                             "Check for negative parameters."));
 
-        // For low temperatures viscosities can become extremely large. These viscosities are physically meaningless
-        // (in composite rheologies other deformation mechanisms will take over), but they can provoke
-        // floating-point overflow errors. Since viscosities of diffusion and dislocation creep are often
-        // multiplied, we constrain each to be smaller than std::sqrt(max_double).
+        // Creep viscosities become extremely large at low
+        // temperatures and can therefore provoke floating-point overflow errors. In
+        // real rocks, other deformation mechanisms become dominant at low temperatures,
+        // so these high viscosities are never achieved. It is therefore both reasonable
+        // and desirable to require the single-mechanism viscosity to be smaller than
+        // std::sqrt(max_double).
         viscosity_dislocation = std::min(viscosity_dislocation, std::sqrt(std::numeric_limits<double>::max()));
 
         return viscosity_dislocation;

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -137,7 +137,21 @@ namespace aspect
 
         const double strain_rate_term = std::pow(strain_rate, (1. / (s + p.stress_exponent)) - 1.);
 
-        return stress_term * arrhenius_term * strain_rate_term;
+        double viscosity_peierls = stress_term * arrhenius_term * strain_rate_term;
+
+        Assert (viscosity_peierls > 0.0,
+                ExcMessage ("Negative peierls viscosity detected. This is unphysical and should not happen. "
+                            "Check for negative parameters."));
+
+        // Creep viscosities become extremely large at low
+        // temperatures and can therefore provoke floating-point overflow errors. In
+        // real rocks, other deformation mechanisms become dominant at low temperatures,
+        // so these high viscosities are never achieved. It is therefore both reasonable
+        // and desirable to require the single-mechanism viscosity to be smaller than
+        // std::sqrt(max_double).
+        viscosity_peierls = std::min(viscosity_peierls, std::sqrt(std::numeric_limits<double>::max()));
+
+        return viscosity_peierls;
       }
 
 


### PR DESCRIPTION
@mibillen and @elodie-kendall could you take a look if this PR fixes your issues #3959 or #3957? It should prevent the diffusion and dislocation viscosities from becoming too large to trigger floating point overflows in the composite rheology. I decided to move this into the individual plugins instead of the combined visco plastic rheology, because it seemed safer (it may happen in other places that use these plugins as well).

