### PR TITLE
[deal.II 9.3] Use std::make_unique instead of std_cxx14::make_unique.

### DIFF
--- a/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
+++ b/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
@@ -214,7 +214,7 @@ namespace aspect
                  ExcMessage("The entropy advection assembler requires "
                             "that adiabatic heating is disabled."));
 
-    assemblers.advection_system[0] = std_cxx14::make_unique<Assemblers::EntropyAdvectionSystem<dim>>();
+    assemblers.advection_system[0] = std::make_unique<Assemblers::EntropyAdvectionSystem<dim>>();
 
     assemblers.advection_system_assembler_properties[0].needed_update_flags = update_hessians;
   }

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -210,7 +210,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -207,7 +207,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -265,7 +265,7 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
     }
 
@@ -364,14 +364,14 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
@@ -478,7 +478,7 @@ namespace aspect
       if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       this->get_material_model().create_additional_named_outputs(material_model_outputs);
@@ -527,13 +527,13 @@ namespace aspect
       for (unsigned int i=0; i<assemblers.stokes_preconditioner.size(); ++i)
         {
           if (Plugins::plugin_type_matches<Assemblers::StokesPreconditioner<dim>>(*(assemblers.stokes_preconditioner[i])))
-            assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim>> ();
+            assemblers.stokes_preconditioner[i] = std::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim>> ();
         }
 
       for (unsigned int i=0; i<assemblers.stokes_system.size(); ++i)
         {
           if (Plugins::plugin_type_matches<Assemblers::StokesIncompressibleTerms<dim>>(*(assemblers.stokes_system[i])))
-            assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim>> ();
+            assemblers.stokes_system[i] = std::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim>> ();
         }
     }
 
@@ -801,7 +801,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
     }
   }

--- a/cookbooks/inner_core_convection/inner_core_assembly.cc
+++ b/cookbooks/inner_core_convection/inner_core_assembly.cc
@@ -127,7 +127,7 @@ namespace aspect
                  ExcMessage ("The phase boundary assembler can only be used with the "
                              "material model 'inner core material'!"));
 
-    assemblers.stokes_system_on_boundary_face.push_back (std_cxx14::make_unique<PhaseBoundaryAssembler<dim>>());
+    assemblers.stokes_system_on_boundary_face.push_back (std::make_unique<PhaseBoundaryAssembler<dim>>());
   }
 }
 

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -28,7 +28,7 @@
 #include <functional>
 #include <memory>
 
-// for std_cxx14::make_unique:
+// for std::make_unique:
 #if DEAL_II_VERSION_GTE(9,3,0)
 // avoid deprecated std_cxx14 inside deal.II
 namespace std_cxx14

--- a/source/adiabatic_conditions/compute_profile.cc
+++ b/source/adiabatic_conditions/compute_profile.cc
@@ -348,7 +348,7 @@ namespace aspect
           if ((this->n_compositional_fields() > 0) && (reference_composition == reference_function))
             {
               composition_function
-                = std_cxx14::make_unique<Functions::ParsedFunction<1>>(this->n_compositional_fields());
+                = std::make_unique<Functions::ParsedFunction<1>>(this->n_compositional_fields());
               try
                 {
                   composition_function->parse_parameters (prm);

--- a/source/boundary_composition/function.cc
+++ b/source/boundary_composition/function.cc
@@ -96,7 +96,7 @@ namespace aspect
           try
             {
               function
-                = std_cxx14::make_unique<Functions::ParsedFunction<dim>>(this->n_compositional_fields());
+                = std::make_unique<Functions::ParsedFunction<dim>>(this->n_compositional_fields());
               function->parse_parameters (prm);
             }
           catch (...)

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -236,9 +236,9 @@ namespace aspect
         for (unsigned int i = 0; i < 2; i++)
           {
             velocities[i]
-              = std_cxx14::make_unique<Functions::InterpolatedUniformGridData<2>> (grid_extent,
-                                                                                   table_intervals,
-                                                                                   velocity_values[i]);
+              = std::make_unique<Functions::InterpolatedUniformGridData<2>> (grid_extent,
+                                                                             table_intervals,
+                                                                             velocity_values[i]);
           }
 
         AssertThrow(i == n_points,
@@ -594,8 +594,8 @@ namespace aspect
                                "preferred coordinate system of the geometry model is spherical "
                                "(e.g. spherical shell, chunk, sphere)."));
 
-      lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
-      old_lookup = std_cxx14::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
+      lookup = std::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
+      old_lookup = std::make_unique<internal::GPlatesLookup<dim>>(pointone, pointtwo);
 
       // display the GPlates module information at model start.
       this->get_pcout() << lookup->screen_output(pointone, pointtwo);

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -363,7 +363,7 @@ namespace aspect
                                       ChunkGeometry<dim>::
                                       clone() const
       {
-        return std_cxx14::make_unique<ChunkGeometry>(*this);
+        return std::make_unique<ChunkGeometry>(*this);
       }
 
 

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -229,7 +229,7 @@ namespace aspect
     std::unique_ptr<Manifold<dim,3>>
                                   EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::clone() const
     {
-      return std_cxx14::make_unique<EllipsoidalChunkGeometry>(*this);
+      return std::make_unique<EllipsoidalChunkGeometry>(*this);
     }
 
     template <int dim>

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -135,7 +135,7 @@ namespace aspect
         return;
 
       inputs.additional_inputs.push_back(
-        std_cxx14::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
+        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
     }
   }
 }

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -102,7 +102,7 @@ namespace aspect
         return;
 
       inputs.additional_inputs.push_back(
-        std_cxx14::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
+        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
     }
   }
 }

--- a/source/initial_composition/function.cc
+++ b/source/initial_composition/function.cc
@@ -89,7 +89,7 @@ namespace aspect
         try
           {
             function
-              = std_cxx14::make_unique<Functions::ParsedFunction<dim>>(this->n_compositional_fields());
+              = std::make_unique<Functions::ParsedFunction<dim>>(this->n_compositional_fields());
             function->parse_parameters (prm);
           }
         catch (...)

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -160,11 +160,11 @@ namespace aspect
     S40RTSPerturbation<dim>::initialize()
     {
       spherical_harmonics_lookup
-        = std_cxx14::make_unique<internal::S40RTS::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
-                                                                             this->get_mpi_communicator());
-      spline_depths_lookup
-        = std_cxx14::make_unique<internal::S40RTS::SplineDepthsLookup>(data_directory+spline_depth_file_name,
+        = std::make_unique<internal::S40RTS::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
                                                                        this->get_mpi_communicator());
