### PR TITLE
Use std::move to move data instead of copy where possible.

### DIFF
--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -85,12 +85,16 @@ namespace aspect
          * The data consists of @p n_components (implicitly given by the size of @p column_names)
          * specified at @p coordinate_values[d] points in each of the dim coordinate directions @p d.
          *
-         * The data in @p raw_data consists of a Table for each of the @p n_components components.
+         * The data in @p data_table consists of a Table for each of the @p n_components components.
+         *
+         * The last two arguments are rvalue references, and the function will
+         * move the data so provided into another storage location. In other
+         * words, after the call, the variables passed as the last two
+         * arguments may be empty or otherwise altered.
          */
         void reinit(const std::vector<std::string> &column_names,
-                    const std::vector<std::vector<double>> &coordinate_values,
-                    const std::vector<Table<dim,double> > &raw_data
-                   );
+                    std::vector<std::vector<double>> &&coordinate_values,
+                    std::vector<Table<dim,double> > &&data_table);
 
         /**
          * Loads a data text file. Throws an exception if the file does not

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -74,7 +74,7 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=1")
   raw_data[1](0) = 5.0;
   raw_data[1](1) = 3.0;
 
-  lookup.reinit(column_names, coordinate_values, raw_data);
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
 
   INFO(lookup.get_data(Point<1>(1.5), 0));
   INFO(lookup.get_data(Point<1>(1.5), 1));
@@ -111,7 +111,7 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=2")
   raw_data[0](1,2) = 0.0;
   raw_data[0](2,2) = 0.0;
 
-  lookup.reinit(column_names, coordinate_values, raw_data);
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
 
   REQUIRE(lookup.get_data(Point<2>(1.0,6.0),0) == Approx(5.0));
   REQUIRE(lookup.get_data(Point<2>(2.0,6.0),0) == Approx(5.5));
@@ -142,7 +142,7 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=2 equid")
   raw_data[0](1,2) = 0.0;
   raw_data[0](2,2) = 0.0;
 
-  lookup.reinit(column_names, coordinate_values, raw_data);
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
 
   REQUIRE(lookup.get_data(Point<2>(1.0,6.0),0) == Approx(5.0));
   REQUIRE(lookup.get_data(Point<2>(1.5,6.0),0) == Approx(5.5));


### PR DESCRIPTION
This is a first necessary step towards de-duplicating data. Related to #4051.

/rebuild