### PR TITLE
Remove an unused variable in the multicomponent incompressible model.

### DIFF
--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -120,13 +120,6 @@ namespace aspect
            * for the background field.
            */
           std::vector<double> specific_heats;
-
-          /**
-           * A vector that stores how many separate phases there are per compositional
-           * field. In other words if there is a background field without phase transitions
-           * and one more composition that has 2 phase transitions this vector would store {1,3}.
-           */
-          std::shared_ptr<std::vector<unsigned int>> n_phases_per_composition;
       };
     }
   }


### PR DESCRIPTION
It turns out that this variable isn't used -- I suspect it's a copy-paste left-over. Found while working on #4187 .

/rebuild