### PR TITLE
Remove duplicated calls to initialize

### DIFF
--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -461,8 +461,6 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-
-      initialize ();
     }
   }
 }

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -471,8 +471,6 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-
-      initialize ();
     }
   }
 }

--- a/source/initial_temperature/patch_on_S40RTS.cc
+++ b/source/initial_temperature/patch_on_S40RTS.cc
@@ -162,10 +162,10 @@ namespace aspect
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-      s40rts.initialize_simulator (this->get_simulator());
 
-      // Note: parse_parameters will call initialize for us
+      s40rts.initialize_simulator (this->get_simulator());
       s40rts.parse_parameters(prm);
+      s40rts.initialize();
 
     }
   }


### PR DESCRIPTION
Found while doing some testing for @wanyingw. The S40RTS_perturbation and SAVANI_perturbation initial temperature plugins called their initialize functions from their parse_parameters functions, which is duplicative and unnecessary, because the initial temperature manager calls these functions immediately after parse_parameters again (which is the way the function is intended to be used). I removed the duplicated calls, but one other plugin actually depended on this behavior, so I fixed that as well.