### PR TITLE
Allow viscosity 0 if Stokes is not solved

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -402,13 +402,13 @@ namespace aspect
     // computing the *geometric* mean of the viscosities, but the
     // formula above is numerically stable.
 
-    // Do return 0 if we do not solve the Stokes equation. Technically, there is
+    // Do return NaN if we do not solve the Stokes equation. Technically, there is
     // no harm in computing the factor anyway, but the viscosity has to be positive
-    // for this function to work, and some models may set it to 0 if not solving
-    // the Stokes equation.
+    // for this function to work, and some models may set viscosity to 0 if not solving
+    // the Stokes equation. Returning NaN guarantees this value cannot be used.
     if (parameters.nonlinear_solver == NonlinearSolver::no_Advection_no_Stokes ||
         parameters.nonlinear_solver == NonlinearSolver::single_Advection_no_Stokes)
-      return 0.0;
+      return numbers::signaling_nan<double>();
 
     const QMidpoint<dim> quadrature_formula;
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -402,6 +402,14 @@ namespace aspect
     // computing the *geometric* mean of the viscosities, but the
     // formula above is numerically stable.
 
+    // Do return 0 if we do not solve the Stokes equation. Technically, there is
+    // no harm in computing the factor anyway, but the viscosity has to be positive
+    // for this function to work, and some models may set it to 0 if not solving
+    // the Stokes equation.
+    if (parameters.nonlinear_solver == NonlinearSolver::no_Advection_no_Stokes ||
+        parameters.nonlinear_solver == NonlinearSolver::single_Advection_no_Stokes)
+      return 0.0;
+
     const QMidpoint<dim> quadrature_formula;
 
     FEValues<dim> fe_values (*mapping,


### PR DESCRIPTION
Should fix #4116. Restores the behavior from before #3681 for models that set viscosity to 0 and dont solve Stokes.

@tjhei: Do you think this is the correct way to fix it? I verified that the model now runs (there are only two models like this, the other one is benchmarks/advection/rotate_shape_* 