### PR TITLE
Fix incorrect doxygen markup.

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -112,7 +112,7 @@ namespace aspect
          *   of the domain on which the point is located at which we are requesting the
          *   temperature.
          * @param location The location of the point at which we ask for the temperature.
-         **/
+         */
         double  boundary_temperature (const types::boundary_id            boundary_indicator,
                                       const Point<dim>                    &location) const override;
 

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -60,7 +60,7 @@ namespace aspect
 
           /**
           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
-          **/
+          */
           virtual
           void
           update_particle_property (const unsigned int data_position,

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -60,7 +60,7 @@ namespace aspect
 
           /**
           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
-          **/
+          */
           virtual
           void
           update_particle_property (const unsigned int data_position,

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -60,7 +60,7 @@ namespace aspect
 
           /**
           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
-          **/
+          */
           virtual
           void
           update_particle_property (const unsigned int data_position,

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -428,7 +428,7 @@ namespace aspect
            * _int_ext and ext_int hold the terms arising from the pairing between a cell
            * and its neighbor, while _ext_ext is the pairing of the neighbor's dofs with
            * themselves. In the continuous Galerkin case, these are unused, and set to size zero.
-           **/
+           */
           std::vector<FullMatrix<double> >         local_matrices_int_ext;
           std::vector<FullMatrix<double> >         local_matrices_ext_int;
           std::vector<FullMatrix<double> >         local_matrices_ext_ext;
@@ -443,7 +443,7 @@ namespace aspect
            * assembly. Entries for matrices not used (for example, those corresponding
            * to non-existent subfaces; or faces being assembled by the neighboring cell)
            * are set to false.
-           **/
+           */
           std::vector<bool>               assembled_matrices;
 
           /**
@@ -463,7 +463,7 @@ namespace aspect
            * in the discontinuous Galerkin method. The outer std::vector has
            * length GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell,
            * and has size zero if in the continuous Galerkin case.
-           **/
+           */
           std::vector<std::vector<types::global_dof_index> >   neighbor_dof_indices;
         };
       }

--- a/include/aspect/volume_of_fluid/assembly.h
+++ b/include/aspect/volume_of_fluid/assembly.h
@@ -135,7 +135,7 @@ namespace aspect
           /**
            * Local contributions to the global rhs from the face terms in the
            * discontinuous Galerkin interpretation of the VolumeOfFluid method.
-           **/
+           */
           std::array<Vector<double>,
               GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
               local_face_rhs;
@@ -148,7 +148,7 @@ namespace aspect
            * field assembly. Entries not used (for example, those corresponding
            * to non-existent subfaces; or faces being assembled by the
            * neighboring cell) are set to false.
-           **/
+           */
           std::array<bool,
               GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
               face_contributions_mask;
@@ -168,7 +168,7 @@ namespace aspect
            * Indices of the degrees of freedom corresponding to the volume_of_fluid field
            * on all possible neighboring cells. This is used in the
            * discontinuous Galerkin interpretation of the VolumeOfFluid method.
-           **/
+           */
           std::array<std::vector<types::global_dof_index>,
               GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
               neighbor_dof_indices;


### PR DESCRIPTION
Uses the lovely perl regex substitution
```
perl -pi -e 's/\*\*\//\*\//g;' `find include`
```
This might be the highlight of my day :-)

/rebuild