### PR TITLE
Add Dockerfile for TACC systems Stampede Frontera

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,7 +86,7 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64
           push: true
-          tags: geodynamics/aspect_tacc:latest
+          tags: geodynamics/aspect:latest-tacc
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -97,4 +97,4 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64
           push: true
-          tags: geodynamics/aspect_tacc:${{github.ref_name}}
+          tags: geodynamics/aspect:${{github.ref_name}}-tacc

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LOGIN }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,3 +57,44 @@ jobs:
           push: true
           tags: geodynamics/aspect:${{github.ref_name}}
 
+  build-docker-tacc:
+    runs-on: ubuntu-latest
+    if: github.repository == 'geodynamics/aspect'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image for main
+        if: contains(github.event_name, 'push')
+        uses: docker/build-push-action@v4
+        with:
+          context: ./contrib/docker/docker_tacc/
+          cache-from: type=registry,ref=ubuntu:22.04
+          cache-to: type=inline
+          platforms: linux/amd64
+          push: true
+          tags: geodynamics/aspect_tacc:latest
+
+      - name: Build and push Docker image for release
+        if: contains(github.event_name, 'release')
+        uses: docker/build-push-action@v4
+        with:
+          context: ./contrib/docker/docker_tacc/
+          cache-from: type=registry,ref=ubuntu:22.04
+          cache-to: type=inline
+          platforms: linux/amd64
+          push: true
+          tags: geodynamics/aspect_tacc:${{github.ref_name}}

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -2,15 +2,12 @@ FROM tacc/tacc-ubuntu18-impi19.0.7-common:latest
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
-RUN apt-get update && apt-get upgrade -y
-
 # we need a newer version of cmake to support unity builds:
 RUN apt-get update && apt-get -yq upgrade && apt-get -yq install \
     libblas-dev \
     liblapack-dev \
     git \
     wget \
-    cmake \
     python \
     numdiff \
     bc \
@@ -24,30 +21,19 @@ RUN cd /opt && \
     cd candi && \
     echo "NATIVE_OPTIMIZATIONS=true" >> local.cfg && \
     echo "STABLE_BUILD=false" >> local.cfg && \
-    echo "DEAL_II_VERSION=master" >> local.cfg && \
-    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_CXX17=OFF -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_COMPONENT_EXAMPLES=OFF -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
-    ./candi.sh -j 64 --packages="once:p4est once:trilinos once:hdf5 dealii" --platform=deal.II-toolchain/platforms/supported/ubuntu18.platform -p /opt && \
+    echo "DEAL_II_VERSION=v9.4.2" >> local.cfg && \
+    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_COMPONENT_EXAMPLES=OFF -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
+    ./candi.sh -j 2 --packages="once:cmake once:p4est once:trilinos once:hdf5 dealii" -p /opt && \
     rm -rf /opt/tmp
 
 # Build aspect, replace git checkout command to create image for release
-RUN cd /opt && \
-    export DEAL_II_DIR=/opt/deal.II-master && \
-    git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
-    mkdir aspect/build-release && \
-    cd aspect/build-release && \
-    git checkout master && \
-    /opt/cmake-3.17.3-Linux-x86_64/bin/cmake -DCMAKE_BUILD_TYPE=Release \
-          .. && \
-    make -j64 && \
-    make install && \
-    make clean
+ENV Aspect_DIR /opt/aspect
+RUN source /opt/configuration/enable.sh && \
+    git clone https://github.com/geodynamics/aspect.git $Aspect_DIR && \
+    mkdir ${Aspect_DIR}/build && \
+    cd ${Aspect_DIR}/build && \
+    cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
+    -DASPECT_INSTALL_EXAMPLES=ON .. && \
+    make -j2 && make install && make clean
 
-RUN cd /opt/aspect && \
-    mkdir build-debug && \
-    cd build-debug && \
-    /opt/cmake-3.17.3-Linux-x86_64/bin/cmake -DCMAKE_BUILD_TYPE=Debug \
-          -DCMAKE_INSTALL_PREFIX=/opt/aspect/debug .. && \
-    make -j64 && \
-    make install && \
-    ln -s /opt/aspect/debug/bin/aspect /usr/local/bin/aspect.debug && \
-    make clean
+ENV PATH ${Aspect_DIR}/bin:${PATH}

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -13,16 +13,13 @@ RUN apt-get update && apt-get -yq upgrade && apt-get -yq install \
     bc \
     ninja-build
 
-RUN cd /opt && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
-ENV PATH /opt/cmake-3.17.3-Linux-x86_64/bin:$PATH
-
 RUN cd /opt && \
     git clone https://github.com/dealii/candi.git && \
     cd candi && \
-    echo "NATIVE_OPTIMIZATIONS=true" >> local.cfg && \
-    echo "STABLE_BUILD=false" >> local.cfg && \
+    echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
     echo "DEAL_II_VERSION=v9.4.2" >> local.cfg && \
-    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_COMPONENT_EXAMPLES=OFF -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
+    echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
+    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_64BIT_INDICES=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
     ./candi.sh -j 2 --packages="once:cmake once:p4est once:trilinos once:hdf5 dealii" -p /opt && \
     rm -rf /opt/tmp
 

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -19,7 +19,8 @@ RUN cd /opt && \
     echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
     echo "DEAL_II_VERSION=v9.4.2" >> local.cfg && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
