### PR TITLE
WIP: generate particles in unit cell 

### DIFF
--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -114,6 +114,24 @@ namespace aspect
               }
             ++iteration;
           }
+        // If the maximum iterations are reached, retry generating particles
+        // within the reference cell
+        if (iteration == maximum_iterations)
+          {
+            iteration = 0;
+
+            // Generate a random point in the reference cell
+            for (unsigned int d=0; d<dim; ++d)
+              particle_position[d] = uniform_distribution_01(random_number_generator);
+
+            const Point<dim> p_real = this->get_mapping().transform_unit_to_real_cell(cell,particle_position);
+
+            // Add the generated particle to the set
+            const Particle<dim> new_particle(p_real, particle_position, id);
+            const Particles::internal::LevelInd cellid(cell->level(), cell->index());
+            return std::make_pair(cellid,new_particle);
+          }
+
         AssertThrow (iteration < maximum_iterations,
                      ExcMessage ("Couldn't generate particle (unusual cell shape?). "
                                  "The ratio between the bounding box volume in which the particle is "


### PR DESCRIPTION
Opening this PR for the purpose of discussion. The PR enables the generation of particles in the unit cell if a point has not been generated in the real cell after 100 attempts. 

After a few preliminary tests, this seems solves the issue of particles not being successfully generated in models with mesh deformation (ex: free surface) that produce highly deformed elements.

A few questions for @gassmoeller and others before proceeding further:
1. Should generating particles in the unit cell be an option that users can switch on and off?
2. If not, how to handle the logic for when the maximum number of iterations is reached for generating particles in the real cell? Right now I reset a variable to 0 so that the Assert is not thrown.
3. Should there be an iteration over the particles generated in the unit cell, or is one always guaranteed to have the generated particle be within the element when mapped to the real cell? My assumption was yes, but maybe this is not the case? The model I ran with this PR did always have the right number of min/max particles per cell.

I am currently working to find a simple test for this feature, as the problem I tried it on is fairly expensive (e.g., not suitable for the test suite).

* [X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
