### PR TITLE
Remove stress averaging parameter (i.e. always average)

### DIFF
--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading.prm
@@ -128,7 +128,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading_fixed_elastic_dt.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading_fixed_elastic_dt.prm
@@ -16,7 +16,6 @@ subsection Material model
   subsection Viscoelastic
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading.prm
@@ -129,7 +129,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading_fixed_elastic_dt.prm
+++ b/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_3D_loading_fixed_elastic_dt.prm
@@ -16,7 +16,6 @@ subsection Material model
   subsection Viscoelastic
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/infill_density/infill_ascii.prm
+++ b/benchmarks/infill_density/infill_ascii.prm
@@ -165,7 +165,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 7500
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam.prm
@@ -143,7 +143,6 @@ subsection Material model
     set Elastic shear moduli = 1.e11, 1.e11, 1.e11, 1.e11, 1.e10
     set Fixed elastic time step     = 1e3
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
   end
 

--- a/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vep.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/gerya_2019/gerya_2019_vep.prm
@@ -51,7 +51,6 @@ subsection Material model
     set Elastic shear moduli        = 1e11
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 20
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     # Nonsensical cohesion values (1e50) are assigned to the compositional fields tracking elastic stresses

--- a/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
@@ -157,7 +157,6 @@ subsection Material model
     set Elastic shear moduli        = 5.e10,5.e10,5.e10,5.e10,1.e50
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
 
     set Angles of internal friction = 30.

--- a/benchmarks/viscoelastic_plastic_simple_shear/viscoelastic_plastic_simple_shear.prm
+++ b/benchmarks/viscoelastic_plastic_simple_shear/viscoelastic_plastic_simple_shear.prm
@@ -127,7 +127,6 @@ subsection Material model
     # as it is used to compute time step 0.
     set Fixed elastic time step     = 0.01
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
 
     set Cohesions                   = 3.5

--- a/benchmarks/viscoelastic_plate_flexure/viscoelastic_plate_flexure.prm
+++ b/benchmarks/viscoelastic_plate_flexure/viscoelastic_plate_flexure.prm
@@ -135,7 +135,6 @@ subsection Material model
      set Elastic shear moduli        = 1.e50, 1.e50, 1.e50, 1.e50, 3.e10, 3.e10
      set Fixed elastic time step     = 5
      set Use fixed elastic time step = false
-     set Use stress averaging        = false
      set Viscosity averaging scheme  = maximum composition
   end
 

--- a/benchmarks/viscoelastic_sheared_torsion/viscoelastic_sheared_torsion.prm
+++ b/benchmarks/viscoelastic_sheared_torsion/viscoelastic_sheared_torsion.prm
@@ -147,7 +147,6 @@ subsection Material model
     # as it is used to compute the elastic time step during time step 0.
     set Fixed elastic time step     = 0.01
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
 
     # Cohesion is set higher than the maximum stress expected in this benchmark,

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up.prm
@@ -154,7 +154,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield.prm
@@ -40,7 +40,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 0.

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
@@ -45,7 +45,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 0.

--- a/doc/manual/parameters.tex
+++ b/doc/manual/parameters.tex
@@ -6034,7 +6034,8 @@ The formula is interpreted as having units W/kg.
 {\it Default:} 0.
 
 
-{\it Description:} The specific rate of heating due to radioactive decay (or other bulk sources you may want to describe). This parameter corresponds to the variable $H$ in the temperature equation stated in the manual, and the heating term is $ho H$. Units: W/kg.
+{\it Description:} The specific rate of heating due to radioactive decay (or other bulk sources you may want to describe). This parameter corresponds to the variable $H$ in the temperature equation stated in the manual, and the heating term is $
+ho H$. Units: W/kg.
 
 
 {\it Possible values:} A floating point number $v$ such that $0 \leq v \leq \text{MAX\_DOUBLE}$
@@ -15894,23 +15895,6 @@ If a compositional field named 'noninitial\_plastic\_strain' is included in the 
 
 
 {\it Possible values:} A boolean value (true or false)
-\item {\it Parameter name:} {\tt Use stress averaging}
-\phantomsection\label{parameters:Material model/Visco Plastic/Use stress averaging}
-\label{parameters:Material_20model/Visco_20Plastic/Use_20stress_20averaging}
-
-
-\index[prmindex]{Use stress averaging}
-\index[prmindexfull]{Material model!Visco Plastic!Use stress averaging}
-{\it Value:} false
-
-
-{\it Default:} false
-
-
-{\it Description:} Whether to apply a stress averaging scheme to account for differences between the fixed elastic time step and numerical time step. 
-
-
-{\it Possible values:} A boolean value (true or false)
 \item {\it Parameter name:} {\tt Viscosity averaging scheme}
 \phantomsection\label{parameters:Material model/Visco Plastic/Viscosity averaging scheme}
 \label{parameters:Material_20model/Visco_20Plastic/Viscosity_20averaging_20scheme}
@@ -16245,23 +16229,6 @@ This parameter is an alias for the parameter ``\texttt{Heat capacities}''.
 
 
 {\it Possible values:} Any one of true, false, unspecified