+      spline_depths_lookup
+        = std::make_unique<internal::S40RTS::SplineDepthsLookup>(data_directory+spline_depth_file_name,
+                                                                 this->get_mpi_communicator());
 
       if (vs_to_density_method == file)
         {

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -162,11 +162,11 @@ namespace aspect
     SAVANIPerturbation<dim>::initialize()
     {
       spherical_harmonics_lookup
-        = std_cxx14::make_unique<internal::SAVANI::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
-                                                                             this->get_mpi_communicator());
-      spline_depths_lookup
-        = std_cxx14::make_unique<internal::SAVANI::SplineDepthsLookup>(data_directory+spline_depth_file_name,
+        = std::make_unique<internal::SAVANI::SphericalHarmonicsLookup>(data_directory+harmonics_coeffs_file_name,
                                                                        this->get_mpi_communicator());
+      spline_depths_lookup
+        = std::make_unique<internal::SAVANI::SplineDepthsLookup>(data_directory+spline_depth_file_name,
+                                                                 this->get_mpi_communicator());
 
       if (vs_to_density_method == file)
         {

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -330,7 +330,7 @@ namespace aspect
               try
                 {
                   function
-                    = std_cxx14::make_unique<Functions::ParsedFunction<1>>(n_compositional_fields);
+                    = std::make_unique<Functions::ParsedFunction<1>>(n_compositional_fields);
                   function->parse_parameters (prm);
                 }
               catch (...)

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -239,7 +239,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
     }
   }

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -235,8 +235,8 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points,
-                                                                             this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points,
+                                                                       this->n_compositional_fields()));
         }
     }
   }

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -254,7 +254,7 @@ namespace aspect
 
         if (viscosity_source == File)
           {
-            depth_dependent_rheology = std_cxx14::make_unique<Rheology::AsciiDepthProfile<dim>>();
+            depth_dependent_rheology = std::make_unique<Rheology::AsciiDepthProfile<dim>>();
             depth_dependent_rheology->initialize_simulator (this->get_simulator());
             depth_dependent_rheology->parse_parameters(prm, "Depth dependent model");
             depth_dependent_rheology->initialize();

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -449,11 +449,11 @@ namespace aspect
           // Rheological parameters
           // Diffusion creep parameters
           diffusion_creep.initialize_simulator (this->get_simulator());
-          diffusion_creep.parse_parameters(prm, std_cxx14::make_unique<std::vector<unsigned int>>(n_fields));
+          diffusion_creep.parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_fields));
 
           // Dislocation creep parameters
           dislocation_creep.initialize_simulator (this->get_simulator());
-          dislocation_creep.parse_parameters(prm, std_cxx14::make_unique<std::vector<unsigned int>>(n_fields));
+          dislocation_creep.parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_fields));
 
 
         }

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -548,7 +548,7 @@ namespace aspect
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
-              std_cxx14::make_unique<MaterialModel::PhaseOutputs<dim>> (n_points));
+              std::make_unique<MaterialModel::PhaseOutputs<dim>> (n_points));
           }
       }
     }

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -54,12 +54,12 @@ namespace aspect
           {
             if (material_file_format == perplex)
               material_lookup
-              .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(data_directory+material_file_names[i],
+              .push_back(std::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(data_directory+material_file_names[i],
                          use_bilinear_interpolation,
                          this->get_mpi_communicator()));
             else if (material_file_format == hefesto)
               material_lookup
-              .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::HeFESToReader>(data_directory+material_file_names[i],
+              .push_back(std::make_unique<MaterialModel::MaterialUtilities::Lookup::HeFESToReader>(data_directory+material_file_names[i],
                          data_directory+derivatives_file_names[i],
                          use_bilinear_interpolation,
                          this->get_mpi_communicator()));
@@ -533,14 +533,14 @@ namespace aspect
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
-              std_cxx14::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (unique_phase_names, n_points));
+              std::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (unique_phase_names, n_points));
           }
 
         if (out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
-              std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+              std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
           }
 
         if (out.template get_additional_output<PhaseOutputs<dim> >() == nullptr

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -90,12 +90,12 @@ namespace aspect
         {
           if (material_file_format == perplex)
             material_lookup
-            .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(datadirectory+material_file_names[i],
+            .push_back(std::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(datadirectory+material_file_names[i],
                        use_bilinear_interpolation,
                        this->get_mpi_communicator()));
           else if (material_file_format == hefesto)
             material_lookup
-            .push_back(std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::HeFESToReader>(datadirectory+material_file_names[i],
+            .push_back(std::make_unique<MaterialModel::MaterialUtilities::Lookup::HeFESToReader>(datadirectory+material_file_names[i],
                        datadirectory+derivatives_file_names[i],
                        use_bilinear_interpolation,
                        this->get_mpi_communicator()));
@@ -1456,7 +1456,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::DislocationViscosityOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::DislocationViscosityOutputs<dim>> (n_points));
         }
 
       // These properties are only output properties.
@@ -1464,7 +1464,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
     }
   }

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -530,7 +530,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -771,7 +771,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -396,7 +396,7 @@ namespace aspect
         use_diffusion_creep = prm.get_bool ("Include diffusion creep in composite rheology");
         if (use_diffusion_creep)
           {
-            diffusion_creep = std_cxx14::make_unique<Rheology::DiffusionCreep<dim>>();
+            diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
             diffusion_creep->initialize_simulator (this->get_simulator());
             diffusion_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
@@ -405,7 +405,7 @@ namespace aspect
         use_dislocation_creep = prm.get_bool ("Include dislocation creep in composite rheology");
         if (use_dislocation_creep)
           {
-            dislocation_creep = std_cxx14::make_unique<Rheology::DislocationCreep<dim>>();
+            dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
             dislocation_creep->initialize_simulator (this->get_simulator());
             dislocation_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
@@ -414,7 +414,7 @@ namespace aspect
         use_peierls_creep = prm.get_bool ("Include Peierls creep in composite rheology");
         if (use_peierls_creep)
           {
-            peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
+            peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
             peierls_creep->initialize_simulator (this->get_simulator());
             peierls_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
@@ -423,7 +423,7 @@ namespace aspect
         use_drucker_prager = prm.get_bool ("Include Drucker Prager plasticity in composite rheology");
         if (use_drucker_prager)
           {
-            drucker_prager = std_cxx14::make_unique<Rheology::DruckerPrager<dim>>();
+            drucker_prager = std::make_unique<Rheology::DruckerPrager<dim>>();
             drucker_prager->initialize_simulator (this->get_simulator());
             drucker_prager->parse_parameters(prm, expected_n_phases_per_composition);
 

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -226,7 +226,7 @@ namespace aspect
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
-              std_cxx14::make_unique<ElasticAdditionalOutputs<dim>> (n_points));
+              std::make_unique<ElasticAdditionalOutputs<dim>> (n_points));
           }
       }
 

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -648,7 +648,7 @@ namespace aspect
         // Frank Kamenetskii viscosity parameters
         if (viscous_flow_law == frank_kamenetskii)
           {
-            frank_kamenetskii_rheology = std_cxx14::make_unique<Rheology::FrankKamenetskii<dim>>();
+            frank_kamenetskii_rheology = std::make_unique<Rheology::FrankKamenetskii<dim>>();
             frank_kamenetskii_rheology->initialize_simulator (this->get_simulator());
             frank_kamenetskii_rheology->parse_parameters(prm);
           }
@@ -657,7 +657,7 @@ namespace aspect
         use_peierls_creep = prm.get_bool ("Include Peierls creep");
         if (use_peierls_creep)
           {
-            peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
+            peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
             peierls_creep->initialize_simulator (this->get_simulator());
             peierls_creep->parse_parameters(prm, expected_n_phases_per_composition);
           }
@@ -695,7 +695,7 @@ namespace aspect
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
-              std_cxx14::make_unique<PlasticAdditionalOutputs<dim>> (n_points));
+              std::make_unique<PlasticAdditionalOutputs<dim>> (n_points));
           }
       }
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -136,11 +136,11 @@ namespace aspect
       equation_of_state.initialize();
 
       lateral_viscosity_lookup
-        = std_cxx14::make_unique<internal::LateralViscosityLookup>(data_directory+lateral_viscosity_file_name,
-                                                                   this->get_mpi_communicator());
+        = std::make_unique<internal::LateralViscosityLookup>(data_directory+lateral_viscosity_file_name,
+                                                             this->get_mpi_communicator());
       radial_viscosity_lookup
-        = std_cxx14::make_unique<internal::RadialViscosityLookup>(data_directory+radial_viscosity_file_name,
-                                                                  this->get_mpi_communicator());
+        = std::make_unique<internal::RadialViscosityLookup>(data_directory+radial_viscosity_file_name,
+                                                            this->get_mpi_communicator());
       average_temperature.resize(n_lateral_slices);
     }
 
