### PR TITLE
Store integrator properties as regular particle properties

### DIFF
--- a/doc/modules/changes/20210708_gassmoeller
+++ b/doc/modules/changes/20210708_gassmoeller
@@ -1,0 +1,6 @@
+Improved: Particle operations have been optimized for speed. Particles now
+always carry a hidden internal property that stores properties necessary for
+their advection scheme. These properties are not written into output but are
+included if the particles are asked for their properties internally.
+<br>
+(Rene Gassmoeller, 2021/07/08)

--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -64,6 +64,19 @@ namespace aspect
                                const std::vector<Tensor<1,dim> > &old_velocities,
                                const std::vector<Tensor<1,dim> > &velocities,
                                const double dt) override;
+
+          /**
+            * We need to tell the property manager how many intermediate properties this integrator requires,
+            * so that it can allocate sufficient space for each particle. However, the integrator is not
+            * created at the time the property manager is set up and we can not reverse the order of creation,
+            * because the integrator needs to know where to store its properties, which requires the property manager
+            * to be finished setting up properties. Luckily the number of properties is constant, so we can make it
+            * a static property of this class. Therefore, the property manager can access this variable even
+            * before any object is constructed.
+            *
+            * The forward euler integrator does not need any intermediate storage space.
+            */
+          static const unsigned int n_integrator_properties = 0;
       };
 
     }

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -54,6 +54,14 @@ namespace aspect
           virtual ~Interface ();
 
           /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           */
+          virtual
+          void
+          initialize ();
+
+          /**
            * Perform an integration step of moving the particles of one cell
            * by the specified timestep dt. Implementations of this function
            * must update the particle location. Between calls to this function

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -34,7 +34,7 @@ namespace aspect
     {
       /**
        * Runge Kutta second order integrator.
-       * This scheme requires storing the original location, and the read/write_data functions reflect this.
+       * This scheme requires storing the original location in the particle properties.
        *
        * @ingroup ParticleIntegrators
        */
@@ -43,6 +43,14 @@ namespace aspect
       {
         public:
           RK2();
+
+          /**
+           * Look up where the RK2 data is stored. Done once and cached to
+           * avoid repeated lookups.
+           */
+          virtual
+          void
+          initialize ();
 
           /**
            * Perform an integration step of moving the particles of one cell
@@ -80,34 +88,6 @@ namespace aspect
            */
           bool new_integration_step() override;
 
-          /**
-           * Return data length of the integration related data required for
-           * communication in terms of number of bytes. When data about
-           * particles is transported from one processor to another, or stored
-           * on disk for snapshots, integrators get the chance to store
-           * whatever information they need with each particle. This function
-           * returns how many pieces of additional information a concrete
-           * integrator class needs to store for each particle.
-           *
-           * @return The number of bytes required to store the relevant
-           * integrator data for one particle.
-           */
-          std::size_t get_data_size() const override;
-
-          /**
-           * @copydoc Interface::read_data()
-           */
-          const void *
-          read_data(const typename ParticleHandler<dim>::particle_iterator &particle,
-                    const void *data) override;
-
-          /**
-           * @copydoc Interface::write_data()
-           */
-          void *
-          write_data(const typename ParticleHandler<dim>::particle_iterator &particle,
-                     void *data) const override;
-
         private:
           /**
            * The current integration step, i.e for RK2 a number that is either
@@ -116,12 +96,9 @@ namespace aspect
           unsigned int integrator_substep;
 
           /**
-           * The particle location before the first integration step. This is
-           * used in the second step and transferred to another process if
-           * the particle leaves the domain during the first step.
+           * The location of the RK2 data that is stored in the particle properties.
            */
-          std::map<types::particle_index, Point<dim> >   loc0;
-
+          unsigned int property_location;
       };
 
     }

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -88,6 +88,19 @@ namespace aspect
            */
           bool new_integration_step() override;
 
