### PR TITLE
Reorder restart checks

### DIFF
--- a/tests/checkpoint_07_enable_free_surface_create.prm
+++ b/tests/checkpoint_07_enable_free_surface_create.prm
@@ -1,0 +1,75 @@
+# Test to start a model without free surface but with a zero mesh deformation
+# enabled and write a checkpoint (this test).
+# Another test (checkpoint_07_enable_free_surface_resume) will then test to
+# resume from this checkpoint and enable a free surface.
+
+# based on checkpoint_06_free_surface
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 3e7
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Pressure normalization                 = surface
+
+subsection Checkpointing
+  set Steps between checkpoint = 4
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+end
+
+
+subsection Geometry model
+  set Model name = spherical shell
+end
+
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Viscosity = 1e20
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+end
+
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: boundary function
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = top
+  set Zero velocity boundary indicators       = bottom
+end
+
+
+subsection Postprocess
+  set List of postprocessors =visualization, composition statistics, temperature statistics, velocity statistics
+ subsection Visualization
+    set Output format                 = gnuplot
+    set Time between graphical output = 1e6
+ end
+end
+
+
+subsection Termination criteria
+  set Checkpoint on termination = false
+end

--- a/tests/checkpoint_07_enable_free_surface_create/screen-output
+++ b/tests/checkpoint_07_enable_free_surface_create/screen-output
@@ -1,0 +1,112 @@
+
+Number of active cells: 768 (on 4 levels)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
+
+Number of mesh deformation degrees of freedom: 1728
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 57+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00000
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0156 m/year, 0.0294 m/year
+
+*** Timestep 1:  t=4.00723e+06 years, dt=4.00723e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 32+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00001
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0156 m/year, 0.0293 m/year
+
+*** Timestep 2:  t=8.02687e+06 years, dt=4.01964e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00002
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0156 m/year, 0.0292 m/year
+
+*** Timestep 3:  t=1.20556e+07 years, dt=4.02875e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 29+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00003
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0155 m/year, 0.0291 m/year
+
+*** Snapshot created!
+
+*** Timestep 4:  t=1.60941e+07 years, dt=4.03844e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 29+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00004
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0155 m/year, 0.0289 m/year
+
+*** Timestep 5:  t=2.01433e+07 years, dt=4.04928e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00005
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0154 m/year, 0.0287 m/year
+
+*** Timestep 6:  t=2.42024e+07 years, dt=4.05905e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 26+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00006
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0154 m/year, 0.0285 m/year
+
+*** Timestep 7:  t=2.82696e+07 years, dt=4.06722e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 24+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00007
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0153 m/year, 0.0283 m/year
+
+*** Snapshot created!
+
+*** Timestep 8:  t=3e+07 years, dt=1.7304e+06 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 18+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_create/solution/solution-00008
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0153 m/year, 0.0282 m/year
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/checkpoint_07_enable_free_surface_create/statistics
+++ b/tests/checkpoint_07_enable_free_surface_create/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+0 0.000000000000e+00 0.000000000000e+00 768 7392 3264 0 56 59 174 output-checkpoint_07_enable_free_surface_create/solution/solution-00000 1.59900000e+03 1.60013520e+03 1.60100000e+03 1.56138836e-02 2.93831873e-02 
+1 4.007228995926e+06 4.007228995926e+06 768 7392 3264 7 31 33  99 output-checkpoint_07_enable_free_surface_create/solution/solution-00001 1.59900419e+03 1.60013507e+03 1.60099843e+03 1.55910246e-02 2.92839004e-02 
+2 8.026868927285e+06 4.019639931359e+06 768 7392 3264 8 24 26  78 output-checkpoint_07_enable_free_surface_create/solution/solution-00002 1.59899925e+03 1.60013483e+03 1.60100022e+03 1.55663999e-02 2.91912298e-02 
+3 1.205562274331e+07 4.028753816027e+06 768 7392 3264 8 28 30  90 output-checkpoint_07_enable_free_surface_create/solution/solution-00003 1.59898934e+03 1.60013446e+03 1.60100491e+03 1.55309277e-02 2.90636542e-02 
+4 1.609406103905e+07 4.038438295739e+06 768 7392 3264 8 28 30  90 output-checkpoint_07_enable_free_surface_create/solution/solution-00004 1.59896485e+03 1.60013399e+03 1.60101285e+03 1.54847428e-02 2.89017222e-02 
+5 2.014333863998e+07 4.049277600926e+06 768 7392 3264 8 27 29  87 output-checkpoint_07_enable_free_surface_create/solution/solution-00005 1.59894842e+03 1.60013349e+03 1.60101396e+03 1.54318731e-02 2.87163688e-02 
+6 2.420238655297e+07 4.059047912990e+06 768 7392 3264 8 25 27  81 output-checkpoint_07_enable_free_surface_create/solution/solution-00006 1.59894141e+03 1.60013302e+03 1.60101495e+03 1.53765673e-02 2.85200219e-02 
+7 2.826960195303e+07 4.067215400060e+06 768 7392 3264 8 23 25  75 output-checkpoint_07_enable_free_surface_create/solution/solution-00007 1.59894409e+03 1.60013262e+03 1.60101206e+03 1.53218477e-02 2.83223245e-02 
+8 3.000000000000e+07 1.730398046973e+06 768 7392 3264 6 17 19  57 output-checkpoint_07_enable_free_surface_create/solution/solution-00008 1.59894963e+03 1.60013248e+03 1.60100930e+03 1.52991482e-02 2.82391453e-02 

