### PR TITLE
Updating viscoplastic_strain_invariants particles

### DIFF
--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -101,6 +101,7 @@ namespace aspect
            * but it is currently not used in a threaded context.
            */
           mutable MaterialModel::MaterialModelInputs<dim> material_inputs;
+          mutable MaterialModel::MaterialModelOutputs<dim> material_outputs;
       };
     }
   }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -321,15 +321,6 @@ namespace aspect
         else
           AssertThrow(false, ExcMessage("Not a valid Strain healing mechanism!"));
 
-        // Currently this functionality only works in field composition
-        if (healing_mechanism != no_healing && this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::Particles<dim>>())
-          {
-            const Postprocess::Particles<dim> &particle_postprocessor = this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim>>();
-            const Particle::Property::Manager<dim> &particle_property_manager = particle_postprocessor.get_particle_world().get_property_manager();
-
-            AssertThrow(particle_property_manager.plugin_name_exists("viscoplastic strain invariants") == false, ExcMessage("This healing mechanism currently does not work if the strain is tracked on particles."));
-          }
-
         // Temperature dependent strain healing requires that adiabatic surface temperature is non zero
         if (healing_mechanism == temperature_dependent)
           {

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -120,51 +120,11 @@ namespace aspect
             material_inputs.composition[0][i] = solution[this->introspection().component_indices.compositional_fields[i]];
           }
 
-        // Find out plastic yielding by calling function in material model.
-        //const MaterialModel::ViscoPlastic<dim> &viscoplastic
-        //  = Plugins::get_plugin_as_type<const MaterialModel::ViscoPlastic<dim>>(this->get_material_model());
-
-        //const bool plastic_yielding = viscoplastic.is_yielding(material_inputs);
-        
         // Evaluate directly in the viscoplastic material model and modify the reaction outputs
         this->get_material_model().evaluate (material_inputs,material_outputs);
 
         for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
           particle->get_properties()[data_position + i] += material_outputs.reaction_terms[0][i];
-
-        /* Next take the integrated strain invariant from the prior time step. When
-         * there are two fields (plastic and viscous), this assumes plastic
-         * strain is always in data position one and viscous strain in position two.
-         * In this case old_strain will first be given the plastic strain, and then,
-         * if there is no plastic yielding it will update to the viscous strain instead.
-         */
-       /* auto &data = particle->get_properties();
-        double old_strain = data[data_position];
-        if (n_components == 2 && plastic_yielding == false)
-          old_strain = data[data_position+(n_components-1)];
-
-
-        // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::fabs(second_invariant(deviator(material_inputs.strain_rate[0]))));
-
-        // New strain is the old strain plus dt*edot_ii
-        const double new_strain = old_strain + dt*edot_ii;
-
-      */
-        /* Once we know whether the particle underwent plastic, viscous, or
-         * total strain assign the new strain to the correct data position.
-         * NOTE: This assumes that total strain cannot be used in combination with the
-         * other fields. If this changes in the future, this will need to be updated.
-         * */
-      /*  if (this->introspection().compositional_name_exists("plastic_strain") && plastic_yielding == true)
-          data[data_position] = new_strain;
-
-        if (this->introspection().compositional_name_exists("viscous_strain") && plastic_yielding == false)
-          data[data_position+(n_components-1)] = new_strain;
-
-        if (this->introspection().compositional_name_exists("total_strain"))
-          data[data_position] = new_strain;
-      */
       }
 
 


### PR DESCRIPTION
I updated the viscoplastic_strain_invariants particle property to follow the method in the elastic stress particle property, this allows strain invariants to evaluate the viscoplastic material model and use outputs to update the reaction terms so that code does not have to be duplicated to include strain healing in particles.

### For all pull requests:

* [X ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X ] I have tested my new feature locally to ensure it is correct.
* [X ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
