### PR TITLE
Minor optimization in read_and_distribute_file_content().

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1097,7 +1097,7 @@ namespace aspect
                   AssertThrowMPI(ierr);
                   AssertThrow (false,
                                ExcMessage (std::string("Reading of file ") + filename + " finished " +
-                                           "before the end of file was reached. Is the file corrupted or"
+                                           "before the end of file was reached. Is the file corrupted or "
                                            "too large for the input buffer?"));
                   return data_string; // never reached
                 }


### PR DESCRIPTION
Just skip some MPI calls if we are have only one process.

/rebuild