### PR TITLE
use =default for virtual destructors

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -59,7 +59,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -51,7 +51,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -50,7 +50,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -61,7 +61,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -53,7 +53,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -59,7 +59,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -57,7 +57,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -63,7 +63,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -51,7 +51,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -126,7 +126,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -60,7 +60,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -60,7 +60,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -768,8 +768,7 @@ namespace aspect
     class AdditionalMaterialInputs
     {
       public:
-        virtual ~AdditionalMaterialInputs()
-        {}
+        virtual ~AdditionalMaterialInputs() = default;
 
         /**
          * Fill the additional inputs. Each additional input
@@ -1216,7 +1215,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -149,8 +149,7 @@ namespace aspect
          * Destructor. Does nothing but is virtual so that derived classes
          * destructors are also virtual.
          */
-        virtual ~MeltFractionModel ()
-        {};
+        virtual ~MeltFractionModel () = default;
     };
 
     /**

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -78,8 +78,7 @@ namespace aspect
          * Destructor. Does nothing but is virtual so that derived classes
          * destructors are also virtual.
          */
-        virtual
-        ~Interface ();
+        virtual ~Interface () = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -76,7 +76,7 @@ namespace aspect
            * Destructor. Made virtual so that derived classes can be created
            * and destroyed through pointers to the base class.
            */
-          ~Interface () override;
+          ~Interface () override = default;
 
           /**
            * Initialization function. This function is called once at the

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -51,7 +51,7 @@ namespace aspect
            * Destructor. Made virtual so that derived classes can be created
            * and destroyed through pointers to the base class.
            */
-          virtual ~Interface ();
+          virtual ~Interface () = default;
 
           /**
            * Initialization function. This function is called once at the

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -54,7 +54,7 @@ namespace aspect
            * Destructor. Made virtual so that derived classes can be created
            * and destroyed through pointers to the base class.
            */
-          virtual ~Interface ();
+          virtual ~Interface () = default;
 
           /**
            * Perform an interpolation of the properties of the particles in

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -312,7 +312,7 @@ namespace aspect
            * Destructor. Made virtual so that derived classes can be created
            * and destroyed through pointers to the base class.
            */
-          virtual ~Interface ();
+          virtual ~Interface () = default;
 
           /**
            * Initialization function. This function is called once at the

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -75,8 +75,7 @@ namespace aspect
          * Destructor. Does nothing but is virtual so that derived classes
          * destructors are also virtual.
          */
-        virtual
-        ~Interface ();
+        virtual ~Interface () = default;
 
         /**
          * Initialize function.

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -128,8 +128,7 @@ namespace aspect
            * Destructor. Does nothing but is virtual so that derived classes
            * destructors are also virtual.
            */
-          virtual
-          ~Interface ();
+          virtual ~Interface () = default;
 
           /**
            * Initialize function.

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -60,7 +60,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~Interface();
+        virtual ~Interface() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -494,7 +494,10 @@ namespace aspect
     class Interface
     {
       public:
-        virtual ~Interface ();
+        /**
+         * Destructor
+         */
+        virtual ~Interface () = default;
 
         /**
          * Execute this assembler object. This function performs the primary work

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -185,8 +185,7 @@ namespace aspect
        * Destructor. Does nothing but is virtual so that derived classes
        * destructors are also virtual.
        */
-      virtual
-      ~SimulatorAccess ();
+      virtual ~SimulatorAccess () = default;
 
       /**
        * Initialize this class for a given simulator. This function is marked

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -69,8 +69,7 @@ namespace aspect
          * Destructor. Does nothing but is virtual so that derived classes'
          * destructors are also virtual.
          */
-        virtual
-        ~Interface ();
+        virtual ~Interface () = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -37,10 +37,6 @@ namespace aspect
   namespace BoundaryComposition
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::update ()
     {}

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -34,10 +34,6 @@ namespace aspect
   namespace BoundaryFluidPressure
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -34,10 +34,6 @@ namespace aspect
   namespace BoundaryHeatFlux
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -37,11 +37,6 @@ namespace aspect
   namespace BoundaryTemperature
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::update ()
     {}

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -34,11 +34,6 @@ namespace aspect
   namespace BoundaryTraction
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -34,11 +34,6 @@ namespace aspect
   namespace BoundaryVelocity
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -32,11 +32,6 @@ namespace aspect
   namespace InitialTopographyModel
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -31,11 +31,6 @@ namespace aspect
   namespace GeometryModel
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -34,10 +34,6 @@ namespace aspect
   namespace GravityModel
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -37,11 +37,6 @@ namespace aspect
   namespace HeatingModel
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -34,11 +34,6 @@ namespace aspect
   namespace InitialComposition
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -33,11 +33,6 @@ namespace aspect
   namespace InitialTemperature
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -73,12 +73,6 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -32,10 +32,6 @@ namespace aspect
 // ------------------------------ Interface -----------------------------
 
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -38,12 +38,6 @@ namespace aspect
 
 
       template <int dim>
