### PR TITLE
Allow selecting individual compositions for world builder

### DIFF
--- a/doc/modules/changes/20210625_gassmoeller
+++ b/doc/modules/changes/20210625_gassmoeller
@@ -1,0 +1,6 @@
+New: It is now possible to only call the world builder to determine initial
+compositions for selected compositional fields by specifying the parameter
+'List of relevant compositions' in the world builder initial composition
+plugin.
+<br>
+(Rene Gassmoeller, Juliane Dannberg, 2021/06/25)

--- a/include/aspect/initial_composition/world_builder.h
+++ b/include/aspect/initial_composition/world_builder.h
@@ -61,6 +61,31 @@ namespace aspect
          */
         double initial_composition (const Point<dim> &position, const unsigned int n_comp) const override;
 
+        /**
+         * Declare the parameters this class takes through input files. The
+         * default implementation of this function does not describe any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         * The default implementation of this function does not read any
+         * parameters. Consequently, derived classes do not have to overload
+         * this function if they do not take any runtime parameters.
+         */
+        void
+        parse_parameters (ParameterHandler &prm) override;
+
+      private:
+        /**
+         * A vector that specifies for each compositional field index if the world builder
+         * should be evaluated for this compositional field.
+         */
+        std::vector<bool> relevant_compositions;
     };
   }
 }

--- a/source/initial_composition/world_builder.cc
+++ b/source/initial_composition/world_builder.cc
@@ -39,14 +39,77 @@ namespace aspect
       CitationInfo::add("GWB");
     }
 
+
+
     template <int dim>
     double
     WorldBuilder<dim>::
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
-      return this->get_world_builder().composition(Utilities::convert_point_to_array(position),
-                                                   -this->get_geometry_model().height_above_reference_surface(position),
-                                                   n_comp);
+      if (relevant_compositions[n_comp] == true)
+        return this->get_world_builder().composition(Utilities::convert_point_to_array(position),
+                                                     -this->get_geometry_model().height_above_reference_surface(position),
+                                                     n_comp);
+
+      return 0.0;
+    }
+
+
+
+    template <int dim>
+    void
+    WorldBuilder<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Initial composition model");
+      {
+        prm.enter_subsection("World builder");
+        {
+          prm.declare_entry ("List of relevant compositions", "",
+                             Patterns::Anything(),
+                             "A list of names of compositional fields for "
+                             "which to determine the initial composition using "
+                             "the World Builder. As World Builder evaluations can "
+                             "be expensive, this parameter allows to only evaluate "
+                             "the fields that are relevant. This plugin returns 0.0 "
+                             "for all compositions that are not selected in the list. "
+                             "By default the list is empty and the world builder is "
+                             "evaluated for all compositional fields.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+    template <int dim>
+    void
+    WorldBuilder<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Initial composition model");
+      {
+        prm.enter_subsection("World builder");
+        {
+          const std::vector<std::string> composition_names = Utilities::split_string_list(prm.get("List of relevant compositions"));
+
+          relevant_compositions.resize(this->n_compositional_fields(),false);
+
+          if (composition_names.size() == 0)
+            for (unsigned int i=0; i<this->n_compositional_fields(); ++i)
+              relevant_compositions[i] = true;
+
+          for (const auto &composition_name: composition_names)
+            {
+              AssertThrow(this->introspection().compositional_name_exists (composition_name),
+                          ExcMessage("All fields in \"List of relevant compositions\" must match names of compositional "
+                                     "fields as assigned in the \"Compositional fields/Names of fields\" parameter."));
+
+              relevant_compositions[this->introspection().compositional_index_for_name(composition_name)] = true;
+            }
+        }
+
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
     }
 
   }
@@ -63,7 +126,9 @@ namespace aspect
                                               "More information on the World Builder can be found at "
                                               "\\url{https://geodynamicworldbuilder.github.io}. "
                                               "Make sure to specify the location of the World Builder file "
-                                              "in the parameter 'World builder file'.")
+                                              "in the parameter 'World builder file'. It is possible to use "
+                                              "the World Builder only for selected compositional fields by "
+                                              "specifying the parameter 'List of relevant compositions'.")
   }
 }
 #endif

