### PR TITLE
Particle evaluation optimizations

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -414,20 +414,16 @@ namespace aspect
                                    const typename ParticleHandler<dim>::particle_iterator &end_particle);
 
         /**
-        * Update the particle properties of one cell.
-        */
+         * Update the particle properties of one cell.
+         */
+        void
+        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle
 #if DEAL_II_VERSION_GTE(9,3,0)
-        void
-        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
-                               internal::SolutionEvaluators<dim> &evaluators);
-#else
-        void
-        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
+                               , internal::SolutionEvaluators<dim> &evaluators
 #endif
+                              );
 
         /**
          * Advect the particles of one cell. Performs only one step for
@@ -436,19 +432,15 @@ namespace aspect
          * during this advection step are removed from the local multimap and
          * stored in @p particles_out_of_cell for further treatment (sorting
          * them into the new cell).
-        */
+         */
+        void
+        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle
 #if DEAL_II_VERSION_GTE(9,3,0)
-        void
-        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
-                               internal::SolutionEvaluators<dim> &evaluators);
-#else
-        void
-        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
+                               , internal::SolutionEvaluators<dim> &evaluators
 #endif
+                              );
 
         /**
          * This function registers the necessary functions to the

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -65,6 +65,12 @@ namespace aspect
       class Manager;
     }
 
+    namespace internal
+    {
+      template <int dim>
+      class SolutionEvaluators;
+    }
+
     /**
      * This class manages the storage and handling of particles. It provides
      * interfaces to generate and store particles, functions to initialize,
@@ -408,12 +414,20 @@ namespace aspect
                                    const typename ParticleHandler<dim>::particle_iterator &end_particle);
 
         /**
-         * Update the particle properties of one cell.
-         */
+        * Update the particle properties of one cell.
+        */
+#if DEAL_II_VERSION_GTE(9,3,0)
+        void
+        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
+                               internal::SolutionEvaluators<dim> &evaluators);
+#else
         void
         local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
                                const typename ParticleHandler<dim>::particle_iterator &end_particle);
+#endif
 
         /**
          * Advect the particles of one cell. Performs only one step for
@@ -422,11 +436,19 @@ namespace aspect
          * during this advection step are removed from the local multimap and
          * stored in @p particles_out_of_cell for further treatment (sorting
          * them into the new cell).
-         */
+        */
+#if DEAL_II_VERSION_GTE(9,3,0)
+        void
+        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
+                               internal::SolutionEvaluators<dim> &evaluators);
+#else
         void
         local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
                                const typename ParticleHandler<dim>::particle_iterator &end_particle);
+#endif
 
         /**
          * This function registers the necessary functions to the

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -428,9 +428,6 @@ namespace aspect
                         particles_to_remove.push_back(particle_to_remove);
                       }
 
-#if DEAL_II_VERSION_GTE(10,0,0)
-                    particle_handler->remove_particles(particles_to_remove);
-#else
                     for (const auto &particle : particles_to_remove)
                       {
                         particle_handler->remove_particle(particle);
@@ -974,17 +971,13 @@ namespace aspect
                 // Only update particles, if there are any in this cell
                 if (particles_in_cell.begin() != particles_in_cell.end())
                   {
-#if !DEAL_II_VERSION_GTE(9,3,0)
-
                     local_update_particles(cell,
                                            particles_in_cell.begin(),
-                                           particles_in_cell.end());
-#else
-                    local_update_particles(cell,
-                                           particles_in_cell.begin(),
-                                           particles_in_cell.end(),
-                                           evaluators);
+                                           particles_in_cell.end()
+#if DEAL_II_VERSION_GTE(9,3,0)
+                                           , evaluators
 #endif
+                                          );
                   }
 
               }
@@ -1192,16 +1185,13 @@ namespace aspect
               // Only advect particles, if there are any in this cell
               if (particles_in_cell.begin() != particles_in_cell.end())
                 {
-#if !DEAL_II_VERSION_GTE(9,3,0)
                   local_advect_particles(cell,
                                          particles_in_cell.begin(),
-                                         particles_in_cell.end());
-#else
-                  local_advect_particles(cell,
-                                         particles_in_cell.begin(),
-                                         particles_in_cell.end(),
-                                         evaluators);
+                                         particles_in_cell.end()
+#if DEAL_II_VERSION_GTE(9,3,0)
+                                         , evaluators
 #endif
+                                        );
                 }
             }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -651,7 +651,7 @@ namespace aspect
                            solution_values.begin(),
                            solution_values.end());
 
-      if (((update_flags & update_values) == true) || ((update_values & update_gradients) == true))
+      if (update_flags & (update_values | update_gradients))
         evaluators.reinit(cell, positions, {solution_values.data(), solution_values.size()}, update_flags);
 
       auto particle = begin_particle;


### PR DESCRIPTION
With the new particle abilities in deal.II there is a lot that can be optimized in ASPECT's particle implementation. This is a first stab. The implementation is far from clean right now, I mostly open this to remind myself to finish it during the hackathon.

Major new changes:
- integrators should use particle properties instead of storing their own cached properties, making transfer and storage much more efficient. But these are temporary properties we usually do not want to appear in the output. I need to find a way to hide certain particle properties
- advection and update can be much more efficient using the FEPointEvaluation class instead of manually evaluating shape functions, or using FEValues

Missing features at the moment:
- boxes without mesh deformation do not benefit from FEPointEvaluation, because MappingCartesian is not implemented for that, only MappingQGeneric; boxes with mesh deformation may benefit, because they use MappingEulerian (not checked)
- particles that should be advected with the melt velocity fall back to the old implementation at the moment (no technical problem, just not implemented to evaluate melt velocity right now)
- rk2 integrator is faster, but needs the 'position' particle property as first property to store its temperorary data in (currently hard-coded); euler and rk4 are unchanged