--- a/tests/checkpoint_07_enable_free_surface_resume.cc
+++ b/tests/checkpoint_07_enable_free_surface_resume.cc
@@ -1,0 +1,35 @@
+#include <aspect/simulator.h>
+#include <iostream>
+
+/*
+ * Launch the following function when this plugin is created. Copy checkpoint
+ * files into the correct place to resume model.
+ */
+int f()
+{
+  if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) != 0)
+    return 42;
+
+  std::cout << "* Copying checkpoint files." << std::endl;
+
+  std::string command;
+
+  command = ("mkdir -p output-checkpoint_07_enable_free_surface_resume; "
+             "cp -r output-checkpoint_07_enable_free_surface_create/restart* output-checkpoint_07_enable_free_surface_resume/");
+  std::cout << "Executing the following command:\n"
+            << command
+            << std::endl;
+  const int ret = system (command.c_str());
+  if (ret!=0)
+    {
+      std::cout << "system() returned error " << ret << std::endl;
+      exit(1);
+    }
+
+  std::cout << "* Finished copying files. Now resuming model." << std::endl;
+
+  return 42;
+}
+
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/checkpoint_07_enable_free_surface_resume.prm
+++ b/tests/checkpoint_07_enable_free_surface_resume.prm
@@ -1,0 +1,23 @@
+# Test to start a model without free surface but with a zero mesh deformation
+# enabled and write a checkpoint (this test).
+# Another test (checkpoint_07_enable_free_surface_resume) will then test to
+# resume from this checkpoint and enable a free surface.
+
+# based on checkpoint_06_free_surface
+
+# DEPENDS-ON: checkpoint_07_enable_free_surface_create
+
+include $ASPECT_SOURCE_DIR/tests/checkpoint_07_enable_free_surface_create.prm
+
+set Dimension = 2
+set Resume computation = true
+set Pressure normalization = no
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: free surface
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators =
+end

