### PR TITLE
Add assert to avoid silently ignored boundary temperature constraints

### DIFF
--- a/benchmarks/annulus/annulus.prm
+++ b/benchmarks/annulus/annulus.prm
@@ -68,10 +68,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/benchmarks/burstedde/burstedde.prm
+++ b/benchmarks/burstedde/burstedde.prm
@@ -75,9 +75,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
 
 subsection Initial temperature model
   set Model name = function

--- a/benchmarks/doneahuerta/doneahuerta.prm
+++ b/benchmarks/doneahuerta/doneahuerta.prm
@@ -46,10 +46,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/benchmarks/finite_strain/pure_shear.prm
+++ b/benchmarks/finite_strain/pure_shear.prm
@@ -97,10 +97,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/finite_strain/simple_shear.prm
+++ b/benchmarks/finite_strain/simple_shear.prm
@@ -84,10 +84,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/hollow_sphere/hollow_sphere.prm
+++ b/benchmarks/hollow_sphere/hollow_sphere.prm
@@ -59,10 +59,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
@@ -48,10 +48,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
@@ -49,10 +49,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Initial temperature model
   set Model name = perturbed box

--- a/benchmarks/layeredflow/layeredflow.prm
+++ b/benchmarks/layeredflow/layeredflow.prm
@@ -51,10 +51,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/benchmarks/polydiapirs/polydiapirs.prm
+++ b/benchmarks/polydiapirs/polydiapirs.prm
@@ -46,10 +46,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/rayleigh_taylor_instability/blank.prm
+++ b/benchmarks/rayleigh_taylor_instability/blank.prm
@@ -29,9 +29,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.prm
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.prm
@@ -41,9 +41,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/rigid_shear/instantaneous/rigid_shear.prm
+++ b/benchmarks/rigid_shear/instantaneous/rigid_shear.prm
@@ -61,7 +61,7 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators =
-  set List of model names = box
+  set List of model names =
 end
 
 

--- a/benchmarks/rigid_shear/time-dependent/rigid_shear.prm
+++ b/benchmarks/rigid_shear/time-dependent/rigid_shear.prm
@@ -65,7 +65,7 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators =
-  set List of model names = box
+  set List of model names =
 end
 
 

--- a/benchmarks/shear_bands/magmatic_shear_bands.prm
+++ b/benchmarks/shear_bands/magmatic_shear_bands.prm
@@ -38,20 +38,6 @@ subsection Compositional fields
   set Names of fields = porosity
 end
 
-
-subsection Boundary temperature model
-  set List of model names = initial temperature
-
-  subsection Initial temperature
-    # Temperature at the inner boundary (core mantle boundary). Units: \\si{\\kelvin}.
-    set Maximal temperature = 3773 # default: 6000
-
-    # Temperature at the outer boundary (lithosphere water/air). \\si{\\kelvin}.
-    set Minimal temperature = 273  # default: 0
-  end
-
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/benchmarks/shear_bands/shear_bands.prm
+++ b/benchmarks/shear_bands/shear_bands.prm
@@ -43,20 +43,6 @@ subsection Compositional fields
   set Names of fields = porosity
 end
 
-
-subsection Boundary temperature model
-  set List of model names = initial temperature
-
-  subsection Initial temperature
-    # Temperature at the inner boundary (core mantle boundary). Units: K.
-    set Maximal temperature = 3773 # default: 6000
-
-    # Temperature at the outer boundary (lithosphere water/air). Units: K.
-    set Minimal temperature = 273  # default: 0
-  end
-
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/benchmarks/sinking_block/blank.prm
+++ b/benchmarks/sinking_block/blank.prm
@@ -31,10 +31,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/sinking_block/sinking_block.prm
+++ b/benchmarks/sinking_block/sinking_block.prm
@@ -40,9 +40,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/slab_detachment/slab_detachment.prm
+++ b/benchmarks/slab_detachment/slab_detachment.prm
@@ -106,9 +106,6 @@ end
 
 # Temperature effects are not considered,
 # so we set everything to zero.
-subsection Boundary temperature model
-  set List of model names = box
-end
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
@@ -46,10 +46,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -46,10 +46,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Initial temperature model
   set Model name = perturbed box

--- a/benchmarks/solcx/solcx.prm
+++ b/benchmarks/solcx/solcx.prm
@@ -51,10 +51,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Initial temperature model
   set Model name = perturbed box

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
@@ -41,10 +41,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -42,10 +42,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/benchmarks/solkz/solkz.prm
+++ b/benchmarks/solkz/solkz.prm
@@ -47,10 +47,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Initial temperature model
   set Model name = perturbed box

--- a/benchmarks/viscoelastic_plastic_simple_shear/viscoelastic_plastic_simple_shear.prm
+++ b/benchmarks/viscoelastic_plastic_simple_shear/viscoelastic_plastic_simple_shear.prm
@@ -139,9 +139,6 @@ end
 
 
 # The temperature plays no role in this model
-subsection Boundary temperature model
-  set List of model names = box
-end
 
 subsection Initial temperature model
   set Model name = function

--- a/benchmarks/viscosity_grooves/viscosity_grooves.prm
+++ b/benchmarks/viscosity_grooves/viscosity_grooves.prm
@@ -45,10 +45,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/benchmarks/yamauchi_takei_2016_anelasticity/yamauchi_takei_2016_anelasticity.prm
+++ b/benchmarks/yamauchi_takei_2016_anelasticity/yamauchi_takei_2016_anelasticity.prm
@@ -35,11 +35,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
 end

--- a/contrib/perplex/perplex_lookup_composition.prm
+++ b/contrib/perplex/perplex_lookup_composition.prm
@@ -1,4 +1,4 @@
-# This test ensures that the PerpleX lookup material model works 
+# This test ensures that the PerpleX lookup material model works
 # with compositional fields enabled
 
 # WARNING: Please understand that the PerpleX Lookup material model is only a
@@ -41,21 +41,17 @@ subsection Material model
 end
 
 subsection Geometry model
