### PR TITLE
Avoid unhelpful error message

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2197,9 +2197,12 @@ namespace aspect
                     f << "\n";
                   }
 
-
-                for (unsigned int i=0; i<solver_control_expensive.get_history_data().size(); ++i)
-                  f << i << " " << solver_control_expensive.get_history_data()[i] << "\n";
+                // Only request the solver history if a history has actually been created
+                if (sim.parameters.n_expensive_stokes_solver_steps > 0)
+                  {
+                    for (unsigned int i=0; i<solver_control_expensive.get_history_data().size(); ++i)
+                      f << i << " " << solver_control_expensive.get_history_data()[i] << "\n";
+                  }
 
                 f.close();
 


### PR DESCRIPTION
If the matrix free Stokes solver with the cheap preconditioner does not converge and the parameter file set 0 expensive iterations we currently throw a non-helpful error message ("No history data found, maybe Stokes solver has not been run" or something similar). 

We should only try to access the history data if the solver has actually been run. This allows for a more helpful error message("The Stokes solver did not converge in the number of requested cheap iterations and you requested 0 for ``Maximum number of expensive Stokes solver steps''. Aborting.").

