### PR TITLE
improved parse_map error message for string format

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -186,11 +186,19 @@ namespace aspect
           {
             // No Patterns matches were found!
             AssertThrow (false,
-                         ExcMessage ("The required format for property <"
+                         ExcMessage ("The string for property <"
                                      + property_name
-                                     + "> was not found. Specify a comma separated "
-                                     + "list of `<double>' or `<key1> : <double>|<double>|..., "
-                                     + "<key2> : <double>|... , ... '."));
+                                     + "> does not have the expected format. "
+                                     + "Check that the string is either a "
+                                     + "comma separated list of `<double>' or "
+                                     + "`<key1> : <double>|<double>|..., "
+                                     + "<key2> : <double>|... , ... '. "
+                                     + "If the string looks correct, "
+                                     + "it is likely that the length of the "
+                                     + "list of keys passed to "
+                                     + "parse_map_to_double_array does not "
+                                     + "match the length of the "
+                                     + "comma separated property list."));
           }
 
         return parsed_map;

--- a/tests/stokes_solver_fail_A/screen-output
+++ b/tests/stokes_solver_fail_A/screen-output
@@ -32,7 +32,7 @@ Additional information:
     The solver reported the following error:
     
     --------------------------------------------------------
-    An error occurred in line <2413> of file
+    An error occurred in line <2421> of file
 (line in output replaced by default.sh script)
     void aspect::Utilities::linear_solver_failed(const string&, const
     string&, const std::vector<dealii::SolverControl>&, const

--- a/tests/stokes_solver_fail_S/screen-output
+++ b/tests/stokes_solver_fail_S/screen-output
@@ -32,7 +32,7 @@ Additional information:
     The solver reported the following error:
     
     --------------------------------------------------------
-    An error occurred in line <2413> of file
+    An error occurred in line <2421> of file
 (line in output replaced by default.sh script)
     void aspect::Utilities::linear_solver_failed(const string&, const
     string&, const std::vector<dealii::SolverControl>&, const

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -266,7 +266,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
     aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4;400, C5:500, bg:3",
   {"C1","C2","C3","C4","C5"},
   true,
-  "TestField"), Contains("The required format for property"));
+  "TestField"), Contains("does not have the expected format"));
 
 
   INFO("check fail 4: ");
@@ -305,7 +305,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   {"C1","C2","C3","C4","C5"},
   false,
   "TestField",
-  true), Contains("The required format for property"));
+  true), Contains("does not have the expected format"));
 
   // No subentries
   INFO("check fail 9: ");
@@ -314,7 +314,7 @@ TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
   {"C1","C2","C3","C4","C5"},
   false,
   "TestField",
-  true), Contains("The required format for property"));
+  true), Contains("does not have the expected format"));
 
   // Wrong input structure
   {


### PR DESCRIPTION
This PR improves the error message for parse_map_to_double_array, to include cases where the prm has the correct format but there is a mismatch in argument sizes (i.e. when the code is in error).

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
