### PR TITLE
Migrate support points function to utilities

### DIFF
--- a/cookbooks/prescribed_velocity/prescribed_velocity.cc
+++ b/cookbooks/prescribed_velocity/prescribed_velocity.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/parsed_function.h>
 #include <deal.II/fe/fe_values.h>
 #include <aspect/global.h>
+#include <aspect/utilities.h>
 #include <aspect/simulator_signals.h>
 
 namespace aspect
@@ -37,6 +38,8 @@ namespace aspect
   Functions::ParsedFunction<3> prescribed_velocity_indicator_function_3d (3);
   Functions::ParsedFunction<2> prescribed_velocity_function_2d (2);
   Functions::ParsedFunction<3> prescribed_velocity_function_3d (3);
+
+
 
   /**
    * Declare additional parameters.
@@ -78,6 +81,8 @@ namespace aspect
     }
     prm.leave_subsection ();
   }
+
+
 
   template <int dim>
   void parse_parameters(const Parameters<dim> &,
@@ -129,53 +134,7 @@ namespace aspect
     prm.leave_subsection ();
   }
 
-  /**
-   * This function retrieves the unit support points (in the unit cell) for the current element.
-   * The DGP element used when 'set Use locally conservative discretization = true' does not
-   * have support points. If these elements are in use, a fictitious support point at the cell
-   * center is returned for each shape function that corresponds to the pressure variable,
-   * whereas the support points for the velocity are correct; the fictitious points don't matter
-   * because we only use this function when interpolating the velocity variable, and ignore the
-   * evaluation at the pressure support points.
-   */
-  template <int dim>
-  std::vector< Point<dim>>
-                        get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access)
-  {
-    std::vector< Point<dim>> unit_support_points;
-    if ( !simulator_access.get_parameters().use_locally_conservative_discretization )
-      {
-        return simulator_access.get_fe().get_unit_support_points();
-      }
-    else
-      {
-        //special case for discontinuous pressure elements, which lack unit support points
-        std::vector< Point<dim>> unit_support_points;
-        const unsigned int dofs_per_cell = simulator_access.get_fe().dofs_per_cell;
-        for (unsigned int dof=0; dof < dofs_per_cell; ++dof)
-          {
-            // base will hold element, base_index holds node/shape function within that element
-            const unsigned int
-            base       = simulator_access.get_fe().system_to_base_index(dof).first.first,
-            base_index = simulator_access.get_fe().system_to_base_index(dof).second;
-            // get the unit support points for the relevant element
-            std::vector< Point<dim>> my_support_points = simulator_access.get_fe().base_element(base).get_unit_support_points();
-            if ( my_support_points.size() == 0 )
-              {
-                //manufacture a support point, arbitrarily at cell center
-                if ( dim==2 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5) );
-                if ( dim==3 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5,0.5) );
-              }
-            else
-              {
-                unit_support_points.push_back(my_support_points[base_index]);
-              }
-          }
-        return unit_support_points;
-      }
-  }
+
 
   /**
    * A set of helper functions that either return the point passed to it (if
@@ -206,6 +165,7 @@ namespace aspect
   }
 
 
+
   /**
    * This function is called by a signal which is triggered after the other constraints
    * have been calculated. This enables us to define additional constraints in the mass
@@ -217,7 +177,7 @@ namespace aspect
   {
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim>> points = get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim>> points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;

--- a/cookbooks/prescribed_velocity/prescribed_velocity.cc
+++ b/cookbooks/prescribed_velocity/prescribed_velocity.cc
@@ -177,7 +177,7 @@ namespace aspect
   {
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim>> points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim>> points = aspect::Utilities::get_unit_support_points(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;

--- a/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
+++ b/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
@@ -190,7 +190,7 @@ namespace aspect
 
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;

--- a/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
+++ b/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
@@ -46,6 +46,8 @@ namespace aspect
   Functions::ParsedFunction<2> prescribed_velocity_function_2d (2);
   Functions::ParsedFunction<3> prescribed_velocity_function_3d (3);
 
+
+
   /**
    * Declare additional parameters.
    */
@@ -84,6 +86,8 @@ namespace aspect
     }
     prm.leave_subsection ();
   }
