### PR TITLE
update citing_aspect.bib with missing information

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -804,9 +804,10 @@ opturl="https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611"
 @article{Njinju2020,
   doi = {10.1002/essoar.10503939.1},
   url = {https://doi.org/10.1002/essoar.10503939.1},
+	pages = {37},
   year = {2020},
   month = aug,
-  publisher = {Wiley},
+	journal = {Earth and Space Science Open Archive},
   author = {Emmanuel A. Njinju and D. Sarah Stamps and James Gallagher and Kodi Neumiller},
   title = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
 }
@@ -862,6 +863,7 @@ title="Mantle convection and surface expressions",
 series="AGU Geophysical Monograph Series",
 year="2021",
 address="Washington, D.C.",
+publisher="AGU",
 doi="10.1002/9781119528609.ch15"
 }
 
@@ -962,14 +964,15 @@ year = {2020}
     eprint = {https://academic.oup.com/gji/article-pdf/225/3/1624/36583045/ggab051.pdf},
 }
 
-@article{sandiford2021,
-  doi = {10.1002/essoar.10506103.1},
-  url = {https://doi.org/10.1002/essoar.10506103.1},
-  year = {2021},
-  month = feb,
-  publisher = {Wiley},
-  author = {Dan Sandiford and Sascha Brune and Anne Glerum and John Naliboff and Joanne M Whittaker},
-  title = {Kinematics of footwall exhumation at oceanic detachment faults: solid-block rotation and apparent unbending}
+article{10.1002/essoar.10506103.1,
+author = {Sandiford, Dan and Brune, Sascha and Glerum, Anne and Naliboff, John and Whittaker, Joanne M},
+title = {Kinematics of footwall exhumation at oceanic detachment faults: solid-block rotation and apparent unbending},
+journal = {Earth and Space Science Open Archive},
+pages = {25},
+year = {2021},
+DOI = {10.1002/essoar.10506103.1},
+url = {https://doi.org/10.1002/essoar.10506103.1},
+abstract = {Seaﬂoor spreading at slow rates can be accommodated on large-offset oceanic detachment faults (ODFs), that exhume lower crustal and mantle rocks in footwall domes termed oceanic core complexes (OCCs). Footwall rock experiences large rotation during exhumation, yet important aspects of the kinematics - particularly the relative roles of rigid block rotation and flexure - are not clearly understood. Using a high-resolution numerical model, we explore the exhumation kinematics in the footwall beneath an emergent ODF/OCC. A key feature of the models is that footwall motion is dominated by solid rotation, accommodated by the concave-down ODF. This is attributed to a system behaviour in which the accumulation of distributed plastic strain is minimized. A consequence of these kinematics is that curvature measured along the ODF is representative of a neutral stress conﬁguration, rather than a “bent” one. Instead, it is in the subsequent process of `apparent unbending’ that signiﬁcant ﬂexural stresses are developed in the model footwall. The brittle strain associated with apparent unbending is produced dominantly in extension, beneath the OCC, consistent with earthquake clustering observed in the Trans-Atlantic Geotraverse at the Mid-Atlantic Ridge.}
 }
 
 @article{FACCENNA2021116905,


### PR DESCRIPTION
When updating the co-author network diagram, the R parser complain about a few of the entries. This updates their bibliographic information. 

Note that .bib from publisher's website did not include the "publisher" attribute, hence, it no longer appears for Njinju and Sandiford.
