### PR TITLE
Specify requested properties for Material Model

### DIFF
--- a/benchmarks/annulus/annulus.cc
+++ b/benchmarks/annulus/annulus.cc
@@ -527,6 +527,7 @@ namespace aspect
                   MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
                   MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
                   fe_face_values[this->introspection().extractors.temperature].get_function_values(topo_vector, topo_values);
+                  in_face.requested_properties = MaterialModel::MaterialProperties::density;
                   material_model.evaluate(in_face, out_face);
 
                   for (unsigned int q=0; q < quadrature_formula.size(); ++q)

--- a/benchmarks/entropy_adiabat/plugins/compute_entropy_profile.cc
+++ b/benchmarks/entropy_adiabat/plugins/compute_entropy_profile.cc
@@ -66,7 +66,8 @@ namespace aspect
       const unsigned int entropy_index = this->introspection().compositional_index_for_name("entropy");
 
       // Constant properties on the reference profile
-      in.strain_rate.resize(0); // we do not need the viscosity
+      // We only need the material model to compute the density
+      in.requested_properties = MaterialModel::MaterialProperties::density | MaterialModel::MaterialProperties::additional_outputs;
       in.velocity[0] = Tensor <1,dim> ();
       // The entropy along an adiabat is constant (equals the surface entropy)
       in.composition[0][entropy_index] = surface_entropy;

