### PR TITLE
Add check to CMakeLists.txt preventing insource builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ MESSAGE(STATUS "====================================================")
 MESSAGE(STATUS "============ Configuring ASPECT ====================")
 MESSAGE(STATUS "====================================================")
 
+IF ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+  MESSAGE(FATAL_ERROR  "ASPECT does not support in-source builds in ${CMAKE_BINARY_DIR}. \
+  Run cmake from a separate build directory. \
+  \
+  Note that cmake created a file \
+  called CMakeCache.txt and a folder called CMakeFiles in the source \
+  directory that you have to remove before you can begin a build in a \
+  different directory.")
+ENDIF()
+
 # Set the name of the project and target:
 SET(TARGET "aspect")
 


### PR DESCRIPTION
This prevents in-source builds. Unfortunately there is no way to prevent cmake from writing the CMakeCache and CMakeFiles, and as soon as those are written in the source directory all future calls to cmake will crash (see https://dpiepgrass.medium.com/cmake-fights-against-disabling-in-source-builds-ab1d71c1d26f). I think this is the best we can do, explaining this to the user.