-  set Model name = box 
+  set Model name = box
   subsection Box
-    set X extent                = 200e3 
-    set X repetitions           = 1      
-    set Y extent                = 800e3  
+    set X extent                = 200e3
+    set X repetitions           = 1
+    set Y extent                = 800e3
     set Y repetitions           = 16
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = initial temperature 
-end
-
 subsection Initial temperature model
-  set Model name = function 
+  set Model name = function
   subsection Function
     set Function expression = 1300
   end
@@ -66,15 +62,15 @@ subsection Boundary velocity model
 end
 
 subsection Gravity model
-  set Model name = vertical 
+  set Model name = vertical
   subsection Vertical
-    set Magnitude = 9.81 
+    set Magnitude = 9.81
   end
 end
 
 subsection Mesh refinement
-  set Initial adaptive refinement              = 0         
-  set Initial global refinement                = 1         
+  set Initial adaptive refinement              = 0
+  set Initial global refinement                = 1
 end
 
 subsection Postprocess

--- a/contrib/perplex/perplex_lookup_composition.prm
+++ b/contrib/perplex/perplex_lookup_composition.prm
@@ -1,4 +1,4 @@
-# This test ensures that the PerpleX lookup material model works
+# This test ensures that the PerpleX lookup material model works 
 # with compositional fields enabled
 
 # WARNING: Please understand that the PerpleX Lookup material model is only a
@@ -41,17 +41,17 @@ subsection Material model
 end
 
 subsection Geometry model
-  set Model name = box
+  set Model name = box 
   subsection Box
-    set X extent                = 200e3
-    set X repetitions           = 1
-    set Y extent                = 800e3
+    set X extent                = 200e3 
+    set X repetitions           = 1      
+    set Y extent                = 800e3  
     set Y repetitions           = 16
   end
 end
 
 subsection Initial temperature model
-  set Model name = function
+  set Model name = function 
   subsection Function
     set Function expression = 1300
   end
@@ -62,15 +62,15 @@ subsection Boundary velocity model
 end
 
 subsection Gravity model
-  set Model name = vertical
+  set Model name = vertical 
   subsection Vertical
-    set Magnitude = 9.81
+    set Magnitude = 9.81 
   end
 end
 
 subsection Mesh refinement
-  set Initial adaptive refinement              = 0
-  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 0         
+  set Initial global refinement                = 1         
 end
 
 subsection Postprocess

--- a/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
+++ b/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
@@ -14,10 +14,6 @@ set Use years in output instead of seconds = false  # default: true
 set Output directory                       = output-AV-Rayleigh-Taylor-noAV
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/cookbooks/crustal_deformation/crustal_model_2D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_2D.prm
@@ -85,10 +85,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/cookbooks/crustal_deformation/crustal_model_3D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_3D.prm
@@ -79,10 +79,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
+++ b/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
@@ -43,10 +43,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/cookbooks/stokes.prm
+++ b/cookbooks/stokes.prm
@@ -63,10 +63,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/cookbooks/van-keken-discontinuous.prm
+++ b/cookbooks/van-keken-discontinuous.prm
@@ -42,10 +42,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/cookbooks/van-keken-smooth.prm
+++ b/cookbooks/van-keken-smooth.prm
@@ -44,10 +44,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/cookbooks/van-keken-vof/van-keken-vof.prm
+++ b/cookbooks/van-keken-vof/van-keken-vof.prm
@@ -42,10 +42,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/doc/manual/cookbooks/benchmarks/inclusion/inclusion.prm
+++ b/doc/manual/cookbooks/benchmarks/inclusion/inclusion.prm
@@ -49,11 +49,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/doc/manual/cookbooks/benchmarks/solcx/solcx.prm
+++ b/doc/manual/cookbooks/benchmarks/solcx/solcx.prm
@@ -45,11 +45,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/doc/manual/cookbooks/benchmarks/solkz/solkz.prm
+++ b/doc/manual/cookbooks/benchmarks/solkz/solkz.prm
@@ -44,10 +44,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Initial temperature model
   set Model name = perturbed box

--- a/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
+++ b/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
@@ -4,11 +4,11 @@
 # equal to the start time to force a single time
 # step before the program terminates.
 
-set Dimension                              = 3 
+set Dimension                              = 3
 
-set Start time                             = 0 
-set End time                               = 0 
-set Use years in output instead of seconds = false 
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = false
 
 set Output directory                       = output-stokes
 
@@ -22,12 +22,12 @@ set Output directory                       = output-stokes
 
 
 subsection Geometry model
-  set Model name = box 
+  set Model name = box
 
   subsection Box
-    set X extent  = 2890000 
-    set Y extent  = 2890000 
-    set Z extent  = 2890000 
+    set X extent  = 2890000
+    set Y extent  = 2890000
+    set Z extent  = 2890000
   end
 end
 
@@ -38,20 +38,20 @@ end
 
 
 subsection Material model
-  set Model name = simple 
+  set Model name = simple
 
   subsection Simple model
-    set Reference density             = 3300 
-    set Viscosity                     = 1e22 
+    set Reference density             = 3300
+    set Viscosity                     = 1e22
   end
 end
 
 
 subsection Gravity model
-  set Model name = vertical 
+  set Model name = vertical
 
   subsection Vertical
-    set Magnitude = 9.81 
+    set Magnitude = 9.81
   end
 end
 
@@ -60,15 +60,11 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box 
-end
-
 subsection Initial temperature model
-  set Model name = function 
+  set Model name = function
 
   subsection Function
-    set Function expression = 0 
+    set Function expression = 0
   end
 end
 
@@ -85,22 +81,22 @@ end
 # 100.
 
 subsection Compositional fields
-  set Number of fields = 1 
+  set Number of fields = 1
 end
 
 subsection Initial composition model
-  set Model name = function 
+  set Model name = function
 
   subsection Function
