### PR TITLE
Add elastic stresses to surface stress output

### DIFF
--- a/include/aspect/postprocess/visualization/surface_stress.h
+++ b/include/aspect/postprocess/visualization/surface_stress.h
@@ -43,7 +43,8 @@ namespace aspect
        * - \tfrac 13 \textrm{trace}\ \varepsilon(\mathbf u) \mathbf 1) +pI =
        * 2\eta (\varepsilon(\mathbf u) - \frac 13 (\nabla \cdot \mathbf u)
        * \mathbf I) + pI$.  The second term in the parentheses is zero if the
-       * model is incompressible.
+       * model is incompressible. If elasticity is used, its contribution
+       * is accounted for.
        *
        * The member functions are all implementations of those declared in the
        * base class. See there for their meaning.

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -64,8 +64,8 @@ namespace aspect
             const double eta = out.viscosities[q];
 
             // Compressive stress is positive in geoscience applications
-            const SymmetricTensor<2,dim> stress = -2.*eta*deviatoric_strain_rate +
-                                                  in.pressure[q] * unit_symmetric_tensor<dim>();
+            SymmetricTensor<2,dim> stress = -2.*eta*deviatoric_strain_rate +
+                                            in.pressure[q] * unit_symmetric_tensor<dim>();
 
             // Add elastic stresses if existent
             if (this->get_parameters().enable_elasticity == true)
@@ -99,25 +99,31 @@ namespace aspect
       SurfaceStress<dim>::get_names () const
       {
         std::vector<std::string> names;
-        switch (dim)
+        if (this->get_parameters().enable_elasticity == true)
           {
-            case 2:
-              names.emplace_back("ve_stress_xx");
-              names.emplace_back("ve_stress_yy");
-              names.emplace_back("ve_stress_xy");
-              break;
+            names.emplace_back("surface_ve_stress_xx");
+            names.emplace_back("surface_ve_stress_yy");
+            names.emplace_back("surface_ve_stress_xy");
 
-            case 3:
-              names.emplace_back("ve_stress_xx");
-              names.emplace_back("ve_stress_yy");
-              names.emplace_back("ve_stress_zz");
-              names.emplace_back("ve_stress_xy");
-              names.emplace_back("ve_stress_xz");
-              names.emplace_back("ve_stress_yz");
-              break;
+            if (dim == 3)
+              {
+                names.emplace_back("surface_ve_stress_zz");
+                names.emplace_back("surface_ve_stress_xz");
+                names.emplace_back("surface_ve_stress_yz");
+              }
+          }
+        else
+          {
+            names.emplace_back("surface_stress_xx");
+            names.emplace_back("surface_stress_yy");
+            names.emplace_back("surface_stress_xy");
 
-            default:
-              Assert (false, ExcNotImplemented());
+            if (dim == 3)
+              {
+                names.emplace_back("surface_stress_zz");
+                names.emplace_back("surface_stress_xz");
+                names.emplace_back("surface_stress_yz");
+              }
           }
 
         return names;

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -66,6 +66,22 @@ namespace aspect
             // Compressive stress is positive in geoscience applications
             const SymmetricTensor<2,dim> stress = -2.*eta*deviatoric_strain_rate +
                                                   in.pressure[q] * unit_symmetric_tensor<dim>();
+
+            // Add elastic stresses if existent
+            if (this->get_parameters().enable_elasticity == true)
+              {
+                stress[0][0] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_xx")];
+                stress[1][1] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_yy")];
+                stress[0][1] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_xy")];
+
+                if (dim == 3)
+                  {
+                    stress[2][2] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_zz")];
+                    stress[0][2] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_xz")];
+                    stress[1][2] += in.composition[q][this->introspection().compositional_index_for_name("ve_stress_yz")];
+                  }
+              }
+
             for (unsigned int i=0; i<SymmetricTensor<2,dim>::n_independent_components; ++i)
               computed_quantities[q](i) = stress[stress.unrolled_to_component_indices(i)];
           }
@@ -149,7 +165,8 @@ namespace aspect
                                                   "in the incompressible case and "
                                                   "$-2\\eta\\left[\\varepsilon(\\mathbf u)-"
                                                   "\\tfrac 13(\\textrm{tr}\\;\\varepsilon(\\mathbf u))\\mathbf I\\right]+pI$ "
-                                                  "in the compressible case. Note that the convention of positive "
+                                                  "in the compressible case. If elasticity is included, "
+                                                  "its contribution is accounted for. Note that the convention of positive "
                                                   "compressive stress is followed. ")
     }
   }

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -99,31 +99,15 @@ namespace aspect
       SurfaceStress<dim>::get_names () const
       {
         std::vector<std::string> names;
-        if (this->get_parameters().enable_elasticity == true)
-          {
-            names.emplace_back("surface_ve_stress_xx");
-            names.emplace_back("surface_ve_stress_yy");
-            names.emplace_back("surface_ve_stress_xy");
+        names.emplace_back("surface_stress_xx");
+        names.emplace_back("surface_stress_yy");
+        names.emplace_back("surface_stress_xy");
 
-            if (dim == 3)
-              {
-                names.emplace_back("surface_ve_stress_zz");
-                names.emplace_back("surface_ve_stress_xz");
-                names.emplace_back("surface_ve_stress_yz");
-              }
-          }
-        else
+        if (dim == 3)
           {
-            names.emplace_back("surface_stress_xx");
-            names.emplace_back("surface_stress_yy");
-            names.emplace_back("surface_stress_xy");
-
-            if (dim == 3)
-              {
-                names.emplace_back("surface_stress_zz");
-                names.emplace_back("surface_stress_xz");
-                names.emplace_back("surface_stress_yz");
-              }
+            names.emplace_back("surface_stress_zz");
+            names.emplace_back("surface_stress_xz");
+            names.emplace_back("surface_stress_yz");
           }
 
         return names;

--- a/tests/stress_vs_surface_stress/solution/solution_surface-00000.0000.gnuplot
+++ b/tests/stress_vs_surface_stress/solution/solution_surface-00000.0000.gnuplot
@@ -4,7 +4,7 @@
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <ve_stress_xx> <ve_stress_yy> <ve_stress_xy> 
+# <x> <y> <surface_stress_xx> <surface_stress_yy> <surface_stress_xy> 
 0 0 9426.38 9926.64 -0.000656362 
 0 0.0625 9426.38 9926.64 -0.000656362 
 


### PR DESCRIPTION
In line with the normal stress visualization postprocessor, the surface stress PP now includes the elastic stresses as well. The names of the stress tensor components are also updated to avoid running into duplicate paraview output names and to differentiate between viscous and visco-elastic stresses. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