@@ -392,7 +392,7 @@ namespace aspect
           has_background_field = (equation_of_state.number_of_lookups() == this->n_compositional_fields() + 1);
 
           // All compositional fields are assumed to represent mass fractions.
-          composition_mask = std_cxx14::make_unique<ComponentMask> (this->n_compositional_fields(), true);
+          composition_mask = std::make_unique<ComponentMask> (this->n_compositional_fields(), true);
 
           prm.leave_subsection();
         }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1219,7 +1219,7 @@ namespace aspect
         // Retrieve the list of composition names
         const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        n_phase_transitions_per_composition = std_cxx14::make_unique<std::vector<unsigned int>>();
+        n_phase_transitions_per_composition = std::make_unique<std::vector<unsigned int>>();
 
         use_depth_instead_of_pressure = prm.get_bool ("Define transition by depth instead of pressure");
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -379,7 +379,7 @@ namespace aspect
           // Equation of state parameters
           equation_of_state.initialize_simulator (this->get_simulator());
           equation_of_state.parse_parameters (prm,
-                                              std_cxx14::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
+                                              std::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
 
 
           thermal_diffusivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal diffusivities"))),
@@ -394,7 +394,7 @@ namespace aspect
 
           rheology = std::make_unique<Rheology::ViscoPlastic<dim>>();
           rheology->initialize_simulator (this->get_simulator());
-          rheology->parse_parameters(prm, std_cxx14::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
+          rheology->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
         }
         prm.leave_subsection();
       }

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -392,7 +392,7 @@ namespace aspect
                                                                            n_fields,
                                                                            "Thermal conductivities");
 
-          rheology = std_cxx14::make_unique<Rheology::ViscoPlastic<dim>>();
+          rheology = std::make_unique<Rheology::ViscoPlastic<dim>>();
           rheology->initialize_simulator (this->get_simulator());
           rheology->parse_parameters(prm, std_cxx14::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
         }

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -86,7 +86,7 @@ namespace aspect
             n_components = prm.get_integer ("Number of components");
             try
               {
-                function = std_cxx14::make_unique<Functions::ParsedFunction<dim>>(n_components);
+                function = std::make_unique<Functions::ParsedFunction<dim>>(n_components);
                 function->parse_parameters (prm);
               }
             catch (...)

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -784,7 +784,7 @@ namespace aspect
           }
 
         // lastly store internal integrator properties
-        property_list.emplace_back (std_cxx14::make_unique<IntegratorProperties<dim>>());
+        property_list.emplace_back (std::make_unique<IntegratorProperties<dim>>());
         property_list.back()->parse_parameters (prm);
       }
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -69,9 +69,9 @@ namespace aspect
       // Create a particle handler that stores the future particles.
       // If we restarted from a checkpoint we will fill this particle handler
       // later with its serialized variables and stored particles
-      particle_handler = std_cxx14::make_unique<ParticleHandler<dim>>(this->get_triangulation(),
-                                                                      this->get_mapping(),
-                                                                      property_manager->get_n_property_components());
+      particle_handler = std::make_unique<ParticleHandler<dim>>(this->get_triangulation(),
+                                                                this->get_mapping(),
+                                                                property_manager->get_n_property_components());
 
       particle_handler_backup.initialize(this->get_triangulation(),
                                          this->get_mapping(),
@@ -1498,7 +1498,7 @@ namespace aspect
       generator->initialize();
 
       // Create a property_manager object and initialize its properties
-      property_manager = std_cxx14::make_unique<Property::Manager<dim>> ();
+      property_manager = std::make_unique<Property::Manager<dim>> ();
       SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_manager.get());
       sim->initialize_simulator (this->get_simulator());
       property_manager->parse_parameters(prm);

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1089,18 +1089,18 @@ namespace aspect
             melt_component_indices[1] = simulator_access.introspection().variable("fluid pressure").first_component_index;
             melt_component_indices[2] = simulator_access.introspection().variable("compaction pressure").first_component_index;
 
-            fluid_velocity = std_cxx14::make_unique<FEPointEvaluation<dim, dim>>(simulator_access.get_mapping(),
-                                                                                 simulator_access.get_fe(),
-                                                                                 update_flags,
-                                                                                 melt_component_indices[0]);
-            fluid_pressure = std_cxx14::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
-                                                                               simulator_access.get_fe(),
-                                                                               update_flags,
-                                                                               melt_component_indices[1]);
-            compaction_pressure = std_cxx14::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
-                                                                                    simulator_access.get_fe(),
-                                                                                    update_flags,
-                                                                                    melt_component_indices[2]);
+            fluid_velocity = std::make_unique<FEPointEvaluation<dim, dim>>(simulator_access.get_mapping(),
+                                                                           simulator_access.get_fe(),
+                                                                           update_flags,
+                                                                           melt_component_indices[0]);
+            fluid_pressure = std::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
+                                                                         simulator_access.get_fe(),
+                                                                         update_flags,
+                                                                         melt_component_indices[1]);
+            compaction_pressure = std::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
+                                                                              simulator_access.get_fe(),
+                                                                              update_flags,
+                                                                              melt_component_indices[2]);
 
           }
       }

--- a/source/postprocess/boundary_velocity_residual_statistics.cc
+++ b/source/postprocess/boundary_velocity_residual_statistics.cc
@@ -39,7 +39,7 @@ namespace aspect
       if (use_ascii_data)
         {
           // The input ascii table contains dim data columns (velocity components) in addition to the coordinate columns.
-          data_lookup = std_cxx14::make_unique<Utilities::StructuredDataLookup<dim>>(dim, scale_factor);
+          data_lookup = std::make_unique<Utilities::StructuredDataLookup<dim>>(dim, scale_factor);
           data_lookup->load_file(data_directory + data_file_name, this->get_mpi_communicator());
         }
       else
@@ -50,7 +50,7 @@ namespace aspect
           Point<2> point_one(numbers::PI/2., 0.);
           Point<2> point_two(numbers::PI/2., numbers::PI/2.);
 
-          gplates_lookup =  std_cxx14::make_unique<BoundaryVelocity::internal::GPlatesLookup<dim>> (
+          gplates_lookup =  std::make_unique<BoundaryVelocity::internal::GPlatesLookup<dim>> (
                               point_one, point_two);
 
           gplates_lookup->load_file(data_directory + data_file_name, this->get_mpi_communicator());

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -638,7 +638,7 @@ namespace aspect
       // If there is a deforming mesh, also attach the mesh velocity object
       if ( this->get_parameters().mesh_deformation_enabled && output_mesh_velocity)
         {
-          mesh_deformation_variables = std_cxx14::make_unique<internal::MeshDeformationPostprocessor<dim>>();
+          mesh_deformation_variables = std::make_unique<internal::MeshDeformationPostprocessor<dim>>();
           mesh_deformation_variables->initialize_simulator(this->get_simulator());
 
           // Insert mesh deformation variable names into set of all output field names

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -78,7 +78,7 @@ namespace aspect
                     in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, out);
 
 
@@ -89,7 +89,7 @@ namespace aspect
                     in.pressure[0]=this->get_adiabatic_conditions().pressure(in.position[0]);
 
                     adiabatic_out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, adiabatic_out);
 
 
@@ -137,7 +137,7 @@ namespace aspect
                     in.reinit (fe_values, cell, this->introspection(), this->get_solution(), /* compute_strain_rate = */ false);
 
                     out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, out);
 
                     MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