-    set Variable names      = x,y,z 
-    set Function constants  = r=200000,p=1445000 
-    set Function expression = if(sqrt((x-p)*(x-p)+(y-p)*(y-p)+(z-p)*(z-p)) > r, 0, 1) 
+    set Variable names      = x,y,z
+    set Function constants  = r=200000,p=1445000
+    set Function expression = if(sqrt((x-p)*(x-p)+(y-p)*(y-p)+(z-p)*(z-p)) > r, 0, 1)
   end
 end
 
 subsection Material model
   subsection Simple model
-    set Density differential for compositional field 1 = 100 
+    set Density differential for compositional field 1 = 100
   end
 end
 
@@ -114,10 +110,10 @@ end
 # indicator to use when refining the mesh adaptively.
 
 subsection Mesh refinement
-  set Initial adaptive refinement        = 4 
-  set Initial global refinement          = 4 
-  set Refinement fraction                = 0.2 
-  set Strategy                           = velocity 
+  set Initial adaptive refinement        = 4
+  set Initial global refinement          = 4
+  set Refinement fraction                = 0.2
+  set Strategy                           = velocity
 end
 
 
@@ -130,9 +126,9 @@ end
 # velocity field.
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics 
+  set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity 
+    set List of output variables = density, viscosity
   end
 end

--- a/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
+++ b/doc/manual/cookbooks/benchmarks/stokes/stokeslaw.prm
@@ -4,11 +4,11 @@
 # equal to the start time to force a single time
 # step before the program terminates.
 
-set Dimension                              = 3
+set Dimension                              = 3 
 
-set Start time                             = 0
-set End time                               = 0
-set Use years in output instead of seconds = false
+set Start time                             = 0 
+set End time                               = 0 
+set Use years in output instead of seconds = false 
 
 set Output directory                       = output-stokes
 
@@ -22,12 +22,12 @@ set Output directory                       = output-stokes
 
 
 subsection Geometry model
-  set Model name = box
+  set Model name = box 
 
   subsection Box
-    set X extent  = 2890000
-    set Y extent  = 2890000
-    set Z extent  = 2890000
+    set X extent  = 2890000 
+    set Y extent  = 2890000 
+    set Z extent  = 2890000 
   end
 end
 
@@ -38,20 +38,20 @@ end
 
 
 subsection Material model
-  set Model name = simple
+  set Model name = simple 
 
   subsection Simple model
-    set Reference density             = 3300
-    set Viscosity                     = 1e22
+    set Reference density             = 3300 
+    set Viscosity                     = 1e22 
   end
 end
 
 
 subsection Gravity model
-  set Model name = vertical
+  set Model name = vertical 
 
   subsection Vertical
-    set Magnitude = 9.81
+    set Magnitude = 9.81 
   end
 end
 
@@ -61,10 +61,10 @@ end
 # temperature boundary conditions.
 
 subsection Initial temperature model
-  set Model name = function
+  set Model name = function 
 
   subsection Function
-    set Function expression = 0
+    set Function expression = 0 
   end
 end
 
@@ -81,22 +81,22 @@ end
 # 100.
 
 subsection Compositional fields
-  set Number of fields = 1
+  set Number of fields = 1 
 end
 
 subsection Initial composition model
-  set Model name = function
+  set Model name = function 
 
   subsection Function
-    set Variable names      = x,y,z
-    set Function constants  = r=200000,p=1445000
-    set Function expression = if(sqrt((x-p)*(x-p)+(y-p)*(y-p)+(z-p)*(z-p)) > r, 0, 1)
+    set Variable names      = x,y,z 
+    set Function constants  = r=200000,p=1445000 
+    set Function expression = if(sqrt((x-p)*(x-p)+(y-p)*(y-p)+(z-p)*(z-p)) > r, 0, 1) 
   end
 end
 
 subsection Material model
   subsection Simple model
-    set Density differential for compositional field 1 = 100
+    set Density differential for compositional field 1 = 100 
   end
 end
 
@@ -110,10 +110,10 @@ end
 # indicator to use when refining the mesh adaptively.
 
 subsection Mesh refinement
-  set Initial adaptive refinement        = 4
-  set Initial global refinement          = 4
-  set Refinement fraction                = 0.2
-  set Strategy                           = velocity
+  set Initial adaptive refinement        = 4 
+  set Initial global refinement          = 4 
+  set Refinement fraction                = 0.2 
+  set Strategy                           = velocity 
 end
 
 
@@ -126,9 +126,9 @@ end
 # velocity field.
 
 subsection Postprocess
-  set List of postprocessors = visualization, velocity statistics
+  set List of postprocessors = visualization, velocity statistics 
 
   subsection Visualization
-    set List of output variables = density, viscosity
+    set List of output variables = density, viscosity 
   end
 end

--- a/doc/manual/cookbooks/sinker-with-averaging/full.prm
+++ b/doc/manual/cookbooks/sinker-with-averaging/full.prm
@@ -44,10 +44,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/doc/manual/empty.prm
+++ b/doc/manual/empty.prm
@@ -18,6 +18,7 @@ end
 
 subsection Boundary temperature model
   set List of model names = box
+  set Fixed temperature boundary indicators   = left, right, bottom, top
 end
 
 subsection Initial temperature model

--- a/doc/modules/changes/20210709b_bobmyhill
+++ b/doc/modules/changes/20210709b_bobmyhill
@@ -1,0 +1,5 @@
+Changed: The Boundary temperature model plugin now requires that the
+"Fixed temperature boundary indicators" parameter is non-empty whenever
+the "Model names" parameter is not empty.
+<br>
+(Bob Myhill, 2021/07/09)

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -171,14 +171,13 @@ namespace aspect
             // If that is indeed the case, clear the model_operators vector. Otherwise, raise an exception.
             if (fixed_temperature_boundary_indicators.size() == 0)
               {
-                if (model_names.size() == 0)
-                  model_operators.clear();
-                else
-                  AssertThrow(false,
-                              ExcMessage ("You have indicated that you wish to apply a boundary temperature "
-                                          "model, but the <Fixed temperature boundary indicators> parameter "
-                                          "is empty. Please use this parameter to specify the boundaries "
-                                          "on which the model(s) should be applied."));
+                AssertThrow(model_names.size() == 0,
+                            ExcMessage ("You have indicated that you wish to apply a boundary temperature "
+                                        "model, but the <Fixed temperature boundary indicators> parameter "
+                                        "is empty. Please use this parameter to specify the boundaries "
+                                        "on which the model(s) should be applied."));
+
+                model_operators.clear();
               }
           }
         catch (const std::string &error)

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -167,12 +167,18 @@ namespace aspect
               = std::set<types::boundary_id> (x_fixed_temperature_boundary_indicators.begin(),
                                               x_fixed_temperature_boundary_indicators.end());
 