+          /**
+           * We need to tell the property manager how many intermediate properties this integrator requires,
+           * so that it can allocate sufficient space for each particle. However, the integrator is not
+           * created at the time the property manager is set up and we can not reverse the order of creation,
+           * because the integrator needs to know where to store its properties, which requires the property manager
+           * to be finished setting up properties. Luckily the number of properties is constant, so we can make it
+           * a static property of this class. Therefore, the property manager can access this variable even
+           * before any object is constructed.
+           *
+           * The Runge-Kutta 2 integrator requires a single point with dim components.
+           */
+          static const unsigned int n_integrator_properties = dim;
+
         private:
           /**
            * The current integration step, i.e for RK2 a number that is either
@@ -98,7 +111,7 @@ namespace aspect
           /**
            * The location of the RK2 data that is stored in the particle properties.
            */
-          unsigned int property_location;
+          unsigned int property_index_old_location;
       };
 
     }

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -87,6 +87,19 @@ namespace aspect
            */
           bool new_integration_step() override;
 
+          /**
+            * We need to tell the property manager how many intermediate properties this integrator requires,
+            * so that it can allocate sufficient space for each particle. However, the integrator is not
+            * created at the time the property manager is set up and we can not reverse the order of creation,
+            * because the integrator needs to know where to store its properties, which requires the property manager
+            * to be finished setting up properties. Luckily the number of properties is constant, so we can make it
+            * a static property of this class. Therefore, the property manager can access this variable even
+            * before any object is constructed.
+            *
+            * The Runge-Kutta 4 integrator requires 4 tensors with dim components each.
+            */
+          static const unsigned int n_integrator_properties = 4*dim;
+
         private:
           /**
            * The current integration step, i.e. for RK4 a number between 0
@@ -97,7 +110,7 @@ namespace aspect
           /**
            * The location of the 4 RK4 data fields stored in the particle properties.
            */
-          std::array<unsigned int,4> property_k;
+          std::array<unsigned int,4> property_index_k;
       };
     }
   }

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -500,6 +500,50 @@ namespace aspect
           parse_parameters (ParameterHandler &prm);
       };
 
+      /**
+       * A particle property that provides storage space for
+       * the properties that particle integrators need to
+       * store.
+       *
+       * @ingroup ParticleProperties
+       */
+      template <int dim>
+      class IntegratorProperties : public Interface<dim>
+      {
+        public:
+          /**
+           * Initialization function. Since these properties are set and used
+           * only by the integrator there is not much to do.
+           */
+          void
+          initialize_one_particle_property (const Point<dim> &position,
+                                            std::vector<double> &particle_properties) const override;
+
+          /**
+           * Set up the information about the names and number of components
+           * this property requires. This depends on the chosen integration scheme.
+           *
+           * @return A vector that contains pairs of the property names and the
+           * number of components this property plugin defines.
+           */
+          std::vector<std::pair<std::string, unsigned int> >
+          get_property_information() const override;
+
+          /**
+           * Read the parameters this class needs to determine which integrator is used,
+           * and therefore how many properties to reserve.
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          /**
+           * The number of integrator properties to store.
+           */
+          unsigned int n_integrator_properties;
+      };
+
 
 
       /**

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -503,7 +503,9 @@ namespace aspect
       /**
        * A particle property that provides storage space for
        * the properties that particle integrators need to
-       * store.
+       * store. This is an internal property that is not
+       * intended for use outside of the particle integrators
+       * and that will not be written to output files.
        *
        * @ingroup ParticleProperties
        */