-\item {\it Parameter name:} {\tt Use stress averaging}
-\phantomsection\label{parameters:Material model/Viscoelastic/Use stress averaging}
-\label{parameters:Material_20model/Viscoelastic/Use_20stress_20averaging}
-
-
-\index[prmindex]{Use stress averaging}
-\index[prmindexfull]{Material model!Viscoelastic!Use stress averaging}
-{\it Value:} false
-
-
-{\it Default:} false
-
-
-{\it Description:} Whether to apply a stress averaging scheme to account for differences between the fixed elastic time step and numerical time step. 
-
-
-{\it Possible values:} A boolean value (true or false)
 \item {\it Parameter name:} {\tt Viscosities}
 \phantomsection\label{parameters:Material model/Viscoelastic/Viscosities}
 \label{parameters:Material_20model/Viscoelastic/Viscosities}

--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -163,15 +163,6 @@ namespace aspect
           bool use_fixed_elastic_time_step;
 
           /**
-           * Bool indicating whether to use a stress averaging scheme to account
-           * for differences between the numerical and fixed elastic time step
-           * (if true). When set to false, the viscoelastic stresses are not
-           * modified to account for differences between the viscoelastic time
-           * step and the numerical time step. Read from parameter file.
-           */
-          bool use_stress_averaging;
-
-          /**
            * Double for fixed elastic time step value, read from parameter file
            */
           double fixed_elastic_time_step;

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -80,7 +80,7 @@ namespace aspect
                            "relationship uses the regular numerical time step or a separate fixed "
                            "elastic time step throughout the model run. The fixed elastic time step "
                            "is always used during the initial time step. If a fixed elastic time "
-                           "step is used throughout the model run, a stress averaging scheme can be "
+                           "step is used throughout the model run, a stress averaging scheme is "
                            "applied to account for differences with the numerical time step. An "
                            "alternative approach is to limit the maximum time step size so that it "
                            "is equal to the elastic time step. The default value of this parameter is "
@@ -91,10 +91,6 @@ namespace aspect
                            "The fixed elastic time step $dte$. Units: years if the "
                            "'Use years in output instead of seconds' parameter is set; "
                            "seconds otherwise.");