-            // If model names have been set, but no boundaries on which to use them,
-            // ignore the set values, do not create objects that are never used.
+            // If no fixed temperature boundary indicators have been set, there should be no model_names chosen either.
+            // If that is indeed the case, clear the model_operators vector. Otherwise, raise an exception.
             if (fixed_temperature_boundary_indicators.size() == 0)
               {
-                model_names.clear();
-                model_operators.clear();
+                if (model_names.size() == 0)
+                  model_operators.clear();
+                else
+                  AssertThrow(false,
+                              ExcMessage ("You have indicated that you wish to apply a boundary temperature "
+                                          "model, but the <Fixed temperature boundary indicators> parameter "
+                                          "is empty. Please use this parameter to specify the boundaries "
+                                          "on which the model(s) should be applied."));
               }
           }
         catch (const std::string &error)

--- a/tests/anisotropic_viscosity.prm
+++ b/tests/anisotropic_viscosity.prm
@@ -20,10 +20,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = no Advection, iterated Stokes
 set Max nonlinear iterations               = 1
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/annulus.prm
+++ b/tests/annulus.prm
@@ -69,10 +69,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/artificial_viscosity.prm
+++ b/tests/artificial_viscosity.prm
@@ -27,12 +27,6 @@ subsection Compositional fields
   set Names of fields = porosity
 end
 
-
-subsection Boundary temperature model
-  set List of model names = initial temperature
-
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/tests/ascii_data_initial_temperature_2d_box.prm
+++ b/tests/ascii_data_initial_temperature_2d_box.prm
@@ -25,11 +25,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/ascii_data_layered_initial_composition_2d_box.prm
+++ b/tests/ascii_data_layered_initial_composition_2d_box.prm
@@ -29,11 +29,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Compositional fields
   set Number of fields = 1
 end

--- a/tests/average_arithmetic.prm
+++ b/tests/average_arithmetic.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_geometric.prm
+++ b/tests/average_geometric.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_harmonic.prm
+++ b/tests/average_harmonic.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_log.prm
+++ b/tests/average_log.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_none.prm
+++ b/tests/average_none.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_nwd_arithmetic.prm
+++ b/tests/average_nwd_arithmetic.prm
@@ -54,10 +54,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_nwd_geometric.prm
+++ b/tests/average_nwd_geometric.prm
@@ -53,10 +53,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_nwd_harmonic.prm
+++ b/tests/average_nwd_harmonic.prm
@@ -53,10 +53,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_pick_largest.prm
+++ b/tests/average_pick_largest.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/average_project_to_q1.prm
+++ b/tests/average_project_to_q1.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/box_end_time_1e7_terminate.prm
+++ b/tests/box_end_time_1e7_terminate.prm
@@ -12,11 +12,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 
 subsection Gravity model
   set Model name = vertical

--- a/tests/box_lithostatic_pressure_2d.prm
+++ b/tests/box_lithostatic_pressure_2d.prm
@@ -90,10 +90,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/box_lithostatic_pressure_3d.prm
+++ b/tests/box_lithostatic_pressure_3d.prm
@@ -89,10 +89,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/box_steady_state_terminate.prm
+++ b/tests/box_steady_state_terminate.prm
@@ -8,11 +8,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 
 subsection Gravity model
   set Model name = vertical

--- a/tests/box_steady_temperature_terminate.prm
+++ b/tests/box_steady_temperature_terminate.prm
@@ -10,10 +10,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 set Use conduction timestep = true
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Gravity model
   set Model name = vertical

--- a/tests/burstedde.prm
+++ b/tests/burstedde.prm
@@ -68,10 +68,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/burstedde_stokes_rhs.prm
+++ b/tests/burstedde_stokes_rhs.prm
@@ -73,10 +73,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/checkpoint_01.prm
+++ b/tests/checkpoint_01.prm
@@ -18,10 +18,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 4
 end

--- a/tests/checkpoint_01_check_parameters.prm
+++ b/tests/checkpoint_01_check_parameters.prm
@@ -12,10 +12,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 4
 end

--- a/tests/checkpoint_02.prm
+++ b/tests/checkpoint_02.prm
@@ -17,10 +17,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 5
 end

--- a/tests/checkpoint_02_direct.prm
+++ b/tests/checkpoint_02_direct.prm
@@ -12,10 +12,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 5
 end

--- a/tests/checkpoint_02_petsc.prm
+++ b/tests/checkpoint_02_petsc.prm
@@ -13,10 +13,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 5
 end

--- a/tests/checkpoint_03_particles.prm
+++ b/tests/checkpoint_03_particles.prm
@@ -18,10 +18,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 4
 end

--- a/tests/checkpoint_04_particles_no_output.prm
+++ b/tests/checkpoint_04_particles_no_output.prm
@@ -18,10 +18,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Checkpointing
   set Steps between checkpoint = 4
 end

--- a/tests/checkpoint_06_spherical_shell.prm
+++ b/tests/checkpoint_06_spherical_shell.prm
@@ -18,9 +18,6 @@ set Surface pressure                       = 0
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
-subsection Boundary temperature model
-  set List of model names = function
-end
 
 subsection Checkpointing
   set Steps between checkpoint = 4

--- a/tests/command_postprocessor.prm
+++ b/tests/command_postprocessor.prm
@@ -4,10 +4,6 @@
 set Dimension = 2
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Geometry model
   set Model name = box
 end