@@ -213,7 +213,7 @@ namespace aspect
                     in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>>(n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>>(n_q_points));
                     this->get_material_model().evaluate(in, out);
 
                     // Substitute the adiabatic reference state for temperature and pressure,
@@ -222,7 +222,7 @@ namespace aspect
                     in.pressure[0]=this->get_adiabatic_conditions().pressure(in.position[0]);
 
                     adiabatic_out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, adiabatic_out);
 
 
@@ -295,7 +295,7 @@ namespace aspect
                     in.current_cell = cell;
 
                     out.additional_outputs.push_back(
-                      std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
+                      std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, out);
 
                     MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -59,7 +59,7 @@ namespace aspect
                                                      this->n_compositional_fields());
 
         out.additional_outputs.push_back(
-          std_cxx14::make_unique<MaterialModel::MaterialModelDerivatives<dim>> (n_quadrature_points));
+          std::make_unique<MaterialModel::MaterialModelDerivatives<dim>> (n_quadrature_points));
 
         this->get_material_model().evaluate(in, out);
 

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -198,23 +198,23 @@ namespace aspect
                                  update_flags),
           face_finite_element_values (face_quadrature.size() > 0
                                       ?
-                                      std_cxx14::make_unique<FEFaceValues<dim>> (mapping,
-                                                                                 finite_element, face_quadrature,
-                                                                                 face_update_flags)
+                                      std::make_unique<FEFaceValues<dim>> (mapping,
+                                                                           finite_element, face_quadrature,
+                                                                           face_update_flags)
                                       :
                                       nullptr),
           neighbor_face_finite_element_values (face_quadrature.size() > 0
                                                ?
-                                               std_cxx14::make_unique<FEFaceValues<dim>> (mapping,
-                                                                                          finite_element, face_quadrature,
-                                                                                          face_update_flags)
+                                               std::make_unique<FEFaceValues<dim>> (mapping,
+                                                                                    finite_element, face_quadrature,
+                                                                                    face_update_flags)
                                                :
                                                nullptr),
           subface_finite_element_values (face_quadrature.size() > 0
                                          ?
-                                         std_cxx14::make_unique<FESubfaceValues<dim>> (mapping,
-                                                                                       finite_element, face_quadrature,
-                                                                                       face_update_flags)
+                                         std::make_unique<FESubfaceValues<dim>> (mapping,
+                                                                                 finite_element, face_quadrature,
+                                                                                 face_update_flags)
                                          :
                                          nullptr),
           local_dof_indices (finite_element.dofs_per_cell),
@@ -286,26 +286,26 @@ namespace aspect
                                  scratch.finite_element_values.get_update_flags()),
           face_finite_element_values (scratch.face_finite_element_values.get()
                                       ?
-                                      std_cxx14::make_unique<FEFaceValues<dim>> (scratch.face_finite_element_values->get_mapping(),
-                                                                                 scratch.face_finite_element_values->get_fe(),
-                                                                                 scratch.face_finite_element_values->get_quadrature(),
-                                                                                 scratch.face_finite_element_values->get_update_flags())
+                                      std::make_unique<FEFaceValues<dim>> (scratch.face_finite_element_values->get_mapping(),
+                                                                           scratch.face_finite_element_values->get_fe(),
+                                                                           scratch.face_finite_element_values->get_quadrature(),
+                                                                           scratch.face_finite_element_values->get_update_flags())
                                       :
                                       nullptr),
           neighbor_face_finite_element_values (scratch.neighbor_face_finite_element_values.get()
                                                ?
-                                               std_cxx14::make_unique<FEFaceValues<dim>> (scratch.neighbor_face_finite_element_values->get_mapping(),
-                                                                                          scratch.neighbor_face_finite_element_values->get_fe(),
-                                                                                          scratch.neighbor_face_finite_element_values->get_quadrature(),
-                                                                                          scratch.neighbor_face_finite_element_values->get_update_flags())
+                                               std::make_unique<FEFaceValues<dim>> (scratch.neighbor_face_finite_element_values->get_mapping(),
+                                                                                    scratch.neighbor_face_finite_element_values->get_fe(),
+                                                                                    scratch.neighbor_face_finite_element_values->get_quadrature(),
+                                                                                    scratch.neighbor_face_finite_element_values->get_update_flags())
                                                :
                                                nullptr),
           subface_finite_element_values (scratch.subface_finite_element_values.get()
                                          ?
-                                         std_cxx14::make_unique<FESubfaceValues<dim>> (scratch.subface_finite_element_values->get_mapping(),
-                                                                                       scratch.subface_finite_element_values->get_fe(),
-                                                                                       scratch.subface_finite_element_values->get_quadrature(),
-                                                                                       scratch.subface_finite_element_values->get_update_flags())
+                                         std::make_unique<FESubfaceValues<dim>> (scratch.subface_finite_element_values->get_mapping(),
+                                                                                 scratch.subface_finite_element_values->get_fe(),
+                                                                                 scratch.subface_finite_element_values->get_quadrature(),
+                                                                                 scratch.subface_finite_element_values->get_update_flags())
                                          :
                                          nullptr),
           local_dof_indices (scratch.finite_element_values.get_fe().dofs_per_cell),

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -502,7 +502,7 @@ namespace aspect
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
@@ -514,7 +514,7 @@ namespace aspect
           outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_elasticity
@@ -527,7 +527,7 @@ namespace aspect
           && outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
+            std::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_prescribed_dilation

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -450,7 +450,7 @@ namespace aspect
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
@@ -463,7 +463,7 @@ namespace aspect
           && outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
+            std::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_prescribed_dilation
@@ -476,7 +476,7 @@ namespace aspect
           outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
         }
 
       Assert(!this->get_parameters().enable_elasticity

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -122,31 +122,31 @@ namespace aspect
   Simulator<dim>::
   set_stokes_assemblers()
   {
-    assemblers->stokes_preconditioner.push_back(std_cxx14::make_unique<aspect::Assemblers::StokesPreconditioner<dim>>());
-    assemblers->stokes_system.push_back(std_cxx14::make_unique<aspect::Assemblers::StokesIncompressibleTerms<dim>>());
+    assemblers->stokes_preconditioner.push_back(std::make_unique<aspect::Assemblers::StokesPreconditioner<dim>>());
+    assemblers->stokes_system.push_back(std::make_unique<aspect::Assemblers::StokesIncompressibleTerms<dim>>());
 
     if (material_model->is_compressible())
       {
         // The compressible part of the preconditioner is only necessary if we use the simplified A block
         if (parameters.use_full_A_block_preconditioner == false)
           assemblers->stokes_preconditioner.push_back(
-            std_cxx14::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
+            std::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
 
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesCompressibleStrainRateViscosityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesCompressibleStrainRateViscosityTerm<dim>>());
       }
 
     if (parameters.formulation_mass_conservation ==
         Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile)
       {
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesImplicitReferenceDensityCompressibilityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesImplicitReferenceDensityCompressibilityTerm<dim>>());
       }
     else if (parameters.formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::reference_density_profile)
       {
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesReferenceDensityCompressibilityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesReferenceDensityCompressibilityTerm<dim>>());
       }
     else if (parameters.formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::incompressible)
@@ -157,20 +157,20 @@ namespace aspect
              Parameters<dim>::Formulation::MassConservation::isentropic_compression)
       {
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesIsentropicCompressionTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesIsentropicCompressionTerm<dim>>());
       }
     else if (parameters.formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::hydrostatic_compression)
       {
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesHydrostaticCompressionTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesHydrostaticCompressionTerm<dim>>());
       }
     else if (parameters.formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::projected_density_field)
       {
         CitationInfo::add("pda");
         assemblers->stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesProjectedDensityFieldTerm<dim>>());
+          std::make_unique<aspect::Assemblers::StokesProjectedDensityFieldTerm<dim>>());
       }
     else
       AssertThrow(false,
@@ -181,13 +181,13 @@ namespace aspect
     if (!boundary_traction.empty())
       {
         assemblers->stokes_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());
+          std::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());
       }
 
     // add the terms necessary to normalize the pressure
     if (do_pressure_rhs_compatibility_modification)
       assemblers->stokes_system.push_back(
-        std_cxx14::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim>>());
+        std::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim>>());
 
   }
 
@@ -197,13 +197,13 @@ namespace aspect
   set_advection_assemblers()
   {
     assemblers->advection_system.push_back(
-      std_cxx14::make_unique<aspect::Assemblers::AdvectionSystem<dim>>());
+      std::make_unique<aspect::Assemblers::AdvectionSystem<dim>>());
 
     // add the diffusion assemblers if we have fields that use this method
     if (std::find(parameters.compositional_field_methods.begin(), parameters.compositional_field_methods.end(),
                   Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion) != parameters.compositional_field_methods.end())
       assemblers->advection_system.push_back(
-        std_cxx14::make_unique<aspect::Assemblers::DiffusionSystem<dim>>());
+        std::make_unique<aspect::Assemblers::DiffusionSystem<dim>>());
 
     if (parameters.use_discontinuous_temperature_discretization ||
         parameters.use_discontinuous_composition_discretization)
@@ -226,16 +226,16 @@ namespace aspect
                                "Please switch off any of those options or run on a single process."));
 
         assemblers->advection_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim>>());
+          std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryFace<dim>>());
 
         assemblers->advection_system_on_interior_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemInteriorFace<dim>>());
+          std::make_unique<aspect::Assemblers::AdvectionSystemInteriorFace<dim>>());
       }
 
     if (parameters.fixed_heat_flux_boundary_indicators.size() != 0)
       {
         assemblers->advection_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
+          std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
       }
 
     if (parameters.use_discontinuous_temperature_discretization
@@ -457,11 +457,11 @@ namespace aspect
                                       constant_modes);
 
     if (parameters.include_melt_transport)
-      Mp_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionAMG>();
+      Mp_preconditioner = std::make_unique<LinearAlgebra::PreconditionAMG>();
     else
-      Mp_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionILU>();
+      Mp_preconditioner = std::make_unique<LinearAlgebra::PreconditionILU>();
 
-    Amg_preconditioner = std_cxx14::make_unique<LinearAlgebra::PreconditionAMG>();
+    Amg_preconditioner = std::make_unique<LinearAlgebra::PreconditionAMG>();
 
     LinearAlgebra::PreconditionAMG::AdditionalData Amg_data;
     Amg_data.constant_modes = constant_modes;

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -289,7 +289,7 @@ namespace aspect
       if (parameters.mesh_deformation_enabled)
         {
           mesh_deformation_trans
-            = std_cxx14::make_unique<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>>
+            = std::make_unique<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>>
               (mesh_deformation->mesh_deformation_dof_handler);
 
           x_fs_system[0] = &mesh_deformation->mesh_displacements;

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -107,11 +107,11 @@ namespace aspect
                                                  const InitialTopographyModel::Interface<dim> &initial_topography_model)
     {
       if (geometry_model.has_curved_elements())
-        return std_cxx14::make_unique<MappingQCache<dim>>(4);
+        return std::make_unique<MappingQCache<dim>>(4);
       if (Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(initial_topography_model))
-        return std_cxx14::make_unique<MappingCartesian<dim>>();
+        return std::make_unique<MappingCartesian<dim>>();
 
-      return std_cxx14::make_unique<MappingQ1<dim>>();
+      return std::make_unique<MappingQ1<dim>>();
     }
   }
 
@@ -138,19 +138,19 @@ namespace aspect
                              ParameterHandler &prm)
     :
     simulator_is_past_initialization (false),
-    assemblers (std_cxx14::make_unique<Assemblers::Manager<dim>>()),
+    assemblers (std::make_unique<Assemblers::Manager<dim>>()),
     parameters (prm, mpi_communicator_),
     melt_handler (parameters.include_melt_transport ?
-                  std_cxx14::make_unique<MeltHandler<dim>>(prm) :
+                  std::make_unique<MeltHandler<dim>>(prm) :
                   nullptr),
     newton_handler (Parameters<dim>::is_defect_correction(parameters.nonlinear_solver) ?
-                    std_cxx14::make_unique<NewtonHandler<dim>>() :
+                    std::make_unique<NewtonHandler<dim>>() :
                     nullptr),
     post_signal_creation(
       std::bind (&internals::SimulatorSignals::call_connector_functions<dim>,
                  std::ref(signals))),
     volume_of_fluid_handler (parameters.volume_of_fluid_tracking_enabled ?
-                             std_cxx14::make_unique<VolumeOfFluidHandler<dim>> (*this, prm) :
+                             std::make_unique<VolumeOfFluidHandler<dim>> (*this, prm) :
                              nullptr),
     introspection (construct_variables<dim>(parameters, signals, melt_handler), parameters),
     mpi_communicator (Utilities::MPI::duplicate_communicator (mpi_communicator_)),
@@ -183,7 +183,7 @@ namespace aspect
     adiabatic_conditions (AdiabaticConditions::create_adiabatic_conditions<dim>(prm)),
 #ifdef ASPECT_WITH_WORLD_BUILDER
     world_builder (parameters.world_builder_file != "" ?
-                   std_cxx14::make_unique<WorldBuilder::World>(parameters.world_builder_file) :
+                   std::make_unique<WorldBuilder::World>(parameters.world_builder_file) :
                    nullptr),
 #endif
     boundary_heat_flux (BoundaryHeatFlux::create_boundary_heat_flux<dim>(prm)),
@@ -363,7 +363,7 @@ namespace aspect
         parameters.use_full_A_block_preconditioner = true;
 
         // Allocate the MeshDeformationHandler object
-        mesh_deformation = std_cxx14::make_unique<MeshDeformation::MeshDeformationHandler<dim>>(*this);
+        mesh_deformation = std::make_unique<MeshDeformation::MeshDeformationHandler<dim>>(*this);
         mesh_deformation->initialize_simulator(*this);
         mesh_deformation->parse_parameters(prm);
         mesh_deformation->initialize();
@@ -394,10 +394,10 @@ namespace aspect
         switch (parameters.stokes_velocity_degree)
           {
             case 2:
-              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImplementation<dim,2>>(*this, prm);
+              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,2>>(*this, prm);
               break;
             case 3:
-              stokes_matrix_free = std_cxx14::make_unique<StokesMatrixFreeHandlerImplementation<dim,3>>(*this, prm);
+              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,3>>(*this, prm);
               break;
             default:
               AssertThrow(false, ExcMessage("The finite element degree for the Stokes system you selected is not supported yet."));
@@ -1596,7 +1596,7 @@ namespace aspect
           x_fs_system[1] = &mesh_deformation->old_mesh_displacements;
           x_fs_system[2] = &mesh_deformation->initial_topography;
           mesh_deformation_trans
-            = std_cxx14::make_unique<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>>
+            = std::make_unique<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>>
               (mesh_deformation->mesh_deformation_dof_handler);
         }
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -280,7 +280,7 @@ namespace aspect
     // but, as mentioned above, if we could use C++14, we wouldn't have to
     // use a pointer in the first place.)
     std::shared_ptr<TableHandler> statistics_copy_ptr
