### PR TITLE
add units for visualization postprocessors

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -127,9 +127,9 @@ namespace aspect
           /**
            * Constructor. The constructor takes as argument the physical
            * units of the quantity (scalar or vector-valued) computed by
-           * derived classes.
+           * derived classes.  "" refers to an unknown or nonexistent unit.
            */
-          Interface (const std::string &physical_units);
+          Interface (const std::string &physical_units); // "" refers to an unknown or nonexistent unit.
 
           /**
            * Destructor. Does nothing but is virtual so that derived classes
@@ -263,7 +263,7 @@ namespace aspect
            * units of the quantity (scalar or vector-valued) computed by
            * derived classes.
            */
-          CellDataVectorCreator (const std::string &physical_units);
+          explicit CellDataVectorCreator (const std::string &physical_units);
 
           /**
            * Destructor.

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -259,6 +259,13 @@ namespace aspect
       {
         public:
           /**
+           * Constructor. The constructor takes as argument the physical
+           * units of the quantity (scalar or vector-valued) computed by
+           * derived classes.
+           */
+          CellDataVectorCreator (const std::string &physical_units);
+
+          /**
            * Destructor.
            */
           ~CellDataVectorCreator ()  override = default;

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -125,6 +125,13 @@ namespace aspect
       {
         public:
           /**
+           * Constructor. The constructor takes as argument the physical
+           * units of the quantity (scalar or vector-valued) computed by
+           * derived classes.
+           */
+          Interface (const std::string &physical_units);
+
+          /**
            * Destructor. Does nothing but is virtual so that derived classes
            * destructors are also virtual.
            */
@@ -224,6 +231,13 @@ namespace aspect
            */
           virtual
           void load (const std::map<std::string, std::string> &status_strings);
+
+        private:
+          /**
+           * The physical units of the quantity (scalar or
+           * vector-valued) computed by derived classes.
+           */
+          const std::string physical_units;
       };
 
 

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -53,14 +53,14 @@ namespace aspect
       class ISARotationTimescale: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
-        /**
-         * Constructor.
-        */          
-        ISARotationTimescale();
+          /**
+           * Constructor.
+          */
+          ISARotationTimescale();
 
 
-           * @copydoc CellDataVectorCreator<dim>::execute()
-           */
+          *@copydoc CellDataVectorCreator<dim>::execute()
+          */
           std::pair<std::string, Vector<float> *>
           execute() const override;
 

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -55,12 +55,12 @@ namespace aspect
         public:
           /**
            * Constructor.
-          */
+           */
           ISARotationTimescale();
 
-
-          *@copydoc CellDataVectorCreator<dim>::execute()
-          */
+          /**
+           *@copydoc CellDataVectorCreator<dim>::execute()
+           */
           std::pair<std::string, Vector<float> *>
           execute() const override;
 

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -53,8 +53,12 @@ namespace aspect
       class ISARotationTimescale: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
+        /**
+         * Constructor.
+        */          
         ISARotationTimescale();