-    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_64BIT_INDICES=ON -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
+    echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
+    echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \
     ./candi.sh -j 2 --packages="once:cmake once:p4est once:trilinos once:hdf5 dealii" -p /opt && \
     rm -rf /opt/tmp
 

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -1,0 +1,53 @@
+FROM tacc/tacc-ubuntu18-impi19.0.7-common:latest
+
+LABEL maintainer <rene.gassmoeller@mailbox.org>
+
+RUN apt-get update && apt-get upgrade -y
+
+# we need a newer version of cmake to support unity builds:
+RUN apt-get update && apt-get -yq upgrade && apt-get -yq install \
+    libblas-dev \
+    liblapack-dev \
+    git \
+    wget \
+    cmake \
+    python \
+    numdiff \
+    bc \
+    ninja-build
+
+RUN cd /opt && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
+ENV PATH /opt/cmake-3.17.3-Linux-x86_64/bin:$PATH
+
+RUN cd /opt && \
+    git clone https://github.com/dealii/candi.git && \
+    cd candi && \
+    echo "NATIVE_OPTIMIZATIONS=true" >> local.cfg && \
+    echo "STABLE_BUILD=false" >> local.cfg && \
+    echo "DEAL_II_VERSION=master" >> local.cfg && \
+    echo "DEAL_CONFOPTS=-D DEAL_II_WITH_CXX17=OFF -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_COMPONENT_EXAMPLES=OFF -DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON" >> local.cfg && \
+    ./candi.sh -j 64 --packages="once:p4est once:trilinos once:hdf5 dealii" --platform=deal.II-toolchain/platforms/supported/ubuntu18.platform -p /opt && \
+    rm -rf /opt/tmp
+
+# Build aspect, replace git checkout command to create image for release
+RUN cd /opt && \
+    export DEAL_II_DIR=/opt/deal.II-master && \
+    git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
+    mkdir aspect/build-release && \
+    cd aspect/build-release && \
+    git checkout master && \
+    /opt/cmake-3.17.3-Linux-x86_64/bin/cmake -DCMAKE_BUILD_TYPE=Release \
+          .. && \
+    make -j64 && \
+    make install && \
+    make clean
+
+RUN cd /opt/aspect && \
+    mkdir build-debug && \
+    cd build-debug && \
+    /opt/cmake-3.17.3-Linux-x86_64/bin/cmake -DCMAKE_BUILD_TYPE=Debug \
+          -DCMAKE_INSTALL_PREFIX=/opt/aspect/debug .. && \
+    make -j64 && \
+    make install && \
+    ln -s /opt/aspect/debug/bin/aspect /usr/local/bin/aspect.debug && \
+    make clean

--- a/contrib/docker/docker_tacc/build.sh
+++ b/contrib/docker/docker_tacc/build.sh
@@ -6,5 +6,5 @@
 # webpage for an explanation).
 # Note: This container is build from the developer version on Github, it does not use
 # the local ASPECT folder. Therefore local changes are not included in the container.
-
-docker build --no-cache -t gassmoeller/aspect-tacc .
+VERSION=`cat ../../../VERSION`
+docker build -t ghcr.io/geodynamics/aspect:${VERSION}-tacc .

--- a/contrib/docker/docker_tacc/build.sh
+++ b/contrib/docker/docker_tacc/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script generates a docker image from the latest aspect development version.
+# It requires a docker installation on the local machine, and the ability to
+# communicate with the docker daemon without root user privileges (see the docker
+# webpage for an explanation).
+# Note: This container is build from the developer version on Github, it does not use
+# the local ASPECT folder. Therefore local changes are not included in the container.
+
+docker build --no-cache -t gassmoeller/aspect-tacc .

--- a/contrib/docker/docker_tacc/instructions.txt
+++ b/contrib/docker/docker_tacc/instructions.txt
@@ -1,6 +1,9 @@
+# To use this docker image on TACC systems, login to a compute node.
+# Then run:
 
 module load tacc-singularity
 
-singularity pull docker://gassmoeller/aspect-tacc
+singularity pull docker://geodynamics/aspect:latest-tacc
 
-ibrun singularity run aspect-tacc_latest.sif aspect cookbook/gplates_2d.prm
+# Replace PARAMETERFILE with a parameter file.
+ibrun singularity run aspect_latest-tacc.sif aspect PARAMETERFILE

--- a/contrib/docker/docker_tacc/instructions.txt
+++ b/contrib/docker/docker_tacc/instructions.txt
@@ -1,0 +1,6 @@
+
+module load tacc-singularity
+
+singularity pull docker://gassmoeller/aspect-tacc
+
+ibrun singularity run aspect-tacc_latest.sif aspect cookbook/gplates_2d.prm


### PR DESCRIPTION
The TACC systems Stampede2 and Frontera support running singularity containers. This is a preliminary Docker image that uses their base images. They run successfully in parallel on Frontera across nodes. I need to do some more testing regarding performance and extend the documentation, but I think this is something we may want to keep around to make installation on Stampede and Frontera trivial (you can put the lines in instructions.txt in any slurm script and it will download and run ASPECT without local installation).