+
+
 
   template <int dim>
   void parse_parameters(const Parameters<dim> &,
@@ -127,54 +131,6 @@ namespace aspect
 
 
   /**
-   * This function retrieves the unit support points (in the unit cell) for the current element.
-   * The DGP element used when 'set Use locally conservative discretization = true' does not
-   * have support points. If these elements are in use, a fictitious support point at the cell
-   * center is returned for each shape function that corresponds to the pressure variable,
-   * whereas the support points for the velocity are correct; the fictitious points don't matter
-   * because we only use this function when interpolating the velocity variable, and ignore the
-   * evaluation at the pressure support points.
-   */
-  template <int dim>
-  std::vector< Point<dim> >
-  get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access)
-  {
-    std::vector< Point<dim> > unit_support_points;
-    if ( !simulator_access.get_parameters().use_locally_conservative_discretization )
-      {
-        return simulator_access.get_fe().get_unit_support_points();
-      }
-    else
-      {
-        //special case for discontinuous pressure elements, which lack unit support points
-        std::vector< Point<dim> > unit_support_points;
-        const unsigned int dofs_per_cell = simulator_access.get_fe().dofs_per_cell;
-        for (unsigned int dof=0; dof < dofs_per_cell; ++dof)
-          {
-            // base will hold element, base_index holds node/shape function within that element
-            const unsigned int
-            base       = simulator_access.get_fe().system_to_base_index(dof).first.first,
-            base_index = simulator_access.get_fe().system_to_base_index(dof).second;
-            // get the unit support points for the relevant element
-            std::vector< Point<dim> > my_support_points = simulator_access.get_fe().base_element(base).get_unit_support_points();
-            if ( my_support_points.size() == 0 )
-              {
-                //manufacture a support point, arbitrarily at cell center
-                if ( dim==2 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5) );
-                if ( dim==3 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5,0.5) );
-              }
-            else
-              {
-                unit_support_points.push_back(my_support_points[base_index]);
-              }
-          }
-        return unit_support_points;
-      }
-  }
-
-  /**
    * A set of helper functions that either return the point passed to it (if
    * the current dimension is the same) or return a dummy value (otherwise).
    */
@@ -201,6 +157,7 @@ namespace aspect
     }
 
   }
+
 
 
   /**
@@ -233,7 +190,7 @@ namespace aspect
 
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim> > points = get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -203,13 +203,12 @@ namespace aspect
      * The DGP element used when 'set Use locally conservative discretization = true' does not
      * have support points. If these elements are in use, a fictitious support point at the cell
      * center is returned for each shape function that corresponds to the pressure variable,
-     * whereas the support points for the velocity are correct; the fictitious points don't matter
+     * whereas the support points for the velocity are correct. The fictitious points don't matter
      * because we only use this function when interpolating the velocity variable, and ignore the
      * evaluation at the pressure support points.
      */
     template <int dim>
-    std::vector<Point<dim>>
-                         get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access);
+    std::vector<Point<dim>> get_unit_support_points(const SimulatorAccess<dim> &simulator_access);
 
 
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -198,6 +198,19 @@ namespace aspect
     IndexSet extract_locally_active_dofs_with_component(const DoFHandler<dim> &dof_handler,
                                                         const ComponentMask &component_mask);
 
+    /**
+     * This function retrieves the unit support points (in the unit cell) for the current element.
+     * The DGP element used when 'set Use locally conservative discretization = true' does not
+     * have support points. If these elements are in use, a fictitious support point at the cell
+     * center is returned for each shape function that corresponds to the pressure variable,
+     * whereas the support points for the velocity are correct; the fictitious points don't matter
+     * because we only use this function when interpolating the velocity variable, and ignore the
+     * evaluation at the pressure support points.
+     */
+    template <int dim>
+    std::vector<Point<dim>>
+                         get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access);
+
 
 
     namespace Coordinates

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -431,10 +431,8 @@ namespace aspect
 
 
     template <int dim>
