### PR TITLE
Rename an argument.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -265,11 +265,18 @@ namespace aspect
        *
        * @param input_data The data used to populate the material model input quantities.
        * @param introspection A reference to the simulator introspection object.
-       * @param use_strain_rate Whether to compute the strain rates.
+       * @param compute_strain_rate If set to `true`, then the object that
+       *   is currently created will also store the strain rates at all evaluation
+       *   points. This is an expensive operation. If set to `false`, then the
+       *   `strain_rate` array is going to be empty, and strain rates are not
+       *   evaluated. As a consequence, strain rates are then also not
+       *   available to functions that take this MaterialModelInputs
+       *   object as input, for example to compute strain rate-dependent
+       *   viscosities.
        */
       MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
                           const Introspection<dim> &introspection,
-                          const bool use_strain_rate = true);
+                          const bool compute_strain_rate = true);
 
 
       /**
@@ -282,13 +289,20 @@ namespace aspect
        * @param cell The currently active cell for the fe_values object.
        * @param introspection A reference to the simulator introspection object.
        * @param solution_vector The finite element vector from which to construct the inputs.
-       * @param use_strain_rates Whether to compute the strain rates.
+       * @param compute_strain_rate If set to `true`, then the object that
+       *   is currently created will also store the strain rates at all evaluation
+       *   points. This is an expensive operation. If set to `false`, then the
+       *   `strain_rate` array is going to be empty, and strain rates are not
+       *   evaluated. As a consequence, strain rates are then also not
+       *   available to functions that take this MaterialModelInputs
+       *   object as input, for example to compute strain rate-dependent
+       *   viscosities.
        */
       MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
                           const typename DoFHandler<dim>::active_cell_iterator &cell,
                           const Introspection<dim> &introspection,
                           const LinearAlgebra::BlockVector &solution_vector,
-                          const bool use_strain_rates = true);
+                          const bool compute_strain_rates = true);
 
       /**
        * Copy constructor. This constructor copies all data members of the
@@ -323,13 +337,14 @@ namespace aspect
 
       /**
        * Function to re-initialize and populate the pre-existing arrays
-       * created by the constructor MaterialModelInputs.
+       * created by the constructor MaterialModelInputs. The arguments here
+       * have the same meaning as in the constructor of this class.
        */
-      void reinit(const FEValuesBase<dim,dim> &fe_values,
+      void reinit(const FEValuesBase<dim,dim>                          &fe_values,
                   const typename DoFHandler<dim>::active_cell_iterator &cell,
-                  const Introspection<dim> &introspection,
-                  const LinearAlgebra::BlockVector &solution_vector,
-                  const bool use_strain_rates = true);
+                  const Introspection<dim>                             &introspection,
+                  const LinearAlgebra::BlockVector                     &solution_vector,
+                  const bool                                            compute_strain_rates = true);
 
       /**
        * Function that returns the number of points at which

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -271,10 +271,12 @@ namespace aspect
       requested_properties(MaterialProperties::all_properties)
     {}
 
+
+
     template <int dim>
     MaterialModelInputs<dim>::MaterialModelInputs(const DataPostprocessorInputs::Vector<dim> &input_data,
                                                   const Introspection<dim> &introspection,
-                                                  const bool use_strain_rate)
+                                                  const bool compute_strain_rate)
       :
       position(input_data.evaluation_points),
       temperature(input_data.solution_values.size(), numbers::signaling_nan<double>()),
@@ -290,6 +292,9 @@ namespace aspect
 #endif
       requested_properties(MaterialProperties::all_properties)
     {
+      if (compute_strain_rate == false)
+        this->strain_rate.resize(0);
+
       for (unsigned int q=0; q<input_data.solution_values.size(); ++q)
         {
           Tensor<2,dim> grad_u;
@@ -300,10 +305,8 @@ namespace aspect
               this->pressure_gradient[q][d] = input_data.solution_gradients[q][introspection.component_indices.pressure][d];
             }
 
-          if (use_strain_rate)
+          if (compute_strain_rate)
             this->strain_rate[q] = symmetrize (grad_u);
-          else
-            this->strain_rate.resize(0);
 
           this->pressure[q] = input_data.solution_values[q][introspection.component_indices.pressure];
           this->temperature[q] = input_data.solution_values[q][introspection.component_indices.temperature];
@@ -313,12 +316,14 @@ namespace aspect
         }
     }
 
+
+
     template <int dim>
     MaterialModelInputs<dim>::MaterialModelInputs(const FEValuesBase<dim,dim> &fe_values,
                                                   const typename DoFHandler<dim>::active_cell_iterator &cell_x,
                                                   const Introspection<dim> &introspection,
                                                   const LinearAlgebra::BlockVector &solution_vector,
-                                                  const bool use_strain_rate)
+                                                  const bool compute_strain_rate)
       :
       position(fe_values.get_quadrature_points()),
       temperature(fe_values.n_quadrature_points, numbers::signaling_nan<double>()),
@@ -331,7 +336,7 @@ namespace aspect
       requested_properties(MaterialProperties::all_properties)
     {
       // Call the function reinit to populate the new arrays.
-      this->reinit(fe_values, current_cell, introspection, solution_vector, use_strain_rate);
+      this->reinit(fe_values, current_cell, introspection, solution_vector, compute_strain_rate);
     }
 
 
@@ -362,14 +367,14 @@ namespace aspect
                                      const typename DoFHandler<dim>::active_cell_iterator &cell_x,
                                      const Introspection<dim> &introspection,
                                      const LinearAlgebra::BlockVector &solution_vector,
-                                     const bool use_strain_rate)
+                                     const bool compute_strain_rate)
     {
       // Populate the newly allocated arrays
       fe_values[introspection.extractors.temperature].get_function_values (solution_vector, this->temperature);
       fe_values[introspection.extractors.velocities].get_function_values (solution_vector, this->velocity);
       fe_values[introspection.extractors.pressure].get_function_values (solution_vector, this->pressure);
       fe_values[introspection.extractors.pressure].get_function_gradients (solution_vector, this->pressure_gradient);
-      if (use_strain_rate)
+      if (compute_strain_rate)
         fe_values[introspection.extractors.velocities].get_function_symmetric_gradients (solution_vector,this->strain_rate);
       else
         this->strain_rate.resize(0);


### PR DESCRIPTION
The previous name 'use_strain_rate' did not quite describe what the argument
represented. Better to call it 'compute_strain_rate'. While there, document
what that argument actually means.

/rebuild