### PR TITLE
Enforce consistent constant temperature boundary indicators

### DIFF
--- a/doc/modules/changes/20210708c_bobmyhill
+++ b/doc/modules/changes/20210708c_bobmyhill
@@ -1,0 +1,5 @@
+Changed: When using the constant temperature boundary plugin, ASPECT
+now checks that the Fixed temperature boundary indicators match the
+indicators in the model subsection.
+<br>
+(Bob Myhill, 2021/07/09)

--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -145,12 +145,6 @@ namespace aspect
                 {
                   boundary_id
                     = this->get_geometry_model().translate_symbolic_boundary_name_to_id (parts[0]);
-
-                  AssertThrow((this->get_fixed_temperature_boundary_indicators().find(boundary_id) != this->get_fixed_temperature_boundary_indicators().end()),
-                              ExcMessage ("You have indicated a temperature mapping for "
-                                          "Boundary indicator " + parts[0] + ", but that "
-                                          "indicator isn't in the "
-                                          "list of Fixed temperature boundary indicators."));
                 }
               catch (const std::string &error)
                 {
@@ -159,6 +153,12 @@ namespace aspect
                                                   "the conversion function complained as follows: "
                                                   + error));
                 }
+
+              AssertThrow((this->get_fixed_temperature_boundary_indicators().find(boundary_id) != this->get_fixed_temperature_boundary_indicators().end()),
+                          ExcMessage ("You have indicated a temperature mapping for "
+                                      "boundary indicator " + parts[0] + ", but that "
+                                      "indicator isn't in the "
+                                      "list of Fixed temperature boundary indicators."));
 
               AssertThrow (boundary_temperatures.find(boundary_id) == boundary_temperatures.end(),
                            ExcMessage ("Boundary indicator <" + Utilities::int_to_string(boundary_id) +

--- a/source/boundary_temperature/constant.cc
+++ b/source/boundary_temperature/constant.cc
@@ -145,6 +145,12 @@ namespace aspect
                 {
                   boundary_id
                     = this->get_geometry_model().translate_symbolic_boundary_name_to_id (parts[0]);
+
+                  AssertThrow((this->get_fixed_temperature_boundary_indicators().find(boundary_id) != this->get_fixed_temperature_boundary_indicators().end()),
+                              ExcMessage ("You have indicated a temperature mapping for "
+                                          "Boundary indicator " + parts[0] + ", but that "
+                                          "indicator isn't in the "
+                                          "list of Fixed temperature boundary indicators."));
                 }
               catch (const std::string &error)
                 {

--- a/tests/chunk_topography_postprocessor.prm
+++ b/tests/chunk_topography_postprocessor.prm
@@ -15,8 +15,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = inner, outer
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = inner:0,outer:0
   end
 end
 
@@ -89,10 +90,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = inner, outer
-end
 
 subsection Boundary velocity model
   set Zero velocity boundary indicators       = inner, east, west

--- a/tests/depth_postprocessor_ellipsoidal_chunk.prm
+++ b/tests/depth_postprocessor_ellipsoidal_chunk.prm
@@ -10,8 +10,9 @@ set Nonlinear solver scheme                = single Advection, single Stokes
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = east, west
   subsection Constant
-    set Boundary indicator to temperature mappings = west: 0, east: 1, south: 2, north: 3, inner: 4, outer:5
+    set Boundary indicator to temperature mappings = west: 0, east: 1
   end
 end
 
@@ -69,10 +70,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 0, 1
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 1

--- a/tests/free_surface_adaptive_blob.prm
+++ b/tests/free_surface_adaptive_blob.prm
@@ -91,10 +91,6 @@ end
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
 
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1
 end

--- a/tests/free_surface_adaptive_blob.prm
+++ b/tests/free_surface_adaptive_blob.prm
@@ -16,8 +16,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 

--- a/tests/free_surface_adaptive_blob_petsc.prm
+++ b/tests/free_surface_adaptive_blob_petsc.prm
@@ -16,8 +16,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -89,10 +90,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_blob.prm
+++ b/tests/free_surface_blob.prm
@@ -14,8 +14,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -87,10 +88,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_blob_melt.prm
+++ b/tests/free_surface_blob_melt.prm
@@ -18,8 +18,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -91,10 +92,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_blob_nonzero_melt.prm
+++ b/tests/free_surface_blob_nonzero_melt.prm
@@ -21,8 +21,9 @@ set Maximum time step                      = 1e4
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -104,10 +105,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_iterated_IMPES.prm
+++ b/tests/free_surface_iterated_IMPES.prm
@@ -16,8 +16,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -89,10 +90,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_iterated_stokes.prm
+++ b/tests/free_surface_iterated_stokes.prm
@@ -15,8 +15,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -88,10 +89,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/free_surface_relaxation.prm
+++ b/tests/free_surface_relaxation.prm
@@ -15,8 +15,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -93,10 +94,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/melt_velocity_boundary_conditions.prm
+++ b/tests/melt_velocity_boundary_conditions.prm
@@ -27,8 +27,9 @@ set Maximum time step                      = 1e4
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -106,10 +107,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1,3

--- a/tests/mesh_velocity_output.prm
+++ b/tests/mesh_velocity_output.prm
@@ -14,8 +14,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -87,10 +88,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/periodic_box.prm
+++ b/tests/periodic_box.prm
@@ -14,8 +14,9 @@ set Nonlinear solver scheme                = single Advection, single Stokes
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -86,10 +87,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 2,3

--- a/tests/periodic_box_freesurface.prm
+++ b/tests/periodic_box_freesurface.prm
@@ -14,8 +14,9 @@ set Nonlinear solver scheme                = single Advection, single Stokes
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -87,10 +88,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 2

--- a/tests/periodic_linear_momentum.prm
+++ b/tests/periodic_linear_momentum.prm
@@ -13,8 +13,9 @@ set Nonlinear solver scheme                = single Advection, single Stokes
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -85,10 +86,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 2,3

--- a/tests/resume_free_surface.prm
+++ b/tests/resume_free_surface.prm
@@ -10,8 +10,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:200,1:200,2:200,3:200
+    set Boundary indicator to temperature mappings = 2:200,3:200
   end
 end
 
@@ -92,10 +93,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1

--- a/tests/slope_refinement.prm
+++ b/tests/slope_refinement.prm
@@ -14,8 +14,9 @@ set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
   set List of model names = constant
+  set Fixed temperature boundary indicators   = 2,3
   subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
+    set Boundary indicator to temperature mappings = 2:0,3:0
   end
 end
 
@@ -87,10 +88,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 2,3
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0,1


### PR DESCRIPTION
When using the constant temperature boundary plugin, ASPECT now checks that the Fixed temperature boundary indicators match the indicators in the model subsection.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
