### PR TITLE
Add dealii dev tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,3 +68,27 @@ jobs:
       with:
         name: manual.log
         path: doc/manual/manual.log
+
+  dealii-dev:
+    # linux build with deal.II dev
+    name: test-dealii-dev
+    runs-on: [ubuntu-18.04]
+    container:
+      image: dealii/dealii:master-focal
+      options: --user 0
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: compile
+      run: |
+        mkdir build
+        cd build
+        cmake \
+        -G 'Ninja' \
+        -D CMAKE_CXX_FLAGS='-Werror' \
+        -D ASPECT_TEST_GENERATOR='Ninja' \
+        -D ASPECT_PRECOMPILE_HEADERS=ON \
+        -D ASPECT_UNITY_BUILD=ON \
+        ..
+        ninja
+        ./aspect --test


### PR DESCRIPTION
This adds a github action that compiles ASPECT against the dealii/dealii:master-focal container with every PR. Currently does not run the test suite.

No more PRs that work on the tester but break on deal.II dev :tada: