### PR TITLE
Avoid string comparisons in spherical constant boundary temperature plugin

### DIFF
--- a/doc/modules/changes/20230802_gassmoeller
+++ b/doc/modules/changes/20230802_gassmoeller
@@ -1,0 +1,6 @@
+ Improved: The 'spherical constant' boundary composition and boundary
+ temperature plugins have been updated. In particular the boundary
+ composition plugin can now prescribe different values for different
+ compositional fields.
+ <br>
+ (Rene Gassmoeller, 2023/08/02)

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -46,6 +46,12 @@ namespace aspect
     {
       public:
         /**
+         * Initialize some variables.
+        */
+        void
+        initialize() override;
+
+        /**
          * This function returns the constant compositions read from the
          * parameter file for the inner and outer boundaries.
          *
@@ -54,20 +60,6 @@ namespace aspect
         double boundary_composition (const types::boundary_id boundary_indicator,
                                      const Point<dim> &position,
                                      const unsigned int compositional_field) const override;
-
-        /**
-         * Return the minimal composition on that part of the boundary on
-         * which Dirichlet conditions are posed.
-         */
-        virtual
-        double minimal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;
-
-        /**
-         * Return the maximal composition on that part of the boundary on
-         * which Dirichlet conditions are posed.
-         */
-        virtual
-        double maximal_composition (const std::set<types::boundary_id> &fixed_boundary_ids) const;
 
         /**
          * Declare the parameters this class takes through input files. This
@@ -87,8 +79,14 @@ namespace aspect
         /**
          * Compositions at the inner and outer boundaries.
          */
-        double inner_composition;
-        double outer_composition;
+        std::vector<double> inner_composition;
+        std::vector<double> outer_composition;
+
+        /**
+         * Boundary indicators for the inner and outer boundaries.
+         */
+        types::boundary_id inner_boundary_indicator;
+        types::boundary_id outer_boundary_indicator;
     };
   }
 }

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -43,6 +43,12 @@ namespace aspect
     {
       public:
         /**
+        * Initialize some variables.
+        */
+        void
+        initialize() override;
+
+        /**
          * This function returns the constant compositions read from the
          * parameter file for the inner and outer boundaries.
          *
@@ -89,6 +95,12 @@ namespace aspect
          */
         double inner_temperature;
         double outer_temperature;
+
+        /**
+         * The boundary indicator for the inner and outer boundaries.
+         */
+        types::boundary_id inner_boundary_indicator;
+        types::boundary_id outer_boundary_indicator;
     };
   }
 }

--- a/source/boundary_composition/spherical_constant.cc
+++ b/source/boundary_composition/spherical_constant.cc
@@ -115,11 +115,11 @@ namespace aspect
         {
           inner_composition = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Inner composition"))),
                                                                       n_compositional_fields,
-                                                                      "boundary composition values");
+                                                                      "Inner boundary composition values");
 
           outer_composition = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Outer composition"))),
                                                                       n_compositional_fields,
-                                                                      "boundary composition values");
+                                                                      "Outer boundary composition values");
         }
         prm.leave_subsection ();
       }

--- a/source/boundary_temperature/spherical_constant.cc
+++ b/source/boundary_temperature/spherical_constant.cc
@@ -25,15 +25,34 @@
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 
-#include <utility>
-#include <limits>
-
 
 namespace aspect
 {
   namespace BoundaryTemperature
   {
-// ------------------------------ SphericalConstant -------------------
+    template <int dim>
+    void
+    SphericalConstant<dim>::
+    initialize ()
+    {
+      // verify that the geometry is supported by this plugin
+      AssertThrow ( Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>>(this->get_geometry_model()) ||
+                    Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>>(this->get_geometry_model()) ||
+                    Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>>(this->get_geometry_model()) ||
+                    Plugins::plugin_type_matches<const GeometryModel::EllipsoidalChunk<dim>>(this->get_geometry_model()),
+                    ExcMessage ("This boundary model is only implemented if the geometry is "
+                                "one of the spherical geometries."));
+
+      // no inner boundary in a full sphere
+      if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>>(this->get_geometry_model()))
+        inner_boundary_indicator = numbers::invalid_unsigned_int;
+      else
+        inner_boundary_indicator = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");
+
+      outer_boundary_indicator = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
+    }
+
+
 
     template <int dim>
     double
@@ -41,20 +60,18 @@ namespace aspect
     boundary_temperature (const types::boundary_id boundary_indicator,
                           const Point<dim> &) const
     {
-      const GeometryModel::Interface<dim> *geometry_model = &this->get_geometry_model();
-      const std::string boundary_name = geometry_model->translate_id_to_symbol_name(boundary_indicator);
-
-      if (boundary_name == "bottom")
-        return inner_temperature;
-      else if (boundary_name =="top")
+      if (boundary_indicator == outer_boundary_indicator)
         return outer_temperature;
+      else if (boundary_indicator == inner_boundary_indicator)
+        return inner_temperature;
       else
-        {
-          Assert (false, ExcMessage ("Unknown boundary indicator for geometry model. "
-                                     "The given boundary should be ``top'' or ``bottom''."));
-          return numbers::signaling_nan<double>();
-        }
+        AssertThrow (false,
+                     ExcMessage ("Unknown boundary indicator for geometry model. "
+                                 "The given boundary should be ``top'' or ``bottom''."));
+
+      return numbers::signaling_nan<double>();
     }
+
 
 
     template <int dim>
@@ -96,6 +113,7 @@ namespace aspect
       }
       prm.leave_subsection ();
     }
