### PR TITLE
Disable failing particle integration schemes in periodic shells

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -25,6 +25,7 @@
 #include <aspect/geometry_model/box.h>
 #include <aspect/geometry_model/two_merged_boxes.h>
 #include <aspect/geometry_model/spherical_shell.h>
+#include <aspect/particle/integrator/euler.h>
 #include <aspect/citation_info.h>
 
 #include <deal.II/base/quadrature_lib.h>
@@ -552,6 +553,9 @@ namespace aspect
               AssertThrow(geometry.opening_angle() == 90,
                           ExcMessage("Periodic boundaries combined with particles currently "
                                      "only work with 90 degree opening angle in spherical shell."));
+              AssertThrow(Plugins::plugin_type_matches<Particle::Integrator::Euler<dim>>(*integrator),
+                          ExcMessage("Periodic boundaries combined with particles currently "
+                                     "only work in spherical shells with the forward euler integration scheme."));
 
               typename ParticleHandler<dim>::particle_iterator particle = particle_handler->begin();
               for (; particle != particle_handler->end(); ++particle)

--- a/tests/particle_periodic_quarter_shell.prm
+++ b/tests/particle_periodic_quarter_shell.prm
@@ -108,6 +108,7 @@ subsection Postprocess
     set Number of particles = 20
     set Time between data output = 5
     set Data output format = vtu
+    set Integration scheme = euler
     set List of particle properties = function, initial composition, initial position
 
   end

--- a/tests/particle_periodic_quarter_shell/particles/particles-00001.0000.vtu
+++ b/tests/particle_periodic_quarter_shell/particles/particles-00001.0000.vtu
@@ -11,7 +11,7 @@
 <Piece NumberOfPoints="10" NumberOfCells="10" >
   <Points>
     <DataArray type="Float32" NumberOfComponents="3" format="binary">
-AQAAAHgAAAB4AAAAZgAAAA==eNr78nyLwxyHSfYMQJC/d75DMv8CMPvTspkODtmLwWwu/Q0OHqs/gdnz3kx28Dz4FMyuEmhzcLRrcgCx4xkbHDYZ54LZnTdqHCqTXcDsyh3JDrdDpoLZ77fkOyz/UQhmAwAZAiTp
+AQAAAHgAAAB4AAAAZgAAAA==eNrb83iLw+nMSfYMQPBrw3wHec0FYHbG9JkOXJWLwezzuhsc5sz+BGYfejLZoXraUzD7tHibg4FNkwOIXcfb4GBlkgtmZ/+ocdic4gJmB+xNdngSOhXM5j6V78DIWARmAwBTaCN0
     </DataArray>
   </Points>
 

--- a/tests/particle_periodic_quarter_shell/particles/particles-00001.0001.vtu
+++ b/tests/particle_periodic_quarter_shell/particles/particles-00001.0001.vtu
@@ -11,7 +11,7 @@
 <Piece NumberOfPoints="10" NumberOfCells="10" >
   <Points>
     <DataArray type="Float32" NumberOfComponents="3" format="binary">
-AQAAAHgAAAB4AAAAYwAAAA==eNozKuF3CKxIcGAAgvCSN/bbmPeC2Qzb5R0CeSaD2dPfN9hP+70KzOax9bPffR7C9lY+ZS9/txXMNpzw1t7mSziYbT7zkP3BSYVg9uR9qfaOrA1gtpXVWTutvhwwGwDy5iD6
+AQAAAHgAAAB4AAAAZAAAAA==eNq7lc3v4FOf4MAABB1lb+zfM+8Fs7dulXfYzj8ZzN7+p8Femnk1mP04zM++6NYqMPu95in7llutYDZ7/1v7k+/DweyKaYfsl7YVgtmzddLsOf/Xg9mFPOfsQntywGwA9wEkeg==
     </DataArray>
   </Points>
 


### PR DESCRIPTION
This is a minimal version of #4264 that only disables the broken functionality. I have checked that the test still gives reasonable results with forward euler, and that it now crashes if used with rk2 or rk4.#4264 
@tjhei: Would you be ok cherry-picking this into the release?