### PR TITLE
Use user-branch name for concurrency

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: linux
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.actor }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fixup for #4101 to ensure branches from different users with the same branch name do not interfere.