### PR TITLE
adjusted error message for time stepping function

### DIFF
--- a/source/time_stepping/function.cc
+++ b/source/time_stepping/function.cc
@@ -76,7 +76,7 @@ namespace aspect
         catch (...)
           {
             std::cerr << "ERROR: FunctionParser failed to parse\n"
-                      << "\t'Heating model.Function'\n"
+                      << "\t'Timestepping.Function'\n"
                       << "with expression\n"
                       << "\t'" << prm.get("Function expression") << "'"
                       << "More information about the cause of the parse error \n"


### PR DESCRIPTION
I noticed that the error message in the time stepping function was saying heating model. I guess this was just a mistake from copying it over so I changed to timestepping. 

### Before your first pull request:

* [ X] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [ X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
