### PR TITLE
Apply free surface stabilization to other mesh deformation plugins

### DIFF
--- a/include/aspect/mesh_deformation/ascii_data.h
+++ b/include/aspect/mesh_deformation/ascii_data.h
@@ -69,6 +69,11 @@ namespace aspect
                                                 const Point<dim> &position) const override;
 
         /**
+         * Returns whether or not the plugin requires surface stabilization
+         */
+        bool needs_surface_stabilization () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/mesh_deformation/diffusion.h
+++ b/include/aspect/mesh_deformation/diffusion.h
@@ -57,6 +57,8 @@ namespace aspect
          */
         void update() override;
 
+
+
         /**
          * A function that creates constraints for the velocity of certain mesh
          * vertices (e.g. the surface vertices) for a specific boundary.
@@ -67,6 +69,11 @@ namespace aspect
         compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                  AffineConstraints<double> &mesh_velocity_constraints,
                                                  const std::set<types::boundary_id> &boundary_id) const override;
+
+        /**
+         * Returns whether or not the plugin requires surface stabilization
+         */
+        bool needs_surface_stabilization () const override;
 
         /**
          * Declare parameters for the diffusion of the surface.

--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -85,11 +85,6 @@ namespace aspect
          */
         void parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Return the stabilization parameter for the free surface.