--- a/benchmarks/entropy_adiabat/plugins/prescribed_temperature.cc
+++ b/benchmarks/entropy_adiabat/plugins/prescribed_temperature.cc
@@ -38,6 +38,7 @@ namespace aspect
       // Evaluate the material model to get the temperature
       MaterialModel::MaterialModelInputs<dim> in(1, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(1, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
       in.position[0]=position;
       in.temperature[0]=this->get_adiabatic_conditions().temperature(position);

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -601,6 +601,7 @@ namespace aspect
                   fe_face_values.reinit(cell, f);
                   MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
                   MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+                  in_face.requested_properties = MaterialModel::MaterialProperties::density;
                   fe_face_values[this->introspection().extractors.temperature].get_function_values(topo_vector, topo_values);
                   this->get_material_model().evaluate(in_face, out_face);
 

--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -283,7 +283,7 @@ namespace aspect
             thermal_conductivities += volume_fractions[c] * thermal_diffusivity[c] * heat_capacity[c] * densities[c];
 
           // calculate effective viscosity
-          if (in.strain_rate.size())
+          if (in.requests_property(MaterialProperties::viscosity))
             {
               // This function calculates viscosities assuming that all the compositional fields
               // experience the same strain rate (isostrain). Since there is only one process in

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -559,6 +559,7 @@ namespace aspect
                                                                      this->n_compositional_fields());
       typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
                                                                        this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 
       // loop over active, locally owned cells and
       // extract material model input and compute integrals

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -203,6 +203,9 @@ namespace aspect
         entropy_derivative_pressure    = 128,
         entropy_derivative_temperature = 256,
         reaction_terms                 = 512,
+        reaction_rates                 = 1024,
+        force_terms                    = 2048,
+        additional_outputs             = 4096,
 
         equation_of_state_properties   = density |
                                          thermal_expansion_coefficient |
@@ -213,7 +216,10 @@ namespace aspect
         all_properties                 = equation_of_state_properties |
                                          viscosity |
                                          thermal_conductivity |
-                                         reaction_terms
+                                         reaction_terms |
+                                         reaction_rates |
+                                         force_terms |
+                                         additional_outputs
       };
 
       /**

--- a/source/adiabatic_conditions/compute_profile.cc
+++ b/source/adiabatic_conditions/compute_profile.cc
@@ -70,7 +70,7 @@ namespace aspect
       MaterialModel::MaterialModelOutputs<dim> out(1, this->n_compositional_fields());
 
       // Constant properties on the reference profile
-      in.strain_rate.resize(0); // we do not need the viscosity
+      in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties;
       in.velocity[0] = Tensor <1,dim> ();
 
       // Check whether gravity is pointing up / out or down / in. In the normal case it should

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -675,6 +675,9 @@ namespace aspect
 
         typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
         typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+        // Do not request viscosity or reaction rates
+        in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties |
+                                  MaterialModel::MaterialProperties::thermal_conductivity;
 
         // for every surface face on which it makes sense to compute a
         // heat flux and that is owned by this processor,

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -122,6 +122,7 @@ namespace aspect
       // Set up the input for the density function of the material model.
       typename MaterialModel::Interface<dim>::MaterialModelInputs in0(1, n_compositional_fields);
       typename MaterialModel::Interface<dim>::MaterialModelOutputs out0(1, n_compositional_fields);
+      in0.requested_properties = MaterialModel::MaterialProperties::density;
 
       // Where to calculate the density
       // for cartesian domains
@@ -172,6 +173,7 @@ namespace aspect
           // Set up the input for the density function of the material model
           typename MaterialModel::Interface<dim>::MaterialModelInputs in(1, n_compositional_fields);
           typename MaterialModel::Interface<dim>::MaterialModelOutputs out(1, n_compositional_fields);
+          in.requested_properties = MaterialModel::MaterialProperties::density;
 
           // Where to calculate the density:
           // for cartesian domains
@@ -199,8 +201,8 @@ namespace aspect
           for (unsigned int c=0; c<n_compositional_fields; ++c)
             in.composition[0][c] = this->get_initial_composition_manager().initial_composition(in.position[0], c);
 
-          // We do not need the viscosity.
-          in.strain_rate.resize(0);
+          // We only need the density from the material model
+          in.requested_properties = MaterialModel::MaterialProperties::density;
 
           // We set all entries of the velocity vector to zero since this is the lithostatic case.
           in.velocity[0] = Tensor<1,dim> ();

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -329,7 +329,7 @@ namespace aspect
               in.velocity[0] = Tensor<1,dim> ();
               for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                 in.composition[0][c] = this->get_initial_composition_manager().initial_composition(position, c);
-              in.strain_rate.resize(0);
+              in.requested_properties = MaterialModel::MaterialProperties::thermal_expansion_coefficient;
 
               this->get_material_model().evaluate(in, out);
 

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -337,7 +337,7 @@ namespace aspect
               in.velocity[0] = Tensor<1,3> ();
               for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                 in.composition[0][c] = this->get_initial_composition_manager().initial_composition(position, c);
-              in.strain_rate.resize(0);
+              in.requested_properties = MaterialModel::MaterialProperties::thermal_expansion_coefficient;
 
               this->get_material_model().evaluate(in, out);
 

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -88,7 +88,8 @@ namespace aspect
       in.velocity[0]= Tensor<1,dim> ();
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
         in.composition[0][c] = function->value(Point<1>(depth),c);
-      in.strain_rate.resize(0); // adiabat has strain=0.
+      in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties |
+                                MaterialModel::MaterialProperties::thermal_conductivity;
       this->get_material_model().evaluate(in, out);
 
       const double kappa = ( (this->get_parameters().formulation_temperature_equation ==

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -283,7 +283,12 @@ namespace aspect
       requested_properties(MaterialProperties::all_properties)
     {
       if (compute_strain_rate == false)
-        this->strain_rate.resize(0);
+        {
+          this->strain_rate.resize(0);
+          requested_properties = MaterialProperties::Property(requested_properties & ~MaterialProperties::viscosity);
+        }
+      else
+        requested_properties = requested_properties | MaterialProperties::viscosity;
 
       for (unsigned int q=0; q<input_data.solution_values.size(); ++q)
         {
@@ -370,9 +375,15 @@ namespace aspect
       // length of the strain_rate vector to 0, we signal to evaluate()
       // that we do not need to access the viscosity.
       if (compute_strain_rate)
-        fe_values[introspection.extractors.velocities].get_function_symmetric_gradients (solution_vector,this->strain_rate);
+        {
+          fe_values[introspection.extractors.velocities].get_function_symmetric_gradients (solution_vector,this->strain_rate);
+          requested_properties = requested_properties | MaterialProperties::viscosity;
+        }
       else
-        this->strain_rate.resize(0);
+        {
+          this->strain_rate.resize(0);
+          requested_properties = MaterialProperties::Property(requested_properties & ~MaterialProperties::viscosity);
+        }
 
       // Vectors for evaluating the compositional field parts of the finite element solution
       std::vector<std::vector<double>> composition_values (introspection.n_compositional_fields,
@@ -409,14 +420,6 @@ namespace aspect
     bool
     MaterialModelInputs<dim>::requests_property(const MaterialProperties::Property &property) const
     {
-      //TODO: Remove this once all callers set requested_properties correctly
-      if ((property & MaterialProperties::Property::viscosity) != 0)
-        return (strain_rate.size() != 0);
-
-      //TODO: Remove this once all callers set requested_properties correctly
-      if ((property & MaterialProperties::Property::reaction_terms) != 0)
-        return (strain_rate.size() != 0);
-
       // Note that this means 'requested_properties' can include other properties than
       // just 'property', but in any case it at least requests 'property'.
       return (requested_properties & property) != 0;

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -227,7 +227,7 @@ namespace aspect
           out.densities[i] = (reference_rho_s + delta_rho)
                              * temperature_dependence * std::exp(compressibility * (in.pressure[i] - this->get_surface_pressure()));
 
-          if (this->include_melt_transport() && in.requests_property(MaterialProperties::reaction_terms))
+          if (this->include_melt_transport())
             {
               const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
               const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
@@ -301,11 +301,10 @@ namespace aspect
               for (unsigned int c=0; c<in.composition[i].size(); ++c)
                 {
                   // fill reaction rate outputs
-                  if (reaction_rate_out != nullptr)
+                  if (reaction_rate_out != nullptr && in.requests_property(MaterialProperties::reaction_rates))
                     {
                       if (c == peridotite_idx && this->get_timestep_number() > 0)
-                        reaction_rate_out->reaction_rates[i][c] = porosity_change / melting_time_scale
-                                                                  * (1 - maximum_melt_fraction) / (1 - old_porosity);
+                        reaction_rate_out->reaction_rates[i][c] = porosity_change / melting_time_scale * (1 - maximum_melt_fraction) / (1 - old_porosity);
                       else if (c == porosity_idx && this->get_timestep_number() > 0)
                         reaction_rate_out->reaction_rates[i][c] = porosity_change / melting_time_scale;
                       else

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -249,20 +249,21 @@ namespace aspect
         if (force_out == nullptr)
           return;
 
-        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
-          {
-            // Get old stresses from compositional fields
-            SymmetricTensor<2,dim> stress_old;
-            for (unsigned int j=0; j < SymmetricTensor<2,dim>::n_independent_components; ++j)
-              stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(j)] = in.composition[i][j];
+        if (in.requests_property(MaterialProperties::force_terms))
+          for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
+            {
+              // Get old stresses from compositional fields
+              SymmetricTensor<2,dim> stress_old;
+              for (unsigned int j=0; j < SymmetricTensor<2,dim>::n_independent_components; ++j)
+                stress_old[SymmetricTensor<2,dim>::unrolled_to_component_indices(j)] = in.composition[i][j];
 
-            // Average viscoelastic viscosity
-            const double average_viscoelastic_viscosity = out.viscosities[i];
+              // Average viscoelastic viscosity
+              const double average_viscoelastic_viscosity = out.viscosities[i];
 
-            // Fill elastic force outputs (See equation 30 in Moresi et al., 2003, J. Comp. Phys.)
-            force_out->elastic_force[i] = -1. * ( average_viscoelastic_viscosity / calculate_elastic_viscosity(average_elastic_shear_moduli[i]) * stress_old );
+              // Fill elastic force outputs (See equation 30 in Moresi et al., 2003, J. Comp. Phys.)
+              force_out->elastic_force[i] = -1. * ( average_viscoelastic_viscosity / calculate_elastic_viscosity(average_elastic_shear_moduli[i]) * stress_old );
 
-          }
+            }
       }
 
 

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -63,6 +63,7 @@ namespace aspect
                                                  this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(),
                                                    this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/source/mesh_refinement/nonadiabatic_temperature.cc
+++ b/source/mesh_refinement/nonadiabatic_temperature.cc
@@ -66,7 +66,6 @@ namespace aspect
             fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
                                                                                          in.temperature);
             in.position = fe_values.get_quadrature_points();
-            in.strain_rate.resize(0);// we are not reading the viscosity
 
             cell->get_dof_indices (local_dof_indices);
 

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -62,6 +62,7 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(), this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -68,6 +68,7 @@ namespace aspect
                                                  this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(),
                                                    this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/source/postprocess/basic_statistics.cc
+++ b/source/postprocess/basic_statistics.cc
@@ -63,6 +63,9 @@ namespace aspect
 
           MaterialModel::MaterialModelInputs<dim> in (1, this->n_compositional_fields());
           MaterialModel::MaterialModelOutputs<dim> out (1, this->n_compositional_fields());
+          in.requested_properties = MaterialModel::MaterialProperties::thermal_conductivity |
+                                    MaterialModel::MaterialProperties::equation_of_state_properties |
+                                    MaterialModel::MaterialProperties::viscosity;
 
           in.position[0] = representative_point;
           in.temperature[0] = temperature;

--- a/source/postprocess/boundary_densities.cc
+++ b/source/postprocess/boundary_densities.cc
@@ -50,7 +50,8 @@ namespace aspect
 
       typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
       typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-      std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (fe_face_values.n_quadrature_points));
+      in.requested_properties = MaterialModel::MaterialProperties::density;
+      std::vector<std::vector<double>> composition_values(this->n_compositional_fields(), std::vector<double>(fe_face_values.n_quadrature_points));
 
       const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
       const types::boundary_id bottom_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -147,6 +147,7 @@ namespace aspect
             // Evaluate the material model in the cell volume.
             MaterialModel::MaterialModelInputs<dim> in_volume(fe_volume_values, cell, this->introspection(), this->get_solution());
             MaterialModel::MaterialModelOutputs<dim> out_volume(fe_volume_values.n_quadrature_points, this->n_compositional_fields());
+            in_volume.requested_properties = MaterialModel::MaterialProperties::density | MaterialModel::MaterialProperties::viscosity;
             this->get_material_model().evaluate(in_volume, out_volume);
 
             // Get solution values for the divergence of the velocity, which is not
@@ -267,6 +268,7 @@ namespace aspect
             // Evaluate the material model on the cell face.
             MaterialModel::MaterialModelInputs<dim> in_support(fe_support_values, cell, this->introspection(), this->get_solution());
             MaterialModel::MaterialModelOutputs<dim> out_support(fe_support_values.n_quadrature_points, this->n_compositional_fields());
+            in_support.requested_properties = MaterialModel::MaterialProperties::density;
             this->get_material_model().evaluate(in_support, out_support);
 
             fe_support_values[this->introspection().extractors.velocities].get_function_values(topo_vector, stress_support_values);
@@ -315,6 +317,7 @@ namespace aspect
             // Evaluate the material model on the cell face.
             MaterialModel::MaterialModelInputs<dim> in_output(fe_output_values, cell, this->introspection(), this->get_solution());
             MaterialModel::MaterialModelOutputs<dim> out_output(fe_output_values.n_quadrature_points, this->n_compositional_fields());
+            in_output.requested_properties = MaterialModel::MaterialProperties::density;
             this->get_material_model().evaluate(in_output, out_output);
 
             fe_output_values[this->introspection().extractors.velocities].get_function_values(topo_vector, stress_output_values);

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -108,8 +108,10 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<3> in(fe_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<3> out(fe_values.n_quadrature_points, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density;
 
-      std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+      std::vector<std::vector<double>>
+      composition_values(this->n_compositional_fields(), std::vector<double>(quadrature_formula.size()));
 
       // Directly do the global 3D integral over each quadrature point of every cell (different from traditional way to do layer integral).
       // This is necessary because of ASPECT's adaptive mesh refinement feature.

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -251,6 +251,7 @@ namespace aspect
                                                  this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature_formula.size(),
                                                    this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -62,6 +62,7 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density;
 
       // for every surface face on which it makes sense to compute a
       // mass flux and that is owned by this processor,

--- a/source/postprocess/material_statistics.cc
+++ b/source/postprocess/material_statistics.cc
@@ -48,6 +48,7 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density | MaterialModel::MaterialProperties::viscosity;
 
       double local_volume = 0.0;
       double local_mass = 0.0;

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -58,6 +58,7 @@ namespace aspect
                                                                      n_compositional_fields);
       typename MaterialModel::Interface<dim>::MaterialModelOutputs out(n_q_points,
                                                                        n_compositional_fields);
+      in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
@@ -68,7 +69,6 @@ namespace aspect
                       cell,
                       this->introspection(),
                       this->get_solution());
-            in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 
             this->get_material_model().fill_additional_material_model_inputs(in,
                                                                              this->get_solution(),

--- a/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
+++ b/source/postprocess/visualization/maximum_horizontal_compressive_stress.cc
@@ -57,6 +57,9 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        // We do not need to compute anything but the viscosity
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
         // Compute the viscosity...
         this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -107,6 +107,9 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        // We do not need to compute anything but the viscosity
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
         // Compute the viscosity...
         this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -68,6 +68,7 @@ namespace aspect
 
         MaterialModel::MaterialModelInputs<dim> in(n_q_points, this->n_compositional_fields());
         MaterialModel::MaterialModelOutputs<dim> out(n_q_points, this->n_compositional_fields());
+        in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
         std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 
@@ -211,6 +212,7 @@ namespace aspect
 
         MaterialModel::MaterialModelInputs<dim> in(n_q_points, this->n_compositional_fields());
         MaterialModel::MaterialModelOutputs<dim> out(n_q_points, this->n_compositional_fields());
+        in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
         std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
 
@@ -296,9 +298,6 @@ namespace aspect
                     fe_values[this->introspection().extractors.pressure].get_function_gradients (this->get_solution(),
                                                                                                  in.pressure_gradient);
                     in.position = fe_values.get_quadrature_points();
-
-                    // we do not need the strain rate
-                    in.strain_rate.resize(0);
 
                     // Loop over compositional fields to get composition values
                     for (unsigned int c=0; c<this->n_compositional_fields(); ++c)

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -58,6 +58,9 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        // We do not need to compute anything but the viscosity
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
         // Compute the viscosity...
         this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -58,6 +58,7 @@ namespace aspect
                                                    this->introspection());
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity | MaterialModel::MaterialProperties::additional_outputs;
 
         out.additional_outputs.push_back(
           std::make_unique<MaterialModel::MaterialModelDerivatives<dim>> (n_quadrature_points));

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -58,6 +58,9 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        // We do not need to compute anything but the viscosity
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
         // Compute the viscosity...
         this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -58,6 +58,9 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        // We do not need to compute anything but the viscosity
+        in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
         // Compute the viscosity...
         this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -64,6 +64,10 @@ namespace aspect
                                                    false);
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
+        in.requested_properties = MaterialModel::MaterialProperties::density |
+                                  MaterialModel::MaterialProperties::specific_heat |
+                                  MaterialModel::MaterialProperties::thermal_conductivity;
+
         this->get_material_model().evaluate(in, out);
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -426,6 +426,9 @@ namespace aspect
     MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
                                                  introspection.n_compositional_fields);
 
+    // We do not need to compute anything but the viscosity
+    in.requested_properties = MaterialModel::MaterialProperties::viscosity;
+
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
         {

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1115,6 +1115,7 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(), this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
       create_material_model_outputs(out);
 

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -283,20 +283,22 @@ namespace aspect
                                                      introspection.n_compositional_fields);
           MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
                                                        introspection.n_compositional_fields);
-          if ( ! use_constant_density)
+          in.requested_properties = MaterialModel::MaterialProperties::density;
+
+          if (!use_constant_density)
             {
-              fe[introspection.extractors.pressure].get_function_values (relevant_dst, in.pressure);
-              fe[introspection.extractors.temperature].get_function_values (relevant_dst, in.temperature);
+              fe[introspection.extractors.pressure].get_function_values(relevant_dst, in.pressure);
+              fe[introspection.extractors.temperature].get_function_values(relevant_dst, in.temperature);
               in.velocity = velocities;
-              fe[introspection.extractors.pressure].get_function_gradients (relevant_dst, in.pressure_gradient);
-              for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+              fe[introspection.extractors.pressure].get_function_gradients(relevant_dst, in.pressure_gradient);
+              for (unsigned int c = 0; c < introspection.n_compositional_fields; ++c)
                 fe[introspection.extractors.compositional_fields[c]].get_function_values(relevant_dst,
                                                                                          composition_values[c]);
 
-              for (unsigned int i=0; i<n_q_points; ++i)
+              for (unsigned int i = 0; i < n_q_points; ++i)
                 {
                   in.position[i] = fe.quadrature_point(i);
-                  for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+                  for (unsigned int c = 0; c < introspection.n_compositional_fields; ++c)
                     in.composition[i][c] = composition_values[c][i];
                 }
               material_model->evaluate(in, out);
@@ -390,13 +392,13 @@ namespace aspect
                                                introspection.n_compositional_fields);
     MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
                                                  introspection.n_compositional_fields);
+    in.requested_properties = MaterialModel::MaterialProperties::density;
 
     // loop over all local cells
-    for (const auto &cell : dof_handler.active_cell_iterators())
-      if (cell->is_locally_owned())
+    for (const auto &cell : dof_handler.active_cell_iterators()) if (cell->is_locally_owned())
         {
           if (limit_to_top_faces == false)
-            fe_values.reinit (cell);
+            fe_values.reinit(cell);
           else
             {
               // We only want the output at the top boundary, so only compute it if the current cell
@@ -404,13 +406,13 @@ namespace aspect
               bool cell_at_top_boundary = false;
               for (const unsigned int f : cell->face_indices())
                 if (cell->at_boundary(f) &&
-                    (geometry_model->translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top"))
+                    (geometry_model->translate_id_to_symbol_name(cell->face(f)->boundary_id()) == "top"))
                   {
                     Assert(cell_at_top_boundary == false,
                            ExcInternalError("Error, more than one top surface found in a cell."));
 
                     cell_at_top_boundary = true;
-                    fe_face_values.reinit(cell,f);
+                    fe_face_values.reinit(cell, f);
                   }
 
               if (cell_at_top_boundary == false)
@@ -428,11 +430,11 @@ namespace aspect
           else
             {
               // Get the velocity at each quadrature point
-              fe[introspection.extractors.velocities].get_function_values (solution, in.velocity);
+              fe[introspection.extractors.velocities].get_function_values(solution, in.velocity);
             }
 
           // actually compute the moment of inertia and angular momentum
-          for (unsigned int k=0; k<n_q_points; ++k)
+          for (unsigned int k = 0; k < n_q_points; ++k)
             {
               // get the position and density at this quadrature point
               const Point<dim> r_vec = q_points[k];
@@ -442,17 +444,17 @@ namespace aspect
               if (dim == 2)
                 {
                   // Get the velocity perpendicular to the position vector
-                  const Tensor<1,dim> r_perp = cross_product_2d(r_vec);
+                  const Tensor<1, dim> r_perp = cross_product_2d(r_vec);
 
                   local_scalar_angular_momentum += in.velocity[k] * r_perp * rho * JxW;
                   local_scalar_moment_of_inertia += r_vec.norm_square() * rho * JxW;
                 }
               else
                 {
-                  const Tensor<1,dim> r_cross_v = cross_product_3d(r_vec, in.velocity[k]);
+                  const Tensor<1, dim> r_cross_v = cross_product_3d(r_vec, in.velocity[k]);
 
                   local_angular_momentum += r_cross_v * rho * JxW;
-                  local_moment_of_inertia += (r_vec.norm_square() * unit_symmetric_tensor<dim>() - symmetrize(outer_product(r_vec,r_vec))) * rho * JxW;
+                  local_moment_of_inertia += (r_vec.norm_square() * unit_symmetric_tensor<dim>() - symmetrize(outer_product(r_vec, r_vec))) * rho * JxW;
                 }
             }
         }

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1460,6 +1460,7 @@ namespace aspect
                                update_JxW_values);
 
       MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, sim.introspection.n_compositional_fields);
+      in.requested_properties = MaterialModel::MaterialProperties::viscosity;
       MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, sim.introspection.n_compositional_fields);
 
       // This function call computes a cellwise projection of data defined at quadrature points to
@@ -1819,6 +1820,7 @@ namespace aspect
             sim.mesh_deformation->get_free_surface_boundary_indicators();
 
           MaterialModel::MaterialModelInputs<dim> face_material_inputs(n_face_q_points, sim.introspection.n_compositional_fields);
+          face_material_inputs.requested_properties = MaterialModel::MaterialProperties::density;
           MaterialModel::MaterialModelOutputs<dim> face_material_outputs(n_face_q_points, sim.introspection.n_compositional_fields);
 
           active_cell_data.free_surface_stabilization_term_table.reinit(n_faces_boundary, n_face_q_points);

--- a/source/time_stepping/conduction_time_step.cc
+++ b/source/time_stepping/conduction_time_step.cc
@@ -49,6 +49,8 @@ namespace aspect
                                                  this->introspection().n_compositional_fields);
       MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
                                                    this->introspection().n_compositional_fields);
+      in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties |
+                                MaterialModel::MaterialProperties::thermal_conductivity;
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/tests/compressibility.cc
+++ b/tests/compressibility.cc
@@ -124,6 +124,7 @@ namespace aspect
 
       MaterialModel::MaterialModelInputs<dim> in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::density;
 
       // compute the integral of the viscosity. since we're on a unit box,
       // this also is the average value

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -490,7 +490,7 @@ namespace aspect
             }
         }
 
-      if (in.strain_rate.size() )
+      if (in.requests_property(MaterialProperties::viscosity) )
         {
           // 5) Compute plastic weakening of the viscosity
           for (unsigned int i=0; i<in.n_evaluation_points(); ++i)

--- a/tests/shear_thinning.cc
+++ b/tests/shear_thinning.cc
@@ -117,6 +117,7 @@ namespace aspect
 
       typename MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
       typename MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
+      in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 
       // compute the integral of the viscosity. since we're on a unit box,
       // this also is the average value

--- a/unit_tests/additional_outputs.cc
+++ b/unit_tests/additional_outputs.cc
@@ -74,6 +74,7 @@ TEST_CASE("AdditionalOutputs works")
   using namespace aspect::MaterialModel;
   MaterialModelInputs<dim> in(1,1);
   MaterialModelOutputs<dim> out(1,1);
+  in.requested_properties = MaterialProperties::additional_outputs;
 
 
   REQUIRE(out.get_additional_output<AdditionalOutputs1<dim>>() == NULL);


### PR DESCRIPTION
There are many places where we evaluate the material model to get at one material property. However, many other properties are also computed, like the reaction_terms. This PR specifies in several places that only the viscosity is requested. This should avoid computing the reaction terms and force terms for elasticity and strain dependent rheologies, as both Elasticity and StrainDependent check for `in.requests_property(MaterialProperties::reaction_terms)`.

However, currently request_property() still does
```
      //TODO: Remove this once all callers set requested_properties correctly
      if ((property & MaterialProperties::Property::reaction_terms) != 0)
        return (strain_rate.size() != 0);
```
so if in.strain_rate is filled (like for viscosity) then reaction_terms are still computed. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
