### PR TITLE
Move a screen message.

### DIFF
--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -610,10 +610,10 @@ namespace aspect
           else
             {
               const std::string filename (create_filename (next_file_number, boundary_id));
-              this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                                << filename << "." << std::endl << std::endl;
               if (Utilities::fexists(filename))
                 {
+                  this->get_pcout() << std::endl << "   Also loading next Ascii data boundary file "
+                                    << filename << "." << std::endl << std::endl;
                   lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
                   lookups.find(boundary_id)->second->load_file(filename, this->get_mpi_communicator());
                 }
@@ -849,6 +849,8 @@ namespace aspect
         end_time_dependence ();
     }
 
+
+
     template <int dim>
     void
     AsciiDataBoundary<dim>::end_time_dependence ()
@@ -865,6 +867,7 @@ namespace aspect
                         << "   that time-dependence ends at this timestep  (i.e. the boundary condition" << std::endl
                         << "   will continue unchanged from the last known state into the future)." << std::endl << std::endl;
     }
+
 
 
     template <int dim>

--- a/tests/ascii_data_boundary_composition_2d_box_time/screen-output
+++ b/tests/ascii_data_boundary_composition_2d_box_time/screen-output
@@ -3,7 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_2d_left.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_2d_left.1.txt.
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_2d_left.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,581 (738+105+369+369)

--- a/tests/ascii_data_boundary_temperature_2d_box_time/screen-output
+++ b/tests/ascii_data_boundary_temperature_2d_box_time/screen-output
@@ -3,7 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_2d_left.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_2d_left.1.txt.
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_2d_left.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_box_time/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_time/screen-output
@@ -3,9 +3,6 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.1.txt.
-
-
    From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
    This is either because ASPECT has already read all the files necessary to impose
    the requested boundary condition, or that the last available file has been read.
@@ -15,9 +12,6 @@
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.1.txt.
 
 
    From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
@@ -31,7 +25,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_box_time_backward/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_time_backward/screen-output
@@ -3,7 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.2.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_box_time_non_equidistant/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_time_non_equidistant/screen-output
@@ -3,7 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top_non_equidistant.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top_non_equidistant.1.txt.
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top_non_equidistant.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -3,9 +3,6 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-traction/ascii-data/test/box_2d_left.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-traction/ascii-data/test/box_2d_left.1.txt.
-
-
    From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
    This is either because ASPECT has already read all the files necessary to impose
    the requested boundary condition, or that the last available file has been read.


### PR DESCRIPTION
I was confused by the presence of an message on screen that turns out to just be written in the wrong place. Move it to where the action described in the message is actually happening, not before the guarding `if`.

/rebuild