### PR TITLE
Update the pressure scaling once per nonlinear iteration

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -568,21 +568,6 @@ namespace aspect
     if (particle_world.get() != nullptr)
       particle_world->backup_particles();
 
-    // Re-compute the pressure scaling factor. In some sense, it would be nice
-    // if we did this not just once per time step, but once for each solve --
-    // i.e., multiple times per time step if we iterate out the nonlinearity
-    // during a Newton or Picard iteration. But that's more work,
-    // and the function would need to be called in more different places.
-    // Unless we have evidence that that's necessary, let's assume that
-    // the reference viscosity does not change too much between nonlinear
-    // iterations and that it's ok to update it only once per time step.
-    //
-    // The call to this function must precede the one to the computation
-    // of constraints because some kinds of constraints require scaling
-    // pressure degrees of freedom to a size adjusted by the pressure_scaling
-    // factor.
-    pressure_scaling = compute_pressure_scaling_factor();
-
     // then interpolate the current boundary velocities. copy constraints
     // into current_constraints and then add to current_constraints
     compute_current_constraints ();

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -350,6 +350,13 @@ namespace aspect
         (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
       rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
 
+    // Re-compute the pressure scaling factor.
+    // The call to this function must precede the one to the computation
+    // of constraints because some kinds of constraints require scaling
+    // pressure degrees of freedom to a size adjusted by the pressure_scaling
+    // factor.
+    pressure_scaling = compute_pressure_scaling_factor();
+
     // set constraints for p_c if porosity is below a threshold
     if (nonlinear_iteration == 0 && parameters.include_melt_transport)
       {


### PR DESCRIPTION
Move the pressure scaling computation so that it is updated once per nonlinear iteration instead of the beginning of the timestep. We have a model that relies on the solution of the advection equations before it can reliably compute a viscosity. I timed the computation and it seems significantly faster than the Stokes solution even for simple models.

I expect this to potentially change some tests, although it should only improve convergence of the Stokes solver.