### PR TITLE
Update docker container versions

### DIFF
--- a/contrib/release/release-tasklist
+++ b/contrib/release/release-tasklist
@@ -4,7 +4,7 @@
     . go through the list of TODOs in the source code and see what can be done
     . make sure the description of the interfaces that need to be updated
       are up to date in the manual
-    . update the used deal.II version for the Docker container in docker/Dockerfile
+    . update the used deal.II version for the Docker container in contrib/docker/docker/Dockerfile
       and in the manual
     . check that README.md and http://aspect.dealii.org/ReadMe.html are okay
       and the links to the mailinglists are working (also in manual.pdf)
@@ -77,7 +77,7 @@
       tar xf $PREFIX.tar.gz
       cd $PREFIX
       docker run --rm -it -v `pwd`:/home/dealii/aspect \
-      	     dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease /bin/bash
+            tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5 /bin/bash
 
       mkdir build; cd build
       cmake -G "Ninja" -D ASPECT_RUN_ALL_TESTS=ON -D \
@@ -120,8 +120,8 @@
        update the list of contributors
        ...
   . update docker image geodynamics/aspect:
-    - modify docker/Dockerfile and docker/build.sh to checkout the release
-      cd docker && ./build.sh
+    - modify contrib/docker/docker/Dockerfile and contrib/docker/docker/build.sh to checkout the release
+      cd contrib/docker/docker && ./build.sh
       docker push geodynamics/aspect:v$TAG
   . update the spack installation package with the latest tarball, 
     see https://github.com/spack/spack/pull/13830 for an example

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -3029,9 +3029,9 @@ of the container. An example workflow could look as following (assuming you
 navigated in a terminal into the modified \aspect{} source folder):
 
 \begin{lstlisting}[frame=single,language=ksh,showstringspaces=false]
-docker pull dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease
+docker pull tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5
 docker run -it -v "$(pwd):/home/dealii/aspect:ro" \
-  dealii/dealii:v8.5.pre.4-gcc-mpi-fulldepsmanual-debugrelease bash
+  tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5 bash
 \end{lstlisting}
 
 Inside of the container you now find a read-only \aspect{} directory that
@@ -11836,7 +11836,7 @@ the path to your \aspect{} directory):
 \begin{lstlisting}[frame=single,language=ksh]
     docker run -v ASPECT_SOURCE_DIR:/home/dealii/aspect \
     --name=aspect-tester --rm -it \
-    dealii/dealii:v8.5.0-gcc-mpi-fulldepscandi-debugrelease \
+    tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5 \
     bash /home/dealii/aspect/cmake/compile_and_update_tests.sh
 \end{lstlisting}
 


### PR DESCRIPTION
Working towards #4069. We should automate this by having a container named aspect-tester that gets rebuild in a CI workflow from a defined deal.II image, then we would not need to update the doc (see e.g. https://hub.docker.com/repository/docker/gassmoeller/aspect-tester).