### PR TITLE
Revert some particle performance regressions

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -419,11 +419,23 @@ namespace aspect
         void
         local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
+
 #if DEAL_II_VERSION_GTE(9,3,0)
-                               , internal::SolutionEvaluators<dim> &evaluators
+        /**
+         * Update the particle properties of one cell.
+         *
+         * This version of the function above uses the deal.II class FEPointEvaluation,
+         * which allows for a faster evaluation of the solution under certain conditions.
+         * Check the place where this function is called for a list of conditions
+         * (they will change while FEPointEvaluation is generalized).
+         */
+        void
+        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
+                               internal::SolutionEvaluators<dim> &evaluators);
 #endif
-                              );
 
         /**
          * Advect the particles of one cell. Performs only one step for
@@ -436,11 +448,28 @@ namespace aspect
         void
         local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
+
 #if DEAL_II_VERSION_GTE(9,3,0)
-                               , internal::SolutionEvaluators<dim> &evaluators
+        /**
+         * Advect the particles of one cell. Performs only one step for
+         * multi-step integrators. Needs to be called until integrator->continue()
+         * evaluates to false. Particles that moved out of their old cell
+         * during this advection step are removed from the local multimap and
+         * stored in @p particles_out_of_cell for further treatment (sorting
+         * them into the new cell).
+         *
+         * This version of the above function uses the deal.II class FEPointEvaluation,
+         * which allows for a faster evaluation of the solution under certain conditions.
+         * Check the place where this function is called for a list of conditions
+         * (they will change while FEPointEvaluation is generalized).
+         */
+        void
+        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
+                               const typename ParticleHandler<dim>::particle_iterator &end_particle,
+                               internal::SolutionEvaluators<dim> &evaluators);
 #endif
-                              );
 
         /**
          * This function registers the necessary functions to the

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -647,7 +647,10 @@ namespace aspect
                                                 gradients);
         }
     }
-#else
+#endif
+
+
+
     template <int dim>
     void
     World<dim>::local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
@@ -693,7 +696,7 @@ namespace aspect
                                                 gradients[i]);
         }
     }
-#endif
+
 
 
 
@@ -751,7 +754,10 @@ namespace aspect
                                        velocities,
                                        this->get_timestep());
     }
-#else
+#endif
+
+
+
     template <int dim>
     void
     World<dim>::local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
@@ -844,7 +850,6 @@ namespace aspect
                                        velocity,
                                        this->get_timestep());
     }
-#endif
 
 
 
@@ -945,13 +950,23 @@ namespace aspect
                 // Only update particles, if there are any in this cell
                 if (particles_in_cell.begin() != particles_in_cell.end())
                   {
+#if DEAL_II_VERSION_GTE(9,3,0)
+                    // Only use deal.II FEPointEvaluation if it's fast path is used
+                    const bool use_fast_path = dynamic_cast<const MappingQGeneric<dim> *>(&this->get_mapping()) != nullptr;
+                    if (use_fast_path)
+                      local_update_particles(cell,
+                                             particles_in_cell.begin(),
+                                             particles_in_cell.end(),
+                                             evaluators);
+                    else
+                      local_update_particles(cell,
+                                             particles_in_cell.begin(),
+                                             particles_in_cell.end());
+#else
                     local_update_particles(cell,
                                            particles_in_cell.begin(),
-                                           particles_in_cell.end()
-#if DEAL_II_VERSION_GTE(9,3,0)
-                                           , evaluators
+                                           particles_in_cell.end());
 #endif
-                                          );
                   }
 
               }
@@ -1240,13 +1255,25 @@ namespace aspect
               // Only advect particles, if there are any in this cell
               if (particles_in_cell.begin() != particles_in_cell.end())
                 {
+#if DEAL_II_VERSION_GTE(9,3,0)
+                  // Only use deal.II FEPointEvaluation if it's fast path is used
+                  const bool use_fast_path = dynamic_cast<const MappingQGeneric<dim> *>(&this->get_mapping()) != nullptr;
+                  if (use_fast_path)
+                    local_advect_particles(cell,
+                                           particles_in_cell.begin(),
+                                           particles_in_cell.end(),
+                                           evaluators);
+                  else
+                    local_advect_particles(cell,
+                                           particles_in_cell.begin(),
+                                           particles_in_cell.end());
+#else
                   local_advect_particles(cell,
                                          particles_in_cell.begin(),
-                                         particles_in_cell.end()
-#if DEAL_II_VERSION_GTE(9,3,0)
-                                         , evaluators
+                                         particles_in_cell.end());
 #endif
-                                        );
+
+
                 }
             }
 


### PR DESCRIPTION
It turns out the changes in #4060 only speed up things under very specific conditions like very many particles per cell >>100 and few compositional fields. Unfortunately I did not benchmark more realistic models, where they seem to perform much worse than before and those I did benchmark I combined with #4062, which more or less offsets the changes to the advection part. 

I think the performance can be fixed with improvements to the FEPointEvaluation class in deal.II, in particular to teach it how to handle FESystems efficiently, currently we recalculate mapping related data for each base element separately. However, these changes would still need to be made and benchmarked so the changes only make sense starting with deal.II 10 at the earliest.

I would like to disable #4060 for now to avoid slowing everyone's particle models, but I understand that we do not want to keep disabled code around. If you prefer I can also revert #4060 and open a new PR in the future that introduces it when it is faster. Opinions? 