### PR TITLE
[WIP] Field types for viscoelasticity and corresponding rheology and EoS modules

### DIFF
--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
@@ -90,10 +90,11 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = bottom, top, right
 end
 
-# Number and name of compositional fields
+# Number, name and type of compositional fields
 subsection Compositional fields
   set Number of fields = 4
   set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, beam
+  set Types of fields  = stress,       stress,       stress,       composition
 end
 
 # Spatial domain of different compositional fields
@@ -138,9 +139,9 @@ subsection Material model
   set Model name = viscoelastic
 
   subsection Viscoelastic
-    set Densities            =  2800,  2800,  2800,  2800,  3300
-    set Viscosities          = 1.e18, 1.e18, 1.e18, 1.e18, 1.e24
-    set Elastic shear moduli = 1.e11, 1.e11, 1.e11, 1.e11, 1.e10
+    set Densities            =  2800,  3300
+    set Viscosities          = 1.e18, 1.e24
+    set Elastic shear moduli = 1.e11, 1.e10
     set Fixed elastic time step     = 1e3
     set Use fixed elastic time step = false
     set Use stress averaging        = false

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
@@ -94,7 +94,7 @@ end
 subsection Compositional fields
   set Number of fields = 4
   set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, beam
-  set Types of fields  = stress,       stress,       stress,       composition
+  set Types of fields  = stress,       stress,       stress,       chemical_composition
 end
 
 # Spatial domain of different compositional fields

--- a/doc/modules/changes/20210718_bobmyhill
+++ b/doc/modules/changes/20210718_bobmyhill
@@ -1,9 +1,0 @@
-New: The "Compositional fields" subsection in ASPECT has a new parameter called
-"Types of fields" that is used to specify the types of all the "compositional" fields.
-The parameter is used to fill a new FieldTypeIndices structure,
-that itself contains a series of std::vector<unsigned int>
-objects containing the indices of the fields corresponding to each type.
-This structure can be called from within material models
-via this->introspection().get_field_type_indices().
-<br>
-(Bob Myhill, 2021/07/18)

--- a/doc/modules/changes/20210718_bobmyhill
+++ b/doc/modules/changes/20210718_bobmyhill
@@ -1,0 +1,9 @@
+New: The "Compositional fields" subsection in ASPECT has a new parameter called
+"Types of fields" that is used to specify the types of all the "compositional" fields.
+The parameter is used to fill a new FieldTypeIndices structure,
+that itself contains a series of std::vector<unsigned int>
+objects containing the indices of the fields corresponding to each type.
+This structure can be called from within material models
+via this->introspection().get_field_type_indices().
+<br>
+(Bob Myhill, 2021/07/18)

--- a/doc/modules/changes/20210831_bobmyhill
+++ b/doc/modules/changes/20210831_bobmyhill
@@ -1,7 +1,7 @@
 New: The "Compositional fields" subsection in ASPECT has a new parameter called
 "Types of fields" that is used to specify the types of all the
 "compositional" fields. Supported types are currently
-"composition", "stress", "grain_size", "porosity", or "generic".
+"chemical_composition", "stress", "grain_size", "porosity", or "generic".
 The parameter is used to fill a vector of FieldDescription objects
 that store metadata about each field.
 This vector can be called from within material models

--- a/doc/modules/changes/20210831_bobmyhill
+++ b/doc/modules/changes/20210831_bobmyhill
@@ -1,0 +1,10 @@
+New: The "Compositional fields" subsection in ASPECT has a new parameter called
+"Types of fields" that is used to specify the types of all the
+"compositional" fields. Supported types are currently
+"composition", "stress", "grain_size", "porosity", or "generic".
+The parameter is used to fill a vector of FieldDescription objects
+that store metadata about each field.
+This vector can be called from within material models
+via this->introspection().get_field_descriptions().
+<br>
+(Bob Myhill, 2021/08/31)

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -355,10 +355,10 @@ namespace aspect
 
 
       /**
-       * A function that returns the full list of compositional field type indices.
+       * A function that returns the full vector of field descriptions.
        */
-      const typename Parameters<dim>::FieldTypeIndices &
-      get_field_type_indices () const;
+      const std::vector<typename Parameters<dim>::FieldDescription> &
+      get_field_descriptions () const;
 
       /**
        * A function that gets the name of a compositional field as an input
@@ -388,7 +388,11 @@ namespace aspect
        */
       std::vector<std::string> composition_names;
 
-      typename Parameters<dim>::FieldTypeIndices field_type_indices;
+      /**
+       * A vector that stores descriptions of each field, including its type
+       * (i.e. whether the field corresponds to a composition, porosity etc.).
+       */
+      std::vector<typename Parameters<dim>::FieldDescription> field_descriptions;
 
   };
 }

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -353,6 +353,13 @@ namespace aspect
       const std::vector<std::string> &
       get_composition_names () const;
 
+
+      /**
+       * A function that returns the full list of compositional field type indices.
+       */
+      const typename Parameters<dim>::FieldTypeIndices &
+      get_field_type_indices () const;
+
       /**
        * A function that gets the name of a compositional field as an input
        * parameter and returns if the compositional field is used in this
@@ -380,6 +387,8 @@ namespace aspect
        * be used in the simulation.
        */
       std::vector<std::string> composition_names;
+
+      typename Parameters<dim>::FieldTypeIndices field_type_indices;
 
   };
 }

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -353,7 +353,6 @@ namespace aspect
       const std::vector<std::string> &
       get_composition_names () const;
 
-
       /**
        * A function that returns the full vector of compositional
        * field descriptions.
@@ -371,6 +370,20 @@ namespace aspect
        */
       bool
       compositional_name_exists (const std::string &name) const;
+
+      /**
+       * Get the indices of the compositional fields which are of a
+       * particular type (chemical composition, porosity, etc.).
+       */
+      const std::vector<unsigned int>
+      get_indices_for_fields_of_type (const std::string &type_name) const;
+
+      /**
+      * Get the names of the compositional fields which are of a
+      * particular type (chemical composition, porosity, etc.).
+       */
+      const std::vector<std::string>
+      get_names_for_fields_of_type (const std::string &type_name) const;
 
       /**
        * A function that gets a component index as an input

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -355,10 +355,11 @@ namespace aspect
 
 
       /**
-       * A function that returns the full vector of field descriptions.
+       * A function that returns the full vector of compositional
+       * field descriptions.
        */