-         */
-        double get_free_surface_theta () const;
-
       private:
         /**
          * Project the Stokes velocity solution onto the

--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -32,35 +32,6 @@ namespace aspect
 {
   using namespace dealii;
 
-  namespace Assemblers
-  {
-    /**
-     * Apply stabilization to a cell of the system matrix. The
-     * stabilization is only added to cells on a free surface. The
-     * scheme is based on that of Kaus et. al., 2010. Called during
-     * assembly of the system matrix.
-     */
-    template <int dim>
-    class ApplyStabilization: public Assemblers::Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        ApplyStabilization(const double stabilization_theta);
-
-        void
-        execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                 internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;
-
-      private:
-        /**
-         * Stabilization parameter for the free surface. Should be between
-         * zero and one. A value of zero means no stabilization. See Kaus
-         * et. al. 2010 for more details.
-         */
-        const double free_surface_theta;
-    };
-  }
-
   namespace MeshDeformation
   {
     /**
@@ -86,6 +57,7 @@ namespace aspect
         void set_assemblers(const SimulatorAccess<dim> &simulator_access,
                             aspect::Assemblers::Manager<dim> &assemblers) const;
 
+
         /**
          * A function that creates constraints for the velocity of certain mesh
          * vertices (e.g. the surface vertices) for a specific boundary.
@@ -96,6 +68,11 @@ namespace aspect
         compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                  AffineConstraints<double> &mesh_velocity_constraints,
                                                  const std::set<types::boundary_id> &boundary_id) const override;
+
+        /**
+         * Returns whether or not the plugin requires surface stabilization
+         */
+        bool needs_surface_stabilization () const override;
 
         /**
          * Declare parameters for the free surface handling.
@@ -122,13 +99,6 @@ namespace aspect
                                              const IndexSet &mesh_locally_owned,
                                              const IndexSet &mesh_locally_relevant,
                                              LinearAlgebra::Vector &output) const;
-
-        /**
-         * Stabilization parameter for the free surface. Should be between
-         * zero and one. A value of zero means no stabilization.  See Kaus
-         * et. al. 2010 for more details.
-         */
-        double free_surface_theta;
 
         /**
          * A struct for holding information about how to advect the free surface.

--- a/include/aspect/mesh_deformation/function.h
+++ b/include/aspect/mesh_deformation/function.h
@@ -59,6 +59,11 @@ namespace aspect
                                                  const std::set<types::boundary_id> &boundary_id) const override;
 
         /**
+         * Returns whether or not the plugin requires surface stabilization
+         */
+        bool needs_surface_stabilization () const override;
+
+        /**
          * Declare parameters for the free surface handling.
          */
         static

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -299,6 +299,11 @@ namespace aspect
         get_free_surface_boundary_indicators () const;
 
         /**
+         * Return the stabilization parameter for the free surface.
+         */
+        double get_free_surface_theta () const;
+
+        /**
          * Return the initial topography stored on
          * the Q1 finite element that describes the mesh geometry.
          * Note that a topography is set for all mesh nodes,

--- a/source/mesh_deformation/ascii_data.cc
+++ b/source/mesh_deformation/ascii_data.cc
@@ -76,6 +76,16 @@ namespace aspect
 
 
     template <int dim>
+    bool
+    AsciiData<dim>::
+    needs_surface_stabilization () const
+    {
+      return false;
+    }
+
+
+
+    template <int dim>
     void
     AsciiData<dim>::declare_parameters (ParameterHandler &prm)
     {

--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -477,6 +477,16 @@ namespace aspect
 
 
     template <int dim>
+    bool
+    Diffusion<dim>::
+    needs_surface_stabilization () const
+    {
+      return false;
+    }
+
+
+
+    template <int dim>
     void Diffusion<dim>::declare_parameters(ParameterHandler &prm)
     {
       prm.enter_subsection("Mesh deformation");

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -68,13 +68,6 @@ namespace aspect
                     ExcMessage("The free surface mesh deformation plugin cannot be used with the current velocity boundary conditions"));
     }
 
-    template <int dim>
-    double FreeSurface<dim>::get_free_surface_theta()const
-    {
-      return free_surface_theta;
-    }
-
-
 
     template <int dim>
     void FreeSurface<dim>::project_velocity_onto_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -32,112 +32,6 @@
 
 namespace aspect
 {
-  namespace Assemblers
-  {
-    template <int dim>
-    ApplyStabilization<dim>::ApplyStabilization(const double stabilization_theta)
-      :
-      free_surface_theta(stabilization_theta)
-    {}
-
-    template <int dim>
-    void
-    ApplyStabilization<dim>::
-    execute (internal::Assembly::Scratch::ScratchBase<dim>       &scratch_base,
-             internal::Assembly::CopyData::CopyDataBase<dim>      &data_base) const
-    {
-      internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
-      internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>&> (data_base);
-
-      AssertThrow(!this->get_mesh_deformation_handler().get_free_surface_boundary_indicators().empty(),
-                  ExcMessage("Applying free surface stabilization, even though no free surface is active. "));
-
-      if (this->get_parameters().include_melt_transport)
-        {
-          this->get_melt_handler().apply_free_surface_stabilization_with_melt (free_surface_theta,
-                                                                               scratch.cell,
-                                                                               scratch,
-                                                                               data);
-          return;
-        }
-
-      const Introspection<dim> &introspection = this->introspection();
-      const FiniteElement<dim> &fe = this->get_fe();
-
-      const typename DoFHandler<dim>::active_cell_iterator cell (&this->get_triangulation(),
-                                                                 scratch.finite_element_values.get_cell()->level(),
-                                                                 scratch.finite_element_values.get_cell()->index(),
-                                                                 &this->get_dof_handler());
-
-      const unsigned int n_face_q_points = scratch.face_finite_element_values.n_quadrature_points;
-      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
-
-      // Get the boundary indicators of those boundaries with a free surface
-      const std::set<types::boundary_id> tmp_free_surface_boundary_indicators = this->get_mesh_deformation_handler().get_free_surface_boundary_indicators();
-
-      // only apply on free surface faces
-      if (cell->at_boundary() && cell->is_locally_owned())
-        for (const unsigned int face_no : cell->face_indices())
-          if (cell->face(face_no)->at_boundary())
-            {
-              const types::boundary_id boundary_indicator
-                = cell->face(face_no)->boundary_id();
-
-              if (tmp_free_surface_boundary_indicators.find(boundary_indicator)
-                  == tmp_free_surface_boundary_indicators.end())
-                continue;
-
-              scratch.face_finite_element_values.reinit(cell, face_no);
-
-              scratch.face_material_model_inputs.reinit  (scratch.face_finite_element_values,
-                                                          cell,
-                                                          this->introspection(),
-                                                          this->get_solution(),
-                                                          false);
-
-              this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
-
-              for (unsigned int q_point = 0; q_point < n_face_q_points; ++q_point)
-                {
-                  for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
-                    {
-                      if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
-                        {
-                          scratch.phi_u[i_stokes] = scratch.face_finite_element_values[introspection.extractors.velocities].value(i, q_point);
-                          ++i_stokes;
-                        }
-                      ++i;
-                    }
-
-                  const Tensor<1,dim>
-                  gravity = this->get_gravity_model().gravity_vector(scratch.face_finite_element_values.quadrature_point(q_point));
-                  const double g_norm = gravity.norm();
-
-                  // construct the relevant vectors
-                  const Tensor<1,dim> n_hat = scratch.face_finite_element_values.normal_vector(q_point);
-                  const Tensor<1,dim> g_hat = (g_norm == 0.0 ? Tensor<1,dim>() : gravity/g_norm);
-
-                  const double pressure_perturbation = scratch.face_material_model_outputs.densities[q_point] *
-                                                       this->get_timestep() *
-                                                       free_surface_theta *
-                                                       g_norm;
-
-                  // see Kaus et al 2010 for details of the stabilization term
-                  for (unsigned int i=0; i< stokes_dofs_per_cell; ++i)
-                    for (unsigned int j=0; j< stokes_dofs_per_cell; ++j)
-                      {
-                        // The fictive stabilization stress is (phi_u[i].g)*(phi_u[j].n)
-                        const double stress_value = -pressure_perturbation*
-                                                    (scratch.phi_u[i]*g_hat) * (scratch.phi_u[j]*n_hat)
-                                                    *scratch.face_finite_element_values.JxW(q_point);
-
-                        data.local_matrix(i,j) += stress_value;
-                      }
-                }
-            }
-    }
-  }
-
   namespace MeshDeformation
   {
     template <int dim>
@@ -172,40 +66,7 @@ namespace aspect
       for (const auto &p : tmp_mesh_deformation_boundary_indicators)
         AssertThrow(velocity_boundary_indicators.find(p) == velocity_boundary_indicators.end(),
                     ExcMessage("The free surface mesh deformation plugin cannot be used with the current velocity boundary conditions"));
-
-      this->get_signals().set_assemblers.connect(
-        [&](const SimulatorAccess<dim> &sim_access,
-            aspect::Assemblers::Manager<dim> &assemblers)
-      {
-        this->set_assemblers(sim_access, assemblers);
-      });
     }
-
-
-
-    template <int dim>
-    void FreeSurface<dim>::set_assemblers(const SimulatorAccess<dim> &,
-                                          aspect::Assemblers::Manager<dim> &assemblers) const
-    {
-      aspect::Assemblers::ApplyStabilization<dim> *surface_stabilization
-        = new aspect::Assemblers::ApplyStabilization<dim>(free_surface_theta);
-
-      assemblers.stokes_system.push_back(
-        std::unique_ptr<aspect::Assemblers::ApplyStabilization<dim>> (surface_stabilization));
-
-      // Note that we do not want face_material_model_data, because we do not
-      // connect to a face assembler. We instead connect to a normal assembler,
-      // and compute our own material_model_inputs in apply_stabilization
-      // (because we want to use the solution instead of the current_linearization_point
-      // to compute the material properties).
-      assemblers.stokes_system_assembler_on_boundary_face_properties.needed_update_flags |= (update_values  |
-          update_gradients |
-          update_quadrature_points |
-          update_normal_vectors |
-          update_JxW_values);
-    }
-
-
 
     template <int dim>
     double FreeSurface<dim>::get_free_surface_theta()const
@@ -393,23 +254,22 @@ namespace aspect
 
 
     template <int dim>
+    bool
+    FreeSurface<dim>::
+    needs_surface_stabilization () const
+    {
+      return true;
+    }
+
+
+
+    template <int dim>
     void FreeSurface<dim>::declare_parameters(ParameterHandler &prm)
     {
       prm.enter_subsection ("Mesh deformation");
       {
         prm.enter_subsection ("Free surface");
         {
-          prm.declare_entry("Free surface stabilization theta", "0.5",
-                            Patterns::Double(0., 1.),
-                            "Theta parameter described in \\cite{KMM2010}. "
-                            "An unstabilized free surface can overshoot its "
-                            "equilibrium position quite easily and generate "
-                            "unphysical results.  One solution is to use a "
-                            "quasi-implicit correction term to the forces near the "
-                            "free surface.  This parameter describes how much "
-                            "the free surface is stabilized with this term, "
-                            "where zero is no stabilization, and one is fully "
-                            "implicit.");
           prm.declare_entry("Surface velocity projection", "normal",
                             Patterns::Selection("normal|vertical"),
                             "After each time step the free surface must be "
@@ -438,7 +298,6 @@ namespace aspect
       {
         prm.enter_subsection ("Free surface");
         {
-          free_surface_theta = prm.get_double("Free surface stabilization theta");
           std::string advection_dir = prm.get("Surface velocity projection");
 
           if ( advection_dir == "normal")

--- a/source/mesh_deformation/function.cc
+++ b/source/mesh_deformation/function.cc
@@ -73,6 +73,16 @@ namespace aspect
 
 
     template <int dim>
+    bool
+    BoundaryFunction<dim>::
+    needs_surface_stabilization () const
+    {
+      return false;
+    }
+
+
+
+    template <int dim>
     void BoundaryFunction<dim>::declare_parameters(ParameterHandler &prm)
     {
       prm.enter_subsection ("Mesh deformation");

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -101,11 +101,11 @@ namespace aspect
 
               scratch.face_finite_element_values.reinit(cell, face_no);
 
-              this->compute_material_model_input_values (this->get_solution(),
-                                                         scratch.face_finite_element_values,
-                                                         cell,
-                                                         false,
-                                                         scratch.face_material_model_inputs);
+              scratch.face_material_model_inputs.reinit  (scratch.face_finite_element_values,
+                                                          cell,
+                                                          this->introspection(),
+                                                          this->get_solution(),
+                                                          false);
 
               this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1488,6 +1488,14 @@ namespace aspect
 
 
     template <int dim>
+    double MeshDeformationHandler<dim>::get_free_surface_theta()const
+    {
+      return surface_theta;
+    }
+
+
+
+    template <int dim>
     const LinearAlgebra::Vector &
     MeshDeformationHandler<dim>::get_mesh_displacements () const
     {

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -39,10 +39,119 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
-
+#include <aspect/melt.h>
 
 namespace aspect
 {
+  namespace Assemblers
+  {
+    template <int dim>
+    ApplyStabilization<dim>::ApplyStabilization(const double stabilization_theta)
+      :
+      free_surface_theta(stabilization_theta)
+    {}
+
+    template <int dim>
+    void
+    ApplyStabilization<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>       &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim>      &data_base) const
+    {
+      internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>& > (data_base);
+
+      AssertThrow(!this->get_mesh_deformation_handler().get_boundary_indicators_requiring_stabilization().empty(),
+                  ExcMessage("Applying surface stabilization, even though no boundary requires it."));
+
+
+      if (this->get_parameters().include_melt_transport)
+        {
+          this->get_melt_handler().apply_free_surface_stabilization_with_melt (free_surface_theta,
+                                                                               scratch.cell,
+                                                                               scratch,
+                                                                               data);
+          return;
+        }
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+
+      const typename DoFHandler<dim>::active_cell_iterator cell (&this->get_triangulation(),
+                                                                 scratch.finite_element_values.get_cell()->level(),
+                                                                 scratch.finite_element_values.get_cell()->index(),
+                                                                 &this->get_dof_handler());
+
+      const unsigned int n_face_q_points = scratch.face_finite_element_values.n_quadrature_points;
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+
+      // Get the boundary indicators of those boundaries that require stabilization
+      const std::set<types::boundary_id> tmp_boundary_indicators_requiring_stabilization = this->get_mesh_deformation_handler().get_boundary_indicators_requiring_stabilization();
+
+      // only apply on mesh deformation faces that require stabilization
+      if (cell->at_boundary() && cell->is_locally_owned())
+        for (const unsigned int face_no : cell->face_indices())
+          if (cell->face(face_no)->at_boundary())
+            {
+              const types::boundary_id boundary_indicator
+                = cell->face(face_no)->boundary_id();
+
+              if (tmp_boundary_indicators_requiring_stabilization.find(boundary_indicator)
+                  == tmp_boundary_indicators_requiring_stabilization.end())
+                continue;
+
+              scratch.face_finite_element_values.reinit(cell, face_no);
+
+              this->compute_material_model_input_values (this->get_solution(),
+                                                         scratch.face_finite_element_values,
+                                                         cell,
+                                                         false,
+                                                         scratch.face_material_model_inputs);
+
+              this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
+
+              for (unsigned int q_point = 0; q_point < n_face_q_points; ++q_point)
+                {
+                  for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+                    {
+                      if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                        {
+                          scratch.phi_u[i_stokes] = scratch.face_finite_element_values[introspection.extractors.velocities].value(i, q_point);
+                          ++i_stokes;
+                        }
+                      ++i;
+                    }
+
+                  const Tensor<1,dim>
+                  gravity = this->get_gravity_model().gravity_vector(scratch.face_finite_element_values.quadrature_point(q_point));
+                  const double g_norm = gravity.norm();
+
+                  // construct the relevant vectors
+                  const Tensor<1,dim> n_hat = scratch.face_finite_element_values.normal_vector(q_point);
+                  const Tensor<1,dim> g_hat = (g_norm == 0.0 ? Tensor<1,dim>() : gravity/g_norm);
+
+                  const double pressure_perturbation = scratch.face_material_model_outputs.densities[q_point] *
+                                                       this->get_timestep() *
+                                                       free_surface_theta *
+                                                       g_norm;
+
+                  // see Kaus et al 2010 for details of the stabilization term
+                  for (unsigned int i=0; i< stokes_dofs_per_cell; ++i)
+                    for (unsigned int j=0; j< stokes_dofs_per_cell; ++j)
+                      {
+                        // The fictive stabilization stress is (phi_u[i].g)*(phi_u[j].n)
+                        const double stress_value = -pressure_perturbation*
+                                                    (scratch.phi_u[i]*g_hat) * (scratch.phi_u[j]*n_hat)
+                                                    *scratch.face_finite_element_values.JxW(q_point);
+
+                        data.local_matrix(i,j) += stress_value;
+                      }
+                }
+            }
+    }
+  }
+
+
+
   namespace MeshDeformation
   {
     template <int dim>
@@ -56,6 +165,15 @@ namespace aspect
     void
     Interface<dim>::update ()
     {}
+
+
+
+    template <int dim>
+    bool
+    Interface<dim>::needs_surface_stabilization () const
+    {
+      return false;
+    }
 
 
 
@@ -141,6 +259,41 @@ namespace aspect
       // so we need to fetch it separately.
       if (!Plugins::plugin_type_matches<InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
         include_initial_topography = true;
+
+      // If a surface needs to be stabilized, set up the assemblers.
+      if (!this->get_mesh_deformation_handler().get_boundary_indicators_requiring_stabilization().empty())
+        {
+          this->get_signals().set_assemblers.connect(
+            [&](const SimulatorAccess<dim> &sim_access,
+                aspect::Assemblers::Manager<dim> &assemblers)
+          {
+            this->set_assemblers(sim_access, assemblers);
+          });
+        }
+    }
+
+
+
+    template <int dim>
+    void MeshDeformationHandler<dim>::set_assemblers(const SimulatorAccess<dim> &,
+                                                     aspect::Assemblers::Manager<dim> &assemblers) const
+    {
+      aspect::Assemblers::ApplyStabilization<dim> *surface_stabilization
+        = new aspect::Assemblers::ApplyStabilization<dim>(surface_theta);
+
+      assemblers.stokes_system.push_back(
+        std::unique_ptr<aspect::Assemblers::ApplyStabilization<dim>> (surface_stabilization));
+
+      // Note that we do not want face_material_model_data, because we do not
+      // connect to a face assembler. We instead connect to a normal assembler,
+      // and compute our own material_model_inputs in apply_stabilization
+      // (because we want to use the solution instead of the current_linearization_point
+      // to compute the material properties).
+      assemblers.stokes_system_assembler_on_boundary_face_properties.needed_update_flags |= (update_values  |
+          update_gradients |
+          update_quadrature_points |
+          update_normal_vectors |
+          update_JxW_values);
     }
 
 
@@ -172,6 +325,7 @@ namespace aspect
             model->update();
         }
     }
+
 
 
     template <int dim>
@@ -215,11 +369,29 @@ namespace aspect
                            "\n\n"
                            "The format is id1: object1 \\& object2, id2: object3 \\& object2, where "
                            "objects are one of " + std::get<dim>(registered_plugins).get_description_string());
+
+        prm.enter_subsection ("Free surface");
+        {
+          prm.declare_entry("Free surface stabilization theta", "0.5",
+                            Patterns::Double(0., 1.),
+                            "Theta parameter described in \\cite{KMM2010}. "
+                            "An unstabilized free surface can overshoot its "
+                            "equilibrium position quite easily and generate "
+                            "unphysical results.  One solution is to use a "
+                            "quasi-implicit correction term to the forces near the "
+                            "free surface.  This parameter describes how much "
+                            "the free surface is stabilized with this term, "
+                            "where zero is no stabilization, and one is fully "
+                            "implicit.");
+        }
+        prm.leave_subsection ();
       }
       prm.leave_subsection ();
 
       std::get<dim>(registered_plugins).declare_parameters (prm);
     }
+
+
 
     template <int dim>
     void MeshDeformationHandler<dim>::parse_parameters(ParameterHandler &prm)
@@ -328,6 +500,13 @@ namespace aspect
 
         for (const auto &boundary_id : tangential_mesh_deformation_boundary_indicators)
           zero_mesh_deformation_boundary_indicators.erase(boundary_id);
+
+        prm.enter_subsection ("Free surface");
+        {
+          surface_theta = prm.get_double("Free surface stabilization theta");
+        }
+        prm.leave_subsection ();
+
       }
       prm.leave_subsection ();
 
@@ -348,6 +527,14 @@ namespace aspect
               mesh_deformation_objects[boundary_and_object_names.first].back()->parse_parameters (prm);
               mesh_deformation_objects[boundary_and_object_names.first].back()->initialize ();
             }
+        }
+
+      // Go through the objects, and get the indicators for boundaries that need to be stabilized.
+      for (const auto &boundary_and_deformation_objects : mesh_deformation_objects)
+        {
+          for (const auto &model : boundary_and_deformation_objects.second)
+            if (model->needs_surface_stabilization() == true)
+              boundary_indicators_requiring_stabilization.insert(boundary_and_deformation_objects.first);
         }
     }
 
@@ -1278,6 +1465,15 @@ namespace aspect
     MeshDeformationHandler<dim>::get_active_mesh_deformation_boundary_indicators () const
     {
       return prescribed_mesh_deformation_boundary_indicators;
+    }
+
+
+
+    template <int dim>
+    const std::set<types::boundary_id> &
+    MeshDeformationHandler<dim>::get_boundary_indicators_requiring_stabilization () const
+    {
+      return boundary_indicators_requiring_stabilization;
     }
 
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1835,14 +1835,14 @@ namespace aspect
                                               internal::Assembly::Scratch::StokesSystem<dim>       &scratch,
                                               internal::Assembly::CopyData::StokesSystem<dim>      &data) const
   {
-    const std::set<types::boundary_id> free_surface_boundary_indicators = this->get_mesh_deformation_handler().get_free_surface_boundary_indicators();
-    if (free_surface_boundary_indicators.empty())
+    const std::set<types::boundary_id> tmp_boundary_indicators_requiring_stabilization = this->get_mesh_deformation_handler().get_boundary_indicators_requiring_stabilization();
+    if (tmp_boundary_indicators_requiring_stabilization.empty())
       return;
 
     const unsigned int n_face_q_points = scratch.face_finite_element_values.n_quadrature_points;
     const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
 
-    // only apply on free surface faces
+    // only apply on mesh deformation surfaces that require stabilization
     if (cell->at_boundary() && cell->is_locally_owned())
       for (const unsigned int face_no : cell->face_indices())
         if (cell->face(face_no)->at_boundary())
@@ -1850,7 +1850,7 @@ namespace aspect
             const types::boundary_id boundary_indicator
               = cell->face(face_no)->boundary_id();
 
-            if (free_surface_boundary_indicators.find(boundary_indicator) == free_surface_boundary_indicators.end())
+            if (tmp_boundary_indicators_requiring_stabilization.find(boundary_indicator) == tmp_boundary_indicators_requiring_stabilization.end())
               continue;
 
             scratch.face_finite_element_values.reinit(cell, face_no);

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1796,9 +1796,7 @@ namespace aspect
                                                                 && !sim.mesh_deformation->get_free_surface_boundary_indicators().empty();
       if (active_cell_data.apply_stabilization_free_surface_faces == true)
         {
-          const double free_surface_theta =
-            sim.mesh_deformation->template get_matching_mesh_deformation_object<MeshDeformation::FreeSurface<dim>>()
-          .get_free_surface_theta();
+          const double free_surface_theta = sim.mesh_deformation->get_free_surface_theta();
 
           const Quadrature<dim-1> &face_quadrature_formula = sim.introspection.face_quadratures.velocities;
 


### PR DESCRIPTION
At the moment, the free surface stabilization can only be applied to the free surface plugin. However, since multiple plugins can deform the surface, it may help to be able to apply the stabilization to any one plugin. For example, when using FastScape to deform the surface in 2D the model gets stability issues at the same timesteps as the free surface in the benchmark from #3317. Applying the stabilization similarly fixes the issue.

Questions:
1. Does it make sense to apply the same stabilization parameter to different problems other than those with a free surface?

2. What would be the best way to implement this? In this pull request, I've transferred the functionality of the stabilization into the mesh deformation handler. This should apply it to all mesh deformation boundaries unless it is specifically set to 0.  @anne-glerum has suggested that we could also make it a separate mesh deformation plugin to be called in conjunction with the other plugins.

### Before your first pull request:

* [ x ] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [ x ] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ x ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