@@ -540,7 +542,8 @@ namespace aspect
 
         private:
           /**
-           * The number of integrator properties to store.
+           * The number of integrator properties to store. This variable is initialized in
+           * parse_parameters().
            */
           unsigned int n_integrator_properties;
       };

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -513,7 +513,8 @@ namespace aspect
         public:
           /**
            * Initialization function. Since these properties are set and used
-           * only by the integrator there is not much to do.
+           * by the integrator this function only resizes them to the correct
+           * size, but does not need to do any initialization.
            */
           void
           initialize_one_particle_property (const Point<dim> &position,

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -37,6 +37,13 @@ namespace aspect
 
       template <int dim>
       void
+      Interface<dim>::initialize ()
+      {}
+
+
+
+      template <int dim>
+      void
       Interface<dim>::declare_parameters (ParameterHandler &)
       {}
 

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -41,7 +41,7 @@ namespace aspect
       RK2<dim>::initialize ()
       {
         const auto &property_information = this->get_particle_world().get_property_manager().get_data_info();
-        property_location = property_information.get_position_by_field_name("internal: integrator properties");
+        property_index_old_location = property_information.get_position_by_field_name("internal: integrator properties");
       }
 
 
@@ -78,7 +78,7 @@ namespace aspect
                 const Point<dim> loc0 = it->get_location();
 
                 for (unsigned int i=0; i<dim; ++i)
-                  properties[property_location + i] = loc0[i];
+                  properties[property_index_old_location + i] = loc0[i];
 
                 it->set_location(loc0 + 0.5 * k1);
               }
@@ -88,7 +88,7 @@ namespace aspect
                 Point<dim> loc0;
 
                 for (unsigned int i=0; i<dim; ++i)
-                  loc0[i] = properties[property_location + i];
+                  loc0[i] = properties[property_index_old_location + i];
 
                 it->set_location(loc0 + k2);
               }

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -19,6 +19,8 @@
  */
 
 #include <aspect/particle/integrator/rk_2.h>
+#include <aspect/particle/property/interface.h>
+#include <aspect/particle/world.h>
 
 namespace aspect
 {

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -39,7 +39,7 @@ namespace aspect
       RK2<dim>::initialize ()
       {
         const auto &property_information = this->get_particle_world().get_property_manager().get_data_info();
-        property_location = property_information.get_position_by_field_name("integrator properties");
+        property_location = property_information.get_position_by_field_name("internal: integrator properties");
       }
 
 

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -32,6 +32,22 @@ namespace aspect
         integrator_substep(0)
       {}
 
+
+
+      template <int dim>
+      void
+      RK4<dim>::initialize ()
+      {
+        const auto &property_information = this->get_particle_world().get_property_manager().get_data_info();
+
+        property_k[0] = property_information.get_position_by_field_name("integrator properties");
+        property_k[1] = property_k[0] + dim;
+        property_k[2] = property_k[1] + dim;
+        property_k[3] = property_k[2] + dim;
+      }
+
+
+
       template <int dim>
       void
       RK4<dim>::local_integrate_step(const typename ParticleHandler<dim>::particle_iterator &begin_particle,
@@ -50,35 +66,66 @@ namespace aspect
                           "to the number of particles to advect. For some unknown reason they are different, "
                           "most likely something went wrong in the calling function."));
 
