### PR TITLE
Assert SPD factor visualization against full Stokes solver.

### DIFF
--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -56,6 +56,13 @@ namespace aspect
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double>> &computed_quantities) const override;
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           */
+          void
+          parse_parameters (ParameterHandler &prm) override;
+
       };
     }
   }

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -73,6 +73,15 @@ namespace aspect
                                                                            this->get_newton_handler().parameters.SPD_safety_factor);
           }
       }
+
+      template <int dim>
+      void
+      SPD_Factor<dim>::parse_parameters (ParameterHandler &/*prm*/)
+      {
+        AssertThrow(Parameters<dim>::is_defect_correction(this->get_parameters().nonlinear_solver),
+                    ExcMessage("The SPD factor plugin can only be used with defect correction type Stokes or Newton Stokes "
+                               "solvers."));
+      }
     }
   }
 }


### PR DESCRIPTION
Addressing one of the two issues in #4205. This adds an assert to prevent the SPD factor visualization plugin to be used in when we know that the  `simulator->newton_handler.get()` is a  `nullptr`, which is when a non-defect correction type nonlinear solver is used.