### PR TITLE
Make sure visualization names are unique

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -538,6 +538,30 @@ namespace aspect
 
 
 
+    namespace
+    {
+      // Add new output_data_names to a set output_data_names_set, and check for uniqueness of names.
+      // Multiple copies in output_data_names are collapsed into one copy before checking
+      // for uniqueness with output_data_names_set, because vector data fields are represented as multiple
+      // copies of the same name.
+      void add_data_names_to_set(const std::vector<std::string> &output_data_names,
+      std::set<std::string> &output_data_names_set)
+      {
+      const std::set<std::string> set_of_names(output_data_names.begin(),output_data_names.end());
+
+      for (const auto &name: set_of_names)
+        {
+          const auto iterator_and_success = output_data_names_set.insert(name);
+          AssertThrow(iterator_and_success.second == true,
+                      ExcMessage("The output variable <" + name + "> already exists in the list of output "
+                                 "variables. Make sure there is no duplication in the names of visualization output "
+                                 "variables, otherwise output files may be corrupted."));
+        }
+      }
+    }
+
+
+
     template <int dim>
     std::pair<std::string,std::string>
     Visualization<dim>::execute (TableHandler &statistics)
@@ -577,6 +601,12 @@ namespace aspect
       internal::BaseVariablePostprocessor<dim> base_variables;
       base_variables.initialize_simulator (this->get_simulator());
 
+      // Keep a list of the names of all output variables, to ensure unique names
+      std::set<std::string> visualization_field_names;
+
+      // Insert base variable names into set of all output field names
+      add_data_names_to_set(base_variables.get_names(), visualization_field_names);
+
       std::unique_ptr<internal::MeshDeformationPostprocessor<dim> > mesh_deformation_variables;
 
       DataOut<dim> data_out;
@@ -605,6 +635,10 @@ namespace aspect
         {
           mesh_deformation_variables = std_cxx14::make_unique<internal::MeshDeformationPostprocessor<dim>>();
           mesh_deformation_variables->initialize_simulator(this->get_simulator());
+
+          // Insert mesh deformation variable names into set of all output field names
+          add_data_names_to_set(mesh_deformation_variables->get_names(), visualization_field_names);
+
           data_out.add_data_vector (this->get_mesh_velocity(),
                                     *mesh_deformation_variables);
         }
@@ -630,6 +664,8 @@ namespace aspect
               if (const DataPostprocessor<dim> *viz_postprocessor
                   = dynamic_cast<const DataPostprocessor<dim>*>(& *p))
                 {
+                  add_data_names_to_set(viz_postprocessor->get_names(), visualization_field_names);
+
                   if (dynamic_cast<const VisualizationPostprocessors::SurfaceOnlyVisualization<dim>*>
                       (& *p) == nullptr)
                     data_out.add_data_vector (this->get_solution(),
@@ -651,6 +687,8 @@ namespace aspect
                           ExcMessage ("Cell data visualization postprocessors must generate "
                                       "vectors that have as many entries as there are active cells "
                                       "on the current processor."));
+
+                  add_data_names_to_set(std::vector<std::string>(1,cell_data.first), visualization_field_names);
 
                   // store the pointer, then attach the vector to the DataOut object
                   cell_data_vectors.push_back (std::unique_ptr<Vector<float> >

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -545,18 +545,18 @@ namespace aspect
       // for uniqueness with output_data_names_set, because vector data fields are represented as multiple
       // copies of the same name.
       void add_data_names_to_set(const std::vector<std::string> &output_data_names,
-      std::set<std::string> &output_data_names_set)
+                                 std::set<std::string> &output_data_names_set)
       {
-      const std::set<std::string> set_of_names(output_data_names.begin(),output_data_names.end());
+        const std::set<std::string> set_of_names(output_data_names.begin(),output_data_names.end());
 
-      for (const auto &name: set_of_names)
-        {
-          const auto iterator_and_success = output_data_names_set.insert(name);
-          AssertThrow(iterator_and_success.second == true,
-                      ExcMessage("The output variable <" + name + "> already exists in the list of output "
-                                 "variables. Make sure there is no duplication in the names of visualization output "
-                                 "variables, otherwise output files may be corrupted."));
-        }
+        for (const auto &name: set_of_names)
+          {
+            const auto iterator_and_success = output_data_names_set.insert(name);
+            AssertThrow(iterator_and_success.second == true,
+                        ExcMessage("The output variable <" + name + "> already exists in the list of output "
+                                   "variables. Make sure there is no duplication in the names of visualization output "
+                                   "variables, otherwise output files may be corrupted."));
+          }
       }
     }
 