-        // TODO: currently old_velocity is not used in this scheme, but it should,
-        // to make it at least second-order accurate in time.
         typename std::vector<Tensor<1,dim> >::const_iterator old_velocity = old_velocities.begin();
         typename std::vector<Tensor<1,dim> >::const_iterator velocity = velocities.begin();
 
         for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++velocity, ++old_velocity)
           {
-            const types::particle_index particle_id = it->get_id();
+            ArrayView<double> properties = it->get_properties();
+
             if (integrator_substep == 0)
               {
-                loc0[particle_id] = it->get_location();
-                k1[particle_id] = dt * (*old_velocity);
-                it->set_location(it->get_location() + 0.5*k1[particle_id]);
+                const Tensor<1,dim> k1 = dt * (*old_velocity);
+                const Point<dim> loc0 = it->get_location();
+
+                for (unsigned int i=0; i<dim; ++i)
+                  {
+                    properties[property_k[0] + i] = loc0[i];
+                    properties[property_k[1] + i] = k1[i];
+                  }
+
+                it->set_location(loc0 + 0.5 * k1);
               }
             else if (integrator_substep == 1)
               {
-                k2[particle_id] = dt * (*old_velocity + *velocity) / 2.0;
-                it->set_location(loc0[particle_id] + 0.5*k2[particle_id]);
+                const Tensor<1,dim> k2 = dt * ((*old_velocity) + (*velocity)) / 2.0;
+                Point<dim> loc0;
+
+                for (unsigned int i=0; i<dim; ++i)
+                  {
+                    loc0[i] = properties[property_k[0] + i];
+                    properties[property_k[2] + i] = k2[i];
+                  }
+                it->set_location(loc0 + 0.5 * k2);
               }
             else if (integrator_substep == 2)
               {
-                k3[particle_id] = dt * (*old_velocity + *velocity) / 2.0;
-                it->set_location(loc0[particle_id] + k3[particle_id]);
+                const Tensor<1,dim> k3 = dt * (*old_velocity + *velocity) / 2.0;
+                Point<dim> loc0;
+
+                for (unsigned int i=0; i<dim; ++i)
+                  {
+                    loc0[i] = properties[property_k[0] + i];
+                    properties[property_k[3] + i] = k3[i];
+                  }
+
+                it->set_location(loc0 + k3);
               }
             else if (integrator_substep == 3)
               {
                 const Tensor<1,dim> k4 = dt * (*velocity);
-                it->set_location(loc0[particle_id] + (k1[particle_id] + 2.0*k2[particle_id] + 2.0*k3[particle_id] + k4)/6.0);
+                Point<dim> loc0, k1, k2, k3;
+
+                for (unsigned int i=0; i<dim; ++i)
+                  {
+                    loc0[i] = properties[property_k[0] + i];
+                    k1[i] = properties[property_k[1] + i];
+                    k2[i] = properties[property_k[2] + i];
+                    k3[i] = properties[property_k[3] + i];
+                  }
+
+                it->set_location(loc0 + (k1 + 2.0*k2 + 2.0*k3 + k4)/6.0);
               }
             else
               {
@@ -88,99 +135,16 @@ namespace aspect
           }
       }
 
+
+
       template <int dim>
       bool
       RK4<dim>::new_integration_step()
       {
-        if (integrator_substep == 3)
-          {
-            loc0.clear();
-            k1.clear();
-            k2.clear();
-            k3.clear();
-          }
-
         integrator_substep = (integrator_substep+1)%4;
 
         // Continue until we're at the last step
         return (integrator_substep != 0);
-      }
-
-      template <int dim>
-      std::size_t
-      RK4<dim>::get_data_size() const
-      {
-        // If integration is finished, we do not need to transfer integrator
-        // data to other processors, because it will be deleted soon anyway.
-        // Skip the MPI transfer in this case.
-        if (integrator_substep == 3)
-          return 0;
-
-        return 4*dim*sizeof(double);
-      }
-
-      template <int dim>
-      const void *
-      RK4<dim>::read_data(const typename ParticleHandler<dim>::particle_iterator &particle,
-                          const void *data)
-      {
-        // If integration is finished, we do not need to transfer integrator
-        // data to other processors, because it will be deleted soon anyway.
-        // Skip the MPI transfer in this case.
-        if (integrator_substep == 3)
-          return data;
-
-        const double *integrator_data = static_cast<const double *> (data);
-
-        // Read location data
-        for (unsigned int i=0; i<dim; ++i)
-          loc0[particle->get_id()](i) = *integrator_data++;
-
-        // Read k1, k2 and k3
-        for (unsigned int i=0; i<dim; ++i)
-          k1[particle->get_id()][i] = *integrator_data++;
-
-        for (unsigned int i=0; i<dim; ++i)
-          k2[particle->get_id()][i] = *integrator_data++;
-
-        for (unsigned int i=0; i<dim; ++i)
-          k3[particle->get_id()][i] = *integrator_data++;
-
-        return static_cast<const void *> (integrator_data);
-      }
-
-      template <int dim>
-      void *
-      RK4<dim>::write_data(const typename ParticleHandler<dim>::particle_iterator &particle,
-                           void *data) const
-      {
-        // If integration is finished, we do not need to transfer integrator
-        // data to other processors, because it will be deleted soon anyway.
-        // Skip the MPI transfer in this case.
-        if (integrator_substep == 3)
-          return data;
-
-        double *integrator_data = static_cast<double *> (data);
-
-        // Write location data
-        typename std::map<types::particle_index, Point<dim> >::const_iterator it = loc0.find(particle->get_id());
-        for (unsigned int i=0; i<dim; ++i,++integrator_data)
-          *integrator_data = it->second(i);
-
-        // Write k1, k2 and k3
-        typename std::map<types::particle_index, Tensor<1,dim> >::const_iterator it_k = k1.find(particle->get_id());
-        for (unsigned int i=0; i<dim; ++i,++integrator_data)
-          *integrator_data = it_k->second[i];
-
-        it_k = k2.find(particle->get_id());
-        for (unsigned int i=0; i<dim; ++i,++integrator_data)
-          *integrator_data = it_k->second[i];
-
-        it_k = k3.find(particle->get_id());
-        for (unsigned int i=0; i<dim; ++i,++integrator_data)
-          *integrator_data = it_k->second[i];
-
-        return static_cast<void *> (integrator_data);
       }
     }
   }

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -40,7 +40,7 @@ namespace aspect
       {
         const auto &property_information = this->get_particle_world().get_property_manager().get_data_info();
 
-        property_k[0] = property_information.get_position_by_field_name("integrator properties");
+        property_k[0] = property_information.get_position_by_field_name("internal: integrator properties");
         property_k[1] = property_k[0] + dim;
         property_k[2] = property_k[1] + dim;
         property_k[3] = property_k[2] + dim;
@@ -97,6 +97,7 @@ namespace aspect
                     loc0[i] = properties[property_k[0] + i];
                     properties[property_k[2] + i] = k2[i];
                   }