-        prm.declare_entry ("Use stress averaging","false",
-                           Patterns::Bool (),
-                           "Whether to apply a stress averaging scheme to account for differences "
-                           "between the fixed elastic time step and numerical time step. ");
         prm.declare_entry ("Stabilization time scale factor", "1.",
                            Patterns::Double (1.),
                            "A stabilization factor for the elastic stresses that influences how fast "
@@ -133,8 +129,6 @@ namespace aspect
           use_fixed_elastic_time_step = false;
         else
           AssertThrow(false, ExcMessage("'Use fixed elastic time step' must be set to 'true' or 'false'"));
-
-        use_stress_averaging = prm.get_bool ("Use stress averaging");
 
         stabilization_time_scale_factor = prm.get_double ("Stabilization time scale factor");
 
@@ -330,12 +324,11 @@ namespace aspect
                 // stress_new is the (new) stored elastic stress
                 SymmetricTensor<2,dim> stress_new = stress_creep * (1. - (elastic_damper_viscosity / damped_elastic_viscosity)) + elastic_damper_viscosity * stress_0 / damped_elastic_viscosity;
 
-                // Stress averaging scheme to account for difference between fixed elastic time step
-                // and numerical time step (see equation 32 in Moresi et al., 2003, J. Comp. Phys.)
-                if (use_stress_averaging == true)
-                  {
-                    stress_new = ( ( 1. - ( dt / dte ) ) * stress_old ) + ( ( dt / dte ) * stress_new ) ;
-                  }
+                // Stress averaging scheme to account for difference between the elastic time step
+                // and the numerical time step (see equation 32 in Moresi et al., 2003, J. Comp. Phys.)
+                // Note that if there is no difference between the elastic timestep and the numerical
+                // timestep, then no averaging occurs as dt/dte = 1.
+                stress_new = ( ( 1. - ( dt / dte ) ) * stress_old ) + ( ( dt / dte ) * stress_new ) ;
 
                 // Fill reaction terms
                 for (unsigned int j = 0; j < SymmetricTensor<2,dim>::n_independent_components ; ++j)

--- a/tests/boundary_traction_function_cartesian_free_surface.prm
+++ b/tests/boundary_traction_function_cartesian_free_surface.prm
@@ -124,7 +124,6 @@ subsection Material model
     set Elastic shear moduli        = 175.e9
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 2.5
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 end

--- a/tests/boundary_traction_function_spherical_free_surface.prm
+++ b/tests/boundary_traction_function_spherical_free_surface.prm
@@ -125,7 +125,6 @@ subsection Material model
     set Elastic shear moduli        = 175.e9
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 2.5
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 end

--- a/tests/damped_viscoelastic_bending_beam.prm
+++ b/tests/damped_viscoelastic_bending_beam.prm
@@ -32,7 +32,6 @@ subsection Material model
     set Fixed elastic time step     = 1e3
     set Elastic damper viscosity    = 1e14
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
   end
 

--- a/tests/elastic_stabilization_time_scale_factor.prm
+++ b/tests/elastic_stabilization_time_scale_factor.prm
@@ -10,7 +10,6 @@ set Output directory                       = elastic_stabilization_time_scale_fa
 subsection Material model
   subsection Viscoelastic
     set Stabilization time scale factor = 2
-    set Use stress averaging            = true
   end
 end
 

--- a/tests/free_surface_VE_cylinder_2D_loading_fixed_elastic_dt_gmg.prm
+++ b/tests/free_surface_VE_cylinder_2D_loading_fixed_elastic_dt_gmg.prm
@@ -19,7 +19,6 @@ subsection Material model
   subsection Viscoelastic
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/free_surface_timestep_repeat.prm
+++ b/tests/free_surface_timestep_repeat.prm
@@ -135,7 +135,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/gmg_mesh_deform_ghost_entries.prm
+++ b/tests/gmg_mesh_deform_ghost_entries.prm
@@ -14,7 +14,6 @@ subsection Material model
   subsection Viscoelastic
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 1e2
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/newton_postprocess_nonlinear.prm
+++ b/tests/newton_postprocess_nonlinear.prm
@@ -151,7 +151,6 @@ subsection Material model
     set Elastic shear moduli        = 1e50
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 5e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 37., 0., 0., 0., 37., 0., 0.

--- a/tests/visco_plastic_vep_bending_beam.prm
+++ b/tests/visco_plastic_vep_bending_beam.prm
@@ -37,7 +37,6 @@ subsection Material model
     set Elastic shear moduli = 1.e11, 1.e11, 1.e11, 1.e11, 1.e10
     set Fixed elastic time step     = 1e3
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
 
     set Cohesions = 1.e50

--- a/tests/visco_plastic_vep_plate_flexure.prm
+++ b/tests/visco_plastic_vep_plate_flexure.prm
@@ -39,7 +39,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e50, 1.e50, 1.e50, 1.e50, 3.e10, 3.e10
     set Fixed elastic time step     = 5
     set Use fixed elastic time step = false
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = maximum composition
 
     set Cohesions                   = 1.e50

--- a/tests/visco_plastic_vep_stress_build-up.prm
+++ b/tests/visco_plastic_vep_stress_build-up.prm
@@ -45,7 +45,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Densities                   = 2800.

--- a/tests/visco_plastic_vep_stress_build-up_fixed_elastic_time_step.prm
+++ b/tests/visco_plastic_vep_stress_build-up_fixed_elastic_time_step.prm
@@ -44,7 +44,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 2e3
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
 
     set Densities                   = 2800.

--- a/tests/visco_plastic_vep_stress_build-up_stress_averaging.prm
+++ b/tests/visco_plastic_vep_stress_build-up_stress_averaging.prm
@@ -45,7 +45,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 2e3
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
 
     set Densities                   = 2800.

--- a/tests/visco_plastic_vep_stress_build-up_yield.prm
+++ b/tests/visco_plastic_vep_stress_build-up_yield.prm
@@ -57,7 +57,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 0.

--- a/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
+++ b/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
@@ -62,7 +62,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
 
     set Angles of internal friction = 0.

--- a/tests/viscoelastic_fixed_elastic_time_step.prm
+++ b/tests/viscoelastic_fixed_elastic_time_step.prm
@@ -38,7 +38,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 2e3
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/viscoelastic_numerical_elastic_time_step.prm
+++ b/tests/viscoelastic_numerical_elastic_time_step.prm
@@ -39,7 +39,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/viscoelastic_numerical_elastic_time_step_particles.prm
+++ b/tests/viscoelastic_numerical_elastic_time_step_particles.prm
@@ -44,7 +44,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/viscoelastic_stress_averaging.prm
+++ b/tests/viscoelastic_stress_averaging.prm
@@ -40,7 +40,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = true
     set Fixed elastic time step     = 2e3
-    set Use stress averaging        = true
     set Viscosity averaging scheme  = harmonic
   end
 

--- a/tests/viscoelastoplastic_yield_plastic_viscous_strain_weakening.prm
+++ b/tests/viscoelastoplastic_yield_plastic_viscous_strain_weakening.prm
@@ -60,7 +60,6 @@ subsection Material model
     set Elastic shear moduli        = 1.e10
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-    set Use stress averaging        = false
   end
 end
 


### PR DESCRIPTION
I believe there are three valid scenarios for the averaging of the old and new elastic stress:
1. use_fixed_elastic_timestep = false, have dte=dt, and use_stress_averaging=false
2. use_fixed_elastic_timestep=false, have stabilization_factor > 1 so that dte is not dt, use_stress_averaging=true
3. use_fixed_elastic_timestep=true,  use_stress_averaging=true

At the moment, the combination the above parameters as set by the user is not checked.
Also, there is only one case where stress averaging does not need to be applied, and when it is, dte=dt -> dte/dt=1 and averaging doesn't change anything.
However, when use_stress_averaging is incorrectly set to false (the default), scenario 2 and 3 are wrong. 

So I removed the parameter use_stress_averaging, and stress averaging is now always applied. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