--- a/tests/compressibility.prm
+++ b/tests/compressibility.prm
@@ -43,14 +43,6 @@ set Nonlinear solver scheme                = no Advection, iterated Stokes
 set Max nonlinear iterations               = 1
 
 
-
-
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/compressibility_iterated_stokes.prm
+++ b/tests/compressibility_iterated_stokes.prm
@@ -33,12 +33,6 @@ set Max nonlinear iterations               = 5
 
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/compressibility_iterated_stokes_direct_solver.prm
+++ b/tests/compressibility_iterated_stokes_direct_solver.prm
@@ -13,12 +13,6 @@ set Nonlinear solver scheme                = no Advection, iterated Stokes
 set Max nonlinear iterations               = 5
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/compressibility_volumetric_strain_rate.prm
+++ b/tests/compressibility_volumetric_strain_rate.prm
@@ -19,13 +19,6 @@ set Nonlinear solver scheme                = no Advection, iterated Stokes
 set Max nonlinear iterations               = 5
 
 
-
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/compressible_forsterite_box.prm
+++ b/tests/compressible_forsterite_box.prm
@@ -5,9 +5,6 @@
 set Dimension                              = 2
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
 
 subsection Compositional fields
   set Number of fields          = 1

--- a/tests/compression_heating.prm
+++ b/tests/compression_heating.prm
@@ -61,10 +61,6 @@ subsection Initial composition model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/tests/constant_composition_convergence.prm
+++ b/tests/constant_composition_convergence.prm
@@ -25,10 +25,6 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0, 1, 2 ,3
 end
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/tests/crustal_model_3D.prm
+++ b/tests/crustal_model_3D.prm
@@ -84,10 +84,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/depth_average_06.prm
+++ b/tests/depth_average_06.prm
@@ -35,7 +35,7 @@ end
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   =
-  set List of model names = function
+  set List of model names =
 end
 
 

--- a/tests/discontinuous_composition_bound_preserving_limiter.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter_3d.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/doneahuerta_3.prm
+++ b/tests/doneahuerta_3.prm
@@ -45,10 +45,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/drucker_prager_compression.prm
+++ b/tests/drucker_prager_compression.prm
@@ -85,13 +85,6 @@ end
 ############### Parameters describing the temperature field
 # We set the temperature to zero, as it is not important.
 
-subsection Boundary temperature model
-  set List of model names = box
-  subsection Box
-    set Left temperature = 0
-  end
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/drucker_prager_extension.prm
+++ b/tests/drucker_prager_extension.prm
@@ -85,13 +85,6 @@ end
 ############### Parameters describing the temperature field
 # We set the temperature to zero, as it is not important.
 
-subsection Boundary temperature model
-  set List of model names = box
-  subsection Box
-    set Left temperature = 0
-  end
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/dynamic_friction.prm
+++ b/tests/dynamic_friction.prm
@@ -99,10 +99,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/gaussian_initial_temperature.prm
+++ b/tests/gaussian_initial_temperature.prm
@@ -10,6 +10,17 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
+subsection Boundary temperature model
+  set List of model names = spherical constant
+  set Fixed temperature boundary indicators   = bottom, top
+
+  subsection Spherical constant
+    set Inner temperature = 1
+    set Outer temperature = 0
+  end
+end
+
+
 subsection Gravity model
   set Model name = radial constant
 
@@ -61,6 +72,10 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+#  set Fixed temperature boundary indicators   = 0, 1
+end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0

--- a/tests/gaussian_initial_temperature.prm
+++ b/tests/gaussian_initial_temperature.prm
@@ -10,17 +10,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = spherical constant
-  set Fixed temperature boundary indicators   = bottom, top
-
-  subsection Spherical constant
-    set Inner temperature = 1
-    set Outer temperature = 0
-  end
-end
-
-
 subsection Gravity model
   set Model name = radial constant
 
@@ -72,10 +61,6 @@ end
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-#  set Fixed temperature boundary indicators   = 0, 1
-end
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0

--- a/tests/geoid.prm
+++ b/tests/geoid.prm
@@ -50,17 +50,6 @@ subsection Nullspace removal
 end
 
 
-subsection Boundary temperature model
-  set List of model names = function
-  subsection Function
-    set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
-    set Variable names = r,phi,theta,t
-    set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
-  end
-end
-
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/geoid_no_topo.prm
+++ b/tests/geoid_no_topo.prm
@@ -47,17 +47,6 @@ subsection Nullspace removal
 end
 
 
-subsection Boundary temperature model
-  set List of model names = function
-  subsection Function
-    set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
-    set Variable names = r,phi,theta,t
-    set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
-  end
-end
-
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/geoid_visualization.prm
+++ b/tests/geoid_visualization.prm
@@ -47,17 +47,6 @@ subsection Nullspace removal
 end
 
 
-subsection Boundary temperature model
-  set List of model names = function
-  subsection Function
-    set Coordinate system = spherical
-    set Function constants = pi=3.1415926536
-    set Variable names = r,phi,theta,t
-    set Function expression = (5/2)*sqrt(5/pi)*(3*(cos(theta))^2-1)
-  end
-end
-
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/geometric_average_crash.prm
+++ b/tests/geometric_average_crash.prm
@@ -20,6 +20,7 @@
 # safely merged with any existing subsections with the same name.
 
 subsection Boundary temperature model
+   set List of model names    = initial temperature
    set Fixed temperature boundary indicators     = inner, outer
 end
 
@@ -47,10 +48,6 @@ end
      set Radius = 100e3
      set Subadiabaticity = 0
    end
- end
-
- subsection Boundary temperature model
-   set List of model names    = initial temperature
  end
 
  subsection Gravity model

--- a/tests/gravity_point_values_list.prm
+++ b/tests/gravity_point_values_list.prm
@@ -31,14 +31,6 @@ subsection Material model
   end
 end
 
