### PR TITLE
avoiding division by zero in dyn topo pp

### DIFF
--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -293,12 +293,16 @@ namespace aspect
                     if (at_upper_surface)
                       {
                         const double delta_rho = out_support.densities[support_index] - density_above;
+                        AssertThrow(std::abs(delta_rho) > std::numeric_limits<double>::min(),
+                                    ExcMessage("delta_rho is close or equal to zero at the surface."));
                         dynamic_topography = (-stress_support_values[support_index]*normal - surface_pressure)
                                              / delta_rho / gravity_norm;
                       }
                     else
                       {
                         const double delta_rho = out_support.densities[support_index] - density_below;
+                        AssertThrow(std::abs(delta_rho) > std::numeric_limits<double>::min(),
+                                    ExcMessage("delta_rho is close or equal to zero at the bottom."));
                         dynamic_topography = (-stress_support_values[support_index]*normal - bottom_pressure)
                                              / delta_rho / gravity_norm;
                       }


### PR DESCRIPTION
If one is not careful in the choice of densities above the surface or below the CMB, the parameter delta_rho can end up being zero, leading to a division by zero. I have added two AssertThrow's to prevent this from happening.