### PR TITLE
remove lines with code line number from screen-output

### DIFF
--- a/tests/advection_solver_fail/screen-output
+++ b/tests/advection_solver_fail/screen-output
@@ -30,7 +30,7 @@ Additional information:
     The solver reported the following error:
     
     --------------------------------------------------------
-    An error occurred in line <1074> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     void dealii::SolverGMRES<VectorType>::solve(const MatrixType&,
     VectorType&, const VectorType&, const PreconditionerType&) [with

--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -19,8 +19,6 @@ while ( <STDIN> )
   next if $_ =~ m/^-- /;
   next if $_ =~ m/^\|/;
 
-  $line = $_;
-
   if ($skip>0)
   {
     print "(line in output replaced by default.sh script)\n";
@@ -30,20 +28,34 @@ while ( <STDIN> )
 
   if ($_ =~ m/^\s*An error occurred in/)
   {
+    if ($_ =~ /function/)
+    {
+      # These lines have the structure:
+      # "An error occurred in file <...> in function"
+      # The file name is unlikely to change frequently, so we keep this line
+      print "$_";
+    }
+    else
+    {
+      # These lines have the structure:
+      # "An error occurred in line <...> of file"
+      # The line number is likely to change frequently, so we replace this line
+      print "(line in output replaced by default.sh script)\n";
+    }
+    # In both of the above cases, we want to replace the next line
+    # In the first case, the function arguments are formatted differently
+    # when run with a different compiler version.
+    # In the second case, the full file paths are printed.
     $skip=1;
-  }
-
-  if ($_ =~ m/^\s*An error occurred in line/)
-  {
-    $line = "(line in output replaced by default.sh script)\n";
+    next
   }
 
   if ($_ =~ m/^Stacktrace:/)
   {
-    print "$line";
+    print "$_";
     print "(rest of the output replaced by default.sh script)\n";
     last;
   }
 
-  print "$line";
+  print "$_";
 }

--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -12,38 +12,38 @@ $skip = 0;
 
 while ( <STDIN> )
 {
-    # this is not strictly necessary because we are going to remove the
-    # following lines inside the cmake script, but this makes it easier
-    # to generate screen-output files from scratch because the useless
-    # lines are already removed.
-    next if $_ =~ m/^-- /;
-    next if $_ =~ m/^\|/;
+  # this is not strictly necessary because we are going to remove the
+  # following lines inside the cmake script, but this makes it easier
+  # to generate screen-output files from scratch because the useless
+  # lines are already removed.
+  next if $_ =~ m/^-- /;
+  next if $_ =~ m/^\|/;
 
-    $line = $_;
+  $line = $_;
 
-    if ($skip>0)
-    {
-	print "(line in output replaced by default.sh script)\n";
-	$skip=$skip-1;
-	next;
-    }
+  if ($skip>0)
+  {
+    print "(line in output replaced by default.sh script)\n";
+	  $skip=$skip-1;
+	  next;
+  }
 
-    if ($_ =~ m/^\s*An error occurred in/)
-    {
-	$skip=1;
-    }
+  if ($_ =~ m/^\s*An error occurred in/)
+  {
+    $skip=1;
+  }
 
-    if ($_ =~ m/^\s*An error occurred in line/)
-    {
-  $line = "(line in output replaced by default.sh script)\n";
-    }
+  if ($_ =~ m/^\s*An error occurred in line/)
+  {
+    $line = "(line in output replaced by default.sh script)\n";
+  }
 
-    if ($_ =~ m/^Stacktrace:/)
-    {
-	print "$line";
-	print "(rest of the output replaced by default.sh script)\n";
-	last;
-    }
-
+  if ($_ =~ m/^Stacktrace:/)
+  {
     print "$line";
+    print "(rest of the output replaced by default.sh script)\n";
+    last;
+  }
+
+  print "$line";
 }

--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -19,6 +19,8 @@ while ( <STDIN> )
     next if $_ =~ m/^-- /;
     next if $_ =~ m/^\|/;
 
+    $line = $_;
+
     if ($skip>0)
     {
 	print "(line in output replaced by default.sh script)\n";
@@ -31,12 +33,17 @@ while ( <STDIN> )
 	$skip=1;
     }
 
+    if ($_ =~ m/^\s*An error occurred in line/)
+    {
+  $line = "(line in output replaced by default.sh script)\n";
+    }
+
     if ($_ =~ m/^Stacktrace:/)
     {
-	print "$_";
+	print "$line";
 	print "(rest of the output replaced by default.sh script)\n";
 	last;
     }
 
-    print "$_";
+    print "$line";
 }