--- a/tests/checkpoint_07_enable_free_surface_resume/screen-output
+++ b/tests/checkpoint_07_enable_free_surface_resume/screen-output
@@ -1,0 +1,28 @@
+
+Loading shared library <./libcheckpoint_07_enable_free_surface_resume.so>
+* Copying checkpoint files.
+Executing the following command:
+mkdir -p output-checkpoint_07_enable_free_surface_resume; cp -r output-checkpoint_07_enable_free_surface_create/restart* output-checkpoint_07_enable_free_surface_resume/
+* Finished copying files. Now resuming model.
+
+*** Resuming from snapshot!
+
+Number of active cells: 768 (on 4 levels)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
+
+Number of mesh deformation degrees of freedom: 1728
+*** Timestep 8:  t=3e+07 years, dt=1.7304e+06 years
+   Solving mesh velocity system... 1 iterations.
+   Solving temperature system... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+14 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-checkpoint_07_enable_free_surface_resume/solution/solution-00008
+     Temperature min/avg/max:  1599 K, 1600 K, 1601 K
+     RMS, max velocity:        0.0153 m/year, 0.0281 m/year
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/checkpoint_07_enable_free_surface_resume/statistics
+++ b/tests/checkpoint_07_enable_free_surface_resume/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+0 0.000000000000e+00 0.000000000000e+00 768 7392 3264 0  56  59 174 output-checkpoint_07_enable_free_surface_create/solution/solution-00000 1.59900000e+03 1.60013520e+03 1.60100000e+03 1.56138836e-02 2.93831873e-02 
+1 4.007228995926e+06 4.007228995926e+06 768 7392 3264 7  31  33  99 output-checkpoint_07_enable_free_surface_create/solution/solution-00001 1.59900419e+03 1.60013507e+03 1.60099843e+03 1.55910246e-02 2.92839004e-02 
+2 8.026868927285e+06 4.019639931359e+06 768 7392 3264 8  24  26  78 output-checkpoint_07_enable_free_surface_create/solution/solution-00002 1.59899925e+03 1.60013483e+03 1.60100022e+03 1.55663999e-02 2.91912298e-02 
+3 1.205562274331e+07 4.028753816027e+06 768 7392 3264 8  28  30  90 output-checkpoint_07_enable_free_surface_create/solution/solution-00003 1.59898934e+03 1.60013446e+03 1.60100491e+03 1.55309277e-02 2.90636542e-02 
+4 1.609406103905e+07 4.038438295739e+06 768 7392 3264 8  28  30  90 output-checkpoint_07_enable_free_surface_create/solution/solution-00004 1.59896485e+03 1.60013399e+03 1.60101285e+03 1.54847428e-02 2.89017222e-02 
+5 2.014333863998e+07 4.049277600926e+06 768 7392 3264 8  27  29  87 output-checkpoint_07_enable_free_surface_create/solution/solution-00005 1.59894842e+03 1.60013349e+03 1.60101396e+03 1.54318731e-02 2.87163688e-02 
+6 2.420238655297e+07 4.059047912990e+06 768 7392 3264 8  25  27  81 output-checkpoint_07_enable_free_surface_create/solution/solution-00006 1.59894141e+03 1.60013302e+03 1.60101495e+03 1.53765673e-02 2.85200219e-02 
+7 2.826960195303e+07 4.067215400060e+06 768 7392 3264 8  23  25  75 output-checkpoint_07_enable_free_surface_create/solution/solution-00007 1.59894409e+03 1.60013262e+03 1.60101206e+03 1.53218477e-02 2.83223245e-02 
+8 3.000000000000e+07 1.730398046973e+06 768 7392 3264 6 214 859 660 output-checkpoint_07_enable_free_surface_resume/solution/solution-00008 1.59894963e+03 1.60013248e+03 1.60100930e+03 1.53029677e-02 2.81153569e-02 


### PR DESCRIPTION
This is an improvement related to #4341 and #4029. It reorders the operations upon resuming from a checkpoint so that:

- We correctly reach a useful assertion before trying to load the solution vector. This prevents the segmentation fault described in the linked issues and instead provides a useful error message (pressure normalization was changed incorrectly, or mesh deformation was not enabled for checkpoint)
- We now allow disabling pressure normalization during restart. We still do not allow to switch from surface to volume normalization or vice-versa since that makes no sense, however #4341 and #4029 showed that there is demand for switching on mesh deformation during a model for which we would like to be able to switch from surface pressure normalization to no normalization.
