### PR TITLE
Fix split line problem for cmake version 2.8.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,7 @@ SET(ASPECT_WITH_WORLD_BUILDER ON CACHE BOOL "Whether to enable compiling aspect 
 MESSAGE(STATUS "ASPECT_WITH_WORLD_BUILDER = '${ASPECT_WITH_WORLD_BUILDER}'")
 if(ASPECT_WITH_WORLD_BUILDER)
   # Check whether we can find the WorldBuilder.
-  SET(WORLD_BUILDER_SOURCE_DIR "" CACHE PATH "Provide an external World Builder directory to be compiled with ASPECT. \
-    If the path is not not provided or the World Builder is not found in the provided location, the version in the contrib folder is is used.")
+  SET(WORLD_BUILDER_SOURCE_DIR "" CACHE PATH "Provide an external World Builder directory to be compiled with ASPECT. If the path is not not provided or the World Builder is not found in the provided location, the version in the contrib folder is is used.")
   IF (NOT EXISTS ${WORLD_BUILDER_SOURCE_DIR}/VERSION)
     MESSAGE(STATUS "World Builder not found. Using internal version.")
     SET(WORLD_BUILDER_SOURCE_DIR "${CMAKE_SOURCE_DIR}/contrib/world_builder/" CACHE PATH "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ SET(ASPECT_WITH_WORLD_BUILDER ON CACHE BOOL "Whether to enable compiling aspect 
 MESSAGE(STATUS "ASPECT_WITH_WORLD_BUILDER = '${ASPECT_WITH_WORLD_BUILDER}'")
 if(ASPECT_WITH_WORLD_BUILDER)
   # Check whether we can find the WorldBuilder.
-  SET(WORLD_BUILDER_SOURCE_DIR "" CACHE PATH "Provide an external World Builder directory to be compiled with ASPECT. If the path is not not provided or the World Builder is not found in the provided location, the version in the contrib folder is is used.")
+  SET(WORLD_BUILDER_SOURCE_DIR "" CACHE PATH "Provide an external World Builder directory to be compiled with ASPECT. If the path is not provided or the World Builder is not found in the provided location, the version in the contrib folder is used.")
   IF (NOT EXISTS ${WORLD_BUILDER_SOURCE_DIR}/VERSION)
     MESSAGE(STATUS "World Builder not found. Using internal version.")
     SET(WORLD_BUILDER_SOURCE_DIR "${CMAKE_SOURCE_DIR}/contrib/world_builder/" CACHE PATH "" FORCE)


### PR DESCRIPTION
This fixes a reported issue in https://community.geodynamics.org/t/world-builder-causing-error-during-configuration/1823 for cmake version 2.8.12.2. I tested it locally and could reproduce the problem and it is fixed with this change.