### PR TITLE
Remove some wrong input file patterns

### DIFF
--- a/benchmarks/diffusion_of_hill/analytical_topography.cc
+++ b/benchmarks/diffusion_of_hill/analytical_topography.cc
@@ -319,7 +319,7 @@ namespace aspect
         prm.enter_subsection("Topography");
         {
           prm.declare_entry ("Output to file", "false",
-                             Patterns::List(Patterns::Bool()),
+                             Patterns::Bool(),
                              "Whether or not to write topography to a text file named named "
                              "'topography.NNNNN' in the output directory.");
           prm.declare_entry ("Time between text output", "0.",

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -175,7 +175,7 @@ namespace aspect
         prm.enter_subsection("Topography");
         {
           prm.declare_entry ("Output to file", "false",
-                             Patterns::List(Patterns::Bool()),
+                             Patterns::Bool(),
                              "Whether or not to write topography to a text file named named "
                              "'topography.NNNNN' in the output directory");
 


### PR DESCRIPTION
Random find while looking for something else. These parameters could not be parsed if a user actually provided a list of bools.