+
                 it->set_location(loc0 + 0.5 * k2);
               }
             else if (integrator_substep == 2)

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -19,6 +19,8 @@
  */
 
 #include <aspect/particle/integrator/rk_4.h>
+#include <aspect/particle/property/interface.h>
+#include <aspect/particle/world.h>
 
 namespace aspect
 {

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -42,10 +42,10 @@ namespace aspect
       {
         const auto &property_information = this->get_particle_world().get_property_manager().get_data_info();
 
-        property_k[0] = property_information.get_position_by_field_name("internal: integrator properties");
-        property_k[1] = property_k[0] + dim;
-        property_k[2] = property_k[1] + dim;
-        property_k[3] = property_k[2] + dim;
+        property_index_k[0] = property_information.get_position_by_field_name("internal: integrator properties");
+        property_index_k[1] = property_index_k[0] + dim;
+        property_index_k[2] = property_index_k[1] + dim;
+        property_index_k[3] = property_index_k[2] + dim;
       }
 
 
@@ -83,8 +83,8 @@ namespace aspect
 
                 for (unsigned int i=0; i<dim; ++i)
                   {
-                    properties[property_k[0] + i] = loc0[i];
-                    properties[property_k[1] + i] = k1[i];
+                    properties[property_index_k[0] + i] = loc0[i];
+                    properties[property_index_k[1] + i] = k1[i];
                   }
 
                 it->set_location(loc0 + 0.5 * k1);
@@ -96,8 +96,8 @@ namespace aspect
 
                 for (unsigned int i=0; i<dim; ++i)
                   {
-                    loc0[i] = properties[property_k[0] + i];
-                    properties[property_k[2] + i] = k2[i];
+                    loc0[i] = properties[property_index_k[0] + i];
+                    properties[property_index_k[2] + i] = k2[i];
                   }
 
                 it->set_location(loc0 + 0.5 * k2);
@@ -109,8 +109,8 @@ namespace aspect
 
                 for (unsigned int i=0; i<dim; ++i)
                   {
-                    loc0[i] = properties[property_k[0] + i];
-                    properties[property_k[3] + i] = k3[i];
+                    loc0[i] = properties[property_index_k[0] + i];
+                    properties[property_index_k[3] + i] = k3[i];
                   }
 
                 it->set_location(loc0 + k3);
@@ -122,10 +122,10 @@ namespace aspect
 
                 for (unsigned int i=0; i<dim; ++i)
                   {
-                    loc0[i] = properties[property_k[0] + i];
-                    k1[i] = properties[property_k[1] + i];
-                    k2[i] = properties[property_k[2] + i];
-                    k3[i] = properties[property_k[3] + i];
+                    loc0[i] = properties[property_index_k[0] + i];
+                    k1[i] = properties[property_index_k[1] + i];
+                    k2[i] = properties[property_index_k[2] + i];
+                    k3[i] = properties[property_index_k[3] + i];
                   }
 
                 it->set_location(loc0 + (k1 + 2.0*k2 + 2.0*k3 + k4)/6.0);

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -253,8 +253,10 @@ namespace aspect
                       this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim> >();
                     const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
                     const unsigned int n_property_components = particle_property_information.n_components();
-                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("integrator properties");
+                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 
+                    // Check that if a global limiter is used, we were given the minimum and maximum value for each
+                    // particle property that is not an internal property.
                     AssertThrow(global_minimum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -251,13 +251,15 @@ namespace aspect
 
                     const Postprocess::Particles<dim> &particle_postprocessor =
                       this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim> >();
-                    const unsigned int n_property_components = particle_postprocessor.get_particle_world().get_property_manager().get_n_property_components();
+                    const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+                    const unsigned int n_property_components = particle_property_information.n_components();
+                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("integrator properties");
 
-                    AssertThrow(global_minimum_particle_properties.size() == n_property_components,
+                    AssertThrow(global_minimum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));
 
-                    AssertThrow(global_maximum_particle_properties.size() == n_property_components,
+                    AssertThrow(global_maximum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global maximum particle property' "
                                            "is equivalent to the number of particle properties."));
                   }

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -261,6 +261,8 @@ namespace aspect
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));
 
