### PR TITLE
Fix crustal cookbook

### DIFF
--- a/cookbooks/crustal_deformation/crustal_model_2D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_2D.prm
@@ -132,5 +132,6 @@ subsection Solver parameters
     set Linear solver tolerance = 1e-9
     set Number of cheap Stokes solver steps = 0
     set Maximum number of expensive Stokes solver steps = 5000
+    set GMRES solver restart length = 200
   end
 end

--- a/cookbooks/crustal_deformation/crustal_model_2D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_2D.prm
@@ -6,7 +6,11 @@ set Start time                                      = 0
 set End time                                        = 1e6
 set Use years in output instead of seconds          = true
 set Nonlinear solver scheme                         = single Advection, iterated Stokes
-set Nonlinear solver tolerance                      = 1e-8
+
+# This model is very sensitive to the nonlinear solver tolerance,
+# results still change slightly down to a tolerance of 1e-8, but
+# require much more resources than reasonable for a cookbook.
+set Nonlinear solver tolerance                      = 2e-6
 set Max nonlinear iterations                        = 100
 set CFL number                                      = 0.5
 set Output directory                                = output-crustal_model_2D


### PR DESCRIPTION
Fix #4117. The solver restart length alone already fixes the issue of the non-converging linear solver (5000 iterations -> 195 iterations). However, the nonlinear tolerance in this cookbook is so small, that the nonlinear solver very rarely converges for this problem. With a more reasonable tolerance this cookbook is 5 times faster and the results are nearly the same (small visible difference in the shape of the free surface). Let me know if you want me to remove the change to the solver tolerance to keep the cookbook the same.