### PR TITLE
Shrink StructuredData.

### DIFF
--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -138,28 +138,6 @@ namespace aspect
         get_column_names() const;
 
         /**
-         * Returns whether the stored coordinates are equidistant. If
-         * coordinates are equidistant the lookup is more efficient. Returns
-         * false if no coordinates are loaded at the moment.
-         */
-        bool
-        has_equidistant_coordinates() const;
-
-        /**
-         * Returns the coordinates at which data is stored. This function
-         * can be used to determine the number of data points, or to query
-         * data only at exactly the positions at which it is available (avoiding
-         * interpolation).
-         *
-         * @param dimension The spatial direction for which to return the data
-         * coordinates, e.g. 0 for x-direction, 1 for y-direction, or equivalent
-         * values if your data coordinates are other dimensions such as
-         * temperature, pressure.
-         */
-        const std::vector<double> &
-        get_coordinates(const unsigned int dimension) const;
-
-        /**
          * Returns the column index of a column with the given name
          * @p column_name. Throws an exception if no such
          * column exists or no names were provided in the file.
@@ -201,19 +179,9 @@ namespace aspect
         std::vector<std::unique_ptr<Function<dim>>> data;
 
         /**
-         * The coordinate values in each direction as specified in the data file.
-         */
-        std::array<std::vector<double>,dim> coordinate_values;
-
-        /**
          * The maximum value of each component
          */
         std::vector<double> maximum_component_value;
-
-        /**
-         * The min and max of the coordinates in the data file.
-         */
-        std::array<std::pair<double,double>,dim> grid_extent;
 
         /**
          * Number of points in the data grid as specified in the data file.
@@ -227,19 +195,14 @@ namespace aspect
         const double scale_factor;
 
         /**
-         * Stores whether the coordinate values are equidistant or not,
-         * this determines the type of data function stored.
-         */
-        bool coordinate_values_are_equidistant;
-
-        /**
          * Computes the table indices given the size @p sizes of the
          * i-th entry.
          */
         TableIndices<dim>
         compute_table_indices(const TableIndices<dim> &sizes, const unsigned int i) const;
-
     };
+
+
 
     /**
      * AsciDataBase is a generic plugin used for declaring and reading the
@@ -620,15 +583,6 @@ namespace aspect
          */
         std::vector<std::string>
         get_column_names() const;
-
-        /**
-        * Returns the coordinates at which profile data is stored. This function
-        * can be used to determine the number of data points, or to query
-        * data only at exactly the positions at which it is available (avoiding
-        * interpolation).
-        */
-        const std::vector<double> &
-        get_coordinates() const;
 
         /**
          * Returns the column index of a column with the given name

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -41,8 +41,7 @@ namespace aspect
       components(components),
       data(components),
       maximum_component_value(components),
-      scale_factor(scale_factor),
-      coordinate_values_are_equidistant(false)
+      scale_factor(scale_factor)
     {}
 
 
@@ -53,8 +52,7 @@ namespace aspect
       components(numbers::invalid_unsigned_int),
       data(),
       maximum_component_value(),
-      scale_factor(scale_factor),
-      coordinate_values_are_equidistant(false)
+      scale_factor(scale_factor)
     {}
 
 
@@ -64,28 +62,6 @@ namespace aspect
     StructuredDataLookup<dim>::get_column_names() const
     {
       return data_component_names;
-    }
-
-
-
-    template <int dim>
-    bool
-    StructuredDataLookup<dim>::has_equidistant_coordinates() const
-    {
-      return coordinate_values_are_equidistant;
-    }
-
-
-
-    template <int dim>
-    const std::vector<double> &
-    StructuredDataLookup<dim>::get_coordinates(const unsigned int dimension) const
-    {
-      AssertThrow(dimension < dim,
-                  ExcMessage("There is no spatial dimension number " + std::to_string(dimension)
-                             + " in the current data file."));
-
-      return coordinate_values[dimension];
     }
 
 
@@ -105,6 +81,8 @@ namespace aspect
       return std::distance(data_component_names.begin(),column_position);
     }
 
+
+
     template <int dim>
     std::string
     StructuredDataLookup<dim>::get_column_name_from_index(const unsigned int column_index) const
@@ -116,6 +94,8 @@ namespace aspect
 
       return data_component_names[column_index];
     }
+
+
 
     template <int dim>
     double
@@ -133,6 +113,8 @@ namespace aspect
                                       const std::vector<Table<dim,double> > &raw_data)
     {
       Assert(coordinate_values_.size()==dim, ExcMessage("Invalid size of coordinate_values."));
+
+      std::array<std::vector<double>,dim> coordinate_values;
       for (unsigned int d=0; d<dim; ++d)
         {
           coordinate_values[d] = coordinate_values_[d];
@@ -167,7 +149,11 @@ namespace aspect
       // all the coordinates in each direction, which is more costly.
       std::array<unsigned int,dim> table_intervals;
 
-      coordinate_values_are_equidistant = true;
+      // min and max of the coordinates in the data file.
+      std::array<std::pair<double,double>,dim> grid_extent;
+
+
+      bool coordinate_values_are_equidistant = true;
       for (unsigned int d=0; d<dim; ++d)
         {
           table_intervals[d] = table_points[d]-1;
@@ -396,6 +382,7 @@ namespace aspect
     }
 
 
+
     template <int dim>
     double
     StructuredDataLookup<dim>::get_data(const Point<dim> &position,
@@ -405,6 +392,8 @@ namespace aspect
       return data[component]->value(position);
     }
 
+
+
     template <int dim>
     Tensor<1,dim>
     StructuredDataLookup<dim>::get_gradients(const Point<dim> &position,
@@ -412,6 +401,7 @@ namespace aspect
     {
       return data[component]->gradient(position,0);
     }
+
 
 
     template <int dim>
@@ -1307,16 +1297,6 @@ namespace aspect
     {
       return lookup->get_data(position,component);
     }
-
-
-
-    template <int dim>
-    const std::vector<double> &
-    AsciiDataProfile<dim>::get_coordinates() const
-    {
-      return lookup->get_coordinates(0);
-    }
-
 
 
 // Explicit instantiations

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -104,7 +104,12 @@ namespace aspect
       public:
         void initialize() override
         {
-          reference_viscosity_coordinates = reference_viscosity_profile->get_coordinates();
+          this->reference_viscosity_coordinates =
+            std::vector<double> {0.0000000e+00,
+                                 1.0000000e+06,
+                                 2.0000000e+06,
+                                 3.0000000e+06
+                                };
         }
 
         void update() override


### PR DESCRIPTION
The `StructuredData` class stores a number of member variables that are duplicates of what is actually stored further down in the objects that do the interpolation. This patch removes them so that we don't have to store duplicates.

The most noteworthy part is that that also removes a couple of accessor functions that, as it turns out, are not actually used anywhere. As a consequence, I think that it's relatively harmless to get rid of these.

/rebuild