### PR TITLE
Created multicomponent EoS->Material averaging function 

### DIFF
--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -23,6 +23,7 @@
 
 #include <aspect/global.h>
 #include <aspect/material_model/utilities.h>
+#include <aspect/material_model/interface.h>
 
 
 

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -99,6 +99,27 @@ namespace aspect
     };
 
     /**
+    * This function computes averages of multicomponent thermodynamic properties
+    * that are stored in a vector of EquationOfStateOutputs.
+    * Each EquationOfStateOutput contains the thermodynamic properties for
+    * all materials at a given evaluation point.
+    * The averaged properties are:
+    * density, isothermal compressibility, thermal_expansivity,
+    * the specific entropy derivatives with respect to pressure and temperature
+    * and the specific heat capacity. The first three of these properties
+    * are averaged by volume fraction, and the second three
+    * (the specific properties) are averaged by mass fraction.
+    * These averages are used to fill the corresponding attributes of
+    * a MaterialModelOutputs object.
+    */
+    template <int dim>
+    void
+    fill_averaged_equation_of_state_outputs(const std::vector<EquationOfStateOutputs<dim>> &eos_outputs,
+                                            const std::vector<std::vector<double>> &mass_fractions,
+                                            const std::vector<std::vector<double>> &volume_fractions,
+                                            MaterialModelOutputs<dim> &out);
+
+    /**
      * This function takes the output of an equation of state @p eos_outputs_all_phases,
      * which contains the data for all compositions and all of their phases at the
      * current conditions and uses a PhaseFunction object @p phase_function to compute

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -42,6 +42,28 @@ namespace aspect
 
     template <int dim>
     void
+    fill_averaged_equation_of_state_outputs(const std::vector<EquationOfStateOutputs<dim>> &eos_outputs,
+                                            const std::vector<std::vector<double>> &mass_fractions,
+                                            const std::vector<std::vector<double>> &volume_fractions,
+                                            MaterialModelOutputs<dim> &out)
+    {
+      for (unsigned int i=0; i < eos_outputs.size(); ++i)
+        {
+          // The density, isothermal compressibility and thermal expansivity are volume-averaged
+          // The specific entropy derivatives and heat capacity are mass-averaged
+          out.densities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].densities, MaterialUtilities::arithmetic);
+          out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].compressibilities, MaterialUtilities::arithmetic);
+          out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].thermal_expansion_coefficients, MaterialUtilities::arithmetic);
+          out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].entropy_derivative_pressure, MaterialUtilities::arithmetic);
+          out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].entropy_derivative_temperature, MaterialUtilities::arithmetic);
+          out.specific_heat[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].specific_heat_capacities, MaterialUtilities::arithmetic);
+        }
+    }
+
+
+
+    template <int dim>
+    void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
                                             const std::vector<double> &phase_function_values,
                                             const std::vector<unsigned int> &n_phases_per_composition,
@@ -73,6 +95,10 @@ namespace aspect
   {
 #define INSTANTIATE(dim) \
   template struct EquationOfStateOutputs<dim>; \
+  template void fill_averaged_equation_of_state_outputs<dim> (const std::vector<EquationOfStateOutputs<dim>> &, \
+                                                              const std::vector<std::vector<double>> &mass_fractions, \
+                                                              const std::vector<std::vector<double>> &volume_fractions, \
+                                                              MaterialModelOutputs<dim> &); \
   template void phase_average_equation_of_state_outputs<dim> (const EquationOfStateOutputs<dim> &, \
                                                               const std::vector<double> &phase_function_values, \
                                                               const std::vector<unsigned int> &n_phases_per_composition, \

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/material_model/steinberger.h>
+#include <aspect/material_model/equation_of_state/interface.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/utilities.h>
 #include <aspect/lateral_averaging.h>
@@ -233,6 +234,11 @@ namespace aspect
       // Evaluate the equation of state properties over all evaluation points
       equation_of_state.evaluate(in, eos_outputs);
 
+      MaterialModel::fill_averaged_equation_of_state_outputs(eos_outputs, mass_fractions, volume_fractions, out);
+
+      // fill additional outputs if they exist
+      equation_of_state.fill_additional_outputs(in, volume_fractions, out);
+
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           if (in.requests_property(MaterialProperties::viscosity))
@@ -241,18 +247,7 @@ namespace aspect
           out.thermal_conductivities[i] = thermal_conductivity_value;
           for (unsigned int c=0; c<in.composition[i].size(); ++c)
             out.reaction_terms[i][c] = 0;
-
-          // The density and isothermal compressibility are both volume-averaged
-          out.densities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].densities, MaterialUtilities::arithmetic);
-          out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].compressibilities, MaterialUtilities::arithmetic);
-          out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].entropy_derivative_pressure, MaterialUtilities::arithmetic);
-          out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].entropy_derivative_temperature, MaterialUtilities::arithmetic);
-          out.specific_heat[i] = MaterialUtilities::average_value (mass_fractions[i], eos_outputs[i].specific_heat_capacities, MaterialUtilities::arithmetic);
-          out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions[i], eos_outputs[i].thermal_expansion_coefficients, MaterialUtilities::arithmetic);
         }
-
-      // fill additional outputs if they exist
-      equation_of_state.fill_additional_outputs(in, volume_fractions, out);
 
     }
 


### PR DESCRIPTION
This PR adds a function that does multicomponent EquationOfState property averaging. 
This function is stored in the equation of state interface, in the MaterialModel namespace.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