-          /**
+
+
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
           std::pair<std::string, Vector<float> *>

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -53,7 +53,7 @@ namespace aspect
       class ISARotationTimescale: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
-
+        ISARotationTimescale();
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -42,6 +42,10 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+        ArtificialViscosity();
+
+
+        
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -42,9 +42,10 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           ArtificialViscosity();
-
-
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -42,10 +42,10 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
-        ArtificialViscosity();
+          ArtificialViscosity();
 
 
-        
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
@@ -42,6 +42,9 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           ArtificialViscosityComposition();
 
           /**

--- a/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
@@ -42,7 +42,7 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
-        ArtificialViscosityComposition();
+          ArtificialViscosityComposition();
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
@@ -42,6 +42,8 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+        ArtificialViscosityComposition();
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -46,6 +46,9 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           BoundaryIndicator();
 
           /**

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -46,7 +46,7 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
-        BoundaryIndicator();
+          BoundaryIndicator();
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -46,6 +46,8 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
+        BoundaryIndicator();
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -41,7 +41,7 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
-        ErrorIndicator();
+          ErrorIndicator();
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -41,7 +41,11 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           ErrorIndicator();
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -41,6 +41,7 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+        ErrorIndicator();
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -60,7 +60,7 @@ namespace aspect
       class GrainLagAngle: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
-        GrainLagAngle();
+          GrainLagAngle();
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -60,6 +60,9 @@ namespace aspect
       class GrainLagAngle: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           GrainLagAngle();
 
           /**

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -60,6 +60,7 @@ namespace aspect
       class GrainLagAngle: public CellDataVectorCreator<dim>, public SimulatorAccess<dim>
       {
         public:
+        GrainLagAngle();
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
+++ b/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
@@ -50,6 +50,8 @@ namespace aspect
           public Interface<dim>
       {
         public:
+        MaximumHorizontalCompressiveStress();
+        
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double> > &computed_quantities) const override;

--- a/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
+++ b/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
@@ -50,6 +50,9 @@ namespace aspect
           public Interface<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           MaximumHorizontalCompressiveStress();
 
           void

--- a/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
+++ b/include/aspect/postprocess/visualization/maximum_horizontal_compressive_stress.h
@@ -50,8 +50,8 @@ namespace aspect
           public Interface<dim>
       {
         public:
-        MaximumHorizontalCompressiveStress();
-        
+          MaximumHorizontalCompressiveStress();
+
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double> > &computed_quantities) const override;

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -46,6 +46,9 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           ParticleCount();
 
           /**

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -46,6 +46,8 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
+        ParticleCount();
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -46,7 +46,7 @@ namespace aspect
           public SimulatorAccess<dim>
       {
         public:
-        ParticleCount();
+          ParticleCount();
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -43,6 +43,9 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+        SeismicVsAnomaly();
+
+        
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
@@ -98,6 +101,8 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+        SeismicVpAnomaly();
+        
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -43,9 +43,9 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
-        SeismicVsAnomaly();
+          SeismicVsAnomaly();
 
-        
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
@@ -101,8 +101,8 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
-        SeismicVpAnomaly();
-        
+          SeismicVpAnomaly();
+
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -43,8 +43,10 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           SeismicVsAnomaly();
-
 
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
@@ -101,6 +103,9 @@ namespace aspect
         public SimulatorAccess<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           SeismicVpAnomaly();
 
           /**

--- a/include/aspect/postprocess/visualization/surface_stress.h
+++ b/include/aspect/postprocess/visualization/surface_stress.h
@@ -57,6 +57,9 @@ namespace aspect
           public SurfaceOnlyVisualization<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           SurfaceStress();
 
           void

--- a/include/aspect/postprocess/visualization/surface_stress.h
+++ b/include/aspect/postprocess/visualization/surface_stress.h
@@ -57,6 +57,8 @@ namespace aspect
           public SurfaceOnlyVisualization<dim>
       {
         public:
+        SurfaceStress();
+        
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double> > &computed_quantities) const override;

--- a/include/aspect/postprocess/visualization/surface_stress.h
+++ b/include/aspect/postprocess/visualization/surface_stress.h
@@ -57,8 +57,8 @@ namespace aspect
           public SurfaceOnlyVisualization<dim>
       {
         public:
-        SurfaceStress();
-        
+          SurfaceStress();
+
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double> > &computed_quantities) const override;

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -219,6 +219,14 @@ namespace aspect
       void
       Interface<dim>::load (const std::map<std::string,std::string> &)
       {}
+
+
+
+      template <int dim>
+      CellDataVectorCreator<dim>::CellDataVectorCreator (const std::string &physical_units)
+        :
+        Interface<dim> (physical_units)
+      {}
     }
 
 

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -129,7 +129,7 @@ namespace aspect
 
       /**
        * This Postprocessor will generate the output variables of mesh velocity
-       * for when a deforming mesh is used.
+       * for when a deforming mesh is used. 
        */
       template <int dim>
       class MeshDeformationPostprocessor: public DataPostprocessorVector< dim >, public SimulatorAccess<dim>

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -129,7 +129,7 @@ namespace aspect
 
       /**
        * This Postprocessor will generate the output variables of mesh velocity
-       * for when a deforming mesh is used. 
+       * for when a deforming mesh is used.
        */
       template <int dim>
       class MeshDeformationPostprocessor: public DataPostprocessorVector< dim >, public SimulatorAccess<dim>

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -163,6 +163,14 @@ namespace aspect
 
 
       template <int dim>
+      Interface<dim>::Interface (const std::string &physical_units)
+        :
+        physical_units (physical_units)
+      {}
+
+
+
+      template <int dim>
       Interface<dim>::~Interface ()
       {}
 