-# Model boundary temperature
-subsection Boundary temperature model
-  set List of model names = spherical constant
-   subsection Spherical constant
-    set Outer temperature = 273
-  end
-end
-
 # Model initial temperature
 subsection Initial temperature model
   set Model name = function

--- a/tests/gravity_point_values_map.prm
+++ b/tests/gravity_point_values_map.prm
@@ -31,14 +31,6 @@ subsection Material model
   end
 end
 
-# Model boundary temperature
-subsection Boundary temperature model
-  set List of model names = spherical constant
-   subsection Spherical constant
-    set Outer temperature = 273
-  end
-end
-
 # Model initial temperature
 subsection Initial temperature model
   set Model name = function

--- a/tests/gravity_point_values_spiral.prm
+++ b/tests/gravity_point_values_spiral.prm
@@ -31,14 +31,6 @@ subsection Material model
   end
 end
 
-# Model boundary temperature
-subsection Boundary temperature model
-  set List of model names = spherical constant
-   subsection Spherical constant
-    set Outer temperature = 273
-  end
-end
-
 # Model initial temperature
 subsection Initial temperature model
   set Model name = function

--- a/tests/hollow_sphere.prm
+++ b/tests/hollow_sphere.prm
@@ -62,10 +62,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/hollow_sphere_gmg.prm
+++ b/tests/hollow_sphere_gmg.prm
@@ -57,10 +57,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/hollow_sphere_gmg_q3.prm
+++ b/tests/hollow_sphere_gmg_q3.prm
@@ -56,10 +56,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/initial_temperature_list.prm
+++ b/tests/initial_temperature_list.prm
@@ -29,11 +29,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/initial_temperature_list_using_maximum.prm
+++ b/tests/initial_temperature_list_using_maximum.prm
@@ -29,12 +29,6 @@ subsection Initial temperature model
   end
 end
 
-
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/initial_temperature_list_using_minimum.prm
+++ b/tests/initial_temperature_list_using_minimum.prm
@@ -29,12 +29,6 @@ subsection Initial temperature model
   end
 end
 
-
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/initial_temperature_list_using_subtract.prm
+++ b/tests/initial_temperature_list_using_subtract.prm
@@ -30,11 +30,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/latent_heat_melt_statistics.prm
+++ b/tests/latent_heat_melt_statistics.prm
@@ -72,10 +72,6 @@ subsection Initial temperature model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/mass_flux_statistics.prm
+++ b/tests/mass_flux_statistics.prm
@@ -5,10 +5,6 @@ set Dimension                              = 2
 set CFL number                             = 1.0
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
 subsection Gravity model
   set Model name = vertical

--- a/tests/material_model_dependencies_burstedde.prm
+++ b/tests/material_model_dependencies_burstedde.prm
@@ -70,10 +70,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/maximum_horizontal_compressive_stress_case_one.prm
+++ b/tests/maximum_horizontal_compressive_stress_case_one.prm
@@ -59,10 +59,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/maximum_horizontal_compressive_stress_case_two.prm
+++ b/tests/maximum_horizontal_compressive_stress_case_two.prm
@@ -62,10 +62,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/maxtimestep.prm
+++ b/tests/maxtimestep.prm
@@ -12,12 +12,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/melt_fraction_postprocessor.prm
+++ b/tests/melt_fraction_postprocessor.prm
@@ -60,10 +60,6 @@ subsection Initial temperature model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/melt_postprocessor_peridotite.prm
+++ b/tests/melt_postprocessor_peridotite.prm
@@ -56,10 +56,6 @@ subsection Initial temperature model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/melt_postprocessor_pyroxenite.prm
+++ b/tests/melt_postprocessor_pyroxenite.prm
@@ -75,10 +75,6 @@ subsection Initial composition model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Boundary composition model
   set List of model names = box
 end

--- a/tests/melt_statistics.prm
+++ b/tests/melt_statistics.prm
@@ -72,10 +72,6 @@ subsection Initial temperature model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.

--- a/tests/modified_tait_forsterite_box.prm
+++ b/tests/modified_tait_forsterite_box.prm
@@ -6,10 +6,6 @@ set Dimension                              = 2
 set End time                               = 0
 set Adiabatic surface temperature          = 1000
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Compositional fields
   set Number of fields          = 1
 end

--- a/tests/no_adiabatic_heating.prm
+++ b/tests/no_adiabatic_heating.prm
@@ -20,12 +20,6 @@ set Max nonlinear iterations               = 5
 
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/no_adiabatic_heating_02.prm
+++ b/tests/no_adiabatic_heating_02.prm
@@ -16,12 +16,6 @@ set Max nonlinear iterations               = 5
 
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/no_conduction_timestep.prm
+++ b/tests/no_conduction_timestep.prm
@@ -28,10 +28,6 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0, 1, 2 ,3
 end
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/tests/normalize_initial_composition.prm
+++ b/tests/normalize_initial_composition.prm
@@ -4,10 +4,6 @@
 set Dimension                              = 2
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Compositional fields
   set Number of fields          = 2
   set List of normalized fields   =  0,1

