### PR TITLE
added elastic stress contribution to stress and shear stress vis pp

### DIFF
--- a/include/aspect/postprocess/visualization/shear_stress.h
+++ b/include/aspect/postprocess/visualization/shear_stress.h
@@ -44,6 +44,7 @@ namespace aspect
        * \frac 13 (\nabla \cdot \mathbf u) \mathbf I)$ and differs from the
        * full stress by the absence of the pressure.  The second term in the
        * difference is zero if the model is incompressible.
+       * If elasticity is used, the elastic contribution is being accounted for.
        *
        * The member functions are all implementations of those declared in the
        * base class. See there for their meaning.

--- a/include/aspect/postprocess/visualization/stress.h
+++ b/include/aspect/postprocess/visualization/stress.h
@@ -43,6 +43,7 @@ namespace aspect
        * 2\eta (\varepsilon(\mathbf u) - \frac 13 (\nabla \cdot \mathbf u)
        * \mathbf I) + pI$.  The second term in the parentheses is zero if the
        * model is incompressible.
+       * If elasticity is used, the elastic contribution is being accounted for.
        *
        * The member functions are all implementations of those declared in the
        * base class. See there for their meaning.

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -74,7 +74,22 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            const SymmetricTensor<2,dim> shear_stress = -2.*eta*deviatoric_strain_rate;
+            SymmetricTensor<2,dim> shear_stress = -2.*eta*deviatoric_strain_rate;
+
+            // Add elastic stresses if existent
+            if (this->get_parameters().enable_elasticity == true)
+              {
+                shear_stress[0][0] += in.composition[q][this->introspection().compositional_index_for_name("stress_xx")];
+                shear_stress[1][1] += in.composition[q][this->introspection().compositional_index_for_name("stress_yy")];
+                shear_stress[0][1] += in.composition[q][this->introspection().compositional_index_for_name("stress_xy")];
+
+                if (dim == 3)
+                  {
+                    shear_stress[2][2] += in.composition[q][this->introspection().compositional_index_for_name("stress_zz")];
+                    shear_stress[0][2] += in.composition[q][this->introspection().compositional_index_for_name("stress_xz")];
+                    shear_stress[1][2] += in.composition[q][this->introspection().compositional_index_for_name("stress_yz")];
+                  }
+              }
 
             for (unsigned int d=0; d<dim; ++d)
               for (unsigned int e=0; e<dim; ++e)
@@ -108,7 +123,8 @@ namespace aspect
                                                   "in the incompressible case and "
                                                   "$-2\\eta\\left[\\varepsilon(\\mathbf u)-"
                                                   "\\tfrac 13(\\textrm{tr}\\;\\varepsilon(\\mathbf u))\\mathbf I\\right]$ "
-                                                  "in the compressible case. The shear "
+                                                  "in the compressible case. If elasticity is used, the "
+                                                  "elastic contribution is being accounted for. The shear "
                                                   "stress differs from the full stress tensor "
                                                   "by the absence of the pressure. Note that the convention "
                                                   "of positive compressive stress is followed. ")


### PR DESCRIPTION
While the elastic contribution is added to the principal stress postprocesor, it was not in the stress and shear stress postprocesors.

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
