### PR TITLE
Set Github Actions concurrency to speed up feedback

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,10 @@ name: linux
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-nounity:
     #linux build with unity/precomiled headers disabled


### PR DESCRIPTION
This ensures that only a single github actions workflow per PR is run at the same time, and that new pushes will cancel existing runs. Will be useful to get quicker results from Github actions during the hackathon.