--- a/tests/particle_free_surface.prm
+++ b/tests/particle_free_surface.prm
@@ -42,10 +42,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_ascii.prm
+++ b/tests/particle_generator_ascii.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_box.prm
+++ b/tests/particle_generator_box.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_box_3d.prm
+++ b/tests/particle_generator_box_3d.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_quadrature_points.prm
+++ b/tests/particle_generator_quadrature_points.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_radial.prm
+++ b/tests/particle_generator_radial.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform.prm
+++ b/tests/particle_generator_random_uniform.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_3mpi_1particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_1particle.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_3mpi_2particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_2particle.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_3mpi_3particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_3particle.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_3mpi_4particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_4particle.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_deterministic_cell.prm
+++ b/tests/particle_generator_random_uniform_deterministic_cell.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_random_uniform_empty_rank.prm
+++ b/tests/particle_generator_random_uniform_empty_rank.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_generator_reference_cell.prm
+++ b/tests/particle_generator_reference_cell.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_handler_copy.prm
+++ b/tests/particle_handler_copy.prm
@@ -37,10 +37,6 @@ subsection Gravity model
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_initial_adaptive_output.prm
+++ b/tests/particle_initial_adaptive_output.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_initial_adaptive_refinement.prm
+++ b/tests/particle_initial_adaptive_refinement.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_integrator_euler.prm
+++ b/tests/particle_integrator_euler.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_integrator_rk4.prm
+++ b/tests/particle_integrator_rk4.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_interpolator_bilinear_add_particles.prm
+++ b/tests/particle_interpolator_bilinear_add_particles.prm
@@ -44,10 +44,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/tests/particle_interpolator_bilinear_least_squares_solkz.prm
+++ b/tests/particle_interpolator_bilinear_least_squares_solkz.prm
@@ -44,10 +44,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_interpolator_harmonic_average_solkz.prm
+++ b/tests/particle_interpolator_harmonic_average_solkz.prm
@@ -44,10 +44,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/tests/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particle_interpolator_nearest_neighbor.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
@@ -47,10 +47,6 @@ end
 
 ############### Parameters describing the temperature field
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = perturbed box
 end

--- a/tests/particle_load_balancing_none.prm
+++ b/tests/particle_load_balancing_none.prm
@@ -49,9 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
 
 subsection Initial temperature model
   set Model name = function

--- a/tests/particle_load_balancing_refinement.prm
+++ b/tests/particle_load_balancing_refinement.prm
@@ -47,10 +47,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_load_balancing_refinement_02.prm
+++ b/tests/particle_load_balancing_refinement_02.prm
@@ -47,10 +47,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_load_balancing_removal.prm
+++ b/tests/particle_load_balancing_removal.prm
@@ -47,10 +47,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_load_balancing_removal_addition.prm
+++ b/tests/particle_load_balancing_removal_addition.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_gnuplot.prm
+++ b/tests/particle_output_gnuplot.prm
@@ -46,10 +46,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_hdf5.prm
+++ b/tests/particle_output_hdf5.prm
@@ -46,10 +46,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_multiple_formats.prm
+++ b/tests/particle_output_multiple_formats.prm
@@ -45,10 +45,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_none.prm
+++ b/tests/particle_output_none.prm
@@ -50,10 +50,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_vtu.prm
+++ b/tests/particle_output_vtu.prm
@@ -46,10 +46,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_vtu_group.prm
+++ b/tests/particle_output_vtu_group.prm
@@ -48,10 +48,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_output_vtu_temp.prm
+++ b/tests/particle_output_vtu_temp.prm
@@ -47,10 +47,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_periodic_boundaries.prm
+++ b/tests/particle_periodic_boundaries.prm
@@ -52,10 +52,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_periodic_quarter_shell.prm
+++ b/tests/particle_periodic_quarter_shell.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_function.prm
+++ b/tests/particle_property_function.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_initial_composition_boundary.prm
+++ b/tests/particle_property_initial_composition_boundary.prm
@@ -41,10 +41,6 @@ subsection Gravity model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_integrated_strain_pure_shear.prm
+++ b/tests/particle_property_integrated_strain_pure_shear.prm
@@ -55,10 +55,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_integrated_strain_simple_shear.prm
+++ b/tests/particle_property_integrated_strain_simple_shear.prm
@@ -51,10 +51,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_multiple_functions.prm
+++ b/tests/particle_property_multiple_functions.prm
@@ -52,10 +52,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -52,10 +52,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_timing_information.prm
+++ b/tests/particle_timing_information.prm
@@ -50,10 +50,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particle_visualization_particle_count.prm
+++ b/tests/particle_visualization_particle_count.prm
@@ -47,10 +47,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/particles_with_AMR_on.prm
+++ b/tests/particles_with_AMR_on.prm
@@ -46,10 +46,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/periodic_box2.prm
+++ b/tests/periodic_box2.prm
@@ -13,13 +13,6 @@ set Pressure normalization                 = no
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
-subsection Boundary temperature model
-  set List of model names = constant
-  subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
-  end
-end
-
 
 subsection Discretization
   set Stokes velocity polynomial degree       = 2

--- a/tests/periodic_box_mpi4.prm
+++ b/tests/periodic_box_mpi4.prm
@@ -15,14 +15,6 @@ set Pressure normalization                 = no
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
-subsection Boundary temperature model
-  set List of model names = constant
-  subsection Constant
-    set Boundary indicator to temperature mappings = 0:0,1:0,2:0,3:0
-  end
-end
-
-
 subsection Discretization
   set Stokes velocity polynomial degree       = 2
   set Temperature polynomial degree           = 2

--- a/tests/point_value_01.prm
+++ b/tests/point_value_01.prm
@@ -50,10 +50,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/point_value_02.prm
+++ b/tests/point_value_02.prm
@@ -56,10 +56,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/point_value_02_mpi.prm
+++ b/tests/point_value_02_mpi.prm
@@ -55,10 +55,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/postprocess_iterations_Stokes_only.prm
+++ b/tests/postprocess_iterations_Stokes_only.prm
@@ -14,11 +14,6 @@ set Nonlinear solver scheme                = no Advection, iterated Stokes
 set Max nonlinear iterations               = 5
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 
 subsection Gravity model
   set Model name = vertical

--- a/tests/prescribed_dilation.prm
+++ b/tests/prescribed_dilation.prm
@@ -48,10 +48,6 @@ subsection Gravity model
 
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/prescribed_field.prm
+++ b/tests/prescribed_field.prm
@@ -16,10 +16,6 @@ set Adiabatic surface temperature          = 0
 set Surface pressure                       = 0
 set Use years in output instead of seconds = false
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/prescribed_field_temperature.prm
+++ b/tests/prescribed_field_temperature.prm
@@ -18,10 +18,6 @@ subsection Temperature field
   set Temperature method                     = prescribed field
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/prescribed_stokes_solution_DG_periodic.prm
+++ b/tests/prescribed_stokes_solution_DG_periodic.prm
@@ -40,17 +40,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-  subsection Box
-    set Bottom temperature = 0
-    set Left temperature   = 0
-    set Right temperature  = 0
-    set Top temperature    = 0
-  end
-end
-
-
 subsection Gravity model
   set Model name = vertical
   subsection Vertical

