### PR TITLE
Avoid using Worldbuilder in top namespace

### DIFF
--- a/contrib/world_builder/source/config.cc.in
+++ b/contrib/world_builder/source/config.cc.in
@@ -19,17 +19,17 @@
 
 #include "world_builder/config.h"
 
-using namespace WorldBuilder;
+namespace WorldBuilder
+{
+  const std::string Version::MAJOR = "@WORLD_BUILDER_VERSION_MAJOR@";
+  const std::string Version::MINOR = "@WORLD_BUILDER_VERSION_MINOR@";
+  const std::string Version::PATCH = "@WORLD_BUILDER_VERSION_PATCH@";
+  const std::string Version::LABEL = "@WORLD_BUILDER_VERSION_LABEL@";
 
-const std::string Version::MAJOR = "@WORLD_BUILDER_VERSION_MAJOR@";
-const std::string Version::MINOR = "@WORLD_BUILDER_VERSION_MINOR@";
-const std::string Version::PATCH = "@WORLD_BUILDER_VERSION_PATCH@";
-const std::string Version::LABEL = "@WORLD_BUILDER_VERSION_LABEL@";
+  const std::string Version::GIT_SHA1 = "@GIT_SHA1@";
+  const std::string Version::GIT_BRANCH = "@GIT_BRANCH@";
+  const std::string Version::GIT_DATE = "@GIT_DATE@";
+  const std::string Version::GIT_COMMIT_SUBJECT = "@GIT_COMMIT_SUBJECT@";
 
-const std::string Version::GIT_SHA1 = "@GIT_SHA1@";
-const std::string Version::GIT_BRANCH = "@GIT_BRANCH@";
-const std::string Version::GIT_DATE = "@GIT_DATE@";
-const std::string Version::GIT_COMMIT_SUBJECT = "@GIT_COMMIT_SUBJECT@";
-
-const std::string Data::WORLD_BUILDER_SOURCE_DIR = "@WORLD_BUILDER_SOURCE_DIR@"; 
-
+  const std::string Data::WORLD_BUILDER_SOURCE_DIR = "@WORLD_BUILDER_SOURCE_DIR@";
+}


### PR DESCRIPTION
The current form is not technically wrong, but if it is used in a unity build it introduces all symbols from WorldBuilder into the top namespace, which causes a lot of conflicts with deal.II names. And the new form is cleaner anyway I think, unless we rely on things like `Data::WORLD_BUILDER_SOURCE_DIR` instead of `WorldBuilder::Data::WORLD_BUILDER_SOURCE_DIR`. 
I will open a separate companion PR to the world builder repo.