+                    // Check that if a global limiter is used, we were given the minimum and maximum value for each
+                    // particle property that is not an internal property.
                     AssertThrow(global_maximum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global maximum particle property' "
                                            "is equivalent to the number of particle properties."));

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -261,8 +261,10 @@ namespace aspect
                       this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim> >();
                     const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
                     const unsigned int n_property_components = particle_property_information.n_components();
-                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("integrator properties");
+                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 
+                    // Check that if a global limiter is used, we were given the minimum and maximum value for each
+                    // particle property that is not an internal property.
                     AssertThrow(global_minimum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -269,6 +269,8 @@ namespace aspect
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));
 
+                    // Check that if a global limiter is used, we were given the minimum and maximum value for each
+                    // particle property that is not an internal property.
                     AssertThrow(global_maximum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global maximum particle property' "
                                            "is equivalent to the number of particle properties."));

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -259,13 +259,15 @@ namespace aspect
 
                     const Postprocess::Particles<dim> &particle_postprocessor =
                       this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim> >();
-                    const unsigned int n_property_components = particle_postprocessor.get_particle_world().get_property_manager().get_n_property_components();
+                    const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+                    const unsigned int n_property_components = particle_property_information.n_components();
+                    const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("integrator properties");
 
-                    AssertThrow(global_minimum_particle_properties.size() == n_property_components,
+                    AssertThrow(global_minimum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global minimum particle property' "
                                            "is equivalent to the number of particle properties."));
 
-                    AssertThrow(global_maximum_particle_properties.size() == n_property_components,
+                    AssertThrow(global_maximum_particle_properties.size() == n_property_components - n_internal_components,
                                 ExcMessage("Make sure that the size of list 'Global maximum particle property' "
                                            "is equivalent to the number of particle properties."));
                   }

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -300,8 +300,9 @@ namespace aspect
       std::vector<std::pair<std::string, unsigned int> >
       IntegratorProperties<dim>::get_property_information() const
       {
-        const std::vector<std::pair<std::string,unsigned int> > property_information (1,
-                                                                                      std::make_pair("integrator properties",n_integrator_properties));
+        const std::vector<std::pair<std::string, unsigned int>> property_information =
+        {{"internal: integrator properties", n_integrator_properties}};
+
         return property_information;
       }
 
@@ -780,7 +781,7 @@ namespace aspect
             property_list.back()->parse_parameters (prm);
           }
 
