### PR TITLE
Do not compare against NaN time

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -915,11 +915,10 @@ namespace aspect
       initial_topography.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
       fs_mesh_velocity.reinit(mesh_locally_owned, mesh_locally_relevant, sim.mpi_communicator);
 
-      // if we are just starting, we need to set the initial topography
-      if (sim.time == 0)
-        {
-          set_initial_topography();
-        }
+      // if we are just starting, we need to set the initial topography.
+      if (this->simulator_is_past_initialization() == false ||
+          this->get_timestep_number() == 0)
+        set_initial_topography();
 
       // We would like to make sure that the mesh stays conforming upon
       // redistribution, so we construct mesh_vertex_constraints, which


### PR DESCRIPTION
After restart, the setup_dofs function in mesh_deformation/interface.cc is evaluated when sim.time is a NaN. On my local machine, this does not give any issues, but on our cluster, restarted models fail due to this. 

I've replaced the condition with what is used several lines below to deform the initial mesh. However:

When setup_dofs is evaluated at the start of a model run,
sim.time / this->get_time() is 0
sim.timestep_number / this->get_timestep_number() is max int

When setup_dofs is evaluated after restart,
sim.time / this->get_time() is NaN 
sim.timestep_number / this->get_timestep_number() is max int

So the timestep_number comparison seems superfluous, as that condition is never met.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
