### PR TITLE
GMG: fix order of RHS correction [WIP]

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -802,10 +802,6 @@ namespace aspect
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
 
-    // If we change the system_rhs, matrix-free Stokes must update
-    if (stokes_matrix_free)
-      stokes_matrix_free->assemble();
-
     // if the model is compressible then we need to adjust the right hand
     // side of the equation to make it compatible with the matrix on the
     // left
@@ -814,6 +810,10 @@ namespace aspect
         pressure_shape_function_integrals.compress(VectorOperation::add);
         make_pressure_rhs_compatible(system_rhs);
       }
+
+    // If we change the system_rhs, matrix-free Stokes must update
+    if (stokes_matrix_free)
+      stokes_matrix_free->assemble();
 
     // record that we have just rebuilt the matrix
     rebuild_stokes_matrix = false;


### PR DESCRIPTION
Fix the order of GMG correct_stokes_rhs() and make_pressure_rhs_compatible().

this is on top of #4324