### PR TITLE
Improve an error message in the clang-tidy script.

### DIFF
--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -53,6 +53,15 @@ if test ! -d "$SRC/source" -o ! -d "$SRC/include" -o ! -f "$SRC/CMakeLists.txt" 
     echo "  run_clang_tidy.sh /path/to/ASPECT"
     exit 1
 fi
+
+if ! [ -x "$(command -v run-clang-tidy.py)" ] || ! [ -x "$(command -v clang++)" ]; then
+    echo "Error: Either the 'run-clang-tidy.py' or the 'clang++' program could not be found."
+    echo "       Make sure 'clang', 'clang++', and 'run-clang-tidy.py' (part of clang) are in the path."
+    exit 2
+fi
+
+
+
 echo "SRC-DIR=$SRC"
 
 # set cmake arguments:
@@ -62,12 +71,10 @@ echo "SRC-DIR=$SRC"
 ARGS=("-D" "CMAKE_EXPORT_COMPILE_COMMANDS=ON" "-D" "ASPECT_UNITY_BUILD=OFF" "-D" "ASPECT_PRECOMPILE_HEADERS=OFF" "$@")
 
 # for a list of checks, see /.clang-tidy
+echo "###################################"
+echo "The following flags will be used for clang-tidy:"
 cat "$SRC/.clang-tidy"
-
-if ! [ -x "$(command -v run-clang-tidy.py)" ] || ! [ -x "$(command -v clang++)" ]; then
-    echo "make sure clang, clang++, and run-clang-tidy.py (part of clang) are in the path"
-    exit 2
-fi
+echo "###################################"
 
 CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) || exit 2
 


### PR DESCRIPTION
It wasn't clear to me that what I was seeing was actually an error message. Also move it further up before we do other stuff.