### PR TITLE
Initialize current linearization point after melt restart

### DIFF
--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -580,7 +580,10 @@ namespace aspect
     // We have to compute the constraints here because the vector that tells
     // us if a cell is a melt cell is not saved between restarts.
     if (parameters.include_melt_transport)
-      compute_current_constraints ();
+      {
+        initialize_current_linearization_point();
+        compute_current_constraints ();
+      }
   }
 
 }


### PR DESCRIPTION
This should fix #4088. The current constraints in computations with melt depend on the current linearization point (to determine which cells should be treated as melt cells), but we do not serialize the current linearization point and only initialize it after computing the current constraints. This could lead to different results in the first nonlinear iteration after a restart (presumably all cells were treated as non melt cells and only the normal Stokes equations were solved on them).

This PR makes sure the current linearization point is initialized before computing the current constraints after a restart. This means we now initialize the current linearization point twice after a resume, but that should not matter (it's reasonably fast and only happens occasionally).

@anne-glerum: Can you check if this fixes your issue?