### PR TITLE
Print cheap stokes iterations immediately

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -837,6 +837,13 @@ namespace aspect
                           distributed_stokes_rhs,
                           preconditioner_cheap);
 
+            // Success. Print all iterations to screen (0 expensive iterations).
+            pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
+                      solver_control_cheap.last_step():
+                      0)
+                  << "+0"
+                  << " iterations." << std::endl;
+
             final_linear_residual = solver_control_cheap.last_value();
           }
 
@@ -845,6 +852,13 @@ namespace aspect
         // it in n_expensive_stokes_solver_steps steps or less.
         catch (const SolverControl::NoConvergence &)
           {
+            // The cheap solver failed or never ran.
+            // Print the number of cheap iterations to screen to indicate we
+            // try the expensive solver next.
+            pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
+                      solver_control_cheap.last_step():
+                      0) << '+' << std::flush;
+
             // use the value defined by the user
             // OR
             // at least a restart length of 100 for melt models
@@ -867,6 +881,12 @@ namespace aspect
                              distributed_stokes_solution,
                              distributed_stokes_rhs,
                              preconditioner_expensive);
+
+                // Success. Print expensive iterations to screen.
+                pcout << (solver_control_expensive.last_step() != numbers::invalid_unsigned_int ?
+                          solver_control_expensive.last_step():
+                          0)
+                      << " iterations." << std::endl;
 
                 final_linear_residual = solver_control_expensive.last_value();
               }
@@ -915,17 +935,6 @@ namespace aspect
         // into the ghosted one with all solution components
         solution.block(block_vel) = distributed_stokes_solution.block(block_vel);
         solution.block(block_p) = distributed_stokes_solution.block(block_p);
-
-        // print the number of iterations to screen
-        pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
-                  solver_control_cheap.last_step():
-                  0)
-              << '+'
-              << (solver_control_expensive.last_step() != numbers::invalid_unsigned_int ?
-                  solver_control_expensive.last_step():
-                  0)
-              << " iterations.";
-        pcout << std::endl;
       }
 
 

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1881,10 +1881,13 @@ namespace aspect
 
     if (print_details)
       {
-        sim.pcout << "\n    GMG coarse size A: " << coarse_A_size << ", coarse size S: " << coarse_S_size << '\n';
-        sim.pcout << "    GMG n_levels: " << sim.triangulation.n_global_levels() << '\n';
+        sim.pcout << std::endl
+                  << "    GMG coarse size A: " << coarse_A_size << ", coarse size S: " << coarse_S_size << std::endl
+                  << "    GMG n_levels: " << sim.triangulation.n_global_levels() << std::endl;
+
         const double imbalance = MGTools::workload_imbalance(sim.triangulation);
-        sim.pcout << "    GMG workload imbalance: " << imbalance << std::endl;
+        sim.pcout << "    GMG workload imbalance: " << imbalance << std::endl
+                  << "    Stokes solver: " << std::flush;
       }
 
     // Interface matrices
@@ -2140,6 +2143,13 @@ namespace aspect
         else
           Assert(false,ExcNotImplemented());
 
+        // Success. Print all iterations to screen (0 expensive iterations).
+        sim.pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
+                      solver_control_cheap.last_step():
+                      0)
+                  << "+0"
+                  << " iterations." << std::endl;
+
         final_linear_residual = solver_control_cheap.last_value();
       }
     // step 1b: take the stronger solver in case
@@ -2147,6 +2157,13 @@ namespace aspect
     // it in n_expensive_stokes_solver_steps steps or less.
     catch (const SolverControl::NoConvergence &)
       {
+        // The cheap solver failed or never ran.
+        // Print the number of cheap iterations to screen to indicate we
+        // try the expensive solver next.
+        sim.pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
+                      solver_control_cheap.last_step():
+                      0) << '+' << std::flush;
+
         // use the value defined by the user
         // OR
         // at least a restart length of 100 for melt models
@@ -2169,6 +2186,12 @@ namespace aspect
                          solution_copy,
                          rhs_copy,
                          preconditioner_expensive);