-      Interface<dim>::~Interface ()
-      {}
-
-
-
-      template <int dim>
       void
       Interface<dim>::initialize ()
       {

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -30,12 +30,6 @@ namespace aspect
     namespace Integrator
     {
       template <int dim>
-      Interface<dim>::~Interface ()
-      {}
-
-
-
-      template <int dim>
       void
       Interface<dim>::initialize ()
       {}

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -28,12 +28,6 @@ namespace aspect
     namespace Interpolator
     {
       template <int dim>
-      Interface<dim>::~Interface ()
-      {}
-
-
-
-      template <int dim>
       std::vector<std::vector<double>>
                                     Interface<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
                                                                          const std::vector<Point<dim>> &positions,

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -200,12 +200,6 @@ namespace aspect
 
 
       template <int dim>
-      Interface<dim>::~Interface ()
-      {}
-
-
-
-      template <int dim>
       void
       Interface<dim>::initialize ()
       {}

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -31,11 +31,6 @@ namespace aspect
   {
 // ------------------------------ Interface -----------------------------
 
-    template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
 
     template <int dim>
     void

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -160,13 +160,6 @@ namespace aspect
 
     namespace VisualizationPostprocessors
     {
-
-
-      template <int dim>
-      Interface<dim>::~Interface ()
-      {}
-
-
       template <int dim>
       void
       Interface<dim>::initialize ()

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -29,11 +29,6 @@ namespace aspect
   namespace PrescribedStokesSolution
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -495,12 +495,6 @@ namespace aspect
   namespace Assemblers
   {
     template <int dim>
-    Interface<dim>::~Interface()
-    {}
-
-
-
-    template <int dim>
     void
     Interface<dim>::create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &) const
     {}

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1370,8 +1370,7 @@ namespace aspect
         material_model_outputs(scratch.material_model_outputs)
       {}
 
-      virtual ~PcConstraintsAssembleData ()
-      {}
+      virtual ~PcConstraintsAssembleData () = default;
 
       FEValues<dim>                            finite_element_values;
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -33,15 +33,11 @@ namespace aspect
   {}
 
 
+
   template <int dim>
   SimulatorAccess<dim>::SimulatorAccess (const Simulator<dim> &simulator_object)
     :
     simulator (&simulator_object)
-  {}
-
-
-  template <int dim>
-  SimulatorAccess<dim>::~SimulatorAccess ()
   {}
 
 
@@ -71,6 +67,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   SimulatorSignals<dim> &
   SimulatorAccess<dim>::get_signals() const
@@ -81,12 +78,14 @@ namespace aspect
   }
 
 
+
   template <int dim>
   const Introspection<dim> &
   SimulatorAccess<dim>::introspection () const
   {
     return simulator->introspection;
   }
+
 
 
   template <int dim>
@@ -96,12 +95,16 @@ namespace aspect
     return simulator->mpi_communicator;
   }
 
+
+
   template <int dim>
   TimerOutput &
   SimulatorAccess<dim>::get_computing_timer () const
   {
     return simulator->computing_timer;
   }
+
+
 
   template <int dim>
   const ConditionalOStream &
@@ -110,17 +113,23 @@ namespace aspect
     return simulator->pcout;
   }
 
+
+
   template <int dim>
   double SimulatorAccess<dim>::get_time () const
   {
     return simulator->time;
   }
 
+
+
   template <int dim>
   double SimulatorAccess<dim>::get_timestep () const
   {
     return simulator->time_step;
   }
+
+
 
   template <int dim>
   double SimulatorAccess<dim>::get_old_timestep () const
@@ -137,11 +146,13 @@ namespace aspect
   }
 
 
+
   template <int dim>
   unsigned int SimulatorAccess<dim>::get_nonlinear_iteration () const
   {
     return simulator->nonlinear_iteration;
   }
+
 
 
   template <int dim>
@@ -188,12 +199,14 @@ namespace aspect
   }
 
 
