### PR TITLE
correct typo

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -11874,7 +11874,7 @@ so that your new test is added to the test suite. Then you can run it by executi
 \begin{lstlisting}[frame=single,language=ksh]
     ctest -R name_of_your_test -V
 \end{lstlisting}
-in the \texttt{tests} folder and you will get an output telling you if the test has
+and you will get an output telling you if the test has
 passed or failed (and why it failed). If you have just copied the output files of a different
 test in the \texttt{tests/} directory to make your test, you of course expect your test to fail.
 In this case, the output you see should contain a line that starts with \texttt{******* Check}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -11868,13 +11868,13 @@ test and rename it to the name of your parameter file.
 
 To actually run the test, you have to go to your \aspect{} build directory and run
 \begin{lstlisting}[frame=single,language=ksh]
-    make setup\_tests
+    make setup_tests
 \end{lstlisting}
 so that your new test is added to the test suite. Then you can run it by executing
 \begin{lstlisting}[frame=single,language=ksh]
     ctest -R name_of_your_test -V
 \end{lstlisting}
-and you will get an output telling you if the test has
+in the \texttt{tests} folder and you will get an output telling you if the test has
 passed or failed (and why it failed). If you have just copied the output files of a different
 test in the \texttt{tests/} directory to make your test, you of course expect your test to fail.
 In this case, the output you see should contain a line that starts with \texttt{******* Check}


### PR DESCRIPTION
correcting a simple typo and adding a folder location in the manual section about creating tests.