### PR TITLE
README: replace license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ASPECT - Advanced Solver for Problems in Earth's ConvecTion
 ===========================================================
-[![License GPL2:](https://img.shields.io/cran/l/devtools.svg)](https://github.com/geodynamics/aspect/blob/master/LICENSE)
+[![License GPL2+:](https://img.shields.io/badge/License-GPL%202%2B-red)](https://github.com/geodynamics/aspect/blob/master/LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3924604.svg)](https://doi.org/10.5281/zenodo.3924604)
 [![pdf manual](https://img.shields.io/badge/get-PDF-green.svg)](https://doi.org/10.6084/m9.figshare.4865333)
 


### PR DESCRIPTION
the readme currently shows MIT as our license. Pick the right image instead (manually).
