### PR TITLE
delay exit with failure in parallel

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -861,6 +861,11 @@ int main (int argc, char *argv[])
       // root when we already know that processor 0 will generate
       // an exception. We do this to avoid creating too much
       // (duplicate) screen output.
+
+      // Sleep a few seconds before aborting. This allows text output from
+      // other ranks to be printed before the MPI implementation might kill
+      // the computation.
+      std::this_thread::sleep_for(std::chrono::seconds(5));
       return 1;
     }
   catch (...)


### PR DESCRIPTION
When an exception (like solver failure) is triggered, all but rank 0
immeditately return in main() without printing anything. Some MPI
implementations detect abnormal termination and abort the whole job.
This could happen before rank 0 produces an error message.
Avoid this by sleeping before exiting.
