### PR TITLE
Included constraints for interpolate output into advection field.

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1839,6 +1839,7 @@ namespace aspect
     // updating the ghost elements of the 'solution' vector.
     const unsigned int advection_block = adv_field.block_index(introspection);
     distributed_vector.block(advection_block).compress(VectorOperation::insert);
+    current_constraints.distribute (solution);
     solution.block(advection_block) = distributed_vector.block(advection_block);
   }
 


### PR DESCRIPTION
While running one of my models which sets the temperature to a prescribed ASCII data file, I noticed that the boundary conditions for the temperature were also overwritten by the prescribed temperatures. This PR ensures that the constraints are set in the solution while using the function, ```interpolate_material_output_into_advection_field.```

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

* [x] I have tested my new feature locally to ensure it is correct.
