### PR TITLE
Add check that creep prefactors are larger than zero

### DIFF
--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -222,6 +222,14 @@ namespace aspect
                                                                             true,
                                                                             expected_n_phases_per_composition);
         grain_size = prm.get_double("Grain size");
+
+        // Check that there are no entries set to zero,
+        // for example because the entry is for a field
+        // that is masked anyway, like strain. Despite
+        // these compositions being masked, their viscosities
+        // are computed anyway and this will lead to division by zero.
+        for (unsigned int n = 0; n < prefactors_diffusion.size(); ++n)
+          AssertThrow(prefactors_diffusion[n] > 0., ExcMessage("The diffusion prefactor should be larger than zero."));
       }
     }
   }

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -209,6 +209,14 @@ namespace aspect
                                                                                "Activation volumes for dislocation creep",
                                                                                true,
                                                                                expected_n_phases_per_composition);
+
+        // Check that there are no prefactor entries set to zero,
+        // for example because the entry is for a field
+        // that is masked anyway, like strain. Despite
+        // these compositions being masked, their viscosities
+        // are computed anyway and this will lead to division by zero.
+        for (unsigned int n = 0; n < prefactors_dislocation.size(); ++n)
+          AssertThrow(prefactors_dislocation[n] > 0., ExcMessage("The dislocation prefactor should be larger than zero."));
       }
     }
   }


### PR DESCRIPTION
Avoid division by zero by checking the creep prefactors in parse_parameters. With the new phase transition functionality, the pattern of the prefactors can be anything, so there is no checking of the bounds. Values have to be given for all fields, even if they're masked. Often, users give masked fields a nonsensical value, like zero. This can trigger asserts in e.g. harmonic averaging. This PR just checks that the prefactors are larger than zero after reading them in. 

Related to #4182. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
