### PR TITLE
Fix unit tests for deal.II dev

### DIFF
--- a/unit_tests/mesh_refinement.cc
+++ b/unit_tests/mesh_refinement.cc
@@ -54,6 +54,6 @@ TEST_CASE("Isosurfaces min_max_string_to_int function")
   CHECK(min_max_string_to_int("min+5",1,5) == 5);
   CHECK(min_max_string_to_int("max-5",1,5) == 1);
 
-  CHECK_THROWS_WITH(min_max_string_to_int("min-1",1,5),Contains("A value of min-1 was provided, but you can't provide a smaller value than"));
-  CHECK_THROWS_WITH(min_max_string_to_int("max+1",1,5),Contains("A value of max+1 was provided, but you can't provide a larger value than"));
+  CHECK_THROWS_WITH(min_max_string_to_int("min-1",1,5),Contains("A value of min-1 was provided, but you can't provide a smaller value"));
+  CHECK_THROWS_WITH(min_max_string_to_int("max+1",1,5),Contains("A value of max+1 was provided, but you can't provide a larger value"));
 }

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -281,7 +281,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, all:400, C5:500, bg:3",
   {"C1","C2","C3","C4","C5"},
   true,
-  "TestField"), Contains("The keyword `all' in the property TestField is only allowed if there is no other keyword."));
+  "TestField"), Contains("The keyword `all' in the property TestField is only allowed if"));
 
   INFO("check fail 6: ");
   REQUIRE_THROWS_WITH(
@@ -337,7 +337,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     "TestField",
     true,
     n_values_per_key),
-    Contains("the expected number of values"));
+    Contains("The key <C1> in <TestField> does not have the expected number"));
   }
 
   {
@@ -360,7 +360,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     "TestField",
     true,
     n_values_per_key),
-    Contains("the expected number of values"));
+    Contains("The key <C1> in <TestField> does not have the expected number"));
   }
 }
 


### PR DESCRIPTION
Found because of #4099. It seems the formatting of assertion output has changed (or catch has become more strict about comparisons), anyway it does not ignore newlines in the output. Adjust the unit test requirements to not contain strings that are broken by a newline.