### PR TITLE
Add assert max_visc >= min_visc

### DIFF
--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -574,6 +574,8 @@ namespace aspect
         max_visc = prm.get_double ("Maximum viscosity");
         ref_visc = prm.get_double ("Reference viscosity");
 
+        AssertThrow(max_visc >= min_visc, ExcMessage("Maximum viscosity should be larger or equal to the minimum viscosity. "));
+
         viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
                               prm);
 


### PR DESCRIPTION
Currently the min viscosity can be larger than the max viscosity, so when you accidentally switch them in the input file ... Hope it saves somebody else some time :sweat:

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