-    std::vector<Point<dim>>
-                         get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access)
+    std::vector<Point<dim>> get_unit_support_points(const SimulatorAccess<dim> &simulator_access)
     {
-      std::vector<Point<dim>> unit_support_points;
       if ( !simulator_access.get_parameters().use_locally_conservative_discretization )
         {
           return simulator_access.get_fe().get_unit_support_points();
@@ -442,16 +440,17 @@ namespace aspect
       else
         {
           //special case for discontinuous pressure elements, which lack unit support points
-          std::vector<Point<dim>> unit_support_points;
           const unsigned int dofs_per_cell = simulator_access.get_fe().dofs_per_cell;
+          std::vector<Point<dim>> unit_support_points;
+          unit_support_points.reserve(dofs_per_cell);
+
           for (unsigned int dof=0; dof < dofs_per_cell; ++dof)
             {
               // base will hold element, base_index holds node/shape function within that element
-              const unsigned int
-              base       = simulator_access.get_fe().system_to_base_index(dof).first.first,
-              base_index = simulator_access.get_fe().system_to_base_index(dof).second;
+              const unsigned int base       = simulator_access.get_fe().system_to_base_index(dof).first.first;
+              const unsigned int base_index = simulator_access.get_fe().system_to_base_index(dof).second;
               // get the unit support points for the relevant element
-              std::vector<Point<dim>> my_support_points = simulator_access.get_fe().base_element(base).get_unit_support_points();
+              const std::vector<Point<dim>> &my_support_points = simulator_access.get_fe().base_element(base).get_unit_support_points();
               if ( my_support_points.size() == 0 )
                 {
                   //manufacture a support point, arbitrarily at cell center
@@ -2363,7 +2362,7 @@ namespace aspect
   \
   template \
   std::vector<Point<dim>> \
-  get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access); \
+  get_unit_support_points(const SimulatorAccess<dim> &simulator_access); \
   \
   template \
   std::vector<std::string> \

--- a/tests/prescribed_velocity_dgp.cc
+++ b/tests/prescribed_velocity_dgp.cc
@@ -127,7 +127,7 @@ namespace aspect
   {
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;

--- a/tests/prescribed_velocity_dgp.cc
+++ b/tests/prescribed_velocity_dgp.cc
@@ -2,6 +2,7 @@
 #include <deal.II/base/parsed_function.h>
 #include <deal.II/fe/fe_values.h>
 #include <aspect/global.h>
+#include <aspect/utilities.h>
 #include <aspect/simulator_signals.h>
 
 namespace aspect
@@ -17,6 +18,8 @@ namespace aspect
   Functions::ParsedFunction<3> prescribed_velocity_indicator_function_3d (3);
   Functions::ParsedFunction<2> prescribed_velocity_function_2d (2);
   Functions::ParsedFunction<3> prescribed_velocity_function_3d (3);
+
+
 
   /**
    * Declare additional parameters.
@@ -58,6 +61,8 @@ namespace aspect
     }
     prm.leave_subsection ();
   }
+
+
 
   template <int dim>
   void parse_parameters(const Parameters<dim> &,
@@ -109,53 +114,7 @@ namespace aspect
     prm.leave_subsection ();
   }
 
-  /**
-   * This function retrieves the unit support points (in the unit cell) for the current element.
-   * The DGP element used when 'set Use locally conservative discretization = true' does not
-   * have support points. If these elements are in use, a fictitious support point at the cell
-   * center is returned for each shape function that corresponds to the pressure variable,
-   * whereas the support points for the velocity are correct; the fictitious points don't matter
-   * because we only use this function when interpolating the velocity variable, and ignore the
-   * evaluation at the pressure support points.
-   */
-  template <int dim>
-  std::vector< Point<dim> >
-  get_unit_support_points_for_velocity(const SimulatorAccess<dim> &simulator_access)
-  {
-    std::vector< Point<dim> > unit_support_points;
-    if ( !simulator_access.get_parameters().use_locally_conservative_discretization )
-      {
-        return simulator_access.get_fe().get_unit_support_points();
-      }
-    else
-      {
-        //special case for discontinuous pressure elements, which lack unit support points
-        std::vector< Point<dim> > unit_support_points;
-        const unsigned int dofs_per_cell = simulator_access.get_fe().dofs_per_cell;
-        for (unsigned int dof=0; dof < dofs_per_cell; ++dof)
-          {
-            // base will hold element, base_index holds node/shape function within that element
-            const unsigned int
-            base       = simulator_access.get_fe().system_to_base_index(dof).first.first,
-            base_index = simulator_access.get_fe().system_to_base_index(dof).second;
-            // get the unit support points for the relevant element
-            std::vector< Point<dim> > my_support_points = simulator_access.get_fe().base_element(base).get_unit_support_points();
-            if ( my_support_points.size() == 0 )
-              {
-                //manufacture a support point, arbitrarily at cell center
-                if ( dim==2 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5) );
-                if ( dim==3 )
-                  unit_support_points.push_back( Point<dim> (0.5,0.5,0.5) );
-              }
-            else
-              {
-                unit_support_points.push_back(my_support_points[base_index]);
-              }
-          }
-        return unit_support_points;
-      }
-  }
+
 
   /**
    * This function is called by a signal which is triggered after the other constraints
@@ -168,7 +127,7 @@ namespace aspect
   {
     if (prescribe_internal_velocities)
       {
-        const std::vector< Point<dim> > points = get_unit_support_points_for_velocity(simulator_access);
+        const std::vector< Point<dim> > points = aspect::Utilities::get_unit_support_points_for_velocity(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
         typename DoFHandler<dim>::active_cell_iterator cell;


### PR DESCRIPTION
The `get_unit_support_points_for_velocity` function used to prescribe velocities was duplicated in all three plugins. This PR migrates that function into utilities.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.