### PR TITLE
Make particle removal compatible with latest deal.II particle structure

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -389,7 +389,14 @@ namespace aspect
                         particles_to_remove.push_back(particle_to_remove);
                       }
 
-                      particle_handler->remove_particles(particles_to_remove);
+#if DEAL_II_VERSION_GTE(10,0,0)
+                    particle_handler->remove_particles(particles_to_remove);
+#else
+                    for (const auto &particle : particles_to_remove)
+                      {
+                        particle_handler->remove_particle(particle);
+                      }
+#endif
                   }
               }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -378,7 +378,8 @@ namespace aspect
                     while (particle_ids_to_remove.size() < n_particles_to_remove)
                       particle_ids_to_remove.insert(random_number_generator() % n_particles_in_cell);
 
-                    std::list<typename ParticleHandler<dim>::particle_iterator> particles_to_remove;
+                    std::vector<typename ParticleHandler<dim>::particle_iterator> particles_to_remove;
+                    particles_to_remove.reserve(n_particles_to_remove);
 
                     for (const auto id : particle_ids_to_remove)
                       {
@@ -388,10 +389,7 @@ namespace aspect
                         particles_to_remove.push_back(particle_to_remove);
                       }
 
-                    for (const auto &particle : particles_to_remove)
-                      {
-                        particle_handler->remove_particle(particle);
-                      }
+                      particle_handler->remove_particles(particles_to_remove);
                   }
               }
 


### PR DESCRIPTION
Since dealii/dealii#11577 particle iterators are invalidated if another iterator in the same cell is removed. This broke the functionality to limit the number of particles in a cell, because ASPECT stores a list of iterators to remove before removing them one by one. Instead we should remove all of them in one go as is now possible with the `remove_particles` function.