-      = std_cxx14::make_unique<TableHandler>(statistics);
+      = std::make_unique<TableHandler>(statistics);
     auto write_statistics
       = [statistics_copy_ptr,this]()
     {

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -795,7 +795,7 @@ namespace aspect
           }
         else if (property_names[property_index] == "rising_velocity")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageRisingVelocity<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageRisingVelocity<dim>>
                                (this->introspection().extractors.velocities,
                                 &this->get_gravity_model(),
                                 this->convert_output_to_years()));

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -230,7 +230,7 @@ namespace aspect
                                                   MaterialModel::MaterialModelOutputs<dim> &outputs) const override
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
 
         void operator()(const MaterialModel::MaterialModelInputs<dim> &,
@@ -526,10 +526,10 @@ namespace aspect
 
     std::unique_ptr<Quadrature<dim>> quadrature_formula;
     if (geometry_unique_depth_direction != numbers::invalid_unsigned_int)
-      quadrature_formula = std_cxx14::make_unique<Quadrature<dim>>(internal::get_quadrature_formula<dim>(lateral_quadrature_degree,
-                                                                   geometry_unique_depth_direction));
+      quadrature_formula = std::make_unique<Quadrature<dim>>(internal::get_quadrature_formula<dim>(lateral_quadrature_degree,
+                                                             geometry_unique_depth_direction));
     else
-      quadrature_formula = std_cxx14::make_unique<Quadrature<dim>>(QIterated<dim>(QMidpoint<1>(),10));
+      quadrature_formula = std::make_unique<Quadrature<dim>>(QIterated<dim>(QMidpoint<1>(),10));
 
     const unsigned int n_q_points = quadrature_formula->size();
 
@@ -769,7 +769,7 @@ namespace aspect
       {
         if (property_names[property_index] == "temperature")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageField<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageField<dim>>
                                (this->introspection().extractors.temperature));
           }
         else if (this->introspection().compositional_name_exists(property_names[property_index]))
@@ -777,18 +777,18 @@ namespace aspect
             const unsigned int c =
               this->introspection().compositional_index_for_name(property_names[property_index]);
 
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageField<dim>> (
+            functors.push_back(std::make_unique<FunctorDepthAverageField<dim>> (
                                  this->introspection().extractors.compositional_fields[c]));
           }
         else if (property_names[property_index] == "velocity_magnitude")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageVelocityMagnitude<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageVelocityMagnitude<dim>>
                                (this->introspection().extractors.velocities,
                                 this->convert_output_to_years()));
           }
         else if (property_names[property_index] == "sinking_velocity")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageSinkingVelocity<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageSinkingVelocity<dim>>
                                (this->introspection().extractors.velocities,
                                 &this->get_gravity_model(),
                                 this->convert_output_to_years()));
@@ -802,26 +802,26 @@ namespace aspect
           }
         else if (property_names[property_index] == "Vs")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageVsVp<dim>> (true /* Vs */));
+            functors.push_back(std::make_unique<FunctorDepthAverageVsVp<dim>> (true /* Vs */));
           }
         else if (property_names[property_index] == "Vp")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageVsVp<dim>> (false /* Vp */));
+            functors.push_back(std::make_unique<FunctorDepthAverageVsVp<dim>> (false /* Vp */));
           }
         else if (property_names[property_index] == "viscosity")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageViscosity<dim>>());
+            functors.push_back(std::make_unique<FunctorDepthAverageViscosity<dim>>());
           }
         else if (property_names[property_index] == "vertical_heat_flux")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageVerticalHeatFlux<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageVerticalHeatFlux<dim>>
                                (this->introspection().extractors.velocities,
                                 this->introspection().extractors.temperature,
                                 &this->get_gravity_model()));
           }
         else if (property_names[property_index] == "vertical_mass_flux")
           {
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageVerticalMassFlux<dim>>
+            functors.push_back(std::make_unique<FunctorDepthAverageVerticalMassFlux<dim>>
                                (this->introspection().extractors.velocities,
                                 &this->get_gravity_model()));
           }
@@ -831,7 +831,7 @@ namespace aspect
             const unsigned int c =
               this->introspection().compositional_index_for_name(property_names[property_index].substr(0, property_names[property_index].size()-5));
 
-            functors.push_back(std_cxx14::make_unique<FunctorDepthAverageFieldMass<dim>> (
+            functors.push_back(std::make_unique<FunctorDepthAverageFieldMass<dim>> (
                                  this->introspection().extractors.compositional_fields[c]));
           }
         else

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -170,7 +170,7 @@ namespace aspect
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>(n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>(n_points));
         }
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
@@ -1638,8 +1638,8 @@ namespace aspect
   MeltHandler<dim>::
   set_assemblers (Assemblers::Manager<dim> &assemblers) const
   {
-    assemblers.stokes_preconditioner.push_back(std_cxx14::make_unique<Assemblers::MeltStokesPreconditioner<dim>> ());
-    assemblers.stokes_system.push_back(std_cxx14::make_unique<Assemblers::MeltStokesSystem<dim>> ());
+    assemblers.stokes_preconditioner.push_back(std::make_unique<Assemblers::MeltStokesPreconditioner<dim>> ());
+    assemblers.stokes_system.push_back(std::make_unique<Assemblers::MeltStokesSystem<dim>> ());
 
     AssertThrow((this->get_parameters().formulation_mass_conservation ==
                  Parameters<dim>::Formulation::MassConservation::isentropic_compression) ||
@@ -1656,29 +1656,29 @@ namespace aspect
 
 
     assemblers.stokes_system_on_boundary_face.push_back(
-      std_cxx14::make_unique<aspect::Assemblers::MeltStokesSystemBoundary<dim>>());
+      std::make_unique<aspect::Assemblers::MeltStokesSystemBoundary<dim>>());
 
     // add the terms for traction boundary conditions
     if (!this->get_boundary_traction().empty())
       {
         assemblers.stokes_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<Assemblers::MeltBoundaryTraction<dim>> ());
+          std::make_unique<Assemblers::MeltBoundaryTraction<dim>> ());
       }
 
     // add the terms necessary to normalize the pressure
     if (this->pressure_rhs_needs_compatibility_modification())
       {
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<Assemblers::MeltPressureRHSCompatibilityModification<dim>> ());
+          std::make_unique<Assemblers::MeltPressureRHSCompatibilityModification<dim>> ());
       }
 
     assemblers.advection_system.push_back(
-      std_cxx14::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());
+      std::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());
 
     if (this->get_parameters().fixed_heat_flux_boundary_indicators.size() != 0)
       {
         assemblers.advection_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
+          std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
         assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
         assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
       }
@@ -1808,7 +1808,7 @@ namespace aspect
     const unsigned int n_points = output.viscosities.size();
     const unsigned int n_comp = output.reaction_terms[0].size();
     output.additional_outputs.push_back(
-      std_cxx14::make_unique<MaterialModel::MeltOutputs<dim>> (n_points, n_comp));
+      std::make_unique<MaterialModel::MeltOutputs<dim>> (n_points, n_comp));
   }
 
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -48,29 +48,29 @@ namespace aspect
   NewtonHandler<dim>::
   set_assemblers (Assemblers::Manager<dim> &assemblers) const
   {
-    assemblers.stokes_preconditioner.push_back(std_cxx14::make_unique<aspect::Assemblers::NewtonStokesPreconditioner<dim>>());
-    assemblers.stokes_system.push_back(std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIncompressibleTerms<dim>>());
+    assemblers.stokes_preconditioner.push_back(std::make_unique<aspect::Assemblers::NewtonStokesPreconditioner<dim>>());
+    assemblers.stokes_system.push_back(std::make_unique<aspect::Assemblers::NewtonStokesIncompressibleTerms<dim>>());
 
     if (this->get_material_model().is_compressible())
       {
         assemblers.stokes_preconditioner.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
+          std::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
 
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesCompressibleStrainRateViscosityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::NewtonStokesCompressibleStrainRateViscosityTerm<dim>>());
       }
 
     if (this->get_parameters().formulation_mass_conservation ==
         Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile)
       {
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesImplicitReferenceDensityCompressibilityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::NewtonStokesImplicitReferenceDensityCompressibilityTerm<dim>>());
       }
     else if (this->get_parameters().formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::reference_density_profile)
       {
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesReferenceDensityCompressibilityTerm<dim>>());
+          std::make_unique<aspect::Assemblers::NewtonStokesReferenceDensityCompressibilityTerm<dim>>());
       }
     else if (this->get_parameters().formulation_mass_conservation ==
              Parameters<dim>::Formulation::MassConservation::incompressible)
