### PR TITLE
Only set old_(old_)solution in first NI for particles with an iterated Advection scheme

### DIFF
--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -330,11 +330,12 @@ namespace aspect
     const unsigned int blockidx = advection_field.block_index(introspection);
     solution.block(blockidx) = particle_solution.block(blockidx);
 
-    // In the first timestep initialize all solution vectors with the initial
+    // In the first timestep, and for iterative Advection schemes only
+    // in the first nonlinear iteration, initialize all solution vectors with the initial
     // particle solution, identical to the end of the
     // Simulator<dim>::set_initial_temperature_and_compositional_fields ()
     // function.
-    if (timestep_number == 0)
+    if (timestep_number == 0 && nonlinear_iteration == 0)
       {
         old_solution.block(blockidx) = particle_solution.block(blockidx);
         old_old_solution.block(blockidx) = particle_solution.block(blockidx);


### PR DESCRIPTION
At the beginning of every nonlinear iteration of an iterative Advection scheme, particles are reset and then advected and their properties updated. Then the updated properties are interpolated onto the FE. At the moment, during the first timestep, every nonlinear iteration resets the old_solution and old_old_solution. This PR limits it to just the first nonlinear iteration as discussed in #4123 .

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
