### PR TITLE
Add conductivity to MaterialProperties Property all_properties

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -215,6 +215,7 @@ namespace aspect
                                          entropy_derivative_temperature,
         all_properties                 = equation_of_state_properties |
                                          viscosity |
+                                         thermal_conductivity |
                                          reaction_terms
       };
 


### PR DESCRIPTION
The Property `thermal_conductivity` was missing from the list of all properties. 

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
