### PR TITLE
Remove unused MaterialModelOutputs

### DIFF
--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -149,11 +149,6 @@ namespace aspect
             MaterialModel::MaterialModelOutputs<dim> out_volume(fe_volume_values.n_quadrature_points, this->n_compositional_fields());
             this->get_material_model().evaluate(in_volume, out_volume);
 
-            // Evaluate the material model on the cell face.
-            MaterialModel::MaterialModelInputs<dim> in_face(fe_face_values, cell, this->introspection(), this->get_solution());
-            MaterialModel::MaterialModelOutputs<dim> out_face(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-            this->get_material_model().evaluate(in_face, out_face);
-
             // Get solution values for the divergence of the velocity, which is not
             // computed by the material model.
             fe_volume_values[this->introspection().extractors.velocities].get_function_divergences (this->get_solution(), div_solution);

--- a/source/postprocess/visualization/ISA_rotation_timescale.cc
+++ b/source/postprocess/visualization/ISA_rotation_timescale.cc
@@ -49,8 +49,6 @@ namespace aspect
         // Set up material models
         MaterialModel::MaterialModelInputs<dim> in(n_q_points,
                                                    this->n_compositional_fields());
-        MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
-                                                     this->n_compositional_fields());
 
         // Loop over cells and calculate tauISA in each one
         // Note that we start after timestep 0 because we need the strain rate,

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -49,8 +49,6 @@ namespace aspect
         // Set up material models
         MaterialModel::MaterialModelInputs<dim> in(n_q_points,
                                                    this->n_compositional_fields());
-        MaterialModel::MaterialModelOutputs<dim> out(n_q_points,
-                                                     this->n_compositional_fields());
 
         // Loop over cells and calculate theta in each one
         // Note that we start after timestep 0 because we need the strain rate,


### PR DESCRIPTION
This PR removes some MaterialModelInputs and MaterialModelOutputs in postprocessors that were created but not actually used.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
