### PR TITLE
 Add check that printouts Temperature & Pressure values when nonpositive diffusion or dislocation viscosity is detected

### DIFF
--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -99,7 +99,8 @@ namespace aspect
 
         Assert (viscosity_diffusion > 0.0,
                 ExcMessage ("Negative diffusion viscosity detected. This is unphysical and should not happen. "
-                            "Check for negative parameters."));
+                            "Check for negative parameters. Temperature and pressure are "
+                            + Utilities::to_string(temperature) + " K, " + Utilities::to_string(pressure) + " Pa. "));
 
         // Creep viscosities become extremely large at low
         // temperatures and can therefore provoke floating-point overflow errors. In

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -97,7 +97,8 @@ namespace aspect
 
         Assert (viscosity_dislocation > 0.0,
                 ExcMessage ("Negative dislocation viscosity detected. This is unphysical and should not happen. "
-                            "Check for negative parameters."));
+                            "Check for negative parameters. Temperature and pressure are "
+                            + Utilities::to_string(temperature) + " K, " + Utilities::to_string(pressure) + " Pa. "));
 
         // Creep viscosities become extremely large at low
         // temperatures and can therefore provoke floating-point overflow errors. In


### PR DESCRIPTION
Add an output to ExcMessage showing the temperature and pressure values when a negative (or non-positive) diffusion or dislocation viscosity is detected. This helps the user to quickly know if a non-positive viscosity is caused by the wrong solution of temperature or pressure.

This is the same as #4197, which is related to issue #4193.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