+
+            // Success. Print expensive iterations to screen.
+            sim.pcout << (solver_control_expensive.last_step() != numbers::invalid_unsigned_int ?
+                          solver_control_expensive.last_step():
+                          0)
+                      << " iterations." << std::endl;
 
             final_linear_residual = solver_control_expensive.last_value();
           }
@@ -2241,27 +2264,15 @@ namespace aspect
 
     if (print_details)
       {
-        sim.pcout << "    Schur iterations: " << preconditioner_cheap.n_iterations_Schur_complement()
+        sim.pcout << "    Schur complement preconditioner: " << preconditioner_cheap.n_iterations_Schur_complement()
                   << "+"
                   << preconditioner_expensive.n_iterations_Schur_complement()
-                  << '\n';
-        sim.pcout << "    A iterations: " << preconditioner_cheap.n_iterations_A_block()
+                  << " iterations." << std::endl;
+        sim.pcout << "    A block preconditioner: " << preconditioner_cheap.n_iterations_A_block()
                   << "+"
                   << preconditioner_expensive.n_iterations_A_block()
-                  << '\n';
-        sim.pcout <<"    Stokes: " << std::flush;
+                  << " iterations." << std::endl;
       }
-
-    // print the number of iterations to screen
-    sim.pcout << (solver_control_cheap.last_step() != numbers::invalid_unsigned_int ?
-                  solver_control_cheap.last_step():
-                  0)
-              << '+'
-              << (solver_control_expensive.last_step() != numbers::invalid_unsigned_int ?
-                  solver_control_expensive.last_step():
-                  0)
-              << " iterations.";
-    sim.pcout << std::endl;
 
     // do some cleanup now that we have the solution
     sim.remove_nullspace(sim.solution, distributed_stokes_solution);

--- a/tests/nsinker_gmg_idr/screen-output
+++ b/tests/nsinker_gmg_idr/screen-output
@@ -10,9 +10,9 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
     GMG coarse size A: 81, coarse size S: 8
     GMG n_levels: 3
     GMG workload imbalance: 1
-    Schur iterations: 25+0
-    A iterations: 25+0
-    Stokes: 9+0 iterations.
+    Stokes solver: 9+0 iterations.
+    Schur complement preconditioner: 25+0 iterations.
+    A block preconditioner: 25+0 iterations.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.999954
 
 

--- a/tests/poiseuille_2d_pressure_bc_gmg/screen-output
+++ b/tests/poiseuille_2d_pressure_bc_gmg/screen-output
@@ -9,9 +9,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
     GMG coarse size A: 18, coarse size S: 4
     GMG n_levels: 5
     GMG workload imbalance: 1
-    Schur iterations: 15+0
-    A iterations: 15+0
-    Stokes: 14+0 iterations.
+    Stokes solver: 14+0 iterations.
+    Schur complement preconditioner: 15+0 iterations.
+    A block preconditioner: 15+0 iterations.
 
    Postprocessing:
      RMS, max velocity:                  0.193 m/s, 0.27 m/s

--- a/tests/solver_history/screen-output
+++ b/tests/solver_history/screen-output
@@ -8,9 +8,9 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 
+   Solving Stokes system... 30+7 iterations.
+
 post_stokes_solver:
-30+7 iterations.
 
    Postprocessing:
      Writing graphical output:           output-solver_history/solution/solution-00000
@@ -21,9 +21,9 @@ post_stokes_solver:
 
 *** Timestep 1:  t=0.1 seconds, dt=0.1 seconds
    Solving temperature system... 4 iterations.
-   Solving Stokes system... 
+   Solving Stokes system... 8+0 iterations.
+
 post_stokes_solver:
-8+0 iterations.
 
    Postprocessing:
      RMS, max velocity:                  9e-09 m/s, 3.23e-08 m/s


### PR DESCRIPTION
I was chasing a bug for quite some time until I realized it only happens in the expensive solver. It would be nice to get this indicated immediately, by printing the number of cheap Stokes solver steps as soon as we know it (to separate crashes in the cheap solver from crashes in the expensive solver). Related to #4330.

This should not change any test output.