### PR TITLE
check DG limiters only used with cartesian mapping

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -444,6 +444,15 @@ namespace aspect
       map->initialize(triangulation, MappingQGeneric<dim>(4));
 #endif
 
+    // Check that DG limiters are only used with cartesian mapping
+    if ((parameters.use_limiter_for_discontinuous_temperature_solution ||
+         parameters.use_limiter_for_discontinuous_composition_solution) &&
+        geometry_model->natural_coordinate_system() != Utilities::Coordinates::CoordinateSystem::cartesian)
+      AssertThrow(false,
+                  ExcMessage("The limiter for the discontinuous temperature and composition solutions "
+                             "has not been tested in non-cartesian geometries and currently requires "
+                             "the use of a cartesian geometry model."));
+
     for (const auto &p : parameters.prescribed_traction_boundary_indicators)
       {
         BoundaryTraction::Interface<dim> *bv

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -445,13 +445,12 @@ namespace aspect
 #endif
 
     // Check that DG limiters are only used with cartesian mapping
-    if ((parameters.use_limiter_for_discontinuous_temperature_solution ||
-         parameters.use_limiter_for_discontinuous_composition_solution) &&
-        geometry_model->natural_coordinate_system() != Utilities::Coordinates::CoordinateSystem::cartesian)
-      AssertThrow(false,
+    if (parameters.use_limiter_for_discontinuous_temperature_solution ||
+        parameters.use_limiter_for_discontinuous_composition_solution)
+      AssertThrow(geometry_model->natural_coordinate_system() == Utilities::Coordinates::CoordinateSystem::cartesian,
                   ExcMessage("The limiter for the discontinuous temperature and composition solutions "
-                             "has not been tested in non-cartesian geometries and currently requires "
-                             "the use of a cartesian geometry model."));
+                             "has not been tested in non-Cartesian geometries and currently requires "
+                             "the use of a Cartesian geometry model."));
 
     for (const auto &p : parameters.prescribed_traction_boundary_indicators)
       {


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

This PR follows discussions in issues #4259,  #3822 and #4131. In short, the DG limiters have not been tested in spherical geometries and tests reported in the issues above reveal it is currently not functional properly in non-cartesian models. This PR adds an AssertThrow if either the temperature or compositional limiters are used in a non-cartesian geometry.

* [X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