--- a/source/postprocess/visualization/ISA_rotation_timescale.cc
+++ b/source/postprocess/visualization/ISA_rotation_timescale.cc
@@ -33,6 +33,15 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
+      template <int dim>
+      ISARotationTimescale<dim>::
+      ISARotationTimescale ()
+        :
+        CellDataVectorCreator<dim>("s")
+      {}
+
+
+
       template<int dim>
       std::pair<std::string, Vector<float> *> ISARotationTimescale<dim>::execute() const
       {

--- a/source/postprocess/visualization/adiabat.cc
+++ b/source/postprocess/visualization/adiabat.cc
@@ -34,7 +34,7 @@ namespace aspect
       Adiabat ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("units")
+        Interface<dim>("")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/adiabat.cc
+++ b/source/postprocess/visualization/adiabat.cc
@@ -33,7 +33,8 @@ namespace aspect
       Adiabat<dim>::
       Adiabat ()
         :
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("units")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/artificial_viscosity.cc
+++ b/source/postprocess/visualization/artificial_viscosity.cc
@@ -29,6 +29,15 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      ArtificialViscosity<dim>::
+      ArtificialViscosity ()
+        :
+        CellDataVectorCreator<dim>("kg/m/s/s")
+      {}
+
+
+      
+      template <int dim>
       std::pair<std::string, Vector<float> *>
       ArtificialViscosity<dim>::execute() const
       {

--- a/source/postprocess/visualization/artificial_viscosity.cc
+++ b/source/postprocess/visualization/artificial_viscosity.cc
@@ -36,7 +36,7 @@ namespace aspect
       {}
 
 
-      
+
       template <int dim>
       std::pair<std::string, Vector<float> *>
       ArtificialViscosity<dim>::execute() const

--- a/source/postprocess/visualization/artificial_viscosity_composition.cc
+++ b/source/postprocess/visualization/artificial_viscosity_composition.cc
@@ -29,6 +29,13 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      ArtificialViscosityComposition<dim>::
+      ArtificialViscosityComposition ()
+        :
+        CellDataVectorCreator<dim>("kg/m/s/s")
+      {}
+
+      template <int dim>
       std::pair<std::string, Vector<float> *>
       ArtificialViscosityComposition<dim>::execute() const
       {

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -30,6 +30,14 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
+      template <int dim>
+      BoundaryIndicator<dim>::
+      BoundaryIndicator ()
+        :
+        CellDataVectorCreator<dim>("units")
+      {}
+
+
 
       template <int dim>
       std::pair<std::string, Vector<float> *>

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -34,7 +34,7 @@ namespace aspect
       BoundaryIndicator<dim>::
       BoundaryIndicator ()
         :
-        CellDataVectorCreator<dim>("units")
+        CellDataVectorCreator<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -33,7 +33,8 @@ namespace aspect
       BoundaryVelocityResidual ()
         :
         DataPostprocessorVector<dim> ("boundary_velocity_residual",
-                                      update_values | update_quadrature_points | update_gradients)
+                                      update_values | update_quadrature_points | update_gradients),
+                                      Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -34,7 +34,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("boundary_velocity_residual",
                                       update_values | update_quadrature_points | update_gradients),
-                                      Interface<dim>("m/s")
+        Interface<dim>("m/s")
       {}
 
 

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -34,7 +34,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("boundary_velocity_residual",
                                       update_values | update_quadrature_points | update_gradients),
-                                      Interface<dim>("kg/m/s/s")
+                                      Interface<dim>("m/s")
       {}
 
 

--- a/source/postprocess/visualization/compositional_vector.cc
+++ b/source/postprocess/visualization/compositional_vector.cc
@@ -31,7 +31,7 @@ namespace aspect
       CompositionalVector ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("units")
+        Interface<dim>("unitless")
       {}
 
 

--- a/source/postprocess/visualization/compositional_vector.cc
+++ b/source/postprocess/visualization/compositional_vector.cc
@@ -30,7 +30,8 @@ namespace aspect
       CompositionalVector<dim>::
       CompositionalVector ()
         :
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/compositional_vector.cc
+++ b/source/postprocess/visualization/compositional_vector.cc
@@ -31,7 +31,7 @@ namespace aspect
       CompositionalVector ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("unitless")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/depth.cc
+++ b/source/postprocess/visualization/depth.cc
@@ -35,7 +35,8 @@ namespace aspect
       Depth ()
         :
         DataPostprocessorScalar<dim> ("depth",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("m")
       {}
 
 

--- a/source/postprocess/visualization/depth.cc
+++ b/source/postprocess/visualization/depth.cc
@@ -36,7 +36,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("depth",
                                       update_quadrature_points),
-                                      Interface<dim>("m")
+        Interface<dim>("m")
       {}
 
 

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -33,7 +33,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("dynamic_topography",
                                       update_quadrature_points),
-                                      Interface<dim>("m")
+        Interface<dim>("m")
       {}
 
 

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -32,7 +32,8 @@ namespace aspect
       DynamicTopography ()
         :
         DataPostprocessorScalar<dim> ("dynamic_topography",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("m")
       {}
 
 

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -28,6 +28,15 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
+       template <int dim>
+      ErrorIndicator<dim>::
+      ErrorIndicator ()
+        :
+        CellDataVectorCreator<dim>("units")
+      {}
+
+
+
       template <int dim>
       std::pair<std::string, Vector<float> *>
       ErrorIndicator<dim>::execute() const

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -32,7 +32,7 @@ namespace aspect
       ErrorIndicator<dim>::
       ErrorIndicator ()
         :
-        CellDataVectorCreator<dim>("unitless")
+        CellDataVectorCreator<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -28,7 +28,7 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
-       template <int dim>
+      template <int dim>
       ErrorIndicator<dim>::
       ErrorIndicator ()
         :

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -32,7 +32,7 @@ namespace aspect
       ErrorIndicator<dim>::
       ErrorIndicator ()
         :
-        CellDataVectorCreator<dim>("units")
+        CellDataVectorCreator<dim>("unitless")
       {}
 
 

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -39,7 +39,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("geoid",
                                       update_quadrature_points),
-                                      Interface<dim>("m")
+        Interface<dim>("m")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -37,9 +37,9 @@ namespace aspect
       Geoid<dim>::
       Geoid ()
         :
-        Interface<dim>("m"),
         DataPostprocessorScalar<dim> ("geoid",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("m")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -37,6 +37,7 @@ namespace aspect
       Geoid<dim>::
       Geoid ()
         :
+        Interface<dim>("m"),
         DataPostprocessorScalar<dim> ("geoid",
                                       update_quadrature_points)
       {}

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -33,6 +33,15 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
+      template <int dim>
+      GrainLagAngle<dim>::
+      GrainLagAngle ()
+        :
+        CellDataVectorCreator<dim>("units")
+      {}
+
+
+
       template<int dim>
       std::pair<std::string, Vector<float> *> GrainLagAngle<dim>::execute() const
       {

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -37,7 +37,7 @@ namespace aspect
       GrainLagAngle<dim>::
       GrainLagAngle ()
         :
-        CellDataVectorCreator<dim>("units")
+        CellDataVectorCreator<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -37,7 +37,7 @@ namespace aspect
       GrainLagAngle<dim>::
       GrainLagAngle ()
         :
-        CellDataVectorCreator<dim>("")
+        CellDataVectorCreator<dim>("radian")
       {}
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -36,7 +36,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("gravity",
                                       update_quadrature_points),
-                                      Interface<dim>("")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -34,6 +34,7 @@ namespace aspect
       Gravity<dim>::
       Gravity ()
         :
+        Interface<dim>("units"),
         DataPostprocessorVector<dim> ("gravity",
                                       update_quadrature_points)
       {}

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -34,9 +34,9 @@ namespace aspect
       Gravity<dim>::
       Gravity ()
         :
-        Interface<dim>("units"),
         DataPostprocessorVector<dim> ("gravity",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -36,7 +36,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("gravity",
                                       update_quadrature_points),
-        Interface<dim>("")
+        Interface<dim>("m/s^2")
       {}
 
 

--- a/source/postprocess/visualization/gravity.cc
+++ b/source/postprocess/visualization/gravity.cc
@@ -36,7 +36,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("gravity",
                                       update_quadrature_points),
-                                      Interface<dim>("units")
+                                      Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -37,9 +37,9 @@ namespace aspect
       HeatFluxMap<dim>::
       HeatFluxMap ()
         :
-        Interface<dim>("W/m/m"),
         DataPostprocessorScalar<dim> ("heat_flux_map",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("W/m/m")
       {}
 
 

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -39,7 +39,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("heat_flux_map",
                                       update_quadrature_points),
-                                      Interface<dim>("W/m/m")
+        Interface<dim>("W/m/m")
       {}
 
 

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -37,6 +37,7 @@ namespace aspect
       HeatFluxMap<dim>::
       HeatFluxMap ()
         :
+        Interface<dim>("W/m/m"),
         DataPostprocessorScalar<dim> ("heat_flux_map",
                                       update_quadrature_points)
       {}

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -38,8 +38,8 @@ namespace aspect
       Heating<dim>::
       Heating ()
         :
-        Interface<dim>("units"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("units")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -39,7 +39,7 @@ namespace aspect
       Heating ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("units")
+        Interface<dim>("")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -39,7 +39,7 @@ namespace aspect
       Heating ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("")
+        Interface<dim>("J")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -38,6 +38,7 @@ namespace aspect
       Heating<dim>::
       Heating ()
         :
+        Interface<dim>("units"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -36,6 +36,7 @@ namespace aspect
       MaterialProperties<dim>::
       MaterialProperties ()
         :
+        Interface<dim>("units"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -37,7 +37,7 @@ namespace aspect
       MaterialProperties ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("units")
+        Interface<dim>("")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -36,8 +36,8 @@ namespace aspect
       MaterialProperties<dim>::
       MaterialProperties ()
         :
-        Interface<dim>("units"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("units")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
+++ b/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
@@ -31,6 +31,15 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      MaximumHorizontalCompressiveStress<dim>::
+      MaximumHorizontalCompressiveStress ()
+        :
+        Interface<dim>("kg/m/s/s")
+      {}
+
+
+
+      template <int dim>
       void
       MaximumHorizontalCompressiveStress<dim>::
       evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -40,6 +40,7 @@ namespace aspect
       MeltMaterialProperties<dim>::
       MeltMaterialProperties ()
         :
+        Interface<dim>("unit"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -40,8 +40,8 @@ namespace aspect
       MeltMaterialProperties<dim>::
       MeltMaterialProperties ()
         :
-        Interface<dim>("unit"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("unit")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -41,7 +41,7 @@ namespace aspect
       MeltMaterialProperties ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("unit")
+        Interface<dim>("")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -35,6 +35,7 @@ namespace aspect
       MeltFraction<dim>::
       MeltFraction ()
         :
+        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("melt_fraction",
                                       update_values | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -37,7 +37,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("melt_fraction",
                                       update_values | update_quadrature_points),
-                                      Interface<dim>("units")
+                                      Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -35,9 +35,9 @@ namespace aspect
       MeltFraction<dim>::
       MeltFraction ()
         :
-        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("melt_fraction",
-                                      update_values | update_quadrature_points)
+                                      update_values | update_quadrature_points),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -37,7 +37,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("melt_fraction",
                                       update_values | update_quadrature_points),
-                                      Interface<dim>("")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -37,7 +37,7 @@ namespace aspect
       NamedAdditionalOutputs ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("units")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -36,6 +36,7 @@ namespace aspect
       NamedAdditionalOutputs<dim>::
       NamedAdditionalOutputs ()
         :
+        Interface<dim>("units"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -36,8 +36,8 @@ namespace aspect
       NamedAdditionalOutputs<dim>::
       NamedAdditionalOutputs ()
         :
-        Interface<dim>("units"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("nonadiabatic_pressure",
                                       update_values | update_quadrature_points),
-                                      Interface<dim>("kg/m/s/s")
+        Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -33,6 +33,7 @@ namespace aspect
       NonadiabaticPressure<dim>::
       NonadiabaticPressure ()
         :
+        Interface<dim>("kg/m/s/s"),
         DataPostprocessorScalar<dim> ("nonadiabatic_pressure",
                                       update_values | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/nonadiabatic_pressure.cc
+++ b/source/postprocess/visualization/nonadiabatic_pressure.cc
@@ -33,9 +33,9 @@ namespace aspect
       NonadiabaticPressure<dim>::
       NonadiabaticPressure ()
         :
-        Interface<dim>("kg/m/s/s"),
         DataPostprocessorScalar<dim> ("nonadiabatic_pressure",
-                                      update_values | update_quadrature_points)
+                                      update_values | update_quadrature_points),
+                                      Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -33,9 +33,9 @@ namespace aspect
       NonadiabaticTemperature<dim>::
       NonadiabaticTemperature ()
         :
-        Interface<dim>("k"),
         DataPostprocessorScalar<dim> ("nonadiabatic_temperature",
-                                      update_values | update_quadrature_points)
+                                      update_values | update_quadrature_points),
+                                      Interface<dim>("K")
       {}
 
 

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -33,6 +33,7 @@ namespace aspect
       NonadiabaticTemperature<dim>::
       NonadiabaticTemperature ()
         :
+        Interface<dim>("k"),
         DataPostprocessorScalar<dim> ("nonadiabatic_temperature",
                                       update_values | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/nonadiabatic_temperature.cc
+++ b/source/postprocess/visualization/nonadiabatic_temperature.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("nonadiabatic_temperature",
                                       update_values | update_quadrature_points),
-                                      Interface<dim>("K")
+        Interface<dim>("K")
       {}
 
 

--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -33,6 +33,15 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      ParticleCount<dim>::
+      ParticleCount ()
+        :
+        CellDataVectorCreator<dim>("units")
+      {}
+
+
+
+      template <int dim>
       std::pair<std::string, Vector<float> *>
       ParticleCount<dim>::execute() const
       {

--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -36,7 +36,7 @@ namespace aspect
       ParticleCount<dim>::
       ParticleCount ()
         :
-        CellDataVectorCreator<dim>("units")
+        CellDataVectorCreator<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/partition.cc
+++ b/source/postprocess/visualization/partition.cc
@@ -33,6 +33,7 @@ namespace aspect
       Partition<dim>::
       Partition ()
         :
+        Interface<dim>("units"),
         // we don't need to know about any of the solution values
         // in order to determine the partition number. thus, no
         // need to specify any update flags

--- a/source/postprocess/visualization/partition.cc
+++ b/source/postprocess/visualization/partition.cc
@@ -38,7 +38,7 @@ namespace aspect
         // need to specify any update flags
         DataPostprocessorScalar<dim> ("partition",
                                       update_default),
-                                      Interface<dim>("")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/partition.cc
+++ b/source/postprocess/visualization/partition.cc
@@ -33,12 +33,12 @@ namespace aspect
       Partition<dim>::
       Partition ()
         :
-        Interface<dim>("units"),
         // we don't need to know about any of the solution values
         // in order to determine the partition number. thus, no
         // need to specify any update flags
         DataPostprocessorScalar<dim> ("partition",
-                                      update_default)
+                                      update_default),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/partition.cc
+++ b/source/postprocess/visualization/partition.cc
@@ -38,7 +38,7 @@ namespace aspect
         // need to specify any update flags
         DataPostprocessorScalar<dim> ("partition",
                                       update_default),
-                                      Interface<dim>("units")
+                                      Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -32,8 +32,8 @@ namespace aspect
       PrincipalStress<dim>::
       PrincipalStress ()
         :
-        Interface<dim>("kg/m/s/s"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -32,6 +32,7 @@ namespace aspect
       PrincipalStress<dim>::
       PrincipalStress ()
         :
+        Interface<dim>("kg/m/s/s"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -34,6 +34,15 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      SeismicVsAnomaly<dim>::
+      SeismicVsAnomaly ()
+        :
+        CellDataVectorCreator<dim>("m/s")
+      {}
+
+
+
+      template <int dim>
       std::pair<std::string, Vector<float> *>
       SeismicVsAnomaly<dim>::execute() const
       {
@@ -189,6 +198,14 @@ namespace aspect
           }
         return return_value;
       }
+
+
+      template <int dim>
+      SeismicVpAnomaly<dim>::
+      SeismicVpAnomaly ()
+        :
+        CellDataVectorCreator<dim>("m/s")
+      {}
 
 
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -33,9 +33,9 @@ namespace aspect
       ShearStress<dim>::
       ShearStress ()
         :
-        Interface<dim>("kg/m/s/s"),
         DataPostprocessorTensor<dim> ("shear_stress",
-                                      update_values | update_gradients | update_quadrature_points)
+                                      update_values | update_gradients | update_quadrature_points),
+                                      Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorTensor<dim> ("shear_stress",
                                       update_values | update_gradients | update_quadrature_points),
-                                      Interface<dim>("kg/m/s/s")
+        Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -33,6 +33,7 @@ namespace aspect
       ShearStress<dim>::
       ShearStress ()
         :
+        Interface<dim>("kg/m/s/s"),
         DataPostprocessorTensor<dim> ("shear_stress",
                                       update_values | update_gradients | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -37,7 +37,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("spd_factor",
                                       update_values | update_gradients | update_quadrature_points),
-                                      Interface<dim>("units")
+                                      Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -35,9 +35,9 @@ namespace aspect
       SPD_Factor<dim>::
       SPD_Factor ()
         :
-        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("spd_factor",
-                                      update_values | update_gradients | update_quadrature_points)
+                                      update_values | update_gradients | update_quadrature_points),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -37,7 +37,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("spd_factor",
                                       update_values | update_gradients | update_quadrature_points),
-                                      Interface<dim>("")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -35,6 +35,7 @@ namespace aspect
       SPD_Factor<dim>::
       SPD_Factor ()
         :
+        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("spd_factor",
                                       update_values | update_gradients | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/spherical_velocity_components.cc
+++ b/source/postprocess/visualization/spherical_velocity_components.cc
@@ -33,9 +33,9 @@ namespace aspect
       SphericalVelocityComponents<dim>::
       SphericalVelocityComponents ()
         :
-        Interface<dim>("m/s"),
         DataPostprocessorVector<dim> ("spherical_velocity_components",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("m/s")
       {}
 
 

--- a/source/postprocess/visualization/spherical_velocity_components.cc
+++ b/source/postprocess/visualization/spherical_velocity_components.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorVector<dim> ("spherical_velocity_components",
                                       update_quadrature_points),
-                                      Interface<dim>("m/s")
+        Interface<dim>("m/s")
       {}
 
 

--- a/source/postprocess/visualization/spherical_velocity_components.cc
+++ b/source/postprocess/visualization/spherical_velocity_components.cc
@@ -33,6 +33,7 @@ namespace aspect
       SphericalVelocityComponents<dim>::
       SphericalVelocityComponents ()
         :
+        Interface<dim>("m/s"),
         DataPostprocessorVector<dim> ("spherical_velocity_components",
                                       update_quadrature_points)
       {}

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -33,9 +33,9 @@ namespace aspect
       StrainRate<dim>::
       StrainRate ()
         :
-        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("strain_rate",
-                                      update_gradients | update_quadrature_points)
+                                      update_gradients | update_quadrature_points),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -33,6 +33,7 @@ namespace aspect
       StrainRate<dim>::
       StrainRate ()
         :
+        Interface<dim>("units"),
         DataPostprocessorScalar<dim> ("strain_rate",
                                       update_gradients | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("strain_rate",
                                       update_gradients | update_quadrature_points),
-                                      Interface<dim>("1/s")
+        Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("strain_rate",
                                       update_gradients | update_quadrature_points),
-                                      Interface<dim>("units")
+                                      Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -34,7 +34,7 @@ namespace aspect
         :
         DataPostprocessorTensor<dim> ("strain_rate_tensor",
                                       update_gradients | update_quadrature_points),
-                                      Interface<dim>("units")
+                                      Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -32,9 +32,9 @@ namespace aspect
       StrainRateTensor<dim>::
       StrainRateTensor ()
         :
-        Interface<dim>("units"),
         DataPostprocessorTensor<dim> ("strain_rate_tensor",
-                                      update_gradients | update_quadrature_points)
+                                      update_gradients | update_quadrature_points),
+                                      Interface<dim>("units")
       {}
 
 

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -32,6 +32,7 @@ namespace aspect
       StrainRateTensor<dim>::
       StrainRateTensor ()
         :
+        Interface<dim>("units"),
         DataPostprocessorTensor<dim> ("strain_rate_tensor",
                                       update_gradients | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -34,7 +34,7 @@ namespace aspect
         :
         DataPostprocessorTensor<dim> ("strain_rate_tensor",
                                       update_gradients | update_quadrature_points),
-                                      Interface<dim>("1/s")
+        Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorTensor<dim> ("stress",
                                       update_values | update_gradients | update_quadrature_points),
-                                      Interface<dim>("kg/m/s/s")
+        Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -33,6 +33,7 @@ namespace aspect
       Stress<dim>::
       Stress ()
         :
+        Interface<dim>("kg/m/s/s"),
         DataPostprocessorTensor<dim> ("stress",
                                       update_values | update_gradients | update_quadrature_points)
       {}

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -33,9 +33,9 @@ namespace aspect
       Stress<dim>::
       Stress ()
         :
-        Interface<dim>("kg/m/s/s"),
         DataPostprocessorTensor<dim> ("stress",
-                                      update_values | update_gradients | update_quadrature_points)
+                                      update_values | update_gradients | update_quadrature_points),
+                                      Interface<dim>("kg/m/s/s")
       {}
 
 

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -31,6 +31,7 @@ namespace aspect
       SurfaceDynamicTopography<dim>::
       SurfaceDynamicTopography ()
         :
+        Interface<dim>("m"),
         DataPostprocessorScalar<dim> ("surface_dynamic_topography",
                                       update_quadrature_points)
       {}

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -33,7 +33,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("surface_dynamic_topography",
                                       update_quadrature_points),
-                                      Interface<dim>("m")
+        Interface<dim>("m")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -31,9 +31,9 @@ namespace aspect
       SurfaceDynamicTopography<dim>::
       SurfaceDynamicTopography ()
         :
-        Interface<dim>("m"),
         DataPostprocessorScalar<dim> ("surface_dynamic_topography",
-                                      update_quadrature_points)
+                                      update_quadrature_points),
+                                      Interface<dim>("m")
       {}
 
       template <int dim>

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -30,6 +30,15 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
       template <int dim>
+      SurfaceStress<dim>::
+      SurfaceStress ()
+        :
+        Interface<dim>("kg/m/s/s")
+      {}
+
+
+
+      template <int dim>
       void
       SurfaceStress<dim>::
       evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,

--- a/source/postprocess/visualization/temperature_anomaly.cc
+++ b/source/postprocess/visualization/temperature_anomaly.cc
@@ -36,9 +36,9 @@ namespace aspect
       TemperatureAnomaly<dim>::
       TemperatureAnomaly ()
         :
-        Interface<dim>("K"),
         DataPostprocessorScalar<dim> ("temperature_anomaly",
-                                      update_values | update_quadrature_points )
+                                      update_values | update_quadrature_points ),
+                                      Interface<dim>("K")
       {
       }
 

--- a/source/postprocess/visualization/temperature_anomaly.cc
+++ b/source/postprocess/visualization/temperature_anomaly.cc
@@ -36,6 +36,7 @@ namespace aspect
       TemperatureAnomaly<dim>::
       TemperatureAnomaly ()
         :
+        Interface<dim>("K"),
         DataPostprocessorScalar<dim> ("temperature_anomaly",
                                       update_values | update_quadrature_points )
       {

--- a/source/postprocess/visualization/temperature_anomaly.cc
+++ b/source/postprocess/visualization/temperature_anomaly.cc
@@ -38,7 +38,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("temperature_anomaly",
                                       update_values | update_quadrature_points ),
-                                      Interface<dim>("K")
+        Interface<dim>("K")
       {
       }
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -33,9 +33,9 @@ namespace aspect
       VerticalHeatFlux<dim>::
       VerticalHeatFlux ()
         :
-        Interface<dim>("W/m**m"),
         DataPostprocessorScalar<dim> ("vertical_heat_flux",
-                                      update_values | update_quadrature_points | update_gradients)
+                                      update_values | update_quadrature_points | update_gradients),
+                                      Interface<dim>("W/m**m")
       {}
 
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("vertical_heat_flux",
                                       update_values | update_quadrature_points | update_gradients),
-                                      Interface<dim>("W/m/m")
+        Interface<dim>("W/m/m")
       {}
 
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -33,6 +33,7 @@ namespace aspect
       VerticalHeatFlux<dim>::
       VerticalHeatFlux ()
         :
+        Interface<dim>("W/m**m"),
         DataPostprocessorScalar<dim> ("vertical_heat_flux",
                                       update_values | update_quadrature_points | update_gradients)
       {}

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -35,7 +35,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("vertical_heat_flux",
                                       update_values | update_quadrature_points | update_gradients),
-                                      Interface<dim>("W/m**m")
+                                      Interface<dim>("W/m/m")
       {}
 
 

--- a/source/postprocess/visualization/volume_of_fluid_values.cc
+++ b/source/postprocess/visualization/volume_of_fluid_values.cc
@@ -32,8 +32,8 @@ namespace aspect
       VolumeOfFluidValues<dim>::
       VolumeOfFluidValues ()
         :
-        Interface<dim>("m*m*m"),
-        DataPostprocessor<dim> ()
+        DataPostprocessor<dim> (),
+        Interface<dim>("m*m*m")
       {}
 
 

--- a/source/postprocess/visualization/volume_of_fluid_values.cc
+++ b/source/postprocess/visualization/volume_of_fluid_values.cc
@@ -32,6 +32,7 @@ namespace aspect
       VolumeOfFluidValues<dim>::
       VolumeOfFluidValues ()
         :
+        Interface<dim>("m*m*m"),
         DataPostprocessor<dim> ()
       {}
 

--- a/source/postprocess/visualization/volume_of_fluid_values.cc
+++ b/source/postprocess/visualization/volume_of_fluid_values.cc
@@ -33,7 +33,7 @@ namespace aspect
       VolumeOfFluidValues ()
         :
         DataPostprocessor<dim> (),
-        Interface<dim>("m*m*m")
+        Interface<dim>("")
       {}
 
 

--- a/source/postprocess/visualization/volumetric_strain_rate.cc
+++ b/source/postprocess/visualization/volumetric_strain_rate.cc
@@ -33,7 +33,7 @@ namespace aspect
         :
         DataPostprocessorScalar<dim> ("volumetric_strain_rate",
                                       update_gradients | update_quadrature_points),
-                                      Interface<dim>("1/s")
+        Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/volumetric_strain_rate.cc
+++ b/source/postprocess/visualization/volumetric_strain_rate.cc
@@ -31,9 +31,9 @@ namespace aspect
       VolumetricStrainRate<dim>::
       VolumetricStrainRate ()
         :
-        Interface<dim>("1/s"),
         DataPostprocessorScalar<dim> ("volumetric_strain_rate",
-                                      update_gradients | update_quadrature_points)
+                                      update_gradients | update_quadrature_points),
+                                      Interface<dim>("1/s")
       {}
 
 

--- a/source/postprocess/visualization/volumetric_strain_rate.cc
+++ b/source/postprocess/visualization/volumetric_strain_rate.cc
@@ -31,6 +31,7 @@ namespace aspect
       VolumetricStrainRate<dim>::
       VolumetricStrainRate ()
         :
+        Interface<dim>("1/s"),
         DataPostprocessorScalar<dim> ("volumetric_strain_rate",
                                       update_gradients | update_quadrature_points)
       {}


### PR DESCRIPTION
@bangerth 

Interface and CellDataVectorCreator clauses implemented in visualization postprocessors that store unit information.

