### PR TITLE
Fix a mis-spelled parameter.

### DIFF
--- a/doc/manual/parameters.tex
+++ b/doc/manual/parameters.tex
@@ -17967,13 +17967,13 @@ This parameter is an alias for the parameter ``\texttt{Output surface topography
 
 
 {\it Possible values:} A boolean value (true or false)
-\item {\it Parameter name:} {\tt Include the contributon from dynamic topography}
-\phantomsection\label{parameters:Postprocess/Geoid/Include the contributon from dynamic topography}
-\label{parameters:Postprocess/Geoid/Include_20the_20contributon_20from_20dynamic_20topography}
+\item {\it Parameter name:} {\tt Include the contribution from dynamic topography}
+\phantomsection\label{parameters:Postprocess/Geoid/Include the contribution from dynamic topography}
+\label{parameters:Postprocess/Geoid/Include_20the_20contribution_20from_20dynamic_20topography}
 
 
-\index[prmindex]{Include the contributon from dynamic topography}
-\index[prmindexfull]{Postprocess!Geoid!Include the contributon from dynamic topography}
+\index[prmindex]{Include the contribution from dynamic topography}
+\index[prmindexfull]{Postprocess!Geoid!Include the contribution from dynamic topography}
 {\it Value:} true
 
 

--- a/doc/parameter_view/parameters.xml
+++ b/doc/parameter_view/parameters.xml
@@ -16882,7 +16882,7 @@ Option to include the contribution from surface topography on geoid. The default
 [Bool]
 </pattern_description>
 </Include_20surface_20topography_20contribution>
-<Include_20the_20contributon_20from_20dynamic_20topography>
+<Include_20the_20contribution_20from_20dynamic_20topography>
 <value>
 true
 </value>
@@ -16898,7 +16898,7 @@ Option to include the contribution from dynamic topography on geoid. The default
 <pattern_description>
 [Bool]
 </pattern_description>
-</Include_20the_20contributon_20from_20dynamic_20topography>
+</Include_20the_20contribution_20from_20dynamic_20topography>
 <Maximum_20degree>
 <value>
 20

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -939,7 +939,7 @@ namespace aspect
       {
         prm.enter_subsection("Geoid");
         {
-          prm.declare_entry("Include the contributon from dynamic topography", "true",
+          prm.declare_entry("Include the contribution from dynamic topography", "true",
                             Patterns::Bool(),
                             "Option to include the contribution from dynamic topography on geoid. The default is true.");
           prm.declare_entry("Include surface topography contribution", "true",
@@ -1009,10 +1009,10 @@ namespace aspect
       {
         prm.enter_subsection("Geoid");
         {
-          const bool include_topo_contribution = prm.get_bool ("Include the contributon from dynamic topography");
+          const bool include_topo_contribution = prm.get_bool ("Include the contribution from dynamic topography");
 
           AssertThrow (include_topo_contribution == true,
-                       ExcMessage("The parameter 'Include the contributon from dynamic topography' has been "
+                       ExcMessage("The parameter 'Include the contribution from dynamic topography' has been "
                                   " replaced by the two parameters 'Include surface topography contribution' and "
                                   "'Include CMB topography contribution'. Please use them instead."));
 


### PR DESCRIPTION
Found while reading through the hackathon report where this parameter name was copy-pasted :-) @mfmweerdesteijn @jaustermann @gassmoeller -- FYI, I think this is going to affect your input files.

/rebuild