### PR TITLE
update inner_core_traction param file

### DIFF
--- a/cookbooks/inner_core_convection/inner_core_traction.prm
+++ b/cookbooks/inner_core_convection/inner_core_traction.prm
@@ -11,11 +11,14 @@
 
 set Additional shared libraries            = ./libinner_core_convection.so
 
-set Dimension                              = 3
+set Dimension                              = 2
 set Use years in output instead of seconds = false
-set End time                               = 1.5e9
-set Output directory                       = output-inner_core_traction
+set End time                               = 39.275
+set Output directory                       = output_inner_core_traction_Ra_1e2_P_1e-2
 
+subsection Nullspace removal
+  set Remove nullspace = net rotation
+end
 # The equations are non-dimensionalized, and all of the
 # material properties are constant and set to one, except
 # for the density, which scales with temperature.
@@ -45,7 +48,7 @@ subsection Material model
 # and the last variable will be the time
   subsection Inner core
     subsection Phase change resistance function
-      set Variable names      = x,y,z
+      set Variable names      = x,y
       set Function expression = 1e-2     # <-- P
     end
   end
@@ -103,16 +106,17 @@ subsection Gravity model
 
   subsection Radial linear
     set Magnitude at bottom = 0.0
-    set Magnitude at surface = 2     # <-- Ra
+    set Magnitude at surface = 1e2     # <-- Ra
   end
 end
 
 
 subsection Mesh refinement
   set Initial global refinement          = 3
-  set Initial adaptive refinement        = 0
-  set Strategy                           = minimum refinement function
-  set Time steps between mesh refinement = 0
+  set Initial adaptive refinement        = 2
+  set Strategy                           = minimum refinement function, thermal energy density
+
+  set Time steps between mesh refinement = 15
 
   subsection Minimum refinement function
     set Variable names = depth, phi, theta
@@ -126,9 +130,10 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set Time between graphical output = 0
-    set Number of grouped files       = 0
+    set Time between graphical output = 5e-6
+    set Number of grouped files       = 1
     set List of output variables      = strain rate, gravity, density, specific heat, heating
   end
 
 end
+

--- a/cookbooks/inner_core_convection/inner_core_traction.prm
+++ b/cookbooks/inner_core_convection/inner_core_traction.prm
@@ -14,7 +14,7 @@ set Additional shared libraries            = ./libinner_core_convection.so
 set Dimension                              = 2
 set Use years in output instead of seconds = false
 set End time                               = 39.275
-set Output directory                       = output_inner_core_traction_Ra_1e2_P_1e-2
+set Output directory                       = output_inner_core_traction
 
 subsection Nullspace removal
   set Remove nullspace = net rotation


### PR DESCRIPTION
*Describe what you did in this PR and why you did it.*

The inner core traction param file was not really usable (3D too expensive to run; problem with rotation, etc.)
We propose a new param file, changing some parameters to have a set-up that can be run easily on a laptop and provide nice translation instability. The different modifications are listed below:
- We  switched the model from 3D to 2D.
- We prevented the system from rotation (null space removal)
- We increased the Rayleigh number in order to have translation.
- We also changed the mesh refinement (thermal energy density refinement added) and the end time of the run to agree with the Rayleigh number.

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [ X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
