### PR TITLE
Add missing mapping

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2700,7 +2700,7 @@ namespace aspect
                                    sim.mpi_communicator);
 
             QGauss<dim>  quadrature_formula(sim.parameters.stokes_velocity_degree+1);
-            FEValues<dim> fe_values (fe_v, quadrature_formula,
+            FEValues<dim> fe_values (*(sim.mapping), fe_v, quadrature_formula,
                                      update_values   | update_gradients |
                                      update_quadrature_points | update_JxW_values);
             FEValues<dim> fe_values_projection (*(sim.mapping),
@@ -2792,7 +2792,7 @@ namespace aspect
             diagonal_matrix.compress(VectorOperation::add);
 
             dealii::LinearAlgebra::distributed::Vector<GMGNumberType> diagonal;
-            // This assignment converts from type double to GMGNumberType (float).
+            // This assignment converts from type double to GMGNumberType.
             diagonal = diagonal_matrix.get_vector();
             mg_matrices_A_block[level].set_diagonal(diagonal);
           }

--- a/tests/gmg_no_normal_flux_only/screen-output
+++ b/tests/gmg_no_normal_flux_only/screen-output
@@ -14,9 +14,9 @@ Number of degrees of freedom: 89,938 (65,142+3,082+21,714)
 
    Postprocessing:
      Writing graphical output:           output-gmg_no_normal_flux_only/solution/solution-00000
-     RMS, max velocity:                  0.00886 m/year, 0.0594 m/year
+     RMS, max velocity:                  0.00887 m/year, 0.0592 m/year
      Temperature min/avg/max:            973 K, 1462 K, 1973 K
-     Heat fluxes through boundary parts: -5.219e+12 W, 5.878e+12 W
+     Heat fluxes through boundary parts: -5.218e+12 W, 5.859e+12 W
      Writing depth average:              output-gmg_no_normal_flux_only/depth_average
 
 Termination requested by criterion: end time


### PR DESCRIPTION
I think there is a mapping argument missing here.  I have not seen a large influence of this (it only affects the main diagonal for curved meshes with tangential bcs), and it does not solve #4308, but it seem more correct this way anyway. Also fix a comment. 