--- a/tests/composition_names_duplicates.prm
+++ b/tests/composition_names_duplicates.prm
@@ -1,0 +1,109 @@
+# A test to ensure the naming of compositional fields works as expected.
+
+# EXPECT FAILURE
+
+set Adiabatic surface temperature          = 1623
+set CFL number                             = 1.0
+set Dimension                              = 2
+set End time                               = 0
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Resume computation                     = false
+set Start time                             = 0
+
+set Use years in output instead of seconds = true
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = peridotite, density
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 0,3
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Maximal temperature = 3773
+    set Minimal temperature = 273
+  end
+
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent  = 500000
+    set Y extent  = 500000
+  end
+
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function constants  = l=250000
+    set Function expression = if(x < l, 1873, 1623)
+    set Variable names      = x,y
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0;0
+    set Variable names      = x,y
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+end
+
+
+subsection Mesh refinement
+  set Coarsening fraction                      = 0.05
+  set Refinement fraction                      = 0.3
+
+  set Initial adaptive refinement              = 0
+  set Initial global refinement                = 0
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0,1,2,3
+end
+
+
+subsection Postprocess
+
+  set List of postprocessors = visualization,composition statistics
+
+  subsection Visualization
+    set Interpolate output = false
+    set List of output variables      = material properties
+    set Number of grouped files       = 0
+    set Output format                 = gnuplot
+    set Time between graphical output = 0
+  end
+
+end

--- a/tests/composition_names_duplicates/screen-output
+++ b/tests/composition_names_duplicates/screen-output
@@ -1,0 +1,40 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 1 (on 1 levels)
+Number of degrees of freedom: 49 (18+4+9+9+9)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Skipping density composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 5+0 iterations.
+
+   Postprocessing:
+
+
+----------------------------------------------------
+An exception happened on MPI process <0> while running the visualization postprocessor <N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE>: 
+
+--------------------------------------------------------
+An error occurred in line <555> of file </home/rene/software/aspect/source/postprocess/visualization.cc> in function
+(line in output replaced by default.sh script)
+The violated condition was: 
+    iterator_and_success.second == true
+Additional information: 
+    The output variable <density> already exists in the list of output variables. Make sure there is no duplication in the names of visualization output variables, otherwise output files may be corrupted.
+--------------------------------------------------------
+
+Aborting!
+----------------------------------------------------
+--------------------------------------------------------------------------
+MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
+with errorcode 1.
+
+NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
+You may or may not see output from other processes, depending on
+exactly when Open MPI kills them.
+--------------------------------------------------------------------------

--- a/tests/composition_names_duplicates/screen-output
+++ b/tests/composition_names_duplicates/screen-output
@@ -1,8 +1,4 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 Number of active cells: 1 (on 1 levels)
 Number of degrees of freedom: 49 (18+4+9+9+9)
 
@@ -16,25 +12,17 @@ Number of degrees of freedom: 49 (18+4+9+9+9)
    Postprocessing:
 
 
-----------------------------------------------------
 An exception happened on MPI process <0> while running the visualization postprocessor <N6aspect11Postprocess27VisualizationPostprocessors18MaterialPropertiesILi2EEE>: 
 
---------------------------------------------------------
-An error occurred in line <555> of file </home/rene/software/aspect/source/postprocess/visualization.cc> in function
+An error occurred in file <visualization.cc> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
     iterator_and_success.second == true
 Additional information: 
     The output variable <density> already exists in the list of output variables. Make sure there is no duplication in the names of visualization output variables, otherwise output files may be corrupted.
---------------------------------------------------------
 
 Aborting!
-----------------------------------------------------
---------------------------------------------------------------------------
-MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
-with errorcode 1.
-
-NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
-You may or may not see output from other processes, depending on
-exactly when Open MPI kills them.
---------------------------------------------------------------------------
+application called MPI_Abort(MPI_COMM_WORLD, 1) - process 0
+[unset]: write_line error; fd=-1 buf=:cmd=abort exitcode=1
+:
+system msg for write_line failure : Bad file descriptor


### PR DESCRIPTION
Fixes #3996. The task is slightly more complicated than I thought at first, because each postprocessor can rightly return multiple copies of the same name if it returns a vector or tensor. Thus each postprocessors names are first copied into a set to make them unique, and then this set is merged with the existing set of names, while checking for duplicates.