+
 
 
     template <int dim>

--- a/tests/gmg_velocity_boundary_2d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_flux.prm
@@ -59,7 +59,11 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
-  set List of model names = spherical constant
+  set List of model names = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = bottom: 1673, top: 273
+  end
+end
 
   subsection Spherical constant
     set Inner temperature = 1673

--- a/tests/gmg_velocity_boundary_2d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_flux.prm
@@ -65,11 +65,6 @@ subsection Boundary temperature model
   end
 end
 
-  subsection Spherical constant
-    set Inner temperature = 1673
-    set Outer temperature = 273
-  end
-end
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
@@ -58,7 +58,11 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
-  set List of model names = spherical constant
+  set List of model names = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = bottom: 1673, top: 273
+  end
+end
 
   subsection Spherical constant
     set Inner temperature = 1673

--- a/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
@@ -64,11 +64,6 @@ subsection Boundary temperature model
   end
 end
 
-  subsection Spherical constant
-    set Inner temperature = 1673
-    set Outer temperature = 273
-  end
-end
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_3d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_flux.prm
@@ -62,7 +62,11 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
-  set List of model names = spherical constant
+  set List of model names = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = bottom: 1673, top: 273
+  end
+end
 
   subsection Spherical constant
     set Inner temperature = 1673

--- a/tests/gmg_velocity_boundary_3d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_flux.prm
@@ -68,11 +68,6 @@ subsection Boundary temperature model
   end
 end
 
-  subsection Spherical constant
-    set Inner temperature = 1673
-    set Outer temperature = 273
-  end
-end
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
@@ -61,7 +61,11 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
-  set List of model names = spherical constant
+  set List of model names = constant
+  subsection Constant
+    set Boundary indicator to temperature mappings = bottom: 1673, top: 273
+  end
+end
 
   subsection Spherical constant
     set Inner temperature = 1673

--- a/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
@@ -67,11 +67,6 @@ subsection Boundary temperature model
   end
 end
 
-  subsection Spherical constant
-    set Inner temperature = 1673
-    set Outer temperature = 273
-  end
-end
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/shell_boundary_composition_spherical_constant.prm
+++ b/tests/shell_boundary_composition_spherical_constant.prm
@@ -1,0 +1,97 @@
+# 2d shell with 'spherical constant' boundary composition
+# for multiple compositions.
+
+
+set Dimension                              = 2
+set Use years in output instead of seconds = true
+set End time                               = 0
+set Output directory                       = output-shell_boundary_composition_spherical_constant
+
+subsection Material model
+  set Model name = simple
+  set Material averaging = harmonic average only viscosity
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+    set Opening angle = 360
+  end
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, top
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = top, bottom
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 4273
+    set Outer temperature = 973
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = spherical hexagonal perturbation
+end
+
+
+subsection Compositional fields
+  set Number of fields = 2
+end
+
+
+subsection Boundary composition model
+  set List of model names = spherical constant
+  set Fixed composition boundary indicators = top, bottom
+  subsection Spherical constant
+    set Inner composition = 1,2
+    set Outer composition = 2,3
+  end
+end
+
+
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 2; 2
+  end
+end
+
+
+subsection Gravity model
+  set Model name = ascii data
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 0
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 15
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics, composition statistics
+
+  subsection Visualization
+    set Output format                 = vtu
+    set Time between graphical output = 1e6
+    set Number of grouped files       = 0
+  end
+end

--- a/tests/shell_boundary_composition_spherical_constant/screen-output
+++ b/tests/shell_boundary_composition_spherical_constant/screen-output
@@ -1,0 +1,21 @@
+
+Number of active cells: 192 (on 3 levels)
+Number of degrees of freedom: 4,560 (1,728+240+864+864+864)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Solving C_2 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 20+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-shell_boundary_composition_spherical_constant/solution/solution-00000
+     RMS, max velocity:         0.0976 m/year, 0.146 m/year
+     Temperature min/avg/max:   973 K, 2463 K, 4273 K
+     Compositions min/max/mass: 1/2/1.735e+14 // 2/3/1.808e+14
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
The 'spherical constant' boundary temperature and composition plugins currently does a lot of string comparisons when returning the boundary values, so many that they show up when profiling instantaneous models. The gain for the overall model is not huge, but it is a simple change that makes the plugin more similar to the way the box plugins are written already.

I also removed the `minimal_composition` and `maximal_composition` functions from the boundary composition plugin. I think they were copy-pasted from the temperature plugin, because such functions are not defined in the composition interface, and they are nowhere used.

@jdannberg I know you had looked at these plugins before, can you take a look at this?