-      const std::vector<typename Parameters<dim>::FieldDescription> &
-      get_field_descriptions () const;
+      const std::vector<typename Parameters<dim>::CompositionalFieldDescription> &
+      get_composition_descriptions () const;
 
       /**
        * A function that gets the name of a compositional field as an input
@@ -389,10 +390,11 @@ namespace aspect
       std::vector<std::string> composition_names;
 
       /**
-       * A vector that stores descriptions of each field, including its type
-       * (i.e. whether the field corresponds to a composition, porosity etc.).
+       * A vector that stores descriptions of each compositional field,
+       * including its type (i.e. whether the compositional field corresponds
+       * to chemical composition, porosity etc.).
        */
-      std::vector<typename Parameters<dim>::FieldDescription> field_descriptions;
+      std::vector<typename Parameters<dim>::CompositionalFieldDescription> composition_descriptions;
 
   };
 }

--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -142,6 +142,13 @@ namespace aspect
 
         private:
           /**
+           * Indices of the "compositional" fields
+           * corresponding to composition and stress.
+           */
+          std::vector<unsigned int> stress_field_indices;
+          std::vector<unsigned int> compositional_field_indices;
+
+          /**
            * Viscosity of a damper used to stabilize elasticity.
            * A value of 0 Pas is equivalent to not using a damper.
            */

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -261,7 +261,6 @@ namespace aspect
         };
       }
 
-
       /**
        * For multicomponent material models: Given a vector of compositional
        * field values of length N, of which M indices correspond to mass or

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -262,6 +262,24 @@ namespace aspect
       }
 
 
+      /**
+       * For multicomponent material models: Given a vector of compositional
+       * field values of length N, of which M indices correspond to mass or
+       * volume fractions, this function returns a vector of fractions
+       * of length M+1, corresponding to the fraction of a ``background
+       * material'' as the first entry, and fractions for each of the input
+       * fields as the following entries. The returned vector will sum to one.
+       * If the sum of the compositional_fields is greater than
+       * one, we assume that there is no background field (i.e., that field value
+       * is zero). Otherwise, the difference between the sum of the compositional
+       * fields and 1.0 is assumed to be the amount of the background field.
+       * This function makes no assumptions about the units of the
+       * compositional field values; for example, they could correspond to
+       * mass or volume fractions.
+       */
+      std::vector<double>
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices);
 
       /**
        * For multicomponent material models: Given a vector of compositional

--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -205,6 +205,12 @@ namespace aspect
 
       private:
         /**
+         * Indices of the "compositional" fields
+         * corresponding to composition
+         */
+        std::vector<unsigned int> compositional_field_indices;
+
+        /**
          * Enumeration for selecting which viscosity averaging scheme to use.
          */
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -374,18 +374,18 @@ namespace aspect
     };
 
     /**
-     * A data structure containing a description of each field.
+     * A data structure containing a description of each compositional field.
      * At present, this structure only includes the field type
-     * (i.e., whether the field corresponds to a composition, porosity, etc.).
+     * (i.e., whether it is of type chemical_composition, porosity, etc.).
      */
