### PR TITLE
Enable data sharing across processes

### DIFF
--- a/doc/modules/changes/20210728_bangerth
+++ b/doc/modules/changes/20210728_bangerth
@@ -1,0 +1,6 @@
+New: Where possible, when using large data tables as input (e.g., for
+initial conditions specified as tables), these data are now stored
+only once on each node in memory areas that is accessible by all MPI
+processes on that node.
+<br>
+(Wolfgang Bangerth, 2021/07/28)

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -90,7 +90,7 @@ namespace aspect
          * The `coordinate_values` and `data_table` arguments are rvalue references,
          * and the function will move the data so provided into another storage
          * location. In other words, after the call, the variables passed as the
-         * last two arguments may be empty or otherwise altered.
+         * second and third arguments may be empty or otherwise altered.
          *
         #if DEAL_II_VERSION_GTE(9,3,0)
          * If ASPECT is built on deal.II version 9.3 or higher, this class

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -87,14 +87,41 @@ namespace aspect
          *
          * The data in @p data_table consists of a Table for each of the @p n_components components.
          *
-         * The last two arguments are rvalue references, and the function will
-         * move the data so provided into another storage location. In other
-         * words, after the call, the variables passed as the last two
-         * arguments may be empty or otherwise altered.
+         * The `coordinate_values` and `data_table` arguments are rvalue references,
+         * and the function will move the data so provided into another storage
+         * location. In other words, after the call, the variables passed as the
+         * last two arguments may be empty or otherwise altered.
+         *
+        #if DEAL_II_VERSION_GTE(9,3,0)
+         * If ASPECT is built on deal.II version 9.3 or higher, this class
+         * is able to share data between processes located on the same
+         * machine. In this case, if the last argument, `root_process` is
+         * set to anything other than `numbers::invalid_unsigned_int`, then only the
+         * indicated root process within the given MPI communicator needs to
+         * pass in valid arguments whereas on all other processes the values
+         * of `column_names`, `coordinate_values`, and `data_table` are
+         * ignored. Instead, the indicated root process will make sure that
+         * the other processes obtain valid data, for example by sharing
+         * data tables in shared memory spaces. This reduces both the
+         * computational effort in reading data from disk and parsing it on
+         * all processes, and can vastly reduce the amount of memory required
+         * on machines where many processor cores have access to shared memory
+         * resources.
+         *
+         * If `root_process` equals `numbers::invalid_unsigned_int`, then
+         * every process needs to pass data for all arguments and the
+         * `mpi_communicator` argument is ignored.
+        #else
+         * If ASPECT is built on a version of deal.II older than 9.3,
+         * then all processes need to pass in valid values for the first
+         * three arguments and the last two arguments are ignored.
+        #endif
          */
         void reinit(const std::vector<std::string> &column_names,
                     std::vector<std::vector<double>> &&coordinate_values,
-                    std::vector<Table<dim,double>> &&data_table);
+                    std::vector<Table<dim,double>> &&data_table,
+                    const MPI_Comm &mpi_communicator = MPI_COMM_SELF,
+                    const unsigned int root_process = numbers::invalid_unsigned_int);
 
         /**
          * Loads a data text file. Throws an exception if the file does not

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -92,8 +92,8 @@ namespace aspect
          * location. In other words, after the call, the variables passed as the
          * second and third arguments may be empty or otherwise altered.
          *
-        #if DEAL_II_VERSION_GTE(9,3,0)
-         * If ASPECT is built on deal.II version 9.3 or higher, this class
+        #if DEAL_II_VERSION_GTE(9,4,0)
+         * If ASPECT is built on deal.II version 10.0 or higher, this class
          * is able to share data between processes located on the same
          * machine. In this case, if the last argument, `root_process` is
          * set to anything other than `numbers::invalid_unsigned_int`, then only the
@@ -112,7 +112,7 @@ namespace aspect
          * every process needs to pass data for all arguments and the
          * `mpi_communicator` argument is ignored.
         #else
-         * If ASPECT is built on a version of deal.II older than 9.3,
+         * If ASPECT is built on a version of deal.II 9.3 or older,
          * then all processes need to pass in valid values for the first
          * three arguments and the last two arguments are ignored.
         #endif

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -93,7 +93,7 @@ namespace aspect
          * second and third arguments may be empty or otherwise altered.
          *
         #if DEAL_II_VERSION_GTE(9,4,0)
-         * If ASPECT is built on deal.II version 10.0 or higher, this class
+         * If ASPECT is built on deal.II version 9.4 or higher, this class
          * is able to share data between processes located on the same
          * machine. In this case, if the last argument, `root_process` is
          * set to anything other than `numbers::invalid_unsigned_int`, then only the

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -327,14 +327,13 @@ namespace aspect
               if (components == numbers::invalid_unsigned_int)
                 components = name_column_index - dim;
               else if (name_column_index != 0)
-                AssertThrow (components+dim == name_column_index,
+                AssertThrow (components == name_column_index,
                              ExcMessage("The number of expected data columns and the "
                                         "list of column names at the beginning of the data file "
                                         + filename + " do not match. The file should contain "
-                                        + Utilities::int_to_string(name_column_index) + " column "
-                                        "names (one for each dimension and one per data column), "
-                                        "but it only has " + Utilities::int_to_string(components+dim) +
-                                        " column names."));
+                                        "one column name per column (one for each dimension "
+                                        "and one per data column)."));
+
               break;
             }
           catch (const boost::bad_lexical_cast &e)
@@ -381,29 +380,6 @@ namespace aspect
             column_names.push_back("column " + Utilities::int_to_string(c,2));
         }
 
-      // Make sure the data file actually has as many columns as we think it has
-      // (either based on the header, or based on what was passed to the reinit function).
-      const unsigned int position = in.tellg();
-      std::string first_data_row;
-      std::getline(in, first_data_row);
-      std::stringstream linestream(first_data_row);
-      std::string column_entry;
-
-      // We have already read in the first data entry above in the try/catch block,
-      // so there's one more column in the file than in the line we just read in.
-      unsigned int number_of_entries = 1;
-      while (linestream >> column_entry)
-        number_of_entries += 1;
-
-      AssertThrow ((number_of_entries) == column_names.size()+dim,
-                   ExcMessage("ERROR: The number of columns in the data file " + filename +
-                              " is incorrect. It needs to have " + Utilities::int_to_string(column_names.size()+dim) +
-                              " columns, but the first row has " + Utilities::int_to_string(number_of_entries) +
-                              " columns."));
-
-      // Go back to the position in the file where we started the check for the column numbers.
-      in.seekg (position);
-
       // Finally read data lines:
       unsigned int read_data_entries = 0;
       do
@@ -420,14 +396,13 @@ namespace aspect
 
               AssertThrow(old_value == 0. ||
                           (std::abs(old_value-temp_data) < 1e-8*std::abs(old_value)),
-                          ExcMessage("Invalid coordinate in column "
+                          ExcMessage("Invalid coordinate "
                                      + Utilities::int_to_string(column_num) + " in row "
                                      + Utilities::int_to_string(row_num)
                                      + " in file " + filename +
                                      "\nThis class expects the coordinates to be structured, meaning "
                                      "the coordinate values in each coordinate direction repeat exactly "
-                                     "each time. This also means each row in the data file has to have "
-                                     "the same number of columns as the first row containing data."));
+                                     "each time."));
 
               coordinate_values[column_num][idx[column_num]] = temp_data;
             }

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -173,7 +173,7 @@ namespace aspect
                                       const MPI_Comm &mpi_communicator,
                                       const unsigned int root_process)
     {
-#if DEAL_II_VERSION_GTE(9,3,0)
+#if DEAL_II_VERSION_GTE(9,4,0)
       const bool supports_shared_data = true;
 #else
       const bool supports_shared_data = false;
@@ -235,7 +235,7 @@ namespace aspect
           &&
           (root_process != numbers::invalid_unsigned_int))
         {
-#if DEAL_II_VERSION_GTE(9,3,0)
+#if DEAL_II_VERSION_GTE(9,4,0)
           coordinate_values                 = Utilities::MPI::broadcast (mpi_communicator,
                                                                          coordinate_values,
                                                                          root_process);
@@ -329,7 +329,7 @@ namespace aspect
     StructuredDataLookup<dim>::load_file(const std::string &filename,
                                          const MPI_Comm &comm)
     {
-#if DEAL_II_VERSION_GTE(9,3,0)
+#if DEAL_II_VERSION_GTE(9,4,0)
       const bool supports_shared_data = true;
       const unsigned int root_process = 0;
 #else
@@ -549,7 +549,7 @@ namespace aspect
       // contains only empty tables.
       if (supports_shared_data == true)
         {
-#if DEAL_II_VERSION_GTE(9,3,0)
+#if DEAL_II_VERSION_GTE(9,4,0)
           components = Utilities::MPI::broadcast (comm,
                                                   components,
                                                   root_process);

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -302,8 +302,8 @@ namespace aspect
 
               data[c]
                 = std::make_unique<Functions::InterpolatedUniformGridData<dim>> (std::move(grid_extent),
-                                                                                 std::move(table_intervals),
-                                                                                 std::move(data_table[c]));
+                                                                                  std::move(table_intervals),
+                                                                                  std::move(data_table[c]));
             }
           else
             // Create the object and move the big objects. Due to an old design flaw,
@@ -341,7 +341,7 @@ namespace aspect
 #endif
 
       std::vector<std::string> column_names;
-      std::vector<Table<dim,double> > data_tables;
+      std::vector<Table<dim,double>> data_tables;
       std::vector<std::vector<double>> coordinate_values(dim);
 
       // If this is the root process, or if we don't support data sharing,
@@ -1209,7 +1209,7 @@ namespace aspect
                                   "> not found!"));
 
           lookups.push_back(std::make_unique<Utilities::StructuredDataLookup<dim-1>> (components,
-                                                                                      this->scale_factor));
+                                                                                       this->scale_factor));
           lookups[i]->load_file(filename,this->get_mpi_communicator());
         }
     }
@@ -1366,7 +1366,7 @@ namespace aspect
                                "a spherical shell, chunk, or box geometry."));
 
       lookup = std::make_unique<Utilities::StructuredDataLookup<spacedim>> (components,
-                                                                            this->scale_factor);
+                                                                             this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
 

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -179,10 +179,13 @@ namespace aspect
       const bool supports_shared_data = false;
 #endif
 
-      // If this is the root process, or if we don't support data sharing,
+      // If this is the root process, or if the user did not request
+      // sharing, or if we don't support data sharing,
       // then set up the various member variables we need to compute
       // from the input data
       if ((supports_shared_data == false)
+          ||
+          (root_process == numbers::invalid_unsigned_int)
           ||
           ((supports_shared_data == true)
            &&

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -382,8 +382,8 @@ namespace aspect
         }
 
       // Make sure the data file actually has as many columns as we think it has
-      // (either based on the header, or based on what was passed to the constructor).
-      const std::streampos position = in.tellg();
+      // (either based on the header, or based on what was passed to the reinit function).
+      const unsigned int position = in.tellg();
       std::string first_data_row;
       std::getline(in, first_data_row);
       std::stringstream linestream(first_data_row);

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -431,13 +431,14 @@ namespace aspect
                   if (components == numbers::invalid_unsigned_int)
                     components = name_column_index - dim;
                   else if (name_column_index != 0)
-                    AssertThrow (components == name_column_index,
+                    AssertThrow (components+dim == name_column_index,
                                  ExcMessage("The number of expected data columns and the "
                                             "list of column names at the beginning of the data file "
                                             + filename + " do not match. The file should contain "
-                                            "one column name per column (one for each dimension "
-                                            "and one per data column)."));
-
+                                            + Utilities::int_to_string(name_column_index) + " column "
+                                            "names (one for each dimension and one per data column), "
+                                            "but it only has " + Utilities::int_to_string(components+dim) +
+                                            " column names."));
                   break;
                 }
               catch (const boost::bad_lexical_cast &e)
@@ -483,6 +484,29 @@ namespace aspect
                 column_names.push_back("column " + Utilities::int_to_string(c,2));
             }
 
+          // Make sure the data file actually has as many columns as we think it has
+          // (either based on the header, or based on what was passed to the constructor).
+          const std::streampos position = in.tellg();
+          std::string first_data_row;
+          std::getline(in, first_data_row);
+          std::stringstream linestream(first_data_row);
+          std::string column_entry;
+
+          // We have already read in the first data entry above in the try/catch block,
+          // so there's one more column in the file than in the line we just read in.
+          unsigned int number_of_entries = 1;
+          while (linestream >> column_entry)
+            number_of_entries += 1;
+
+          AssertThrow ((number_of_entries) == column_names.size()+dim,
+                       ExcMessage("ERROR: The number of columns in the data file " + filename +
+                                  " is incorrect. It needs to have " + Utilities::int_to_string(column_names.size()+dim) +
+                                  " columns, but the first row has " + Utilities::int_to_string(number_of_entries) +
+                                  " columns."));
+
+          // Go back to the position in the file where we started the check for the column numbers.
+          in.seekg (position);
+
           // Finally read data lines:
           unsigned int read_data_entries = 0;
           do
@@ -499,13 +523,14 @@ namespace aspect
 
                   AssertThrow(old_value == 0. ||
                               (std::abs(old_value-temp_data) < 1e-8*std::abs(old_value)),
-                              ExcMessage("Invalid coordinate "
+                              ExcMessage("Invalid coordinate in column "
                                          + Utilities::int_to_string(column_num) + " in row "
                                          + Utilities::int_to_string(row_num)
                                          + " in file " + filename +
                                          "\nThis class expects the coordinates to be structured, meaning "
                                          "the coordinate values in each coordinate direction repeat exactly "
-                                         "each time."));
+                                         "each time. This also means each row in the data file has to have "
+                                         "the same number of columns as the first row containing data."));
 
                   coordinate_values[column_num][idx[column_num]] = temp_data;
                 }
@@ -567,7 +592,6 @@ namespace aspect
             data_tables.resize (components);
 #endif
         }
-
 
       // Finally create the data. We want to call the move-version of reinit() so
       // that the data doesn't have to be copied, so use std::move on all big

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -227,8 +227,8 @@ namespace aspect
 
               data[c]
                 = std::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
-                                                                                  table_intervals,
-                                                                                  std::move(data_table[c]));
+                                                                                 table_intervals,
+                                                                                 std::move(data_table[c]));
             }
           else
             // Create the object and move the big objects. Due to an old design flaw,
@@ -1095,7 +1095,7 @@ namespace aspect
                                   "> not found!"));
 
           lookups.push_back(std::make_unique<Utilities::StructuredDataLookup<dim-1>> (components,
-                                                                                       this->scale_factor));
+                                                                                      this->scale_factor));
           lookups[i]->load_file(filename,this->get_mpi_communicator());
         }
     }
@@ -1252,7 +1252,7 @@ namespace aspect
                                "a spherical shell, chunk, or box geometry."));
 
       lookup = std::make_unique<Utilities::StructuredDataLookup<spacedim>> (components,
-                                                                             this->scale_factor);
+                                                                            this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
 

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -74,7 +74,8 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=1")
   raw_data[1](0) = 5.0;
   raw_data[1](1) = 3.0;
 
-  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data),
+                MPI_COMM_SELF, numbers::invalid_unsigned_int);
 
   INFO(lookup.get_data(Point<1>(1.5), 0));
   INFO(lookup.get_data(Point<1>(1.5), 1));
@@ -111,7 +112,8 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=2")
   raw_data[0](1,2) = 0.0;
   raw_data[0](2,2) = 0.0;
 
-  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data),
+                MPI_COMM_SELF, numbers::invalid_unsigned_int);
 
   REQUIRE(lookup.get_data(Point<2>(1.0,6.0),0) == Approx(5.0));
   REQUIRE(lookup.get_data(Point<2>(2.0,6.0),0) == Approx(5.5));
@@ -142,7 +144,8 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=2 equid")
   raw_data[0](1,2) = 0.0;
   raw_data[0](2,2) = 0.0;
 
-  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data));
+  lookup.reinit(column_names, std::move(coordinate_values), std::move(raw_data),
+                MPI_COMM_SELF, numbers::invalid_unsigned_int);
 
   REQUIRE(lookup.get_data(Point<2>(1.0,6.0),0) == Approx(5.0));
   REQUIRE(lookup.get_data(Point<2>(1.5,6.0),0) == Approx(5.5));


### PR DESCRIPTION
This builds on #4083, so the first patch is duplicated from there (but because it's identical, we can still merge this assuming #4083 were merged).

I *believe* this should work, but I don't know for sure and it's late and I'm leaving town tomorrow afternoon until Monday. Let us see what the testers say -- they will at least tell us whether it works with deal.II 9.2. Do any of the testers run 9.3?

The real test would be if (i) we have tests that use ASCII data tables in parallel, and (ii) we check with deal.II 9.3. I don't know whether we have any that satisfy (i). Anyone know for sure?

/rebuild