### PR TITLE
fix benchmarks/newton/spiegelman

### DIFF
--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/input.prm
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/input.prm
@@ -24,11 +24,6 @@ subsection Solver parameters
   end
 end
 
-subsection Boundary temperature model
-  set List of model names = box
-end
-
-
  subsection Initial temperature model
    set Model name = function
  end


### PR DESCRIPTION
fixes
An error occurred in line <174> of file
<../source/boundary_temperature/interface.cc> in function
void
aspect::BoundaryTemperature::Manager<dim>::parse_parameters(dealii::ParameterHandler&)
[with int dim = 2]
The violated condition was:
    model_names.size() == 0
Additional information:
You have indicated that you wish to apply a boundary temperature
model, but the <Fixed temperature boundary indicators> parameter is
empty. Please use this parameter to specify the boundaries on which the
model(s) should be applied.
