### PR TITLE
complete implementation of phases in composite creep with peierls

### DIFF
--- a/doc/modules/changes/20210708b_bobmyhill
+++ b/doc/modules/changes/20210708b_bobmyhill
@@ -1,0 +1,4 @@
+New: It is now possible to use phase transitions and Peierls creep
+in composite (viscoplastic) rheologies.
+<br>
+(Bob Myhill, 2021/07/08)

--- a/doc/modules/changes/20210708b_bobmyhill
+++ b/doc/modules/changes/20210708b_bobmyhill
@@ -1,4 +1,4 @@
-New: It is now possible to use phase transitions and Peierls creep
-in composite (viscoplastic) rheologies.
+New: It is now possible to use default or single values for Peierls creep
+parameters in composite (viscoplastic) rheologies with phase transitions.
 <br>
 (Bob Myhill, 2021/07/08)

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -415,7 +415,7 @@ namespace aspect
           {
             peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
             peierls_creep->initialize_simulator (this->get_simulator());
-            peierls_creep->parse_parameters(prm);
+            peierls_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
 
         // Drucker Prager parameters

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -626,7 +626,7 @@ namespace aspect
           {
             peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
             peierls_creep->initialize_simulator (this->get_simulator());
-            peierls_creep->parse_parameters(prm);
+            peierls_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
 
         // Constant viscosity prefactor parameters

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -46,7 +46,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
   peierls_creep->initialize_simulator (simulator_access.get_simulator());
   peierls_creep->declare_parameters(prm);
-  peierls_creep->parse_parameters(prm); // multiple phases not yet implemented for peierls
+  peierls_creep->parse_parameters(prm, n_phases);
 
   std::unique_ptr<Rheology::DruckerPrager<dim>> drucker_prager;
   drucker_prager = std_cxx14::make_unique<Rheology::DruckerPrager<dim>>();

--- a/tests/visco_plastic_phases_peierls_mei_exact.prm
+++ b/tests/visco_plastic_phases_peierls_mei_exact.prm
@@ -49,13 +49,13 @@ subsection Material model
     set Include Peierls creep                     = true
     set Peierls creep flow law                    = exact
     set Prefactors for Peierls creep              = background:2.8e-19|1.4e-19|0.7e-19, right:2.8e-18|1.4e-18|0.7e-18
-    set Activation energies for Peierls creep     = background:320.e3|320.e3|320.e3, right:320.e3|320.e3|320.e3
-    set Activation volumes for Peierls creep      = background:0.|0.|0., right:0.|0.|0.
-    set Peierls stresses                          = background:5.9e9|5.9e9|5.9e9, right:5.9e9|5.9e9|5.9e9
-    set Stress exponents for Peierls creep        = background:2.0|2.0|2.0, right:2.0|2.0|2.0
-    set Peierls fitting parameters                = background:0.15|0.15|0.15, right:0.15|0.15|0.15
-    set Peierls glide parameters p                = background:0.5|0.5|0.5, right:0.5|0.5|0.5
-    set Peierls glide parameters q                = background:1.0|1.0|1.0, right:1.0|1.0|1.0
+    set Activation energies for Peierls creep     = 320.e3
+    set Activation volumes for Peierls creep      = 0.
+    set Peierls stresses                          = 5.9e9
+    set Stress exponents for Peierls creep        = 2.0
+    set Peierls fitting parameters                = 0.15
+    set Peierls glide parameters p                = 0.5
+    set Peierls glide parameters q                = 1.0
 
     set Peierls strain rate residual tolerance = 1e-22
     set Maximum Peierls strain rate iterations = 40


### PR DESCRIPTION
This PR allows users to use default or single values for Peierls creep parameters in composite (viscoplastic) rheologies with phase transitions.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have modified a testcase for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
