### PR TITLE
Avoid the use of TriaAccessor::number_of_children().

### DIFF
--- a/source/mesh_refinement/volume_of_fluid_interface.cc
+++ b/source/mesh_refinement/volume_of_fluid_interface.cc
@@ -157,7 +157,7 @@ namespace aspect
                           }
                         else
                           {
-                            for (unsigned int subface=0; subface < face->number_of_children(); ++subface)
+                            for (unsigned int subface=0; subface < face->n_children(); ++subface)
                               {
                                 const typename DoFHandler<dim>::active_cell_iterator neighbor_sub =
                                   (cell_has_periodic_neighbor

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -1067,7 +1067,7 @@ namespace aspect
           // the children of the periodic neighbor's corresponding face since we know that the letter does indeed have
           // children (because we know that the neighbor is refined).
           typename DoFHandler<dim>::face_iterator neighbor_face=neighbor->face(neighbor2);
-          for (unsigned int subface_no=0; subface_no<neighbor_face->number_of_children(); ++subface_no)
+          for (unsigned int subface_no=0; subface_no<neighbor_face->n_children(); ++subface_no)
             {
               const typename DoFHandler<dim>::active_cell_iterator neighbor_child
                 = ( cell_has_periodic_neighbor

--- a/source/volume_of_fluid/assembler.cc
+++ b/source/volume_of_fluid/assembler.cc
@@ -522,7 +522,7 @@ namespace aspect
         }
       else // face->has_children() so always assemble from here
         {
-          for (unsigned int subface_no=0; subface_no< face->number_of_children(); ++subface_no)
+          for (unsigned int subface_no=0; subface_no< face->n_children(); ++subface_no)
             {
               const typename DoFHandler<dim>::active_cell_iterator neighbor_child
                 = ( cell_has_periodic_neighbor


### PR DESCRIPTION
This function is deprecated. Use TriaAccessor::n_children() instead.

/rebuild