@@ -81,7 +81,7 @@ namespace aspect
              Parameters<dim>::Formulation::MassConservation::isentropic_compression)
       {
         assemblers.stokes_system.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::NewtonStokesIsentropicCompressionTerm<dim>>());
+          std::make_unique<aspect::Assemblers::NewtonStokesIsentropicCompressionTerm<dim>>());
       }
     else
       AssertThrow(false,
@@ -92,13 +92,13 @@ namespace aspect
     if (!this->get_boundary_traction().empty())
       {
         assemblers.stokes_system_on_boundary_face.push_back(
-          std_cxx14::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());
+          std::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());
       }
 
     // add the terms necessary to normalize the pressure
     if (this->pressure_rhs_needs_compatibility_modification())
       assemblers.stokes_system.push_back(
-        std_cxx14::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim>>());
+        std::make_unique<aspect::Assemblers::StokesPressureRHSCompatibilityModification<dim>>());
   }
 
 
@@ -113,7 +113,7 @@ namespace aspect
 
     const unsigned int n_points = output.viscosities.size();
     output.additional_outputs.push_back(
-      std_cxx14::make_unique<MaterialModel::MaterialModelDerivatives<dim>>(n_points));
+      std::make_unique<MaterialModel::MaterialModelDerivatives<dim>>(n_points));
   }
 
 

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -226,9 +226,9 @@ namespace aspect
                 }
 
               data[c]
-                = std_cxx14::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
-                                                                                       table_intervals,
-                                                                                       std::move(data_table[c]));
+                = std::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
+                                                                                 table_intervals,
+                                                                                 std::move(data_table[c]));
             }
           else
             // Create the object and move the big objects. Due to an old design flaw,
@@ -244,7 +244,7 @@ namespace aspect
             // create a temporary object, and that's an rvalue that the constructor
             // we call would bind to. But never a bad idea to be explicit.)
             data[c]
-              = std_cxx14::make_unique<Functions::InterpolatedTensorProductGridData<dim>>
+              = std::make_unique<Functions::InterpolatedTensorProductGridData<dim>>
                 (std::move(std::array<std::vector<double>,dim>(this->coordinate_values)),
                  std::move(data_table[c]));
         }
@@ -567,12 +567,12 @@ namespace aspect
       for (const auto &boundary_id : boundary_ids)
         {
           lookups.insert(std::make_pair(boundary_id,
-                                        std_cxx14::make_unique<Utilities::StructuredDataLookup<dim-1>>
+                                        std::make_unique<Utilities::StructuredDataLookup<dim-1>>
                                         (components,
                                          this->scale_factor)));
 
           old_lookups.insert(std::make_pair(boundary_id,
-                                            std_cxx14::make_unique<Utilities::StructuredDataLookup<dim-1>>
+                                            std::make_unique<Utilities::StructuredDataLookup<dim-1>>
                                             (components,
                                              this->scale_factor)));
 
@@ -1078,8 +1078,8 @@ namespace aspect
                                   +
                                   "> not found!"));
 
-          lookups.push_back(std_cxx14::make_unique<Utilities::StructuredDataLookup<dim-1>> (components,
-                            this->scale_factor));
+          lookups.push_back(std::make_unique<Utilities::StructuredDataLookup<dim-1>> (components,
+                                                                                      this->scale_factor));
           lookups[i]->load_file(filename,this->get_mpi_communicator());
         }
     }
@@ -1235,8 +1235,8 @@ namespace aspect
                    ExcMessage ("This ascii data plugin can only be used when using "
                                "a spherical shell, chunk, or box geometry."));
 
-      lookup = std_cxx14::make_unique<Utilities::StructuredDataLookup<dim>> (components,
-                                                                             this->scale_factor);
+      lookup = std::make_unique<Utilities::StructuredDataLookup<dim>> (components,
+                                                                       this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
 
@@ -1287,7 +1287,7 @@ namespace aspect
     void
     AsciiDataProfile<dim>::initialize (const MPI_Comm &communicator)
     {
-      lookup = std_cxx14::make_unique<Utilities::StructuredDataLookup<1>> (this->scale_factor);
+      lookup = std::make_unique<Utilities::StructuredDataLookup<1>> (this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
 

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -79,7 +79,7 @@ namespace aspect
           return;
 
         std::cout << "   creating additional output!" << std::endl;
-        out.additional_outputs.push_back(std_cxx14::make_unique<MaterialModel::AdditionalOutputs1<dim> > (1));
+        out.additional_outputs.push_back(std::make_unique<MaterialModel::AdditionalOutputs1<dim> > (1));
 
       }
 

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -93,7 +93,7 @@ namespace aspect
           return;
 
         std::cout << "   creating additional output!" << std::endl;
-        out.additional_outputs.push_back(std_cxx14::make_unique<MaterialModel::AdditionalOutputs1<dim> > (2));
+        out.additional_outputs.push_back(std::make_unique<MaterialModel::AdditionalOutputs1<dim> > (2));
 
       }
 

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -223,7 +223,7 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
     }
 
@@ -405,14 +405,14 @@ namespace aspect
       if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> >() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
@@ -578,7 +578,7 @@ namespace aspect
       if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim> >() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
