### PR TITLE
[WIP] Add github test action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,3 +68,39 @@ jobs:
       with:
         name: manual.log
         path: doc/manual/manual.log
+  job:
+    #linux build including indent and documentation
+    name: tests
+    runs-on: [ubuntu-18.04]
+    container: geodynamics/aspect-tester
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: compile
+      run: |
+        mkdir build
+        cd build
+        cmake \
+        -G 'Ninja' \
+        -D CMAKE_CXX_FLAGS='-Werror' \
+        -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \
+        -D ASPECT_TEST_GENERATOR='Ninja' \
+        -D ASPECT_PRECOMPILE_HEADERS=ON \
+        -D ASPECT_UNITY_BUILD=ON \
+        -D ASPECT_USE_PETSC=OFF \
+        -D ASPECT_RUN_ALL_TESTS='ON' \
+        ..
+        ninja
+        ./aspect --test
+    - name: prebuild tests
+      run: |
+        # prebuilding tests...
+        cd build/tests
+        ninja -k 0 tests || true
+    - name: report test results
+      run: |
+      cd build
+      ctest \
+        --no-compress-output \
+        --test-action Test \
+        --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,12 +100,16 @@ jobs:
       run: |
         # prebuilding tests...
         export OMPI_MCA_rmaps_base_oversubscribe=1
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
         cd build/tests
         ninja -k 0 tests || true
     - name: report test results
       run: |
         cd build
         export OMPI_MCA_rmaps_base_oversubscribe=1
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
         ctest \
         --no-compress-output \
         --test-action Test \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,10 @@ name: linux
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-nounity:
     #linux build with unity/precomiled headers disabled
@@ -80,7 +84,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake \
+        cmake \\
         -G 'Ninja' \
         -D CMAKE_CXX_FLAGS='-Werror' \
         -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \
@@ -99,8 +103,8 @@ jobs:
         ninja -k 0 tests || true
     - name: report test results
       run: |
-      cd build
-      ctest \
+        cd build
+        ctest \\
         --no-compress-output \
         --test-action Test \
         --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -99,11 +99,13 @@ jobs:
     - name: prebuild tests
       run: |
         # prebuilding tests...
+        export OMPI_MCA_rmaps_base_oversubscribe=1
         cd build/tests
         ninja -k 0 tests || true
     - name: report test results
       run: |
         cd build
+        export OMPI_MCA_rmaps_base_oversubscribe=1
         ctest \
         --no-compress-output \
         --test-action Test \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ jobs:
     #linux build including indent and documentation
     name: tests
     runs-on: [ubuntu-18.04]
-    container: geodynamics/aspect-tester
+    container: gassmoeller/aspect-tester
 
     steps:
     - uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake \\
+        cmake \
         -G 'Ninja' \
         -D CMAKE_CXX_FLAGS='-Werror' \
         -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \
@@ -104,7 +104,7 @@ jobs:
     - name: report test results
       run: |
         cd build
-        ctest \\
+        ctest \
         --no-compress-output \
         --test-action Test \
         --output-on-failure

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -5,4 +5,4 @@
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 
-docker build -t geodynamics/aspect-tester .
+docker build -t gassmoeller/aspect-tester .


### PR DESCRIPTION
Github now allows more runtime on their hosted runners than before, so we may be able to use them for our tester. It still needs some fixes, because some tests timeout at the moment, I will take a look at them when I get back to this.