-        // laslty store internal integrator properties
+        // lastly store internal integrator properties
         property_list.emplace_back (std::make_unique<IntegratorProperties<dim>>());
         property_list.back()->parse_parameters (prm);
       }

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -287,6 +287,56 @@ namespace aspect
 
 
       template <int dim>
+      void
+      IntegratorProperties<dim>::initialize_one_particle_property(const Point<dim> &/*position*/,
+                                                                  std::vector<double> &data) const
+      {
+        data.resize(data.size() + n_integrator_properties);
+      }
+
+
+
+      template <int dim>
+      std::vector<std::pair<std::string, unsigned int> >
+      IntegratorProperties<dim>::get_property_information() const
+      {
+        const std::vector<std::pair<std::string,unsigned int> > property_information (1,
+                                                                                      std::make_pair("integrator properties",n_integrator_properties));
+        return property_information;
+      }
+
+
+
+      template <int dim>
+      void
+      IntegratorProperties<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        std::string name;
+        prm.enter_subsection ("Postprocess");
+        {
+          prm.enter_subsection ("Particles");
+          {
+            name = prm.get ("Integration scheme");
+
+            if (name == "rk2")
+              n_integrator_properties = dim;
+            else if (name == "rk4")
+              n_integrator_properties = 4*dim;
+            else if (name == "euler")
+              n_integrator_properties = 0;
+            else
+              AssertThrow(false,
+                          ExcMessage("Unknown integrator scheme. The particle property 'Integrator properties' "
+                                     "does not know how many particle properties to store for this integration scheme."));
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+      }
+
+
+
+      template <int dim>
       inline
       Manager<dim>::Manager ()
       {}
@@ -729,6 +779,10 @@ namespace aspect
 
             property_list.back()->parse_parameters (prm);
           }
+
+        // laslty store internal integrator properties
+        property_list.emplace_back (std::make_unique<IntegratorProperties<dim>>());
+        property_list.back()->parse_parameters (prm);
       }
 
 

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -21,6 +21,11 @@
 #include <aspect/particle/property/interface.h>
 #include <aspect/utilities.h>
 
+#include <aspect/particle/integrator/euler.h>
+#include <aspect/particle/integrator/rk_2.h>
+#include <aspect/particle/integrator/rk_4.h>
+
+
 #include <aspect/boundary_composition/interface.h>
 
 #include <deal.II/grid/grid_tools.h>
@@ -291,7 +296,7 @@ namespace aspect
       IntegratorProperties<dim>::initialize_one_particle_property(const Point<dim> &/*position*/,
                                                                   std::vector<double> &data) const
       {
-        data.resize(data.size() + n_integrator_properties);
+        data.resize(data.size() + n_integrator_properties, 0.0);
       }
 
 
@@ -300,10 +305,7 @@ namespace aspect
       std::vector<std::pair<std::string, unsigned int> >
       IntegratorProperties<dim>::get_property_information() const
       {
-        const std::vector<std::pair<std::string, unsigned int>> property_information =
-        {{"internal: integrator properties", n_integrator_properties}};
-
-        return property_information;
+        return {{"internal: integrator properties", n_integrator_properties}};
       }
 
 
@@ -320,11 +322,11 @@ namespace aspect
             name = prm.get ("Integration scheme");
 
             if (name == "rk2")
-              n_integrator_properties = dim;
+              n_integrator_properties = Particle::Integrator::RK2<dim>::n_integrator_properties;
             else if (name == "rk4")
-              n_integrator_properties = 4*dim;
+              n_integrator_properties = Particle::Integrator::RK4<dim>::n_integrator_properties;
             else if (name == "euler")
