### PR TITLE
update parameter doc

### DIFF
--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -52,7 +52,7 @@ namespace aspect
         Assert (computed_quantities[0].size() == 1,                   ExcInternalError());
         Assert (input_data.solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
-        // in case the material model computes the melt fraction iself, we use that output
+        // in case the material model computes the melt fraction itself, we use that output
         if (Plugins::plugin_type_matches<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()))
           {
             MaterialModel::MaterialModelInputs<dim> in(input_data,

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -541,7 +541,7 @@ namespace aspect
                            Patterns::Double (0.),
                            "Set a time step size for computing reactions of compositional fields and the "
                            "temperature field in case operator splitting is used. This is only used "
-                           "when the nonlinear solver scheme ``operator splitting'' is selected. "
+                           "when the parameter ``Use operator splitting'' is set to true. "
                            "The reaction time step must be greater than 0. "
                            "If you want to prescribe the reaction time step only as a relative value "
                            "compared to the advection time step as opposed to as an absolute value, you "
@@ -554,8 +554,8 @@ namespace aspect
         prm.declare_entry ("Reaction time steps per advection step", "0",
                            Patterns::Integer (0),
                            "The number of reaction time steps done within one advection time step "
-                           "in case operator splitting is used. This is only used if the nonlinear "
-                           "solver scheme ``operator splitting'' is selected. If set to zero, this "
+                           "in case operator splitting is used. This is only used if the parameter "
+                           "``Use operator splitting'' is set to true. If set to zero, this "
                            "parameter is ignored. Otherwise, the reaction time step size is chosen according to "
                            "this criterion and the ``Reaction time step'', whichever yields the "
                            "smaller time step. "


### PR DESCRIPTION
There is no nonlinear solver scheme `operator splitting`, but a separate parameter `Use operator splitting`, so I've updated the description of the `Operator splitting parameters`. 

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
