### PR TITLE
Make SimulatorAccess::introspection() 'inline'.

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -934,6 +934,18 @@ namespace aspect
       const Simulator<dim> *simulator;
   };
 
+
+
+  template <int dim>
+  inline
+  const Introspection<dim> &
+  SimulatorAccess<dim>::introspection () const
+  {
+    return simulator->introspection;
+  }
+
+
+
   template <int dim>
   template <typename PostprocessorType>
   inline

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -82,14 +82,6 @@ namespace aspect
 
 
   template <int dim>
-  const Introspection<dim> &
-  SimulatorAccess<dim>::introspection () const
-  {
-    return simulator->introspection;
-  }
-
-
-  template <int dim>
   MPI_Comm
   SimulatorAccess<dim>::get_mpi_communicator () const
   {


### PR DESCRIPTION
We've got more than 500 places where this function is called, many in inner loops. Might as well remove the function call overhead for this one :-)

/rebuild