-              n_integrator_properties = 0;
+              n_integrator_properties = Particle::Integrator::Euler<dim>::n_integrator_properties;
             else
               AssertThrow(false,
                           ExcMessage("Unknown integrator scheme. The particle property 'Integrator properties' "

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -71,35 +71,6 @@ namespace aspect
                                          this->get_mapping(),
                                          property_manager->get_n_property_components());
 
-      auto size_callback_function
-      = [&] () -> std::size_t
-      {
-        return integrator->get_data_size();
-      };
-
-      auto store_callback_function
-        = [&] (const typename ParticleHandler<dim>::particle_iterator &p,
-               void *data) -> void *
-      {
-        return integrator->write_data(p, data);
-      };
-
-
-      const auto load_callback_function
-        = [&] (const typename ParticleHandler<dim>::particle_iterator &p,
-               const void *data) -> const void *
-      {
-        return integrator->read_data(p, data);
-      };
-
-      particle_handler->register_additional_store_load_functions(size_callback_function,
-                                                                 store_callback_function,
-                                                                 load_callback_function);
-
-      particle_handler_backup.register_additional_store_load_functions(size_callback_function,
-                                                                       store_callback_function,
-                                                                       load_callback_function);
-
       connect_to_signals(this->get_signals());
     }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1099,18 +1099,19 @@ namespace aspect
       generator->parse_parameters(prm);
       generator->initialize();
 
-      // Create an integrator object depending on the specified parameter
-      integrator.reset(Integrator::create_particle_integrator<dim> (prm));
-      if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
-        sim->initialize_simulator (this->get_simulator());
-      integrator->parse_parameters(prm);
-
       // Create a property_manager object and initialize its properties
       property_manager = std_cxx14::make_unique<Property::Manager<dim>> ();
       SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_manager.get());
       sim->initialize_simulator (this->get_simulator());
       property_manager->parse_parameters(prm);
       property_manager->initialize();
+
+      // Create an integrator object depending on the specified parameter
+      integrator.reset(Integrator::create_particle_integrator<dim> (prm));
+      if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
+        sim->initialize_simulator (this->get_simulator());
+      integrator->parse_parameters(prm);
+      integrator->initialize();
 
       // Create an interpolator object depending on the specified parameter
       interpolator.reset(Interpolator::create_particle_interpolator<dim> (prm));

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -714,7 +714,7 @@ namespace aspect
           exclude_output_properties = Utilities::split_string_list(prm.get("Exclude output properties"));
 
           // Never output the integrator properties that are for internal use only
-          exclude_output_properties.push_back("integrator properties");
+          exclude_output_properties.push_back("internal: integrator properties");
         }
         prm.leave_subsection ();
       }

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -712,6 +712,9 @@ namespace aspect
             }
 
           exclude_output_properties = Utilities::split_string_list(prm.get("Exclude output properties"));
+
+          // Never output the integrator properties that are for internal use only
+          exclude_output_properties.push_back("integrator properties");
         }
         prm.leave_subsection ();
       }

--- a/unit_tests/particles.cc
+++ b/unit_tests/particles.cc
@@ -20,12 +20,15 @@
 
 #include "common.h"
 #include <aspect/particle/property/interface.h>
+#include <aspect/particle/world.h>
 #include <deal.II/base/parameter_handler.h>
 
 TEST_CASE("Particle Manager plugin names")
 {
-  aspect::Particle::Property::Manager<2> manager;
   dealii::ParameterHandler prm;
+  // The property manager needs to know about the integrator, which is declared in World
+  aspect::Particle::World<2>::declare_parameters(prm);
+  aspect::Particle::Property::Manager<2> manager;
   manager.declare_parameters(prm);
   prm.enter_subsection("Postprocess");
   prm.enter_subsection("Particles");


### PR DESCRIPTION
This PR properly implements the first half of #4060. By not longer storing an internal map for the integrators that hold temporary data we avoid a lot of data allocation and lookups into the maps as well as the complicated data transfer. In one case with nearly 1 million particles per core this saves about 33% of the particle advection time (in most cases it is likely less).

I tried to hide the new particle property by:
 - defining it internally in interface.cc instead of as a separate plugin
 - adding its properties to the end of the particle properties
 - automatically ignoring it for the output

However, it is of course still there, so if you output all particle properties you will see properties at the end that have no relation to the selected particle properties in the list of properties. Is this acceptable? The only reasonable alternative I would see is to assert that the user adds an entry 'integration properties' to the list of particle properties to make it explicitly visible, but that would break a lot of models.