+
   template <int dim>
   unsigned int
   SimulatorAccess<dim>::get_pre_refinement_step () const
   {
     return simulator->pre_refinement_step;
   }
+
 
 
   template <int dim>
@@ -212,6 +225,8 @@ namespace aspect
     return simulator->heating_model_manager.adiabatic_heating_enabled();
   }
 
+
+
   template <int dim>
   bool
   SimulatorAccess<dim>::include_latent_heat () const
@@ -220,12 +235,16 @@ namespace aspect
     return (std::find(heating_models.begin(), heating_models.end(), "latent heat") != heating_models.end());
   }
 
+
+
   template <int dim>
   bool
   SimulatorAccess<dim>::include_melt_transport () const
   {
     return simulator->parameters.include_melt_transport;
   }
+
+
 
   template <int dim>
   int
@@ -234,12 +253,16 @@ namespace aspect
     return simulator->parameters.stokes_velocity_degree;
   }
 
+
+
   template <int dim>
   double
   SimulatorAccess<dim>::get_adiabatic_surface_temperature () const
   {
     return simulator->parameters.adiabatic_surface_temperature;
   }
+
+
 
   template <int dim>
   double
@@ -248,12 +271,16 @@ namespace aspect
     return simulator->parameters.surface_pressure;
   }
 
+
+
   template <int dim>
   void
   SimulatorAccess<dim>::get_refinement_criteria (Vector<float> &estimated_error_per_cell) const
   {
     simulator->mesh_refinement_manager.execute (estimated_error_per_cell);
   }
+
+
 
   template <int dim>
   void
@@ -264,6 +291,8 @@ namespace aspect
     simulator->get_artificial_viscosity(viscosity_per_cell, advection_field, skip_interior_cells);
   }
 
+
+
   template <int dim>
   void
   SimulatorAccess<dim>::get_artificial_viscosity_composition (Vector<float> &viscosity_per_cell,
@@ -273,12 +302,16 @@ namespace aspect
     simulator->get_artificial_viscosity(viscosity_per_cell, advection_field);
   }
 
+
+
   template <int dim>
   const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_current_linearization_point () const
   {
     return simulator->current_linearization_point;
   }
+
+
 
   template <int dim>
   const LinearAlgebra::BlockVector &
@@ -287,12 +320,16 @@ namespace aspect
     return simulator->solution;
   }
 
+
+
   template <int dim>
   const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_old_solution () const
   {
     return simulator->old_solution;
   }
+
+
 
   template <int dim>
   const LinearAlgebra::BlockVector &
@@ -301,12 +338,16 @@ namespace aspect
     return simulator->old_old_solution;
   }
 
+
+
   template <int dim>
   const LinearAlgebra::BlockVector &
   SimulatorAccess<dim>::get_reaction_vector () const
   {
     return simulator->operator_split_reaction_vector;
   }
+
+
 
   template <int dim>
   const LinearAlgebra::BlockVector &
@@ -316,6 +357,7 @@ namespace aspect
             ExcMessage("You cannot get the mesh velocity if mesh deformation is not enabled."));
     return simulator->mesh_deformation->mesh_velocity;
   }
+
 
 
   template <int dim>
@@ -339,6 +381,8 @@ namespace aspect
     return simulator->dof_handler.get_fe();
   }
 
+
+
   template <int dim>
   const LinearAlgebra::BlockSparseMatrix &
   SimulatorAccess<dim>::get_system_matrix () const
@@ -346,12 +390,16 @@ namespace aspect
     return simulator->system_matrix;
   }
 
+
+
   template <int dim>
   const LinearAlgebra::BlockSparseMatrix &
   SimulatorAccess<dim>::get_system_preconditioner_matrix () const
   {
     return simulator->system_preconditioner_matrix;
   }
+
+
 
   template <int dim>
   const MaterialModel::Interface<dim> &
@@ -361,6 +409,7 @@ namespace aspect
             ExcMessage("You can not call this function if no such model is actually available."));
     return *simulator->material_model.get();
   }
+
 
 
   template <int dim>

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -32,10 +32,6 @@ namespace aspect
 // ------------------------------ Interface -----------------------------
 
     template <int dim>
-    Interface<dim>::~Interface ()
-    {}
-
-    template <int dim>
     void
     Interface<dim>::initialize ()
     {}


### PR DESCRIPTION
use =default for empty virtual destructors instead of implementations in
the .cc files.
