### PR TITLE
Fix the description of damage models in the manual.

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1533,16 +1533,23 @@ actually have anything to do with quantities that can be considered related to
 compositions. For example, one may define a field that tracks the grain size
 of rocks. If the strain rate is high, then the grain size decreases as the
 rocks break. If the temperature is high enough, then grains heal and their size
-increases again. Such ``damage'' models would then call for an equation of the
-form (assuming one uses only a single compositional field)
+increases again. Such ``damage models'' would then introduce a
+quantity $c(t)$ describing the ``damage'' to the material (here
+assumed to be described by a single scalar field) that 
+satisfies an equation of the form
 \begin{align*}
   \frac{\partial c}{\partial t} + \mathbf u \cdot \nabla c
   = q(T,c),
 \end{align*}
-where in the simplest case one could postulate
+where in the simplest case (much simplified from real models) one
+could postulate
 \begin{align*}
-  q(T,c) = -A c + B \max\{T-T_{\text{healing}},0\} c.
+  q(T,c) =  A \dot\varepsilon - B \max\{T-T_{\text{healing}},0\} c.
 \end{align*}
+Here, $\dot\varepsilon$ is the strain rate that causes damage; the
+first term then leads to growth of damage as strain continues to be
+accumulate on the material. The second term \textit{decreases} the
+damage if the temperature is high enough.
 One would then use this compositional field in the definition of the viscosity
 of the material: more damage means lower viscosity because the rocks are weaker.
 


### PR DESCRIPTION
I think that the description of the damage model in the section on compositional
fields did not actually make much sense as stated. In particular, it wasn't clear
whether the tracked quantity was supposed to describe grain size or damage.