### PR TITLE
Fix one test for 64bit indices

### DIFF
--- a/tests/prescribed_velocity_dgp.cc
+++ b/tests/prescribed_velocity_dgp.cc
@@ -180,7 +180,7 @@ namespace aspect
           if (! cell->is_artificial())
             {
               fe_values.reinit (cell);
-              std::vector<unsigned int> local_dof_indices(simulator_access.get_fe().dofs_per_cell);
+              std::vector<types::global_dof_index> local_dof_indices(simulator_access.get_fe().dofs_per_cell);
               cell->get_dof_indices (local_dof_indices);
 
               for (unsigned int q=0; q<quadrature.size(); q++)


### PR DESCRIPTION
Found while testing the 2.3 release branch. One of our tests does not use the correct type for Dofs. Not a big deal because it is purely in the test code, but should probably go into 2.3 as well.