--- a/tests/stokes_solver_fail/screen-output
+++ b/tests/stokes_solver_fail/screen-output
@@ -32,7 +32,7 @@ Additional information:
     The solver reported the following error:
     
     --------------------------------------------------------
-    An error occurred in line <1285> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     void dealii::SolverFGMRES<VectorType>::solve(const MatrixType&,
     VectorType&, const VectorType&, const PreconditionerType&) [with

--- a/tests/stokes_solver_fail_A/screen-output
+++ b/tests/stokes_solver_fail_A/screen-output
@@ -13,24 +13,24 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (exception_message.str())' on rank 0 on processing:
+Exception 'ExcMessage (exception_message.str())' on rank 0 on processing: 
 
 An error occurred in file <utilities.cc> in function
 (line in output replaced by default.sh script)
-The violated condition was:
+The violated condition was: 
     false
-Additional information:
+Additional information: 
     The iterative Stokes solver in Simulator::solve_stokes did not
     converge.
-
+    
     The initial residual was: 1.169088e+14
     The final residual is: 1.169088e+14
     The required residual for convergence is: 1.169088e+07
     See output-stokes_solver_fail_A/solver_history.txt for the full
     convergence history.
-
+    
     The solver reported the following error:
-
+    
     --------------------------------------------------------
 (line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
@@ -42,11 +42,11 @@ Additional information:
     Additional information:
     The iterative (top left) solver in BlockSchurPreconditioner::vmult did
     not converge.
-
+    
     The required residual for convergence is: 1.000000e-35
-
+    
     The solver reported the following error:
-
+    
     --------------------------------------------------------
 (line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
@@ -59,8 +59,8 @@ Additional information:
     Additional information:
     AztecOO::Iterate error code -3: loss of precision
     --------------------------------------------------------
-
+    
     --------------------------------------------------------
-
+    
 
 Aborting!

--- a/tests/stokes_solver_fail_A/screen-output
+++ b/tests/stokes_solver_fail_A/screen-output
@@ -13,26 +13,26 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (exception_message.str())' on rank 0 on processing: 
+Exception 'ExcMessage (exception_message.str())' on rank 0 on processing:
 
 An error occurred in file <utilities.cc> in function
 (line in output replaced by default.sh script)
-The violated condition was: 
+The violated condition was:
     false
-Additional information: 
+Additional information:
     The iterative Stokes solver in Simulator::solve_stokes did not
     converge.
-    
+
     The initial residual was: 1.169088e+14
     The final residual is: 1.169088e+14
     The required residual for convergence is: 1.169088e+07
     See output-stokes_solver_fail_A/solver_history.txt for the full
     convergence history.
-    
+
     The solver reported the following error:
-    
+
     --------------------------------------------------------
-    An error occurred in line <2421> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     void aspect::Utilities::linear_solver_failed(const string&, const
     string&, const std::vector<dealii::SolverControl>&, const
@@ -42,13 +42,13 @@ Additional information:
     Additional information:
     The iterative (top left) solver in BlockSchurPreconditioner::vmult did
     not converge.
-    
+
     The required residual for convergence is: 1.000000e-35
-    
+
     The solver reported the following error:
-    
+
     --------------------------------------------------------
-    An error occurred in line <502> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     function
     void dealii::TrilinosWrappers::SolverBase::do_solve(const
@@ -59,8 +59,8 @@ Additional information:
     Additional information:
     AztecOO::Iterate error code -3: loss of precision
     --------------------------------------------------------
-    
+
     --------------------------------------------------------
-    
+
 
 Aborting!

--- a/tests/stokes_solver_fail_S/screen-output
+++ b/tests/stokes_solver_fail_S/screen-output
@@ -13,26 +13,26 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (exception_message.str())' on rank 0 on processing: 
+Exception 'ExcMessage (exception_message.str())' on rank 0 on processing:
 
 An error occurred in file <utilities.cc> in function
 (line in output replaced by default.sh script)
-The violated condition was: 
+The violated condition was:
     false
-Additional information: 
+Additional information:
     The iterative Stokes solver in Simulator::solve_stokes did not
     converge.
-    
+
     The initial residual was: 1.169088e+14
     The final residual is: 1.169088e+14
     The required residual for convergence is: 1.169088e+07
     See output-stokes_solver_fail_S/solver_history.txt for the full
     convergence history.
-    
+
     The solver reported the following error:
-    
+
     --------------------------------------------------------
-    An error occurred in line <2421> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     void aspect::Utilities::linear_solver_failed(const string&, const
     string&, const std::vector<dealii::SolverControl>&, const
@@ -42,13 +42,13 @@ Additional information:
     Additional information:
     The iterative (bottom right) solver in BlockSchurPreconditioner::vmult
     did not converge.
-    
+
     The required residual for convergence is: 1.000000e-35
-    
+
     The solver reported the following error:
-    
+
     --------------------------------------------------------
-    An error occurred in line <502> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     function
     void dealii::TrilinosWrappers::SolverBase::do_solve(const
@@ -59,8 +59,8 @@ Additional information:
     Additional information:
     AztecOO::Iterate error code -3: loss of precision
     --------------------------------------------------------
-    
+
     --------------------------------------------------------
-    
+
 
 Aborting!

--- a/tests/stokes_solver_fail_S/screen-output
+++ b/tests/stokes_solver_fail_S/screen-output
@@ -13,24 +13,24 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (exception_message.str())' on rank 0 on processing:
+Exception 'ExcMessage (exception_message.str())' on rank 0 on processing: 
 
 An error occurred in file <utilities.cc> in function
 (line in output replaced by default.sh script)
-The violated condition was:
+The violated condition was: 
     false
-Additional information:
+Additional information: 
     The iterative Stokes solver in Simulator::solve_stokes did not
     converge.
-
+    
     The initial residual was: 1.169088e+14
     The final residual is: 1.169088e+14
     The required residual for convergence is: 1.169088e+07
     See output-stokes_solver_fail_S/solver_history.txt for the full
     convergence history.
-
+    
     The solver reported the following error:
-
+    
     --------------------------------------------------------
 (line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
@@ -42,11 +42,11 @@ Additional information:
     Additional information:
     The iterative (bottom right) solver in BlockSchurPreconditioner::vmult
     did not converge.
-
+    
     The required residual for convergence is: 1.000000e-35
-
+    
     The solver reported the following error:
-
+    
     --------------------------------------------------------
 (line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
@@ -59,8 +59,8 @@ Additional information:
     Additional information:
     AztecOO::Iterate error code -3: loss of precision
     --------------------------------------------------------
-
+    
     --------------------------------------------------------
-
+    
 
 Aborting!

--- a/tests/stokes_solver_fail_gmg/screen-output
+++ b/tests/stokes_solver_fail_gmg/screen-output
@@ -32,7 +32,7 @@ Additional information:
     The solver reported the following error:
     
     --------------------------------------------------------
-    An error occurred in line <1285> of file
+(line in output replaced by default.sh script)
 (line in output replaced by default.sh script)
     void dealii::SolverFGMRES<VectorType>::solve(const MatrixType&,
     VectorType&, const VectorType&, const PreconditionerType&) [with


### PR DESCRIPTION
Several of the tests which purposefully fail report line numbers of errors in the screen-output. This PR replaces those lines so that the test outputs don't need to be changed so often.

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
