### PR TITLE
Unify particle update for deal.II 9.2 and 9.3

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -618,7 +618,7 @@ namespace aspect
 
       boost::container::small_vector<double, 100> solution_values(this->get_fe().dofs_per_cell);
 
-      cell->get_dof_values(this->get_current_linearization_point(),
+      cell->get_dof_values(this->get_solution(),
                            solution_values.begin(),
                            solution_values.end());
 


### PR DESCRIPTION
Not sure if this is a bug fix (I think current_linearization_point technically is more correct), but in the old version of the function `local_update_particles` that is used with deal.II 9.2 we use the solution vector instead, and the current form using `current_linearization_point` (introduced in #4060) creates oscillations in the viscoelastic_bending_beam_particles benchmark. This benchmark uses a single Advection, single Stokes solver scheme and stresses are transported on particles. I guess because values are extrapolated to the current linearization point and then used to compute the update the particles (without iterating out the nonlinearity) they start to oscillate after some timesteps and the benchmark crashes.

I have verified that with this change the benchmark is back to its old behavior.