### PR TITLE
Fix particle removal in parallel

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -396,8 +396,12 @@ namespace aspect
 #if DEAL_II_VERSION_GTE(10,0,0)
                     for (unsigned int i=0; i < n_particles_to_remove; ++i)
                       {
+                        const unsigned int current_n_particles_in_cell = particle_handler->n_particles_in_cell(cell);
+                        const unsigned int index_to_remove = std::uniform_int_distribution<unsigned int>
+                                                             (0,current_n_particles_in_cell-1)(random_number_generator);
+
                         auto particle_to_remove = particle_handler->particles_in_cell(cell).begin();
-                        std::advance(particle_to_remove, random_number_generator() % particle_handler->n_particles_in_cell(cell));
+                        std::advance(particle_to_remove, index_to_remove);
                         particle_handler->remove_particle(particle_to_remove);
                       }
 #else

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -391,10 +391,18 @@ namespace aspect
                 else if ((particle_load_balancing & ParticleLoadBalancing::remove_particles) &&
                          (n_particles_in_cell > max_particles_per_cell))
                   {
+                    const unsigned int n_particles_to_remove = n_particles_in_cell - max_particles_per_cell;
+
+#if DEAL_II_VERSION_GTE(10,0,0)
+                    for (unsigned int i=0; i < n_particles_to_remove; ++i)
+                      {
+                        auto particle_to_remove = particle_handler->particles_in_cell(cell).begin();
+                        std::advance(particle_to_remove, random_number_generator() % particle_handler->n_particles_in_cell(cell));
+                        particle_handler->remove_particle(particle_to_remove);
+                      }
+#else
                     const boost::iterator_range<typename ParticleHandler<dim>::particle_iterator> particles_in_cell
                       = particle_handler->particles_in_cell(cell);
-
-                    const unsigned int n_particles_to_remove = n_particles_in_cell - max_particles_per_cell;
 
                     std::set<unsigned int> particle_ids_to_remove;
                     while (particle_ids_to_remove.size() < n_particles_to_remove)
@@ -411,9 +419,6 @@ namespace aspect
                         particles_to_remove.push_back(particle_to_remove);
                       }
 
-#if DEAL_II_VERSION_GTE(10,0,0)
-                    particle_handler->remove_particles(particles_to_remove);
-#else
                     for (const auto &particle : particles_to_remove)
                       {
                         particle_handler->remove_particle(particle);


### PR DESCRIPTION
Unfortunately #4063 only fixed serial computations. `remove_particles` is a collective function that updates the cache of the particle handler so it is expected to be called on all processes which we dont, and we dont want to store all the local particle iterators we want to remove either. So instead I rewrote the removal logic for 10.0. It also looks much cleaner now. The code could be further improved if the particle_handler had a function `particle_in_cell(cell,particle_index)` that returned the n-th particle in a cell, but that is something to do for the future.

I have verified that this PR, together with the open fixes for deal.II (dealii/dealii#12485) fixes #4067 and the viscoelastic_bending_beam_particles and the viscoelastic_stress_buildup_particles benchmark finish in parallel.