### PR TITLE
Use the reinit function for MaterialModelInputs

### DIFF
--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -693,30 +693,12 @@ namespace aspect
                 if (cell->face(f)->boundary_id() == CMB_id)
                   {
                     fe_face_values.reinit (cell, f);
+
+                    // Repopulate MaterialInputs, set use_strain_rates to false
+                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
+
                     fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
                         temperature_gradients);
-                    fe_face_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
-                        in.temperature);
-                    fe_face_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
-                                                                                                   in.pressure);
-                    for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                      fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(),
-                          composition_values[c]);
-
-                    in.position = fe_face_values.get_quadrature_points();
-
-                    // since we are not reading the viscosity and the viscosity
-                    // is the only coefficient that depends on the strain rate,
-                    // we need not compute the strain rate. set the corresponding
-                    // array to empty, to prevent accidental use and skip the
-                    // evaluation of the strain rate in evaluate().
-                    in.strain_rate.resize(0);
-
-                    for (unsigned int i=0; i<fe_face_values.n_quadrature_points; ++i)
-                      {
-                        for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                          in.composition[i][c] = composition_values[c][i];
-                      }
 
                     this->get_material_model().evaluate(in, out);
 

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -694,8 +694,7 @@ namespace aspect
                   {
                     fe_face_values.reinit (cell, f);
 
-                    // Repopulate MaterialInputs, set use_strain_rates to false
-                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), /*compute_strain_rates = */ false);
 
                     fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
                         temperature_gradients);

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -134,31 +134,8 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    // get the various components of the solution, then
-                    // evaluate the material properties there
-                    fe_values[this->introspection().extractors.temperature].get_function_values (this->get_solution(),
-                                                                                                 in.temperature);
-                    fe_values[this->introspection().extractors.pressure].get_function_values (this->get_solution(),
-                                                                                              in.pressure);
-                    fe_values[this->introspection().extractors.velocities].get_function_values (this->get_solution(),
-                                                                                                in.velocity);
-                    fe_values[this->introspection().extractors.pressure].get_function_gradients (this->get_solution(),
-                                                                                                 in.pressure_gradient);
-                    in.position = fe_values.get_quadrature_points();
-
-                    // we do not need the strain rate
-                    in.strain_rate.resize(0);
-
-                    // Loop over compositional fields to get composition values
-                    for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                      fe_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(),
-                          composition_values[c]);
-                    for (unsigned int i=0; i<fe_values.n_quadrature_points; ++i)
-                      {
-                        for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-                          in.composition[i][c] = composition_values[c][i];
-                      }
-                    in.current_cell = cell;
+                    // Repopulate MaterialInputs, set use_strain_rates to false
+                    in.reinit (fe_values, cell, this->introspection(), this->get_solution(), false);
 
                     out.additional_outputs.push_back(
                       std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -134,8 +134,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    // Repopulate MaterialInputs, set use_strain_rates to false
-                    in.reinit (fe_values, cell, this->introspection(), this->get_solution(), false);
+                    in.reinit (fe_values, cell, this->introspection(), this->get_solution(), /* compute_strain_rate = */ false);
 
                     out.additional_outputs.push_back(
                       std_cxx14::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));


### PR DESCRIPTION
This PR uses the reinit function to reinitialize the MaterialModel inputs. It shouldn't change anything, but it's late. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