+            std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       this->get_material_model().create_additional_named_outputs(material_model_outputs);
@@ -630,17 +630,17 @@ namespace aspect
       for (unsigned int i=0; i<assemblers.stokes_preconditioner.size(); ++i)
         {
           if (dynamic_cast<Assemblers::StokesPreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != nullptr)
-            assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim> > ();
+            assemblers.stokes_preconditioner[i] = std::make_unique<Assemblers::StokesPreconditionerAnisotropicViscosity<dim> > ();
           if (dynamic_cast<Assemblers::StokesCompressiblePreconditioner<dim> *>(assemblers.stokes_preconditioner[i].get()) != nullptr)
-            assemblers.stokes_preconditioner[i] = std_cxx14::make_unique<Assemblers::StokesCompressiblePreconditionerAnisotropicViscosity<dim> > ();
+            assemblers.stokes_preconditioner[i] = std::make_unique<Assemblers::StokesCompressiblePreconditionerAnisotropicViscosity<dim> > ();
         }
 
       for (unsigned int i=0; i<assemblers.stokes_system.size(); ++i)
         {
           if (dynamic_cast<Assemblers::StokesIncompressibleTerms<dim> *>(assemblers.stokes_system[i].get()) != nullptr)
-            assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim> > ();
+            assemblers.stokes_system[i] = std::make_unique<Assemblers::StokesIncompressibleTermsAnisotropicViscosity<dim> > ();
           if (dynamic_cast<Assemblers::StokesCompressibleStrainRateViscosityTerm<dim> *>(assemblers.stokes_system[i].get()) != nullptr)
-            assemblers.stokes_system[i] = std_cxx14::make_unique<Assemblers::StokesCompressibleStrainRateViscosityTermAnisotropicViscosity<dim> > ();
+            assemblers.stokes_system[i] = std::make_unique<Assemblers::StokesCompressibleStrainRateViscosityTermAnisotropicViscosity<dim> > ();
         }
     }
 

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -136,7 +136,7 @@ namespace aspect
   {
     prm.enter_subsection("Boundary velocity model");
     {
-      member = std_cxx14::make_unique<Utilities::AsciiDataBoundary<dim>>();
+      member = std::make_unique<Utilities::AsciiDataBoundary<dim>>();
       member->initialize_simulator(this->get_simulator());
 
       member->parse_parameters(prm);

--- a/tests/burstedde_stokes_rhs.cc
+++ b/tests/burstedde_stokes_rhs.cc
@@ -383,7 +383,7 @@ namespace aspect
         material_model
           = dynamic_cast<const BursteddeMaterial<dim> *>(&this->get_material_model());
 
-        ref_func = std_cxx14::make_unique<AnalyticSolutions::FunctionBurstedde<dim>>(material_model->get_beta());
+        ref_func = std::make_unique<AnalyticSolutions::FunctionBurstedde<dim>>(material_model->get_beta());
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -24,7 +24,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   // Next, we initialise instances of the composite rheology and
   // individual creep mechanisms.
   std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std_cxx14::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
   composite_creep->initialize_simulator (simulator_access.get_simulator());
   composite_creep->declare_parameters(prm);
   prm.set("Use plastic damper", "true");
@@ -33,25 +33,25 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   composite_creep->parse_parameters(prm, n_phases);
 
   std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std_cxx14::make_unique<Rheology::DiffusionCreep<dim>>();
+  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
   diffusion_creep->initialize_simulator (simulator_access.get_simulator());
   diffusion_creep->declare_parameters(prm);
   diffusion_creep->parse_parameters(prm, n_phases);
 
   std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std_cxx14::make_unique<Rheology::DislocationCreep<dim>>();
+  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
   dislocation_creep->initialize_simulator (simulator_access.get_simulator());
   dislocation_creep->declare_parameters(prm);
   dislocation_creep->parse_parameters(prm, n_phases);
 
   std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
-  peierls_creep = std_cxx14::make_unique<Rheology::PeierlsCreep<dim>>();
+  peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
   peierls_creep->initialize_simulator (simulator_access.get_simulator());
   peierls_creep->declare_parameters(prm);
   peierls_creep->parse_parameters(prm, n_phases);
 
   std::unique_ptr<Rheology::DruckerPrager<dim>> drucker_prager;
-  drucker_prager = std_cxx14::make_unique<Rheology::DruckerPrager<dim>>();
+  drucker_prager = std::make_unique<Rheology::DruckerPrager<dim>>();
   drucker_prager->initialize_simulator (simulator_access.get_simulator());
   drucker_prager->declare_parameters(prm);
   prm.set("Use plastic damper", "true");

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -117,7 +117,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -132,7 +132,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 

--- a/tests/latent_heat_enthalpy.cc
+++ b/tests/latent_heat_enthalpy.cc
@@ -45,7 +45,7 @@ namespace aspect
           const std::string datadirectory = Utilities::expand_ASPECT_SOURCE_DIR("$ASPECT_SOURCE_DIR/data/material-model/latent-heat-enthalpy-test/");
           const std::string material_file_names  = "testdata.txt";
 
-          material_lookup = std_cxx14::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(datadirectory+material_file_names,
+          material_lookup = std::make_unique<MaterialModel::MaterialUtilities::Lookup::PerplexReader>(datadirectory+material_file_names,
                             true,
                             this->get_mpi_communicator());
         }

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -1022,7 +1022,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PlasticAdditionalOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::PlasticAdditionalOutputs<dim>> (n_points));
         }
     }
 

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -66,14 +66,14 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
+            std::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
         }
 
       if (out.template get_additional_output<SeismicAdditionalOutputs<dim> >() == NULL)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
     }
   }

--- a/tests/prescribed_dilation.cc
+++ b/tests/prescribed_dilation.cc
@@ -322,7 +322,7 @@ namespace aspect
         material_model
           = dynamic_cast<const MyMaterial<dim> *>(&this->get_material_model());
 
-        ref_func = std_cxx14::make_unique<AnalyticSolutions::Exact<dim>>(material_model->get_eta());
+        ref_func = std::make_unique<AnalyticSolutions::Exact<dim>>(material_model->get_eta());
       }
 
       const QGauss<dim> quadrature_formula (this->introspection().polynomial_degree.velocities+2);

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -53,7 +53,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/tests/prescribed_field_temperature.cc
+++ b/tests/prescribed_field_temperature.cc
@@ -53,7 +53,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedTemperatureOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::PrescribedTemperatureOutputs<dim>> (n_points));
         }
     }
   }

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -56,7 +56,7 @@ namespace aspect
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
-            std_cxx14::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points, this->n_compositional_fields()));
         }
     }
   }

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -346,7 +346,7 @@ namespace aspect
           material_model
             = dynamic_cast<const InclusionMaterial<dim> *>(&this->get_material_model());
 
-          ref_func = std_cxx14::make_unique<AnalyticSolutions::FunctionInclusion<dim>>(material_model->get_eta_B());
+          ref_func = std::make_unique<AnalyticSolutions::FunctionInclusion<dim>>(material_model->get_eta_B());
         }
       else
         {

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -69,7 +69,7 @@ namespace aspect
           if (outputs.template get_additional_output<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>() == nullptr)
             {
               outputs.additional_outputs.push_back(
-                std_cxx14::make_unique<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>> (n_points));
+                std::make_unique<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>> (n_points));
             }
         }
 
@@ -224,7 +224,7 @@ namespace aspect
             {
               const unsigned int n_points = outputs.n_evaluation_points();
               outputs.additional_outputs.push_back(
-                std_cxx14::make_unique<UnscaledViscosityAdditionalOutputs<dim>> (n_points));
+                std::make_unique<UnscaledViscosityAdditionalOutputs<dim>> (n_points));
             }
         }
 
@@ -245,7 +245,7 @@ namespace aspect
         {
           prm.enter_subsection("Material model");
           {
-            reference_viscosity_profile = std_cxx14::make_unique<Rheology::AsciiDepthProfile<dim>>();
+            reference_viscosity_profile = std::make_unique<Rheology::AsciiDepthProfile<dim>>();
             reference_viscosity_profile->initialize_simulator (this->get_simulator());
             reference_viscosity_profile->parse_parameters(prm, "Depth dependent model");
             reference_viscosity_profile->initialize();

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -118,7 +118,7 @@ int f(double parameter)
   if (out_base.template get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   // initialize the material we want to test.
   SimpleNonlinear<dim> mat;

--- a/tests/spiegelman_material.cc
+++ b/tests/spiegelman_material.cc
@@ -132,7 +132,7 @@ int f(double parameter)
   if (out_base.get_additional_output<MaterialModelDerivatives<dim> >() != nullptr)
     throw "error";
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   SpiegelmanMaterial<dim> mat;
   ParameterHandler prm;

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -123,7 +123,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -138,7 +138,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
 
-  out_base.additional_outputs.push_back(std_cxx14::make_unique<MaterialModelDerivatives<dim> > (5));
+  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim> > (5));
 
   simulator_access.get_material_model().evaluate(in_base, out_base);
 


### PR DESCRIPTION
We had to write the latter before because `make_unique` didn't make it into C++11. But we now require C++14, so this is no longer necessary.

/rebuild