--- a/tests/principal_deviatoric_stress.prm
+++ b/tests/principal_deviatoric_stress.prm
@@ -60,10 +60,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/prmbackslash.prm
+++ b/tests/prmbackslash.prm
@@ -14,10 +14,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 # \ test
 # \
 bla

--- a/tests/pure_shear.prm
+++ b/tests/pure_shear.prm
@@ -94,10 +94,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/q1_q1.prm
+++ b/tests/q1_q1.prm
@@ -54,10 +54,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/q1_q1_6.prm
+++ b/tests/q1_q1_6.prm
@@ -51,10 +51,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/refinement_strainrate.prm
+++ b/tests/refinement_strainrate.prm
@@ -61,10 +61,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/rotation_statistics.prm
+++ b/tests/rotation_statistics.prm
@@ -51,11 +51,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = constant
-end
-
-
 subsection Gravity model
   set Model name = radial constant
 

--- a/tests/rotation_statistics_3d.prm
+++ b/tests/rotation_statistics_3d.prm
@@ -51,11 +51,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = constant
-end
-
-
 subsection Gravity model
   set Model name = radial constant
 

--- a/tests/shear_bands.prm
+++ b/tests/shear_bands.prm
@@ -35,20 +35,6 @@ subsection Compositional fields
   set Names of fields = porosity
 end
 
-
-subsection Boundary temperature model
-  set List of model names = initial temperature
-
-  subsection Initial temperature
-    # Temperature at the inner boundary (core mantle boundary). Units: K.
-    set Maximal temperature = 3773 # default: 6000
-
-    # Temperature at the outer boundary (lithosphere water/air). Units: K.
-    set Minimal temperature = 273  # default: 0
-  end
-
-end
-
 subsection Boundary composition model
   set List of model names = initial composition
 end

--- a/tests/shear_heating.prm
+++ b/tests/shear_heating.prm
@@ -17,12 +17,6 @@ set Nonlinear solver scheme                = single Advection, single Stokes
 
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/simple_compressibility_iterated_stokes.prm
+++ b/tests/simple_compressibility_iterated_stokes.prm
@@ -16,12 +16,6 @@ set Max nonlinear iterations               = 5
 
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/simple_shear.prm
+++ b/tests/simple_shear.prm
@@ -81,10 +81,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/simpler_composition.prm
+++ b/tests/simpler_composition.prm
@@ -4,10 +4,6 @@
 set Dimension                              = 2
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Compositional fields
   set Number of fields          = 1
 end

--- a/tests/skip_initial_conditions_setup_on_initial_refinement.prm
+++ b/tests/skip_initial_conditions_setup_on_initial_refinement.prm
@@ -24,11 +24,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
 end

--- a/tests/skip_solvers_on_initial_refinement.prm
+++ b/tests/skip_solvers_on_initial_refinement.prm
@@ -23,11 +23,6 @@ subsection Initial temperature model
 end
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom:function,left:function,right:function,top:function
 end

--- a/tests/spherical_constant_boundary_3d_sphere.prm
+++ b/tests/spherical_constant_boundary_3d_sphere.prm
@@ -5,10 +5,6 @@
 set Dimension                              = 2
 set End time                               = 0
 
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
-
 subsection Compositional fields
   set Number of fields          = 1
 end

--- a/tests/spiegelman_fail_test.prm
+++ b/tests/spiegelman_fail_test.prm
@@ -36,10 +36,6 @@ subsection Solver parameters
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 
  subsection Initial temperature model
    set Model name = function

--- a/tests/stokes.prm
+++ b/tests/stokes.prm
@@ -68,10 +68,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 

--- a/tests/stress_vs_surface_stress.prm
+++ b/tests/stress_vs_surface_stress.prm
@@ -68,10 +68,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/terminate_user_request.prm
+++ b/tests/terminate_user_request.prm
@@ -13,12 +13,6 @@ set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/time_stepping_fail.prm
+++ b/tests/time_stepping_fail.prm
@@ -19,10 +19,6 @@ subsection Time stepping
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/time_stepping_function.prm
+++ b/tests/time_stepping_function.prm
@@ -17,10 +17,6 @@ subsection Time stepping
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/time_stepping_min.prm
+++ b/tests/time_stepping_min.prm
@@ -20,10 +20,6 @@ subsection Time stepping
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Gravity model
   set Model name = vertical
 end

--- a/tests/van_keken_smooth_particle.prm
+++ b/tests/van_keken_smooth_particle.prm
@@ -49,10 +49,6 @@ end
 ############### Parameters describing the temperature field
 # Note: The temperature plays no role in this model
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/visco_plastic_peierls_mei_exact.prm
+++ b/tests/visco_plastic_peierls_mei_exact.prm
@@ -61,10 +61,7 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = bottom, top, left, right
 end
 
-# Temperature boundary and initial conditions
-subsection Boundary temperature model
-  set List of model names = initial temperature
-end
+# Initial temperature conditions
 subsection Initial temperature model
   set Model name = function
   subsection Function

--- a/tests/viscous_dissipation_statistics.prm
+++ b/tests/viscous_dissipation_statistics.prm
@@ -68,10 +68,6 @@ end
 # As above, there is no need to set anything for the
 # temperature boundary conditions.
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
 subsection Initial temperature model
   set Model name = function
 


### PR DESCRIPTION
The boundary temperature model plugin requires that the user indicate the boundaries on which the model should be applied using the "Fixed temperature boundary indicators" parameter. If this was not set manually, the plugin ignored whatever else was in that section of the parameter file, even if it was otherwise complete. 

In this PR:
- a new assert has been added that requires that if a model name has been chosen, the "Fixed temperature boundary indicators" parameter should have at least one boundary indicator.
- all of the ignored boundary temperature models have been removed from the tests, benchmarks and cookbooks.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.