--- a/tests/world_builder_select_composition.prm
+++ b/tests/world_builder_select_composition.prm
@@ -1,0 +1,67 @@
+# WORLD BUILDER
+# This test is a copy of world_builder_simple.prm and checks that we can select
+# a subset of compositions for which to evaluate the world builder.
+
+set World builder file                     = $ASPECT_SOURCE_DIR/tests/world_builder_select_composition.wb
+set Use years in output instead of seconds = false
+set Adiabatic surface temperature = 1613
+set End time = 0
+
+subsection Adiabatic conditions model
+  subsection Compute profile
+    set Function expression = if(x > 1500000,1.0,0.0);0.0;0.0
+    set Composition reference profile = function
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators = 1
+  set Tangential velocity boundary indicators = 0, 2, 3
+end
+
+subsection Compositional fields
+  set Number of fields = 3
+  set Names of fields = Crust, Lithosphere, Continent
+end
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent = 1500e3
+    set Y extent = 200e3
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Initial temperature model
+  set Model name = world builder
+end
+
+subsection Initial composition model
+  set List of model names = world builder
+
+  subsection World builder
+    set List of relevant compositions = Crust
+  end
+end
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference temperature = 1613
+    set Viscosity = 1e21
+    set Thermal conductivity = 1e-06
+    set Density differential for compositional field 1 = 500
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement = 5
+end
+
+subsection Postprocess
+  set List of postprocessors = composition statistics
+end

--- a/tests/world_builder_select_composition.wb
+++ b/tests/world_builder_select_composition.wb
@@ -1,0 +1,31 @@
+{
+  "version":"0.4",
+  "cross section":[[0,0],[100,0]],
+  "features":
+  [
+    {"model":"oceanic plate", "name":"oceanic plate", "coordinates":[[-1e3,-1e3],[1150e3,-1e3],[1150e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"plate model", "max depth":95e3, "bottom temperature":1600, "spreading velocity":0.005, "ridge coordinates":[[100e3,-1e3],[100e3,1e3]]}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max depth":10e3},
+                           {"model":"uniform", "compositions":[1], "min depth":10e3, "max depth":95e3}]},
+
+    {"model":"continental plate", "name":"continental plate", "coordinates":[[1150e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[1150e3,1e3]],
+     "temperature models":[{"model":"linear", "max depth":95e3, "bottom temperature":1600}],
+     "composition models":[{"model":"uniform", "compositions":[2], "max depth":30e3},
+                           {"model":"uniform", "compositions":[3], "min depth":30e3, "max depth":65e3}]},
+
+    {"model":"mantle layer", "name":"upper mantle", "min depth":95e3, "max depth":660e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"linear", "min depth":95e3, "max depth":660e3, "top temperature":1600, "bottom temperature":1820}],
+     "composition models":[{"model":"uniform", "compositions":[4]}]},
+
+    {"model":"mantle layer", "name":"lower mantle", "min depth":660e3, "max depth":1160e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"linear", "min depth":660e3, "max depth":1160e3, "top temperature":1820, "bottom temperature":2000}],
+     "composition models":[{"model":"uniform", "compositions":[5]}]},
+
+    {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[1150e3,-1e3],[1150e3,1e3]], "dip point":[2000e3,0],
+     "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
+                 {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
+     "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01, "adiabatic heating":false}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
+                           {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3 }]}
+  ]
+}

--- a/tests/world_builder_select_composition/screen-output
+++ b/tests/world_builder_select_composition/screen-output
@@ -1,0 +1,19 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 26,439 (8,450+1,089+4,225+4,225+4,225+4,225)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving Crust system ... 0 iterations.
+   Skipping Lithosphere composition solve because RHS is zero.
+   Skipping Continent composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+2 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 0/1/1.677e+10 // 0/0/0 // 0/0/0
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
We have a model setup where using the world builder to prescribe initial compositions is very expensive, however we only want to use it for 1 of our 5 compositions. At the moment it is impossible to call the world builder function only for selected compositions, but this is now added in this PR. 

@MFraters can you take a look if this makes sense?