### PR TITLE
[WIP] Backup current_linearization_point for use in composition reaction_terms

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -2060,6 +2060,10 @@ namespace aspect
       LinearAlgebra::BlockVector                                system_rhs;
 
       LinearAlgebra::BlockVector                                current_linearization_point;
+      // A copy of the linearization point at the beginning of each timestep,
+      // so that composition reaction terms depending on the composition can use the
+      // composition at the beginning of the timestep. 
+      LinearAlgebra::BlockVector                                initial_linearization_point;
 
       // only used if is_compressible()
       LinearAlgebra::BlockVector                                pressure_shape_function_integrals;

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -2062,7 +2062,7 @@ namespace aspect
       LinearAlgebra::BlockVector                                current_linearization_point;
       // A copy of the linearization point at the beginning of each timestep,
       // so that composition reaction terms depending on the composition can use the
-      // composition at the beginning of the timestep. 
+      // composition at the beginning of the timestep.
       LinearAlgebra::BlockVector                                initial_linearization_point;
 
       // only used if is_compressible()

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -429,6 +429,20 @@ namespace aspect
       get_current_linearization_point () const;
 
       /**
+       * Return a reference to the vector that has the current linearization
+       * point of the entire system, i.e. the velocity and pressure variables
+       * as well as the temperature and compositional fields, at the beginning
+       * of the timestep. It is not updated by subsequent solves, as is the
+       * current_linearization_point, so that it can be used to compute reaction
+       * terms for fields that depend on the particular field's value. 
+       *
+       * @note In general the vector is a distributed vector; however, it
+       * contains ghost elements for all locally relevant degrees of freedom.
+       */
+      const LinearAlgebra::BlockVector &
+      get_initial_linearization_point () const;
+
+      /**
        * Return a reference to the vector that has the current solution of the
        * entire system, i.e. the velocity and pressure variables as well as
        * the temperature and compositional fields.

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -434,7 +434,7 @@ namespace aspect
        * as well as the temperature and compositional fields, at the beginning
        * of the timestep. It is not updated by subsequent solves, as is the
        * current_linearization_point, so that it can be used to compute reaction
-       * terms for fields that depend on the particular field's value. 
+       * terms for fields that depend on the particular field's value.
        *
        * @note In general the vector is a distributed vector; however, it
        * contains ghost elements for all locally relevant degrees of freedom.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1392,6 +1392,7 @@ namespace aspect
     old_solution.reinit(introspection.index_sets.system_partitioning, introspection.index_sets.system_relevant_partitioning, mpi_communicator);
     old_old_solution.reinit(introspection.index_sets.system_partitioning, introspection.index_sets.system_relevant_partitioning, mpi_communicator);
     current_linearization_point.reinit (introspection.index_sets.system_partitioning, introspection.index_sets.system_relevant_partitioning, mpi_communicator);
+    initial_linearization_point.reinit (introspection.index_sets.system_partitioning, introspection.index_sets.system_relevant_partitioning, mpi_communicator);
 
     if (parameters.use_operator_splitting)
       operator_split_reaction_vector.reinit (introspection.index_sets.system_partitioning, introspection.index_sets.system_relevant_partitioning, mpi_communicator);
@@ -1733,6 +1734,11 @@ namespace aspect
     // start any scheme with an extrapolated value from the previous
     // two time steps if those are available
     initialize_current_linearization_point();
+
+    // Copy the current linearization point for use in composition
+    // reaction terms in iterative Advection solver schemes. 
+    initial_linearization_point = current_linearization_point;
+
 
     // The mesh deformation scheme is currently not built to work inside a nonlinear solver.
     // We do the mesh deformation execution at the beginning of the timestep for a specific reason.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1736,7 +1736,7 @@ namespace aspect
     initialize_current_linearization_point();
 
     // Copy the current linearization point for use in composition
-    // reaction terms in iterative Advection solver schemes. 
+    // reaction terms in iterative Advection solver schemes.
     initial_linearization_point = current_linearization_point;
 
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -282,6 +282,13 @@ namespace aspect
 
   template <int dim>
   const LinearAlgebra::BlockVector &
+  SimulatorAccess<dim>::get_initial_linearization_point () const
+  {
+    return simulator->initial_linearization_point;
+  }
+
+  template <int dim>
+  const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_solution () const
   {
     return simulator->solution;


### PR DESCRIPTION
Create a copy of the current_linearization_point at the beginning of each timestep to compute compositional reaction_terms for fields that are updated in an iterative Advection scheme. 

I'd like to discuss with @gassmoeller before actually using the backup.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