-    struct FieldDescription
+    struct CompositionalFieldDescription
     {
       /**
-       * This enum lists available field types.
+       * This enum lists available compositional field types.
        */
       enum Kind
       {
-        composition,
+        chemical_composition,
         stress,
         grain_size,
         porosity,
@@ -394,26 +394,26 @@ namespace aspect
 
       /**
        * This function translates an input string into the
-       * available enum options for the type of field.
+       * available enum options for the type of compositional field.
        */
       static
       Kind
       parse_type(const std::string &input)
       {
-        if (input == "composition")
-          return FieldDescription::composition;
+        if (input == "chemical_composition")
+          return CompositionalFieldDescription::chemical_composition;
         else if (input == "stress")
-          return FieldDescription::stress;
+          return CompositionalFieldDescription::stress;
         else if (input == "grain_size")
-          return FieldDescription::grain_size;
+          return CompositionalFieldDescription::grain_size;
         else if (input == "porosity")
-          return FieldDescription::porosity;
+          return CompositionalFieldDescription::porosity;
         else if (input == "generic")
-          return FieldDescription::generic;
+          return CompositionalFieldDescription::generic;
         else
           AssertThrow(false, ExcNotImplemented());
 
-        return FieldDescription::Kind();
+        return CompositionalFieldDescription::Kind();
       }
     };
 
@@ -706,7 +706,7 @@ namespace aspect
      */
     unsigned int                   n_compositional_fields;
     std::vector<std::string>       names_of_compositional_fields;
-    std::vector<FieldDescription>  field_descriptions;
+    std::vector<CompositionalFieldDescription>  composition_descriptions;
 
     /**
      * A vector that contains the advection field method for every compositional

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -161,7 +161,7 @@ namespace aspect
         anelastic_liquid_approximation,
         isentropic_compression,
         custom
-      };
+      } kind;
 
       /**
        * This function translates an input string into the

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -374,15 +374,47 @@ namespace aspect
     };
 
     /**
-     * A data structure containing vectors of the indices of each
-     * compositional field type.
+     * A data structure containing a description of each field.
+     * At present, this structure only includes the field type
+     * (i.e., whether the field corresponds to a composition, porosity, etc.).
      */
-    struct FieldTypeIndices
+    struct FieldDescription
     {
-      std::vector<unsigned int> composition;
-      std::vector<unsigned int> stress;
-      std::vector<unsigned int> grain_size;
-      std::vector<unsigned int> porosity;
+      /**
+       * This enum lists available field types.
+       */
+      enum Kind
+      {
+        composition,
+        stress,
+        grain_size,
+        porosity,
+        generic
+      } type;
+
+      /**
+       * This function translates an input string into the
+       * available enum options for the type of field.
+       */
+      static
+      Kind
+      parse_type(const std::string &input)
+      {
+        if (input == "composition")
+          return FieldDescription::composition;
+        else if (input == "stress")
+          return FieldDescription::stress;
+        else if (input == "grain_size")
+          return FieldDescription::grain_size;
+        else if (input == "porosity")
+          return FieldDescription::porosity;
+        else if (input == "generic")
+          return FieldDescription::generic;
+        else
+          AssertThrow(false, ExcNotImplemented());
+
+        return FieldDescription::Kind();
+      }
     };
 
     /**
@@ -674,7 +706,7 @@ namespace aspect
      */
     unsigned int                   n_compositional_fields;
     std::vector<std::string>       names_of_compositional_fields;
-    FieldTypeIndices               field_type_indices;
+    std::vector<FieldDescription>  field_descriptions;
 
     /**
      * A vector that contains the advection field method for every compositional

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -374,6 +374,18 @@ namespace aspect
     };
 
     /**
+     * A data structure containing vectors of the indices of each
+     * compositional field type.
+     */
+    struct FieldTypeIndices
+    {
+      std::vector<unsigned int> composition;
+      std::vector<unsigned int> stress;
+      std::vector<unsigned int> grain_size;
+      std::vector<unsigned int> porosity;
+    };
+
+    /**
      * Constructor. Fills the values of member functions from the given
      * parameter object.
      *
@@ -662,6 +674,7 @@ namespace aspect
      */
     unsigned int                   n_compositional_fields;
     std::vector<std::string>       names_of_compositional_fields;
+    FieldTypeIndices               field_type_indices;
 
     /**
      * A vector that contains the advection field method for every compositional

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -411,7 +411,10 @@ namespace aspect
         else if (input == "generic")
           return CompositionalFieldDescription::generic;
         else
-          AssertThrow(false, ExcNotImplemented());
+          AssertThrow(false, ExcMessage("Compositional field type " + input +
+                                        " not recognised. Must be one of "
+                                        "chemical_composition, stress, "
+                                        "grain_size, porosity or generic."));
 
         return CompositionalFieldDescription::Kind();
       }

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -110,25 +110,25 @@ namespace aspect
         // Get the number of fields for composition-dependent material properties
         const bool has_background_field = true;
 
-        std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
+        const std::vector<std::string> chemical_composition_field_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
 
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),
-                                                          list_of_composition_names,
+                                                          chemical_composition_field_names,
                                                           has_background_field,
                                                           "Densities",
                                                           true,
                                                           expected_n_phases_per_composition);
 
         thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Thermal expansivities"),
-                                                                      list_of_composition_names,
+                                                                      chemical_composition_field_names,
                                                                       has_background_field,
                                                                       "Thermal expansivities",
                                                                       true,
                                                                       expected_n_phases_per_composition);
 
         specific_heats = Utilities::parse_map_to_double_array (prm.get("Heat capacities"),
-                                                               list_of_composition_names,
+                                                               chemical_composition_field_names,
                                                                has_background_field,
                                                                "Specific heats",
                                                                true,

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -108,19 +108,9 @@ namespace aspect
         reference_T = prm.get_double ("Reference temperature");
 
         // Get the number of fields for composition-dependent material properties
-        const std::vector<unsigned int> compositional_field_indices = this->introspection().get_field_type_indices().composition;
         const bool has_background_field = true;
 
-        const std::vector<std::string> list_of_field_names = this->introspection().get_composition_names();
-
-        std::vector<std::string> list_of_composition_names(compositional_field_indices.size());
-        std::transform(compositional_field_indices.begin(),
-                       compositional_field_indices.end(),
-                       list_of_composition_names.begin(),
-                       [list_of_field_names](size_t pos)
-        {
-          return list_of_field_names[pos];
-        });
+        std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
 
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -107,11 +107,20 @@ namespace aspect
       {
         reference_T = prm.get_double ("Reference temperature");
 
-        // Establish that a background field is required here
+        // Get the number of fields for composition-dependent material properties
+        const std::vector<unsigned int> compositional_field_indices = this->introspection().get_field_type_indices().composition;
         const bool has_background_field = true;
 
-        // Retrieve the list of composition names
-        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+        const std::vector<std::string> list_of_field_names = this->introspection().get_composition_names();
+
+        std::vector<std::string> list_of_composition_names(compositional_field_indices.size());
+        std::transform(compositional_field_indices.begin(),
+                       compositional_field_indices.end(),
+                       list_of_composition_names.begin(),
+                       [list_of_field_names](size_t pos)
+        {
+          return list_of_field_names[pos];
+        });
 
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -110,7 +110,7 @@ namespace aspect
         // Get the number of fields for composition-dependent material properties
         const bool has_background_field = true;
 
-        std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
+        std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
 
         // Parse multicomponent properties
         densities = Utilities::parse_map_to_double_array (prm.get("Densities"),

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -140,15 +140,15 @@ namespace aspect
           const bool has_background_field = true;
 
           // Retrieve the list of composition names
-          const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+          const std::vector<std::string> chemical_composition_field_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
 
           viscosities = Utilities::parse_map_to_double_array (prm.get("Viscosities"),
-                                                              list_of_composition_names,
+                                                              chemical_composition_field_names,
                                                               has_background_field,
                                                               "Viscosities");
 
           thermal_conductivities = Utilities::parse_map_to_double_array (prm.get("Thermal conductivities"),
-                                                                         list_of_composition_names,
+                                                                         chemical_composition_field_names,
                                                                          has_background_field,
                                                                          "Thermal conductivities");
         }

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -121,24 +121,16 @@ namespace aspect
         // Get the number of fields for composition-dependent material properties
         const bool has_background_field = true;
 
-        stress_field_indices = this->introspection().get_field_type_indices().stress;
-        compositional_field_indices = this->introspection().get_field_type_indices().composition;
+        stress_field_indices = this->introspection().get_indices_for_fields_of_type("stress");
+        compositional_field_indices = this->introspection().get_indices_for_fields_of_type("composition");
 
         AssertThrow (stress_field_indices.size() == (dim == 2 ? 3 : 5),
                      ExcMessage("The Compositional fields subsection must contain the parameter "
                                 "Types of fields. Additionally, there must be three or five fields "
                                 "corresponding to stress (for two- or three-dimensional problems respectively)."));
 
-        const std::vector<std::string> list_of_field_names = this->introspection().get_composition_names();
-
-        std::vector<std::string> list_of_composition_names(compositional_field_indices.size());
-        std::transform(compositional_field_indices.begin(),
-                       compositional_field_indices.end(),
-                       list_of_composition_names.begin(),
-                       [list_of_field_names](size_t pos)
-        {
-          return list_of_field_names[pos];
-        });
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
+        const std::vector<std::string> list_of_stress_names = this->introspection().get_names_for_fields_of_type("stress");
 
         elastic_shear_moduli = Utilities::parse_map_to_double_array(prm.get("Elastic shear moduli"),
                                                                     list_of_composition_names,
@@ -173,30 +165,30 @@ namespace aspect
 
         // Check whether the compositional fields representing the viscoelastic
         // stress tensor are both named correctly and listed in the right order.
-        AssertThrow(list_of_field_names[stress_field_indices[0]] == "ve_stress_xx",
+        AssertThrow(list_of_stress_names[0] == "ve_stress_xx",
                     ExcMessage("Rheology model Elasticity only works if the first "
                                "compositional stress field is called ve_stress_xx."));
-        AssertThrow(list_of_field_names[stress_field_indices[1]] == "ve_stress_yy",
+        AssertThrow(list_of_stress_names[1] == "ve_stress_yy",
                     ExcMessage("Rheology model Elasticity only works if the second "
                                "compositional stress field is called ve_stress_yy."));
         if (dim == 2)
           {
-            AssertThrow(list_of_field_names[stress_field_indices[2]] == "ve_stress_xy",
+            AssertThrow(list_of_stress_names[2] == "ve_stress_xy",
                         ExcMessage("Rheology model Elasticity only works if the third "
                                    "compositional stress field is called ve_stress_xy."));
           }
         else if (dim == 3)
           {
-            AssertThrow(list_of_field_names[stress_field_indices[2]] == "ve_stress_zz",
+            AssertThrow(list_of_stress_names[2] == "ve_stress_zz",
                         ExcMessage("Rheology model Elasticity only works if the third "
                                    "compositional stress field is called ve_stress_zz."));
-            AssertThrow(list_of_field_names[stress_field_indices[3]] == "ve_stress_xy",
+            AssertThrow(list_of_stress_names[3] == "ve_stress_xy",
                         ExcMessage("Rheology model Elasticity only works if the fourth "
                                    "compositional stress field is called ve_stress_xy."));
-            AssertThrow(list_of_field_names[stress_field_indices[4]] == "ve_stress_xz",
+            AssertThrow(list_of_stress_names[4] == "ve_stress_xz",
                         ExcMessage("Rheology model Elasticity only works if the fifth "
                                    "compositional stress field is called ve_stress_xz."));
-            AssertThrow(list_of_field_names[stress_field_indices[5]] == "ve_stress_yz",
+            AssertThrow(list_of_stress_names[5] == "ve_stress_yz",
                         ExcMessage("Rheology model Elasticity only works if the sixth "
                                    "compositional stress field is called ve_stress_yz."));
           }

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -122,14 +122,14 @@ namespace aspect
         const bool has_background_field = true;
 
         stress_field_indices = this->introspection().get_indices_for_fields_of_type("stress");
-        compositional_field_indices = this->introspection().get_indices_for_fields_of_type("composition");
+        compositional_field_indices = this->introspection().get_indices_for_fields_of_type("chemical_composition");
 
         AssertThrow (stress_field_indices.size() == (dim == 2 ? 3 : 5),
                      ExcMessage("The Compositional fields subsection must contain the parameter "
                                 "Types of fields. Additionally, there must be three or five fields "
                                 "corresponding to stress (for two- or three-dimensional problems respectively)."));
 
-        const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
         const std::vector<std::string> list_of_stress_names = this->introspection().get_names_for_fields_of_type("stress");
 
         elastic_shear_moduli = Utilities::parse_map_to_double_array(prm.get("Elastic shear moduli"),

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -129,11 +129,13 @@ namespace aspect
                                 "Types of fields. Additionally, there must be three or five fields "
                                 "corresponding to stress (for two- or three-dimensional problems respectively)."));
 
-        const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
-        const std::vector<std::string> list_of_stress_names = this->introspection().get_names_for_fields_of_type("stress");
+
+        const std::vector<std::string> chemical_composition_field_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
+        const std::vector<std::string> stress_field_names = this->introspection().get_names_for_fields_of_type("stress");
+
 
         elastic_shear_moduli = Utilities::parse_map_to_double_array(prm.get("Elastic shear moduli"),
-                                                                    list_of_composition_names,
+                                                                    chemical_composition_field_names,
                                                                     has_background_field,
                                                                     "Elastic shear moduli",
                                                                     true,
@@ -165,30 +167,30 @@ namespace aspect
 
         // Check whether the compositional fields representing the viscoelastic
         // stress tensor are both named correctly and listed in the right order.
-        AssertThrow(list_of_stress_names[0] == "ve_stress_xx",
+        AssertThrow(stress_field_names[0] == "ve_stress_xx",
                     ExcMessage("Rheology model Elasticity only works if the first "
                                "compositional stress field is called ve_stress_xx."));
-        AssertThrow(list_of_stress_names[1] == "ve_stress_yy",
+        AssertThrow(stress_field_names[1] == "ve_stress_yy",
                     ExcMessage("Rheology model Elasticity only works if the second "
                                "compositional stress field is called ve_stress_yy."));
         if (dim == 2)
           {
-            AssertThrow(list_of_stress_names[2] == "ve_stress_xy",
+            AssertThrow(stress_field_names[2] == "ve_stress_xy",
                         ExcMessage("Rheology model Elasticity only works if the third "
                                    "compositional stress field is called ve_stress_xy."));
           }
         else if (dim == 3)
           {
-            AssertThrow(list_of_stress_names[2] == "ve_stress_zz",
+            AssertThrow(stress_field_names[2] == "ve_stress_zz",
                         ExcMessage("Rheology model Elasticity only works if the third "
                                    "compositional stress field is called ve_stress_zz."));
-            AssertThrow(list_of_stress_names[3] == "ve_stress_xy",
+            AssertThrow(stress_field_names[3] == "ve_stress_xy",
                         ExcMessage("Rheology model Elasticity only works if the fourth "
                                    "compositional stress field is called ve_stress_xy."));
-            AssertThrow(list_of_stress_names[4] == "ve_stress_xz",
+            AssertThrow(stress_field_names[4] == "ve_stress_xz",
                         ExcMessage("Rheology model Elasticity only works if the fifth "
                                    "compositional stress field is called ve_stress_xz."));
-            AssertThrow(list_of_stress_names[5] == "ve_stress_yz",
+            AssertThrow(stress_field_names[5] == "ve_stress_yz",
                         ExcMessage("Rheology model Elasticity only works if the sixth "
                                    "compositional stress field is called ve_stress_yz."));
           }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -791,6 +791,43 @@ namespace aspect
 
 
       std::vector<double>
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices)
+      {
+        std::vector<double> composition_fractions(indices.size()+1);
+
+        // Clip the compositional fields so they are between zero and one,
+        // and sum the compositional fields for normalization purposes.
+        double sum_composition = 0.0;
+        std::vector<double> x_comp (indices.size());
+
+        for (unsigned int i=0; i < x_comp.size(); ++i)
+          {
+            x_comp[i] = std::min(std::max(compositional_fields[indices[i]], 0.0), 1.0);
+            sum_composition += x_comp[i];
+          }
+
+        // Compute background field fraction
+        if (sum_composition >= 1.0)
+          composition_fractions[0] = 0.0;
+        else
+          composition_fractions[0] = 1.0 - sum_composition;
+
+        // Compute and possibly normalize field fractions
+        for (unsigned int i=0; i < x_comp.size(); ++i)
+          {
+            if (sum_composition >= 1.0)
+              composition_fractions[i+1] = x_comp[i]/sum_composition;
+            else
+              composition_fractions[i+1] = x_comp[i];
+          }
+
+        return composition_fractions;
+      }
+
+
+
+      std::vector<double>
       compute_composition_fractions(const std::vector<double> &compositional_fields,
                                     const ComponentMask &field_mask)
       {

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -144,7 +144,7 @@ namespace aspect
       compositional_field_indices = this->introspection().get_indices_for_fields_of_type("chemical_composition");
       const bool has_background_field = true;
 
-      const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
+      const std::vector<std::string> chemical_composition_field_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
 
       AssertThrow(this->get_parameters().enable_elasticity == true,
                   ExcMessage ("Material model Viscoelastic only works if 'Enable elasticity' is set to true"));
@@ -165,14 +165,14 @@ namespace aspect
 
           // Parse viscoelastic properties
           viscosities = Utilities::parse_map_to_double_array(prm.get("Viscosities"),
-                                                             list_of_composition_names,
+                                                             chemical_composition_field_names,
                                                              has_background_field,
                                                              "Viscosities",
                                                              true,
                                                              nullptr);
 
           thermal_conductivities = Utilities::parse_map_to_double_array(prm.get("Thermal conductivities"),
-                                                                        list_of_composition_names,
+                                                                        chemical_composition_field_names,
                                                                         has_background_field,
                                                                         "Thermal conductivities",
                                                                         true,

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -141,19 +141,10 @@ namespace aspect
     {
 
       // Get the number of fields for composition-dependent material properties
-      compositional_field_indices = this->introspection().get_field_type_indices().composition;
+      compositional_field_indices = this->introspection().get_indices_for_fields_of_type("composition");
       const bool has_background_field = true;
 
-      const std::vector<std::string> list_of_field_names = this->introspection().get_composition_names();
-
-      std::vector<std::string> list_of_composition_names(compositional_field_indices.size());
-      std::transform(compositional_field_indices.begin(),
-                     compositional_field_indices.end(),
-                     list_of_composition_names.begin(),
-                     [list_of_field_names](size_t pos)
-      {
-        return list_of_field_names[pos];
-      });
+      const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
 
       AssertThrow(this->get_parameters().enable_elasticity == true,
                   ExcMessage ("Material model Viscoelastic only works if 'Enable elasticity' is set to true"));

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -141,10 +141,10 @@ namespace aspect
     {
 
       // Get the number of fields for composition-dependent material properties
-      compositional_field_indices = this->introspection().get_indices_for_fields_of_type("composition");
+      compositional_field_indices = this->introspection().get_indices_for_fields_of_type("chemical_composition");
       const bool has_background_field = true;
 
-      const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("composition");
+      const std::vector<std::string> list_of_composition_names = this->introspection().get_names_for_fields_of_type("chemical_composition");
 
       AssertThrow(this->get_parameters().enable_elasticity == true,
                   ExcMessage ("Material model Viscoelastic only works if 'Enable elasticity' is set to true"));

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -334,7 +334,7 @@ namespace aspect
     typename Parameters<dim>::CompositionalFieldDescription::Kind type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
 
     for (unsigned int i=0; i<n_compositional_fields; ++i)
-      if (field_descriptions[i].type == type)
+      if (composition_descriptions[i].type == type)
         indices.push_back(i);
 
     return indices;
@@ -350,7 +350,7 @@ namespace aspect
     typename Parameters<dim>::CompositionalFieldDescription::Kind type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
 
     for (unsigned int i=0; i<n_compositional_fields; ++i)
-      if (field_descriptions[i].type == type)
+      if (composition_descriptions[i].type == type)
         names.push_back(composition_names[i]);
 
     return names;

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -327,6 +327,38 @@ namespace aspect
 
 
   template <int dim>
+  const std::vector<unsigned int>
+  Introspection<dim>::get_indices_for_fields_of_type (const std::string &type_name) const
+  {
+    std::vector<unsigned int> indices;
+    typename Parameters<dim>::CompositionalFieldDescription::Kind type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
+
+    for (unsigned int i=0; i<n_compositional_fields; ++i)
+      if (field_descriptions[i].type == type)
+        indices.push_back(i);
+
+    return indices;
+  }
+
+
+
+  template <int dim>
+  const std::vector<std::string>
+  Introspection<dim>::get_names_for_fields_of_type (const std::string &type_name) const
+  {
+    std::vector<std::string> names;
+    typename Parameters<dim>::CompositionalFieldDescription::Kind type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
+
+    for (unsigned int i=0; i<n_compositional_fields; ++i)
+      if (field_descriptions[i].type == type)
+        names.push_back(composition_names[i]);
+
+    return names;
+  }
+
+
+
+  template <int dim>
   bool
   Introspection<dim>::is_stokes_component (const unsigned int component_index) const
   {

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -307,7 +307,7 @@ namespace aspect
   const std::vector<typename Parameters<dim>::FieldDescription> &
   Introspection<dim>::get_field_descriptions () const
   {
-    // Simply return the full vector of compositional field type indices
+    // Return the full vector of FieldDescription objects
     return field_descriptions;
   }
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -202,7 +202,7 @@ namespace aspect
     system_dofs_per_block (n_blocks),
     compositional_field_methods(parameters.compositional_field_methods),
     composition_names(parameters.names_of_compositional_fields),
-    field_type_indices(parameters.field_type_indices)
+    field_descriptions(parameters.field_descriptions)
   {}
 
 
@@ -304,11 +304,11 @@ namespace aspect
 
 
   template <int dim>
-  const typename Parameters<dim>::FieldTypeIndices &
-  Introspection<dim>::get_field_type_indices () const
+  const std::vector<typename Parameters<dim>::FieldDescription> &
+  Introspection<dim>::get_field_descriptions () const
   {
     // Simply return the full vector of compositional field type indices
-    return field_type_indices;
+    return field_descriptions;
   }
 
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -201,7 +201,8 @@ namespace aspect
     component_masks (*this),
     system_dofs_per_block (n_blocks),
     compositional_field_methods(parameters.compositional_field_methods),
-    composition_names(parameters.names_of_compositional_fields)
+    composition_names(parameters.names_of_compositional_fields),
+    field_type_indices(parameters.field_type_indices)
   {}
 
 
@@ -299,6 +300,18 @@ namespace aspect
     // Simply return the full list of composition names
     return composition_names;
   }
+
+
+
+  template <int dim>
+  const typename Parameters<dim>::FieldTypeIndices &
+  Introspection<dim>::get_field_type_indices () const
+  {
+    // Simply return the full vector of compositional field type indices
+    return field_type_indices;
+  }
+
+
 
   template <int dim>
   bool

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -202,7 +202,7 @@ namespace aspect
     system_dofs_per_block (n_blocks),
     compositional_field_methods(parameters.compositional_field_methods),
     composition_names(parameters.names_of_compositional_fields),
-    field_descriptions(parameters.field_descriptions)
+    composition_descriptions(parameters.composition_descriptions)
   {}
 
 
@@ -304,11 +304,11 @@ namespace aspect
 
 
   template <int dim>
-  const std::vector<typename Parameters<dim>::FieldDescription> &
-  Introspection<dim>::get_field_descriptions () const
+  const std::vector<typename Parameters<dim>::CompositionalFieldDescription> &
+  Introspection<dim>::get_composition_descriptions () const
   {
-    // Return the full vector of FieldDescription objects
-    return field_descriptions;
+    // Return the full vector of CompositionalFieldDescription objects
+    return composition_descriptions;
   }
 
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1167,17 +1167,16 @@ namespace aspect
       prm.declare_entry ("Names of fields", "",
                          Patterns::List(Patterns::Anything()),
                          "A user-defined name for each of the compositional fields requested.");
-      prm.declare_entry ("Types of fields", "",
-                         Patterns::List (Patterns::Selection("composition|stress|grain_size|porosity|generic")),
+      prm.declare_entry ("Types of fields", "generic",
+                         Patterns::List (Patterns::Selection("chemical_composition|stress|grain_size|porosity|generic")),
                          "A type for each of the compositional fields requested. "
                          "Each entry of the list must be "
-                         "one of the following field types: "
-                         "composition, stress, grain_size, porosity, generic.");
+                         "one of several recognised types.");
       prm.declare_entry ("Compositional field methods", "",
                          Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|prescribed field|prescribed field with diffusion")),
                          "A comma separated list denoting the solution method of each "
                          "compositional field. Each entry of the list must be "
-                         "one of the currently implemented field types."
+                         "one of the currently implemented field methods."
                          "\n\n"
                          "These choices correspond to the following methods by which "
                          "compositional fields gain their values:"
@@ -1794,11 +1793,10 @@ namespace aspect
         = Utilities::split_string_list
           (prm.get ("Types of fields"));
 
-      AssertThrow ((x_compositional_field_types.size() == 0) ||
-                   (x_compositional_field_types.size() == 1) ||
+      AssertThrow ((x_compositional_field_types.size() == 1) ||
                    (x_compositional_field_types.size() == n_compositional_fields),
                    ExcMessage ("The length of the list of names for the field types of compositional "
-                               "fields needs to be empty, or have one entry, or have a length equal to "
+                               "fields needs to have one entry or have a length equal to "
                                "the number of compositional fields."));
 
       // If only one method is specified apply this to all fields
@@ -1808,10 +1806,10 @@ namespace aspect
       // If field types have been defined, fill the corresponding index vectors
       if (x_compositional_field_types.size() == n_compositional_fields)
         {
-          field_descriptions.resize(n_compositional_fields);
+          composition_descriptions.resize(n_compositional_fields);
 
           for (unsigned int i=0; i<n_compositional_fields; ++i)
-            field_descriptions[i].type = FieldDescription::parse_type(x_compositional_field_types[i]);
+            composition_descriptions[i].type = CompositionalFieldDescription::parse_type(x_compositional_field_types[i]);
         }
 
       std::vector<std::string> x_compositional_field_methods

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1168,11 +1168,11 @@ namespace aspect
                          Patterns::List(Patterns::Anything()),
                          "A user-defined name for each of the compositional fields requested.");
       prm.declare_entry ("Types of fields", "",
-                         Patterns::List (Patterns::Selection("composition|stress|grain_size|porosity|other")),
+                         Patterns::List (Patterns::Selection("composition|stress|grain_size|porosity|generic")),
                          "A type for each of the compositional fields requested. "
                          "Each entry of the list must be "
                          "one of the following field types: "
-                         "composition, stress, grain_size, porosity, other.");
+                         "composition, stress, grain_size, porosity, generic.");
       prm.declare_entry ("Compositional field methods", "",
                          Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|prescribed field|prescribed field with diffusion")),
                          "A comma separated list denoting the solution method of each "
@@ -1808,17 +1808,10 @@ namespace aspect
       // If field types have been defined, fill the corresponding index vectors
       if (x_compositional_field_types.size() == n_compositional_fields)
         {
+          field_descriptions.resize(n_compositional_fields);
+
           for (unsigned int i=0; i<n_compositional_fields; ++i)
-            {
-              if (x_compositional_field_types[i] == "composition")
-                field_type_indices.composition.push_back(i);
-              if (x_compositional_field_types[i] == "stress")
-                field_type_indices.stress.push_back(i);
-              if (x_compositional_field_types[i] == "grain_size")
-                field_type_indices.grain_size.push_back(i);
-              if (x_compositional_field_types[i] == "porosity")
-                field_type_indices.porosity.push_back(i);
-            }
+            field_descriptions[i].type = FieldDescription::parse_type(x_compositional_field_types[i]);
         }
 
       std::vector<std::string> x_compositional_field_methods

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1167,6 +1167,12 @@ namespace aspect
       prm.declare_entry ("Names of fields", "",
                          Patterns::List(Patterns::Anything()),
                          "A user-defined name for each of the compositional fields requested.");
+      prm.declare_entry ("Types of fields", "",
+                         Patterns::List (Patterns::Selection("composition|stress|grain_size|porosity|other")),
+                         "A type for each of the compositional fields requested. "
+                         "Each entry of the list must be "
+                         "one of the following field types: "
+                         "composition, stress, grain_size, porosity, other.");
       prm.declare_entry ("Compositional field methods", "",
                          Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|prescribed field|prescribed field with diffusion")),
                          "A comma separated list denoting the solution method of each "
@@ -1783,6 +1789,33 @@ namespace aspect
 
       AssertThrow (normalized_fields.size() <= n_compositional_fields,
                    ExcMessage("Invalid input parameter file: Too many entries in List of normalized fields"));
+
+      std::vector<std::string> x_compositional_field_types
+        = Utilities::split_string_list
+          (prm.get ("Types of fields"));
+
+      AssertThrow ((x_compositional_field_types.size() == 0) ||
+                   (x_compositional_field_types.size() == 1) ||
+                   (x_compositional_field_types.size() == n_compositional_fields),
+                   ExcMessage ("The length of the list of names for the field types of compositional "
+                               "fields needs to be empty, or have one entry, or have a length equal to "
+                               "the number of compositional fields."));
+
+      // If only one method is specified apply this to all fields
+      if (x_compositional_field_types.size() == 1)
+        x_compositional_field_types = std::vector<std::string> (n_compositional_fields, x_compositional_field_types[0]);
+
+      for (unsigned int i=0; i<n_compositional_fields; ++i)
+        {
+          if (x_compositional_field_types[i] == "composition")
+            field_type_indices.composition.push_back(i);
+          if (x_compositional_field_types[i] == "stress")
+            field_type_indices.stress.push_back(i);
+          if (x_compositional_field_types[i] == "grain_size")
+            field_type_indices.grain_size.push_back(i);
+          if (x_compositional_field_types[i] == "porosity")
+            field_type_indices.porosity.push_back(i);
+        }
 
       std::vector<std::string> x_compositional_field_methods
         = Utilities::split_string_list

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1805,16 +1805,20 @@ namespace aspect
       if (x_compositional_field_types.size() == 1)
         x_compositional_field_types = std::vector<std::string> (n_compositional_fields, x_compositional_field_types[0]);
 
-      for (unsigned int i=0; i<n_compositional_fields; ++i)
+      // If field types have been defined, fill the corresponding index vectors
+      if (x_compositional_field_types.size() == n_compositional_fields)
         {
-          if (x_compositional_field_types[i] == "composition")
-            field_type_indices.composition.push_back(i);
-          if (x_compositional_field_types[i] == "stress")
-            field_type_indices.stress.push_back(i);
-          if (x_compositional_field_types[i] == "grain_size")
-            field_type_indices.grain_size.push_back(i);
-          if (x_compositional_field_types[i] == "porosity")
-            field_type_indices.porosity.push_back(i);
+          for (unsigned int i=0; i<n_compositional_fields; ++i)
+            {
+              if (x_compositional_field_types[i] == "composition")
+                field_type_indices.composition.push_back(i);
+              if (x_compositional_field_types[i] == "stress")
+                field_type_indices.stress.push_back(i);
+              if (x_compositional_field_types[i] == "grain_size")
+                field_type_indices.grain_size.push_back(i);
+              if (x_compositional_field_types[i] == "porosity")
+                field_type_indices.porosity.push_back(i);
+            }
         }
 
       std::vector<std::string> x_compositional_field_methods

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -186,11 +186,19 @@ namespace aspect
           {
             // No Patterns matches were found!
             AssertThrow (false,
-                         ExcMessage ("The required format for property <"
+                         ExcMessage ("The string for property <"
                                      + property_name
-                                     + "> was not found. Specify a comma separated "
-                                     + "list of `<double>' or `<key1> : <double>|<double>|..., "
-                                     + "<key2> : <double>|... , ... '."));
+                                     + "> does not have the expected format. "
+                                     + "Check that the string is either a "
+                                     + "comma separated list of `<double>' or "
+                                     + "`<key1> : <double>|<double>|..., "
+                                     + "<key2> : <double>|... , ... '. "
+                                     + "If the string looks correct, "
+                                     + "it is likely that the length of the "
+                                     + "list of keys passed to "
+                                     + "parse_map_to_double_array does not "
+                                     + "match the length of the "
+                                     + "comma separated property list."));
           }
 
         return parsed_map;

--- a/tests/advect_mesh_vertically.prm
+++ b/tests/advect_mesh_vertically.prm
@@ -99,6 +99,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 1
+  set Types of fields = composition
 end
 
 subsection Termination criteria

--- a/tests/advect_mesh_vertically.prm
+++ b/tests/advect_mesh_vertically.prm
@@ -99,7 +99,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 1
-  set Types of fields = composition
+  set Types of fields = chemical_composition
 end
 
 subsection Termination criteria

--- a/tests/airy_isostasy.prm
+++ b/tests/airy_isostasy.prm
@@ -143,6 +143,7 @@ end
 # One compositional field in the middle of the domain
 subsection Compositional fields
  set Number of fields = 1
+ set Types of fields = chemical_composition
 end
 
 subsection Boundary composition model

--- a/tests/check_compositional_field_names.cc
+++ b/tests/check_compositional_field_names.cc
@@ -1,0 +1,54 @@
+#include <aspect/simulator.h>
+#include <aspect/parameters.h>
+
+template <int dim>
+void f(const aspect::SimulatorAccess<dim> &simulator_access,
+       aspect::Assemblers::Manager<dim> &)
+{
+  // This function tests whether the compositional field types are correctly
+  // processed.
+
+  using namespace aspect::MaterialModel;
+
+  aspect::ParameterHandler prm;
+
+  const std::vector<std::string> c_names = simulator_access.introspection().get_composition_names();
+  const std::vector<typename aspect::Parameters<dim>::CompositionalFieldDescription> descriptions = simulator_access.introspection().get_composition_descriptions();
+
+  for (unsigned int i=0; i<simulator_access.introspection().n_compositional_fields; ++i)
+    {
+      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition)
+        std::cout << c_names[i] << " is of type chemical_composition" << std::endl;
+      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::grain_size)
+        std::cout << c_names[i] << " is of type grain_size" << std::endl;
+      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::porosity)
+        std::cout << c_names[i] << " is of type porosity" << std::endl;
+      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::generic)
+        std::cout << c_names[i] << " is of type generic" << std::endl;
+      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::stress)
+        std::cout << c_names[i] << " is of type stress" << std::endl;
+    }
+
+  exit(0);
+
+}
+
+template <>
+void f(const aspect::SimulatorAccess<2> &,
+       aspect::Assemblers::Manager<2> &)
+{
+  AssertThrow(false,dealii::ExcInternalError());
+}
+
+template <int dim>
+void signal_connector (aspect::SimulatorSignals<dim> &signals)
+{
+  using namespace dealii;
+  std::cout << "* Connecting signals" << std::endl;
+  signals.set_assemblers.connect (std::bind(&f<dim>,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2));
+}
+
+ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                  signal_connector<3>)

--- a/tests/check_compositional_field_names.prm
+++ b/tests/check_compositional_field_names.prm
@@ -1,0 +1,12 @@
+# This test checks whether the compositional field names are
+# processed correctly.
+
+set Dimension = 3
+include $ASPECT_SOURCE_DIR/tests/composite_viscous_outputs.prm
+set Additional shared libraries = tests/libcheck_compositional_field_names.so
+
+subsection Compositional fields
+  set Number of fields = 6
+  set Names of fields =  Field_1, Field_2, Field_3, Field_4, Field_5, Field_6
+  set Types of fields =  chemical_composition, stress, grain_size, porosity, chemical_composition, generic
+end

--- a/tests/check_compositional_field_names/screen-output
+++ b/tests/check_compositional_field_names/screen-output
@@ -1,0 +1,10 @@
+
+Loading shared library <./libcheck_compositional_field_names.so>
+
+* Connecting signals
+Field_1 is of type chemical_composition
+Field_2 is of type stress
+Field_3 is of type grain_size
+Field_4 is of type porosity
+Field_5 is of type chemical_composition
+Field_6 is of type generic

--- a/tests/chunk_lithostatic_pressure_2d.prm
+++ b/tests/chunk_lithostatic_pressure_2d.prm
@@ -129,6 +129,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
  set Number of fields = 1
+ set Types of fields = chemical_composition
 end
 
 

--- a/tests/compositional_heating.prm
+++ b/tests/compositional_heating.prm
@@ -103,6 +103,7 @@ end
 subsection Compositional fields
   set Number of fields = 1
   set Names of fields = upper
+  set Types of fields = chemical_composition
 end
 
 # Initial composition model

--- a/tests/compositional_heating_exclude_background.prm
+++ b/tests/compositional_heating_exclude_background.prm
@@ -64,6 +64,7 @@ end
 subsection Compositional fields
   set Number of fields = 1
   set Names of fields = upper
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/tests/continental_extension.prm
+++ b/tests/continental_extension.prm
@@ -44,6 +44,7 @@ end
 subsection Compositional fields
   set Number of fields = 4
   set Names of fields = upper_crust, lower_crust, lithospheric_mantle, seed
+  set Types of fields = chemical_composition
 end
 
 

--- a/tests/dynamic_friction.prm
+++ b/tests/dynamic_friction.prm
@@ -66,6 +66,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 1
+  set Types of fields = chemical_composition
 end
 
 subsection Gravity model

--- a/tests/lithosphere_boundary_indicator.prm
+++ b/tests/lithosphere_boundary_indicator.prm
@@ -122,6 +122,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
  set Number of fields = 1
+ set Types of fields = chemical_composition
 end
 
 

--- a/tests/lithosphere_boundary_indicator_3d.prm
+++ b/tests/lithosphere_boundary_indicator_3d.prm
@@ -130,6 +130,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
   set Number of fields = 1
+  set Types of fields = chemical_composition
 end
 
 

--- a/tests/lithosphere_boundary_indicator_3d_periodic.prm
+++ b/tests/lithosphere_boundary_indicator_3d_periodic.prm
@@ -140,6 +140,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
   set Number of fields = 1
+  set Types of fields = chemical_composition
 end
 
 

--- a/tests/merged_chunks_2D.prm
+++ b/tests/merged_chunks_2D.prm
@@ -119,6 +119,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
  set Number of fields = 1
+ set Types of fields = chemical_composition
 end
 
 

--- a/tests/merged_chunks_3D.prm
+++ b/tests/merged_chunks_3D.prm
@@ -117,6 +117,7 @@ end
 # higher viscosity compositional field.
 subsection Compositional fields
  set Number of fields = 1
+ set Types of fields = chemical_composition
 end
 
 

--- a/tests/multicomponent_arithmetic.prm
+++ b/tests/multicomponent_arithmetic.prm
@@ -100,6 +100,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 3
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/tests/multicomponent_geometric.prm
+++ b/tests/multicomponent_geometric.prm
@@ -100,6 +100,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 3
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/tests/multicomponent_harmonic.prm
+++ b/tests/multicomponent_harmonic.prm
@@ -100,6 +100,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 3
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/tests/multicomponent_max_composition.prm
+++ b/tests/multicomponent_max_composition.prm
@@ -100,6 +100,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 3
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/tests/newton_postprocess_nonlinear.prm
+++ b/tests/newton_postprocess_nonlinear.prm
@@ -142,7 +142,7 @@ subsection Material model
     set Maximum viscosity           = 1.e23
     set Minimum viscosity           = 1.e17
 
-    set Prefactors for dislocation creep          = 5e-24, 1e-50, 1e-50, 1e-50, 5e-24, 5.e-18, 5e-18
+    set Prefactors for dislocation creep          = 5e-24, 5e-24, 5.e-18, 5e-18
     set Stress exponents for dislocation creep    = 1.0
     set Activation energies for dislocation creep = 0.
     set Activation volumes for dislocation creep  = 0.
@@ -156,7 +156,7 @@ subsection Material model
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 37., 0., 0., 0., 37., 0., 0.
-    set Cohesions                   = 100.e6, 1.e50, 1.e50, 1.e50, 100.e6, 10.e6, 10.e6
+    set Cohesions                   = 100.e6, 100.e6, 10.e6, 10.e6
 
   end
 

--- a/tests/newton_postprocess_nonlinear.prm
+++ b/tests/newton_postprocess_nonlinear.prm
@@ -82,8 +82,8 @@ end
 # Number and name of compositional fields
 subsection Compositional fields
   set Number of fields = 6
-  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, block,       air,         inclusion
-  set Types of fields  = stress,       stress,       stress,       composition, composition, composition
+  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, block,                air,                  inclusion
+  set Types of fields  = stress,       stress,       stress,       chemical_composition, chemical_composition, chemical_composition
 end
 
 # Spatial domain of different compositional fields

--- a/tests/newton_postprocess_nonlinear.prm
+++ b/tests/newton_postprocess_nonlinear.prm
@@ -82,7 +82,8 @@ end
 # Number and name of compositional fields
 subsection Compositional fields
   set Number of fields = 6
-  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, block, air, inclusion
+  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, block,       air,         inclusion
+  set Types of fields  = stress,       stress,       stress,       composition, composition, composition
 end
 
 # Spatial domain of different compositional fields

--- a/tests/slab_tip_depth.prm
+++ b/tests/slab_tip_depth.prm
@@ -68,6 +68,7 @@ end
 subsection Compositional fields
   set Number of fields = 3
   set Names of fields  = OP, ML_SP, crust_SP
+  set Types of fields = chemical_composition
 end
 
 subsection Initial composition model

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -266,7 +266,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4;400, C5:500, bg:3",
   {"C1","C2","C3","C4","C5"},
   true,
-  "TestField"), Contains("The required format for property"));
+  "TestField"), Contains("does not have the expected format"));
 
 
   INFO("check fail 4: ");
@@ -305,7 +305,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   {"C1","C2","C3","C4","C5"},
   false,
   "TestField",
-  true), Contains("The required format for property"));
+  true), Contains("does not have the expected format"));
 
   // No subentries
   INFO("check fail 9: ");
@@ -314,7 +314,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   {"C1","C2","C3","C4","C5"},
   false,
   "TestField",
-  true), Contains("The required format for property"));
+  true), Contains("does not have the expected format"));
 
   // Wrong input structure
   {


### PR DESCRIPTION
A continuation of #4258, to give a feeling for how extensive the changes to the material models will have to be. Opened for discussion.

This will break a lot of tests (61 from the first commit). This is because (a) EquationOfState::MulticomponentIncompressible, Rheology::Elasticity and MaterialModel::Viscoelastic now require the "Types of fields" parameter, and (b) because other rheology models that derive from EquationOfState::MulticomponentIncompressible and Rheology::Elasticity may not yet have been updated.

* [ ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
