### PR TITLE
Optimize boundary name lookups in postprocessors

### DIFF
--- a/source/mesh_refinement/slope.cc
+++ b/source/mesh_refinement/slope.cc
@@ -36,6 +36,8 @@ namespace aspect
     void
     Slope<dim>::execute(Vector<float> &indicators) const
     {
+      const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
+
       indicators = 0;
 
       QMidpoint<dim-1> quadrature;
@@ -61,7 +63,7 @@ namespace aspect
                         this->get_mesh_deformation_boundary_indicators().find(boundary_indicator) !=
                         this->get_mesh_deformation_boundary_indicators().end()) ||
                        (Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()) &&
-                        this->get_geometry_model().translate_symbolic_boundary_name_to_id("top") == boundary_indicator)  )
+                        boundary_indicator == top_boundary_id)  )
                     {
                       fe_face_values.reinit(cell, face_no);
 

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -42,6 +42,9 @@ namespace aspect
       const double surface_pressure = boundary_pressures.pressure_at_top();
       const double bottom_pressure = boundary_pressures.pressure_at_bottom();
 
+      const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
+      const types::boundary_id bottom_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");
+
       // If the gravity vector is pointed *up*, as determined by representative points
       // at the surface and at depth, then we are running backwards advection, and need
       // to reverse the dynamic topography values.
@@ -118,13 +121,13 @@ namespace aspect
             unsigned int face_idx = numbers::invalid_unsigned_int;
             for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
               {
-                if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("top"))
+                if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                   {
                     // If the cell is at the top boundary, assign face_idx.
                     face_idx = f;
                     break;
                   }
-                else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom"))
+                else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == bottom_boundary_id)
                   {
                     // If the cell is at the bottom boundary, assign face_idx.
                     face_idx = f;
@@ -245,14 +248,14 @@ namespace aspect
             bool at_upper_surface = true;
             for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
               {
-                if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("top"))
+                if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                   {
                     // If the cell is at the top boundary, assign face_idx.
                     face_idx = f;
                     at_upper_surface = true;
                     break;
                   }
-                else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom"))
+                else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == bottom_boundary_id)
                   {
                     // If the cell is at the bottom boundary, assign face_idx.
                     face_idx = f;

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -185,6 +185,9 @@ namespace aspect
       const double top_layer_average_density = boundary_densities.density_at_top();
       const double bottom_layer_average_density = boundary_densities.density_at_bottom();
 
+      const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
+      const types::boundary_id bottom_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");
+
       const unsigned int quadrature_degree = this->introspection().polynomial_degree.temperature;
       const QGauss<2> quadrature_formula_face(quadrature_degree);
 
@@ -209,14 +212,14 @@ namespace aspect
             {
               for (unsigned int f=0; f<GeometryInfo<3>::faces_per_cell; ++f)
                 {
-                  if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("top"))
+                  if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                     {
                       // If the cell is at the top boundary, assign face_idx.
                       face_idx = f;
                       at_upper_surface = true;
                       break;
                     }
-                  else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom"))
+                  else if (cell->at_boundary(f) && cell->face(f)->boundary_id() == bottom_boundary_id)
                     {
                       // If the cell is at the bottom boundary, assign face_idx.
                       face_idx = f;
@@ -400,6 +403,8 @@ namespace aspect
       const double outer_radius = geometry_model.outer_radius();
       const double inner_radius = geometry_model.inner_radius();
 
+      const types::boundary_id top_boundary_id = geometry_model.translate_symbolic_boundary_name_to_id("top");
+
       // Get the value of the surface gravity acceleration from the gravity model.
       Point<dim> surface_point;
       surface_point[0] = outer_radius;
@@ -511,7 +516,7 @@ namespace aspect
           {
             // If the cell is at the top boundary, store the cell's upper face midpoint location.
             for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
-              if (cell->at_boundary(f) && cell->face(f)->boundary_id() == this->get_geometry_model().translate_symbolic_boundary_name_to_id("top"))
+              if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                 {
                   fe_face_center_values.reinit(cell,f);
                   const Point<dim> midpoint_at_top_face = fe_face_center_values.get_quadrature_points().at(0);


### PR DESCRIPTION
Seen while reviewing #4210. We have a number of postprocessors that use an expensive name lookup in an inner loop over all faces when the index does not change. Caching the result is faster, and also easier to read.