### PR TITLE
Use std::numeric_limits::lowest() instead of -max().

### DIFF
--- a/source/boundary_temperature/box.cc
+++ b/source/boundary_temperature/box.cc
@@ -70,7 +70,7 @@ namespace aspect
         return *std::max_element(temperature_, temperature_+2*dim);
       else
         {
-          double max = -std::numeric_limits<double>::max();
+          double max = std::numeric_limits<double>::lowest();
           for (const auto id : fixed_boundary_ids)
             max = std::max(max,temperature_[id]);
           return max;

--- a/source/boundary_temperature/two_merged_boxes.cc
+++ b/source/boundary_temperature/two_merged_boxes.cc
@@ -70,7 +70,7 @@ namespace aspect
         return *std::max_element(temperature_values, temperature_values+2*dim+2*(dim-1));
       else
         {
-          double max = -std::numeric_limits<double>::max();
+          double max = std::numeric_limits<double>::lowest();
           for (const auto p : fixed_boundary_ids)
             max = std::max(max,temperature_values[p]);
           return max;

--- a/source/geometry_model/initial_topography_model/prm_polygon.cc
+++ b/source/geometry_model/initial_topography_model/prm_polygon.cc
@@ -110,7 +110,7 @@ namespace aspect
              * we need to fill the point lists and topography values. They
              * are stored in the Topography subsection in the Topography parameter.
              */
-            maximum_topography = -std::numeric_limits<double>::max();
+            maximum_topography = std::numeric_limits<double>::lowest();
             const std::string temptopo = prm.get("Topography parameters");
             const std::vector<std::string> temp_topographies = Utilities::split_string_list(temptopo,'&');
             const unsigned int temp_topographies_size = temp_topographies.size();

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -394,7 +394,7 @@ namespace aspect
                              "The reference temperature that is perturbed by the spherical "
                              "harmonic functions. Only used in incompressible models.");
           prm.declare_entry ("Remove temperature heterogeneity down to specified depth",
-                             boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                             boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                              Patterns::Double (),
                              "This will set the heterogeneity prescribed by S20RTS or S40RTS to zero "
                              "down to the specified depth (in meters). Note that your resolution has "

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -402,7 +402,7 @@ namespace aspect
                              "The reference temperature that is perturbed by the spherical "
                              "harmonic functions. Only used in incompressible models.");
           prm.declare_entry ("Remove temperature heterogeneity down to specified depth",
-                             boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                             boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                              Patterns::Double (),
                              "This will set the heterogeneity prescribed by SAVANI to zero "
                              "down to the specified depth (in meters). Note that your resolution has "

--- a/source/initial_temperature/patch_on_S40RTS.cc
+++ b/source/initial_temperature/patch_on_S40RTS.cc
@@ -125,7 +125,7 @@ namespace aspect
                              "The boundary is smoothed using a depth weighted combination of Vs "
                              "values from the ascii grid and S40RTS at each point in the region of smoothing.");
           prm.declare_entry ("Remove temperature heterogeneity down to specified depth",
-                             boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                             boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                              Patterns::Double (),
                              "This will set the heterogeneity prescribed by the Vs ascii grid and S40RTS to zero "
                              "down to the specified depth (in meters). Note that your resolution has "

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -134,7 +134,7 @@ namespace aspect
           }
           case pick_largest:
           {
-            double max = -std::numeric_limits<double>::max();
+            double max = std::numeric_limits<double>::lowest();
             for (unsigned int i=0; i<N; ++i)
               max = std::max(max, values_out[i]);
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -600,7 +600,7 @@ namespace aspect
 
             case pick_largest:
             {
-              double max = -std::numeric_limits<double>::max();
+              double max = std::numeric_limits<double>::lowest();
               for (unsigned int i=0; i<N; ++i)
                 max = std::max(max, values_out[i]);
 
@@ -617,7 +617,7 @@ namespace aspect
               for (unsigned int i=0; i<N; ++i)
                 min = std::min(min, values_out[i]);
 
-              double max = -std::numeric_limits<double>::max();
+              double max = std::numeric_limits<double>::lowest();
               for (unsigned int i=0; i<N; ++i)
                 max = std::max(max, values_out[i]);
 

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -269,10 +269,10 @@ namespace aspect
           interpolation = interpol;
           delta_press=numbers::signaling_nan<double>();
           min_press=std::numeric_limits<double>::max();
-          max_press=-std::numeric_limits<double>::max();
+          max_press=std::numeric_limits<double>::lowest();
           delta_temp=numbers::signaling_nan<double>();
           min_temp=std::numeric_limits<double>::max();
-          max_temp=-std::numeric_limits<double>::max();
+          max_temp=std::numeric_limits<double>::lowest();
           n_temperature=0;
           n_pressure=0;
 
@@ -475,10 +475,10 @@ namespace aspect
           interpolation = interpol;
           delta_press=numbers::signaling_nan<double>();
           min_press=std::numeric_limits<double>::max();
-          max_press=-std::numeric_limits<double>::max();
+          max_press=std::numeric_limits<double>::lowest();
           delta_temp=numbers::signaling_nan<double>();
           min_temp=std::numeric_limits<double>::max();
-          max_temp=-std::numeric_limits<double>::max();
+          max_temp=std::numeric_limits<double>::lowest();
           n_temperature=0;
           n_pressure=0;
 

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -209,7 +209,7 @@ namespace aspect
                                    "'Global particle property maximum' values separated by ',' has to be "
                                    "the same as the number of particle properties.");
                 prm.declare_entry ("Global particle property minimum",
-                                   boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                                   boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                                    Patterns::List(Patterns::Double ()),
                                    "The minimum global particle property that will be used as a "
                                    "limiter for the bilinear least squares interpolation. The number of the input "

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -218,7 +218,7 @@ namespace aspect
                                    "'Global particle property maximum' values separated by ',' has to be "
                                    "the same as the number of particle properties.");
                 prm.declare_entry ("Global particle property minimum",
-                                   boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                                   boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                                    Patterns::List(Patterns::Double ()),
                                    "The minimum global particle property that will be used as a "
                                    "limiter for the quadratic least squares interpolation. The number of the input "

--- a/source/postprocess/boundary_velocity_residual_statistics.cc
+++ b/source/postprocess/boundary_velocity_residual_statistics.cc
@@ -118,7 +118,7 @@ namespace aspect
 
       for (const auto p : boundary_indicators)
         {
-          local_max_vel[p] = -std::numeric_limits<double>::max();
+          local_max_vel[p] = std::numeric_limits<double>::lowest();
           local_min_vel[p] = std::numeric_limits<double>::max();
         }
 
@@ -141,7 +141,7 @@ namespace aspect
 
                 // determine the max, min, and squared velocity residual on the face
                 // also determine the face area
-                double local_max = -std::numeric_limits<double>::max();
+                double local_max = std::numeric_limits<double>::lowest();
                 double local_min = std::numeric_limits<double>::max();
                 double local_sqvel = 0.0;
                 double local_fe_face_area = 0.0;

--- a/source/postprocess/composition_statistics.cc
+++ b/source/postprocess/composition_statistics.cc
@@ -84,7 +84,7 @@ namespace aspect
       std::vector<double> local_min_compositions (this->n_compositional_fields(),
                                                   std::numeric_limits<double>::max());
       std::vector<double> local_max_compositions (this->n_compositional_fields(),
-                                                  -std::numeric_limits<double>::max());
+                                                  std::numeric_limits<double>::lowest());
 
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         {
@@ -104,7 +104,7 @@ namespace aspect
       std::vector<double> global_min_compositions (this->n_compositional_fields(),
                                                    std::numeric_limits<double>::max());
       std::vector<double> global_max_compositions (this->n_compositional_fields(),
-                                                   -std::numeric_limits<double>::max());
+                                                   std::numeric_limits<double>::lowest());
       {
         Utilities::MPI::min (local_min_compositions,
                              this->get_mpi_communicator(),

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -294,10 +294,10 @@ namespace aspect
       // This loop corresponds to the 3 integrals of Newton law:
       double sum_g = 0;
       double min_g = std::numeric_limits<double>::max();
-      double max_g = -std::numeric_limits<double>::max();
+      double max_g = std::numeric_limits<double>::lowest();
       double sum_g_potential = 0;
       double min_g_potential = std::numeric_limits<double>::max();
-      double max_g_potential = -std::numeric_limits<double>::max();
+      double max_g_potential = std::numeric_limits<double>::lowest();
       for (unsigned int p=0; p < n_satellites; ++p)
         {
 

--- a/source/postprocess/melt_statistics.cc
+++ b/source/postprocess/melt_statistics.cc
@@ -59,7 +59,7 @@ namespace aspect
 
       double local_melt_integral = 0.0;
       double local_min_melt = std::numeric_limits<double>::max();
-      double local_max_melt = -std::numeric_limits<double>::max();
+      double local_max_melt = std::numeric_limits<double>::lowest();
 
       // compute the integral quantities by quadrature
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())

--- a/source/postprocess/pressure_statistics.cc
+++ b/source/postprocess/pressure_statistics.cc
@@ -55,7 +55,7 @@ namespace aspect
 
       double local_pressure_integral = 0;
       double local_min_pressure      = std::numeric_limits<double>::max();
-      double local_max_pressure      = -std::numeric_limits<double>::max();
+      double local_max_pressure      = std::numeric_limits<double>::lowest();
 
       // compute the integral quantities by quadrature. note that compared to
       // the temperature statistics postprocessor, we can not just loop over

--- a/source/postprocess/temperature_statistics.cc
+++ b/source/postprocess/temperature_statistics.cc
@@ -75,7 +75,7 @@ namespace aspect
       // points gives an inaccurate
       // picture of their true values
       double local_min_temperature = std::numeric_limits<double>::max();
-      double local_max_temperature = -std::numeric_limits<double>::max();
+      double local_max_temperature = std::numeric_limits<double>::lowest();
       const unsigned int temperature_block = this->introspection().block_indices.temperature;
       IndexSet range = this->get_solution().block(temperature_block).locally_owned_elements();
       for (unsigned int i=0; i<range.n_elements(); ++i)

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -65,7 +65,7 @@ namespace aspect
       std::ostringstream output_file;
 
       // Choose stupidly large values for initialization
-      double local_max_height = -std::numeric_limits<double>::max();
+      double local_max_height = std::numeric_limits<double>::lowest();
       double local_min_height = std::numeric_limits<double>::max();
 
       // loop over all of the surface cells and save the elevation to stored_value

--- a/source/postprocess/velocity_boundary_statistics.cc
+++ b/source/postprocess/velocity_boundary_statistics.cc
@@ -58,7 +58,7 @@ namespace aspect
         = this->get_geometry_model().get_used_boundary_indicators ();
       for (const auto p : boundary_indicators)
         {
-          local_max_vel[p] = -std::numeric_limits<double>::max();
+          local_max_vel[p] = std::numeric_limits<double>::lowest();
           local_min_vel[p] = std::numeric_limits<double>::max();
         }
 
@@ -77,7 +77,7 @@ namespace aspect
                     velocities);
                 // determine the max, min, and squared velocity on the face
                 // also determine the face area
-                double local_max = -std::numeric_limits<double>::max();
+                double local_max = std::numeric_limits<double>::lowest();
                 double local_min = std::numeric_limits<double>::max();
                 double local_sqvel = 0.0;
                 double local_fe_face_area = 0.0;

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -55,7 +55,7 @@ namespace aspect
     std::vector<double> old_old_field_values(n_q_points);
 
     double min_entropy = std::numeric_limits<double>::max(),
-           max_entropy = -std::numeric_limits<double>::max(),
+           max_entropy = std::numeric_limits<double>::lowest(),
            area = 0,
            entropy_integrated = 0;
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -690,7 +690,7 @@ namespace aspect
     // the communication step at the
     // latest.
     double min_local_field = std::numeric_limits<double>::max(),
-           max_local_field = -std::numeric_limits<double>::max();
+           max_local_field = std::numeric_limits<double>::lowest();
 
     if (timestep_number > 1)
       {

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1107,7 +1107,7 @@ namespace aspect
                            "The maximum global temperature value that will be used in the bound preserving "
                            "limiter for the discontinuous solutions from temperature advection fields.");
         prm.declare_entry ("Global temperature minimum",
-                           boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                           boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                            Patterns::Double (),
                            "The minimum global temperature value that will be used in the bound preserving "
                            "limiter for the discontinuous solutions from temperature advection fields.");
@@ -1120,7 +1120,7 @@ namespace aspect
                            "one or the same as the number of the compositional fields. When only one value "
                            "is supplied, this same value is assumed for all compositional fields.");
         prm.declare_entry ("Global composition minimum",
-                           boost::lexical_cast<std::string>(-std::numeric_limits<double>::max()),
+                           boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                            Patterns::List(Patterns::Double ()),
                            "The minimum global composition value that will be used in the bound preserving "
                            "limiter for the discontinuous solutions from composition advection fields. "

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1361,7 +1361,7 @@ namespace aspect
     const QGauss<dim> quadrature_formula (sim.parameters.stokes_velocity_degree+1);
 
     double min_el = std::numeric_limits<double>::max();
-    double max_el = -std::numeric_limits<double>::max();
+    double max_el = std::numeric_limits<double>::lowest();
 
     // Fill the DGQ0 or DGQ1 vector of viscosity values on the active mesh
     {

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -189,7 +189,7 @@ namespace aspect
                ExcMessage("Error: One of the data tables has an incorrect size."));
 
       // compute maximum_component_value for each component:
-      maximum_component_value = std::vector<double>(components,-std::numeric_limits<double>::max());
+      maximum_component_value = std::vector<double>(components,std::numeric_limits<double>::lowest());
       for (unsigned int c=0; c<components; ++c)
         {
           const unsigned int n_elements = data_table[c].n_elements();


### PR DESCRIPTION
We used `-max()` previously because `lowest()` is a C++11 feature. But the latter is canonically correct, and the former only works because floating point numbers actually store a sign bit, rather than using ones-complement to indicate the sign of a number as integers do.

References:
https://en.cppreference.com/w/cpp/types/numeric_limits/max
https://en.cppreference.com/w/cpp/types/numeric_limits/min
https://en.cppreference.com/w/cpp/types/numeric_limits/lowest

/rebuild