### PR TITLE
move fill_averaged_equation_of_state_outputs to utilities

### DIFF
--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -99,27 +99,7 @@ namespace aspect
       std::vector<double> entropy_derivative_temperature;
     };
 
-    /**
-    * This function computes averages of multicomponent thermodynamic properties
-    * that are stored in a vector of EquationOfStateOutputs.
-    * Each EquationOfStateOutput contains the thermodynamic properties for
-    * all materials at a given evaluation point.
-    * The averaged properties are:
-    * density, isothermal compressibility, thermal_expansivity,
-    * the specific entropy derivatives with respect to pressure and temperature
-    * and the specific heat capacity. The first three of these properties
-    * are averaged by volume fraction, and the second three
-    * (the specific properties) are averaged by mass fraction.
-    * These averages are used to fill the corresponding attributes of
-    * a MaterialModelOutputs object.
-    */
-    template <int dim>
-    void
-    fill_averaged_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs,
-                                            const std::vector<double> &mass_fractions,
-                                            const std::vector<double> &volume_fractions,
-                                            const unsigned int i,
-                                            MaterialModelOutputs<dim> &out);
+
 
     /**
      * This function takes the output of an equation of state @p eos_outputs_all_phases,

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -36,6 +36,9 @@ namespace aspect
   {
     using namespace dealii;
 
+    template <int dim> struct MaterialModelOutputs;
+    template <int dim> struct EquationOfStateOutputs;
+
     /**
      * A namespace in which we define utility functions that
      * might be used in many different places in the material
@@ -316,6 +319,32 @@ namespace aspect
       double average_value (const std::vector<double> &volume_fractions,
                             const std::vector<double> &parameter_values,
                             const CompositionalAveragingOperation &average_type);
+
+
+
+      /**
+      * This function computes averages of multicomponent thermodynamic properties
+      * that are stored in a vector of EquationOfStateOutputs.
+      * Each EquationOfStateOutput contains the thermodynamic properties for
+      * all materials at a given evaluation point.
+      * The averaged properties are:
+      * density, isothermal compressibility, thermal_expansivity,
+      * the specific entropy derivatives with respect to pressure and temperature
+      * and the specific heat capacity. The first three of these properties
+      * are averaged by volume fraction, and the second three
+      * (the specific properties) are averaged by mass fraction.
+      * These averages are used to fill the corresponding attributes of
+      * a MaterialModelOutputs object.
+      */
+      template <int dim>
+      void
+      fill_averaged_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs,
+                                              const std::vector<double> &mass_fractions,
+                                              const std::vector<double> &volume_fractions,
+                                              const unsigned int i,
+                                              MaterialModelOutputs<dim> &out);
+
+
 
       /**
        * Utilities for material models with multiple phases

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -325,7 +325,7 @@ namespace aspect
       /**
       * This function computes averages of multicomponent thermodynamic properties
       * that are stored in a vector of EquationOfStateOutputs.
-      * Each EquationOfStateOutput contains the thermodynamic properties for
+      * Each @p eos_outputs contains the thermodynamic properties for
       * all materials at a given evaluation point.
       * The averaged properties are:
       * density, isothermal compressibility, thermal_expansivity,

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -42,26 +42,6 @@ namespace aspect
 
     template <int dim>
     void
-    fill_averaged_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs,
-                                            const std::vector<double> &mass_fractions,
-                                            const std::vector<double> &volume_fractions,
-                                            const unsigned int i,
-                                            MaterialModelOutputs<dim> &out)
-    {
-      // The density, isothermal compressibility and thermal expansivity are volume-averaged
-      // The specific entropy derivatives and heat capacity are mass-averaged
-      out.densities[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.densities, MaterialUtilities::arithmetic);
-      out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.compressibilities, MaterialUtilities::arithmetic);
-      out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.thermal_expansion_coefficients, MaterialUtilities::arithmetic);
-      out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.entropy_derivative_pressure, MaterialUtilities::arithmetic);
-      out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.entropy_derivative_temperature, MaterialUtilities::arithmetic);
-      out.specific_heat[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.specific_heat_capacities, MaterialUtilities::arithmetic);
-    }
-
-
-
-    template <int dim>
-    void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
                                             const std::vector<double> &phase_function_values,
                                             const std::vector<unsigned int> &n_phases_per_composition,
@@ -93,11 +73,6 @@ namespace aspect
   {
 #define INSTANTIATE(dim) \
   template struct EquationOfStateOutputs<dim>; \
-  template void fill_averaged_equation_of_state_outputs<dim> (const EquationOfStateOutputs<dim> &, \
-                                                              const std::vector<double> &, \
-                                                              const std::vector<double> &, \
-                                                              const unsigned int, \
-                                                              MaterialModelOutputs<dim> &); \
   template void phase_average_equation_of_state_outputs<dim> (const EquationOfStateOutputs<dim> &, \
                                                               const std::vector<double> &phase_function_values, \
                                                               const std::vector<unsigned int> &n_phases_per_composition, \

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -261,7 +261,7 @@ namespace aspect
                               "or correspond to the number of compositional fields (without a background field)"
                               "or correspond to the number of compositional fields + 1 (with a background field)."));
 
-          MaterialModel::fill_averaged_equation_of_state_outputs(eos_outputs[i], mass_fractions, volume_fractions[i], i, out);
+          MaterialUtilities::fill_averaged_equation_of_state_outputs(eos_outputs[i], mass_fractions, volume_fractions[i], i, out);
         }
 
       // fill additional outputs if they exist

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -26,6 +26,7 @@
 #include <aspect/gravity_model/interface.h>
 
 #include <aspect/material_model/interface.h>
+#include <aspect/material_model/equation_of_state/interface.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
 
@@ -879,6 +880,27 @@ namespace aspect
           }
         return averaged_parameter;
       }
+
+
+
+      template <int dim>
+      void
+      fill_averaged_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs,
+                                              const std::vector<double> &mass_fractions,
+                                              const std::vector<double> &volume_fractions,
+                                              const unsigned int i,
+                                              MaterialModelOutputs<dim> &out)
+      {
+        // The density, isothermal compressibility and thermal expansivity are volume-averaged
+        // The specific entropy derivatives and heat capacity are mass-averaged
+        out.densities[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.densities, MaterialUtilities::arithmetic);
+        out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.compressibilities, MaterialUtilities::arithmetic);
+        out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.thermal_expansion_coefficients, MaterialUtilities::arithmetic);
+        out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.entropy_derivative_pressure, MaterialUtilities::arithmetic);
+        out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.entropy_derivative_temperature, MaterialUtilities::arithmetic);
+        out.specific_heat[i] = MaterialUtilities::average_value (mass_fractions, eos_outputs.specific_heat_capacities, MaterialUtilities::arithmetic);
+      }
+
 
 
       double phase_average_value (const std::vector<double> &phase_function_values,

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1218,6 +1218,11 @@ namespace aspect
     namespace MaterialUtilities
     {
 #define INSTANTIATE(dim) \
+  template void fill_averaged_equation_of_state_outputs<dim> (const EquationOfStateOutputs<dim> &, \
+                                                              const std::vector<double> &, \
+                                                              const std::vector<double> &, \
+                                                              const unsigned int, \
+                                                              MaterialModelOutputs<dim> &); \
   template struct PhaseFunctionInputs<dim>; \
   template class PhaseFunction<dim>;
 


### PR DESCRIPTION
The fill_averaged_equation_of_state_outputs function is really a utilities function and should be in the material model utilities rather than in the equation of state interface. 

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

See discussion in #4148. 