### PR TITLE
minor fixes to manual

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -2804,7 +2804,7 @@ To take advantage of the GMG solver, you need to:
   The GMG solver requires that the viscosity is averaged, either as a constant (for example by using harmonic averaging)
   or as a $Q_1$ averaging. (See Section~\ref{sec:sinker-with-averaging}
   for more about averaging.) Averaging other properties is optional. You can
-  use 
+  use
 \lstinputlisting[language=prmfile]{cookbooks/overview/doc/gmg-average.part.prm.out}
 for example. Note that $Q_1$ averaging is a bit slower than averaging to a constant per cell, but it
 might provide more accurate solutions.
@@ -3275,23 +3275,23 @@ Before trying to set up a model to answer your particular research questions,
 we advise you to get familiar with \aspect{} and its functionalities by
 following these steps:
 \begin{enumerate}
-\item Watch the CIG \aspect{} tutorials (\url{https://www.youtube.com/playlist?list=PLdy04DoEepEyeS_HZwa0Ws0kW5Rs2wsQ6}) 
+\item Watch the CIG \aspect{} tutorials (\url{https://www.youtube.com/playlist?list=PLdy04DoEepEyeS_HZwa0Ws0kW5Rs2wsQ6})
 that will show you how to run \aspect{} and construct new setups yourself.
 \item Go through the cookbooks in this manual, see Section~\ref{sec:cookbooks}.
 \item Go through the benchmarks in this manual, see Section~\ref{sec:cookbooks-benchmarks}.
-\item If you want to use some existing functionality that is not discussed in these resources, 
-search in the extensive tests directory. For example, to search for an initial temperature condition called 
+\item If you want to use some existing functionality that is not discussed in these resources,
+search in the extensive tests directory. For example, to search for an initial temperature condition called
 ``spherical gaussian perturbation'' while in the \aspect{} directory, type:
 \begin{verbatim}
   grep 'spherical gaussian perturbation' tests/*.prm
-\end{verbatim} 
-This command will show you all the test input files that use this initial temperature condition. 
+\end{verbatim}
+This command will show you all the test input files that use this initial temperature condition.
 You can also look up any of the parameters used in the input files in this manual.
 \item Have a look at the \aspect{} GitHub repository. Here you can see the planned developments
-(\url{https://github.com/geodynamics/aspect/projects/2}), current issues that others have reported 
-(\url{https://github.com/geodynamics/aspect/issues}), and what is currently being worked on 
+(\url{https://github.com/geodynamics/aspect/projects/2}), current issues that others have reported
+(\url{https://github.com/geodynamics/aspect/issues}), and what is currently being worked on
 (\url{https://github.com/geodynamics/aspect/pulls}).
-\item Have a look at our discussion forum when your model behaves unexpectedly 
+\item Have a look at our discussion forum when your model behaves unexpectedly
 or you need functionality that does not exist yet. The \aspect{} community can tell you
 whether they experienced something similar or are already working on the topic.
 \item If you experience unexpected behavior that you expect is a bug and this problem
@@ -3299,8 +3299,8 @@ has not been reported as an issue on GitHub, please create a new issue so that e
 is aware of the potential problem and can think of a fix. When creating a new issue,
 it is very useful if you can provide a minimum working example, i.e. a small test setup
 that demonstrates the issue and does not require modifications to the code. You can for example
-modify one of the existing test input files, which typically take less than a minute to 
-run using only a few cores. 
+modify one of the existing test input files, which typically take less than a minute to
+run using only a few cores.
 The test input file and an image illustrating the problem can be attached to the issue.
 \end{enumerate}
 
@@ -7489,10 +7489,10 @@ We can observe that when the two-layer viscosity model is added, there is only o
 Early mantle modeling studies of the 1970s, 1980s and 1990s were often concerned with simple set-ups (Cartesian geometries, incompressible fluid, free slip boundary conditions) and investigated the influence of the Rayleigh number, the heating mode or the temperature dependence of the viscosity on temperature, pressure and/or strain rate \cite{youn74,buss75,buss79,BBC89,BC93,vavy93,burb97}. In this cookbook, we use the `simple' material model to reproduce the set-up in \cite{burb96}, which reported that even modest increases in mantle viscosity with depth could have a marked effect on the style of mantle convection. The prm file corresponding to this cookbook can be found at \url{cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm}.
 
 Although the original article showcases results obtained in a 3D hollow sphere, we here run the models in an annular domain of inner radius $R_i = 3480$ \si{\kilo\meter} and outer radius  $R_o = 6370$ \si{\kilo\meter}.
-The surface temperature is set to $T{\textsubscript{surf}}$ = 1060 \si{\kelvin} and 
+The surface temperature is set to $T{\textsubscript{surf}}$ = 1060 \si{\kelvin} and
 the bottom temperature to $T{\textsubscript{cmb}} = 3450$ \si{\kelvin}. The gravity vector is radial and its magnitude is $g = 10$ \si{\metre\per\second\squared}.
 
-There is a single incompressible fluid in the domain, characterized by $\rho_0 = 4500$ \si{\kilogram\per\metre\cubed}, $\alpha = 2.5\cdot10^{-5}$ \si{\per\kelvin}, 
+There is a single incompressible fluid in the domain, characterized by $\rho_0 = 4500$ \si{\kilogram\per\metre\cubed}, $\alpha = 2.5\cdot10^{-5}$ \si{\per\kelvin},
 $k = 4$ \si{\watt\per\metre\per\kelvin},
 $C_p = 1000$ \si{\joule\per\kilogram\per\kelvin} and
 its internal heating rate is $Q{\textsubscript{int}} = 1\cdot10^{-12}$ \si{\watt\per\kilogram}.
@@ -11753,7 +11753,7 @@ The test suite is run using the \texttt{ctest} program that comes with
 compiled \aspect{}.
 
 After running \texttt{cmake} and then compiling \aspect{}, you can run the
-testsuite by using the command \texttt{ctest} in your build directory. By default, this will only run a small
+test suite by using the command \texttt{ctest} in your build directory. By default, this will only run a small
 subset of all tests given that both setting up all tests (several hundred) and
 running them takes a non-trivial amount of time. To set up the full test suite,
 you can run
@@ -11765,7 +11765,7 @@ you can run
     ctest
 \end{lstlisting}
 Unless you have a very fast machine with lots of processors, running the entire
-testsuite will take hours, though it can be made substantially faster if you use
+test suite will take hours, though it can be made substantially faster if you use
 \begin{lstlisting}[frame=single,language=ksh]
     ctest -j <N>
 \end{lstlisting}
@@ -11796,7 +11796,7 @@ Total Test time (real) =   5.88 sec
 \end{lstlisting}
 While the small default subset of tests should work on almost all platforms, you
 will find that some of the tests fail on your machine when you run the entire
-testsuite. This is because success of failure of a test is determined by looking
+test suite. This is because success or failure of a test is determined by looking
 at whether its output matches the one saved at the time when the test was
 written to the last digit, both as far as numerical output in floating point
 precision is concerned (e.g., for heat fluxes or other things we compute via


### PR DESCRIPTION
Three minor fixes to the manual:
- removed trailing spaces
- renamed "testsuite" to "test suite"
- corrected "success of failure" to "success or failure".