### PR TITLE
Use the 'cite' package for the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -9,6 +9,7 @@
 \usepackage{textpos}
 \usepackage{gensymb}
 \usepackage{siunitx}
+\usepackage{cite}
 
 % This adds space between the Appendix number (e.g., A.101) and the title.
 


### PR DESCRIPTION
The package makes sure that references are listed not as [4,2,8,5] but as [2,4,5,8]. As a side effect, it also replaces [1,3,5,6,7,8] by [1,3,5-8].

I'm slightly ambivalent about the latter. It makes the document marginally shorter, but one can't click on a reference individually any more that way -- though one can click on `5` and then quite easily get to 7 from there. Opinions appreciated.