### PR TITLE
Fix gmg only normal flux

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2498,8 +2498,9 @@ namespace aspect
             }
         }
 
-      if (dirichlet_boundary.size()>0)
-        mg_constrained_dofs_A_block.make_zero_boundary_constraints(dof_handler_v, dirichlet_boundary);
+      // Unconditionally call this function, even if the set is empty. Otherwise, the data structure
+      // for boundary indices will not be created (if mesh has no Dirichlet conditions).
+      mg_constrained_dofs_A_block.make_zero_boundary_constraints(dof_handler_v, dirichlet_boundary);
 
       {
         const std::set<types::boundary_id> no_flux_boundary = sim.boundary_velocity_manager.get_tangential_boundary_velocity_indicators();

--- a/tests/gmg_no_normal_flux_only.prm
+++ b/tests/gmg_no_normal_flux_only.prm
@@ -1,0 +1,96 @@
+# 3d shell with GMG, tangential velocity boundary only
+# based on shell_3d_gmg.prm
+# MPI: 2
+
+set Dimension                              = 3
+set Use years in output instead of seconds = true
+set End time                               = 0.0
+set Output directory                       = output-shell_simple_3d
+set Nonlinear solver scheme                = no Advection, single Stokes
+
+subsection Material model
+  set Model name = simple
+
+  set Material averaging = harmonic average only viscosity
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+  end
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = top, bottom
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top, bottom
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 1973
+    set Outer temperature = 973
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1.473e3
+  end
+end
+
+
+subsection Gravity model
+  set Model name = ascii data
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement          = 1
+  set Initial adaptive refinement        = 1
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 15
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
+
+  subsection Visualization
+    set Output format                 = vtu
+    set Time between graphical output = 1e6
+    set Number of grouped files       = 1
+  end
+
+  subsection Depth average
+    set Time between graphical output = 1.5e6
+    set Output format                 = vtu
+  end
+end
+
+
+subsection Checkpointing
+  set Steps between checkpoint = 50
+end
+
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Linear solver tolerance = 1e-4
+  end
+end

--- a/tests/gmg_no_normal_flux_only/screen-output
+++ b/tests/gmg_no_normal_flux_only/screen-output
@@ -1,0 +1,25 @@
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+Number of active cells: 768 (on 2 levels)
+Number of degrees of freedom: 28,690 (20,790+970+6,930)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving Stokes system... 36+0 iterations.
+
+Number of active cells: 2,112 (on 3 levels)
+Number of degrees of freedom: 89,938 (65,142+3,082+21,714)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving Stokes system... 44+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-gmg_no_normal_flux_only/solution/solution-00000
+     RMS, max velocity:                  0.00886 m/year, 0.0594 m/year
+     Temperature min/avg/max:            973 K, 1462 K, 1973 K
+     Heat fluxes through boundary parts: -5.219e+12 W, 5.878e+12 W
+     Writing depth average:              output-gmg_no_normal_flux_only/depth_average
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
GMG would crash/assert in

const dealii::IndexSet&
dealii::MGConstrainedDoFs::get_boundary_indices(unsigned int) const

when no prescribed/fixed boundary conditions are set. Bug was introduced
in #4251

fixes #4282