### PR TITLE
Clean up references somewhat.

### DIFF
--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -5,7 +5,7 @@
 % https://github.com/geodynamics/aspect/issues/2831
 
 @phdthesis{Quinquis2014,
-author = {Quinquis, M},
+author = {Quinquis, M.},
 school = {Charles University},
 title = {{A numerical study of subduction zone dynamics using linear viscous to thermo-mechanical model setups including (de)hydration processes}},
 year = {2014}
@@ -20,7 +20,7 @@ url = {https://dspace.library.uu.nl/handle/1874/297347},
 year = {2014}
 }
 @phdthesis{Dannberg2016a,
-author = {Dannberg, J},
+author = {Dannberg, J.},
 school = {Potsdam University},
 title = {{Dynamics of Mantle Plumes: Linking Scales and Coupling Physics}},
 url = {https://scholar.google.com/scholar?q=dannberg+Dynamics+of+mantle+plumes{\%}3A+Linking+scales+and+coupling+physics{\&}btnG={\&}hl=en{\&}as{\_}sdt=0{\%}2C6 https://publishup.uni-potsdam.de/frontdoor/index/index/docId/9102},
@@ -28,7 +28,6 @@ year = {2016}
 }
 @mastersthesis{Zelst2015,
 author = {Zelst, I},
-file = {:home/heister/.local/share/data/Mendeley Ltd./Mendeley Desktop/Downloaded/Zelst - 2015 - Mantle dynamics on Venus insights from numerical modelling.pdf:pdf},
 school = {Utrecht University},
 title = {{Mantle dynamics on Venus: insights from numerical modelling}},
 url = {https://dspace.library.uu.nl/handle/1874/316227},
@@ -64,14 +63,14 @@ year = {2017}
 }
 
 @article{He2017,
-author = {He, Y and Puckett, EG and Billen, MI},
+author = {He, Y. and Puckett, E. G. and Billen, M. I.},
 journal = {Physics of the Earth and Planetary Interiors},
 title = {{A discontinuous Galerkin method with a bound preserving limiter for the advection of non-diffusive fields in solid Earth geodynamics}},
 url = {http://www.sciencedirect.com/science/article/pii/S0031920116300747},
 year = {2017}
 }
 @article{Gassmoller2016a,
-author = {Gassm{\"{o}}ller, R and Heien, E and Puckett, EG and Bangerth, W},
+author = {Gassm{\"{o}}ller, R. and Heien, E. and Puckett, E. G. and Bangerth, W.},
 journal = {arXiv preprint},
 title = {{Flexible and scalable particle-in-cell methods for massively parallel computations}},
 url = {https://arxiv.org/abs/1612.03369},
@@ -142,14 +141,17 @@ volume = {16},
 year = {2015}
 }
 @article{Dannberg2017,
-author = {Dannberg, J. and Eilon, Z. and Faul, Ulrich and Gassm{\"{o}}ller, Rene and Moulik, Pritwiraj and Myhill, Robert},
-doi = {10.1002/2017GC006944},
-issn = {15252027},
-journal = {Geochemistry, Geophysics, Geosystems},
-month = {aug},
-title = {{The importance of grain size to mantle dynamics and seismological observations}},
-url = {http://doi.wiley.com/10.1002/2017GC006944},
-year = {2017}
+  doi = {10.1002/2017gc006944},
+  url = {https://doi.org/10.1002/2017gc006944},
+  year = {2017},
+  month = aug,
+  publisher = {American Geophysical Union ({AGU})},
+  volume = {18},
+  number = {8},
+  pages = {3034--3061},
+  author = {J. Dannberg and Z. Eilon and Ulrich Faul and Rene Gassm\"{o}ller and Pritwiraj Moulik and Robert Myhill},
+  title = {The importance of grain size to mantle dynamics and seismological observations},
+  journal = {Geochemistry,  Geophysics,  Geosystems}
 }
 @article{Heister2017,
 author = {Heister, Timo and Dannberg, Juliane and Gassm{\"{o}}ller, Rene and Bangerth, Wolfgang},
@@ -216,7 +218,6 @@ year = {2017}
 abstract = {Mass redistribution in the convecting mantle of a planet causes perturbations in its moment of inertia tensor. Conservation of angular momentum dictates that these perturbations change the direction of the rotation vector of the planet, a process known as true polar wander (TPW). Although the existence of TPW on Earth is firmly established, its rate and magnitude over geologic time scales remain controversial. Here we present scaling analyses and numerical simulations of TPW due to mantle convection over a range of parameter space relevant to planetary interiors. For simple rotating convection, we identify a set of dimensionless parameters that fully characterize true polar wander. We use these parameters to define timescales for the growth of moment of inertia perturbations due to convection and for their relaxation due to true polar wander. These timescales, as well as the relative sizes of convective anomalies, control the rate and magnitude of TPW. This analysis also clarifies the nature of so called “inertial interchange” TPW events, and relates them to a broader class of events that enable large and often rapid TPW. We expect these events to have been more frequent in Earth's past.},
 author = {Rose, Ian and Buffett, Bruce},
 doi = {10.1016/J.PEPI.2017.10.003},
-file = {::},
 issn = {0031-9201},
 journal = {Physics of the Earth and Planetary Interiors},
 month = {dec},
@@ -230,7 +231,7 @@ year = {2017}
 @article{ONeill2017impact,
   doi={10.1038/ngeo3029},
   title={Impact-driven subduction on the Hadean Earth},
-  author={O’Neill, C and Marchi, S and Zhang, S and Bottke, W},
+  author={O'Neill, C. and Marchi, S. and Zhang, S. and Bottke, W.},
   journal={Nature Geoscience},
   volume={10},
   number={10},
@@ -251,8 +252,8 @@ year = {2017}
 }
 @article{ONeill2018lateral,
   doi={10.1029/2018JB015698},
-  title={Lateral Mixing Processes in the Hadean},
-  author={O'Neill, CJ and Zhang, S},
+  title={Lateral Mixing Processes in the {H}adean},
+  author={O'Neill, C. J. and Zhang, S.},
   journal={Journal of Geophysical Research: Solid Earth},
   volume={123},
   number={8},
@@ -261,12 +262,17 @@ year = {2017}
   publisher={Wiley Online Library}
 }
 @article{Bredow2018,
-author = {Bredow, Eva and Steinberger, Bernhard},
-doi = {10.1002/2017GL075822},
-journal = {Geophysical Research Letters},
-title = {{Variable melt production rate of the Kerguelen hotspot due to long-term plume-ridge interaction}},
-url = {http://onlinelibrary.wiley.com/doi/10.1002/2017GL075822/full},
-year = {2018}
+  doi = {10.1002/2017gl075822},
+  url = {https://doi.org/10.1002/2017gl075822},
+  year = {2018},
+  month = jan,
+  publisher = {American Geophysical Union ({AGU})},
+  volume = {45},
+  number = {1},
+  pages = {126--136},
+  author = {Eva Bredow and Bernhard Steinberger},
+  title = {Variable Melt Production Rate of the {K}erguelen {HotSpot} Due To Long-Term Plume-Ridge Interaction},
+  journal = {Geophysical Research Letters}
 }
 @mastersthesis{C.A.H.Blom2016,
 author = {{C. A. H. Blom}},
@@ -279,7 +285,7 @@ year = {2016}
 author = {Zhang, N. and Li, Z.-X.},
 journal = {Tectonophysics},
 pages = {1--13},
-title = {{Formation of mantle “lone plumes” in the global downwelling zone — A case for subduction-controlled plume generation beneath the South China Sea}},
+title = {{Formation of mantle ``lone plumes'' in the global downwelling zone -- A case for subduction-controlled plume generation beneath the South China Sea}},
 volume = {723},
 year = {2018}
 }
@@ -316,18 +322,8 @@ title = {{Nonlinear viscoplasticity in ASPECT: benchmarking and applications to 
 volume = {9},
 year = {2018}
 }
-@article{ONeill2017,
-author = {O'Neill, C and Marchi, S and Zhang, S and Bottke, W},
-journal = {Nature Geoscience},
-number = {10},
-pages = {793},
-publisher = {Nature Publishing Group},
-title = {{Impact-driven subduction on the Hadean Earth}},
-volume = {10},
-year = {2017}
-}
 @article{Kronbichler2012,
-author = {Kronbichler, M and Heister, T and Bangerth, W},
+author = {Kronbichler, M. and Heister, T. and Bangerth, W.},
 doi = {10.1111/j.1365-246X.2012.05609.x},
 journal = {Geophysical Journal International},
 pages = {12--29},
@@ -353,14 +349,14 @@ url = {https://doi.org/10.6084/m9.figshare.4865333},
 year = {2017}
 }
 @mastersthesis{Schuurmans2018,
-author = {Schuurmans, L F J},
+author = {Schuurmans, L. F. J.},
 school = {Utrecht University},
 title = {{Numerical modelling of overriding plate deformation and slab rollback in the Western Mediterranean}},
 url = {https://dspace.library.uu.nl/handle/1874/366408},
 year = {2018}
 }
 @article{Heron2018,
-author = {Heron, P J and Pysklywec, R N and Stephenson, R and van Hunen, J},
+author = {Heron, P. J. and Pysklywec, R. N. and Stephenson, R. and van Hunen, J.},
 journal = {Geology},
 publisher = {Geological Society of America},
 title = {{Deformation driven by deep and distant structures: Influence of a mantle lithosphere suture in the Ouachita orogeny, southeastern United States}},
@@ -384,7 +380,7 @@ volume = {216},
 year = {2018}
 }
 @article{Puckett2018,
-author = {Puckett, Elbridge Gerry and Turcotte, Donald L and He, Ying and Lokavarapu, Harsha and Robey, Jonathan M and Kellogg, Louise H},
+author = {Puckett, Elbridge Gerry and Turcotte, Donald L. and He, Ying and Lokavarapu, Harsha and Robey, Jonathan M. and Kellogg, Louise H.},
 journal = {Physics of the Earth and Planetary Interiors},
 pages = {10--35},
 publisher = {Elsevier},
@@ -434,7 +430,7 @@ url = {http://hdl.handle.net/1794/24526},
 year = {2019}
 }
 @article{GiacomoCorti2019,
-author = {{Giacomo Corti} and {Raffaello Cioni} and {Zara Franceschini} and {Federico Sani} and {St{\'{e}}phane Scaillet} and {Paola Molin} and {Ilaria Isola} and {Francesco Mazzarini} and {Sascha Brune} and {Derek Keir} and {Asfaw Erbello} and {Ameha Muluneh} and {Finnigan Illsley-Kemp} and {Anne Glerum}},
+author = {Giacomo Corti and Raffaello Cioni and Zara Franceschini and Federico Sani and St{\'{e}}phane Scaillet and Paola Molin and Ilaria Isola and Francesco Mazzarini and Sascha Brune and Derek Keir and Asfaw Erbello and Ameha Muluneh and Finnigan Illsley-Kemp and Anne Glerum},
 doi = {10.1038/s41467-019-09335-2},
 journal = {Nature Communications},
 pages = {1309},
@@ -520,9 +516,7 @@ year = {2018}
   title={On the Design, Implementation, and Use of a Volume-of-fluid Interface Tracking Algorithm for Modeling Convection and Other Processes in the Earth’s Mantle},
   journal={ProQuest Dissertations and Theses},
   pages={145},
-	school={University of California, Davis},
-  note={Copyright - Database copyright ProQuest LLC; ProQuest does not claim copyright in the individual underlying works; Last updated - 2019-11-04},
-  keywords={Geodynamics; Interface Tracking; Volume-of-fluid; Applied mathematics; 0364:Applied Mathematics},
+  school={University of California, Davis},
   isbn={9781392640074},
   language={English},
   url={https://search.proquest.com/docview/2309838416?accountid=14505},
@@ -613,7 +607,7 @@ year = {2019}
 
 @phdthesis{renaud2019study,
   title={A Study of the Tidal and Thermal Evolution of Rocky \& Icy Worlds Utilizing Advanced Rheological Models},
-  author={Renaud, Joseph P},
+  author={Renaud, Joseph P.},
   year={2019},
   school={George Mason University},
   url={https://search.proquest.com/docview/2303307944?pq-origsite=gscholar}
@@ -628,8 +622,8 @@ year = {2019}
 }
 
 @mastersthesis{janssen2019comparison,
-  title={A comparison of GOCO05c satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
-  author={Janssen, WJ},
+  title={A comparison of {GOCO05c} satellite data to synthetic gravity fields computed from 3D density models in ASPECT},
+  author={Janssen, W. J.},
   year={2019},
   school={Utrecht University},
   url={https://dspace.library.uu.nl/handle/1874/393839}
@@ -656,14 +650,14 @@ year = {2019}
   publisher = {Elsevier {BV}},
   volume = {541},
   pages = {116277},
-  author = {G.P. Farangitakis and P.J. Heron and K.J.W. McCaffrey and J. van Hunen and L.M. Kalnins},
+  author = {G. P. Farangitakis and P. J. Heron and K. J. W. McCaffrey and J. van Hunen and L. M. Kalnins},
   title = {The impact of oblique inheritance and changes in relative plate motion on the development of rift-transform systems},
   journal = {Earth and Planetary Science Letters}
 }
 
 @article{lesher2020iron,
   title={Iron isotope fractionation at the core--mantle boundary by thermodiffusion},
-  author={Lesher, Charles E and Dannberg, Juliane and Barfod, Gry H and Bennett, Neil R and Glessner, Justin JG and Lacks, Daniel J and Brenan, James M},
+  author={Lesher, Charles E. and Dannberg, Juliane and Barfod, Gry H. and Bennett, Neil R. and Glessner, Justin J. G. and Lacks, Daniel J. and Brenan, James M.},
   journal={Nature Geoscience},
   volume={13},
   number={5},
@@ -675,7 +669,7 @@ year = {2019}
 }
 
 @article{mitrovica2020dynamic,
-author = {Mitrovica, J.X. and Austermann, J. and Coulson, S. and Creveling, J.R. and Hoggard, M.J. and Jarvis, G.T. and Richards, F.D.},
+author = {Mitrovica, J. X. and Austermann, J. and Coulson, S. and Creveling, J. R. and Hoggard, M. J. and Jarvis, G. T. and Richards, F. D.},
 title = {Dynamic Topography and Ice Age Paleoclimate},
 journal = {Annual Review of Earth and Planetary Sciences},
 volume = {48},
@@ -701,7 +695,7 @@ url = {https://doi.org/10.1146/annurev-earth-082517-010225}
 
 @article{rajaonarison2020numerical,
   title={Numerical Modeling of Mantle Flow Beneath Madagascar to Constrain Upper Mantle Rheology Beneath Continental Regions},
-  author={Rajaonarison, TA and Stamps, DS and Fishwick, S and Brune, Sascha and Glerum, A and Hu, J},
+  author={Rajaonarison, T. A. and Stamps, D. S. and Fishwick, S. and Brune, Sascha and Glerum, A. and Hu, J.},
   journal={Journal of Geophysical Research. Solid Earth},
   volume={125},
   number={2},
@@ -714,7 +708,7 @@ url = {https://doi.org/10.1146/annurev-earth-082517-010225}
 
 @article{citron2020effects,
   title={Effects of Heat-Producing Elements on the Stability of Deep Mantle Thermochemical Piles},
-  author={Citron, Robert I and Louren{\c{c}}o, Diogo L and Wilson, Alfred J and Grima, Antoniette G and Wipperfurth, Scott A and Rudolph, Maxwell L and Cottaar, Sanne and Mont{\'e}si, Laurent GJ},
+  author={Citron, Robert I. and Louren{\c{c}}o, Diogo L. and Wilson, Alfred J. and Grima, Antoniette G. and Wipperfurth, Scott A. and Rudolph, Maxwell L. and Cottaar, Sanne and Mont{\'e}si, Laurent G. J.},
   journal={Geochemistry, Geophysics, Geosystems},
   volume={21},
   number={4},
@@ -737,7 +731,7 @@ volume="11",
 number="1",
 issn="2041-1723",
 doi="10.1038/s41467-020-16176-x",
-opturl="http://www.nature.com/articles/s41467-020-16176-x"
+url="http://www.nature.com/articles/s41467-020-16176-x"
 }
 
 @article{doi:10.1029/2020GC008935,
@@ -807,7 +801,7 @@ opturl="https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2019GL086611"
 	pages = {37},
   year = {2020},
   month = aug,
-	journal = {Earth and Space Science Open Archive},
+  journal = {Earth and Space Science Open Archive},
   author = {Emmanuel A. Njinju and D. Sarah Stamps and James Gallagher and Kodi Neumiller},
   title = {Lithospheric Control of Melt Generation Beneath the Rungwe Volcanic Province, East Africa}
 }
@@ -826,7 +820,7 @@ number="11",
 pages="985",
 issn="2075-163X",
 doi="10.3390/min10110985",
-opturl="https://www.mdpi.com/2075-163X/10/11/985"
+url="https://www.mdpi.com/2075-163X/10/11/985"
 }
 
 
@@ -883,7 +877,7 @@ year="2021",
 abstract="Deformation in the orogen-foreland system of the southern Central Andes between 33{\textdegree} and 36{\textdegree} S varies in style, locus, and amount of shortening. The controls that determine these spatially variable characteristics have largely remained unknown, yet both the subduction of the oceanic Nazca plate and the strength of the South American plate have been invoked to play a major role. While the parameters governing the subduction processes are similar between 33{\textdegree} and 36{\textdegree} S, the lithospheric strength of the upper plate is spatially variable due to structures inherited from past geodynamic regimes and associated compositional differences in the South American plate. Regional Mesozoic crustal horizontal extension generated a < 40-km-thick crust with a more mafic composition in the lower crust south of 35{\textdegree}S; north of this latitude, however, a more felsic lower crust is inferred from geophysical data. To assess the influence of different structural and compositional heterogeneities on the style of deformation in the southern Central Andes, we developed a suite of geodynamic models of intraplate lithospheric shortening for two E-W transects (33{\textdegree} 40{\textquoteright} S and 36{\textdegree} S) across the Andes. The models are constrained by local geological and geophysical information. Our results demonstrate a decoupled shortening mode between the brittle upper crust and the ductile lower crust in those areas characterized by a mafic lower crust (36{\textdegree} S transect). In contrast, a more felsic lower crust, such as in the 33{\textdegree} 40{\textquoteright} S transect, results in a coupled shortening mode. Furthermore, we find that differences in lithospheric thickness and the asymmetry of the lithosphere-asthenosphere boundary may promote the formation of a crustal-scale, west-dipping detachment zone that drives the overall deformation and lateral expansion of the orogen. Our study represents the first geodynamic modeling effort in the southern Central Andes aimed at understanding the roles of heterogeneities (crustal composition and thickness) at the scale of the entire lithosphere as well as the geometry of the lithosphere-asthenosphere boundary with respect to mountain building.",
 issn="1437-3262",
 doi="10.1007/s00531-021-01982-5",
-opturl="https://doi.org/10.1007/s00531-021-01982-5"
+url="https://doi.org/10.1007/s00531-021-01982-5"
 }
 
 @article {BredowM56-2020-2,
@@ -972,7 +966,7 @@ pages = {25},
 year = {2021},
 DOI = {10.1002/essoar.10506103.1},
 url = {https://doi.org/10.1002/essoar.10506103.1},
-abstract = {Seaﬂoor spreading at slow rates can be accommodated on large-offset oceanic detachment faults (ODFs), that exhume lower crustal and mantle rocks in footwall domes termed oceanic core complexes (OCCs). Footwall rock experiences large rotation during exhumation, yet important aspects of the kinematics - particularly the relative roles of rigid block rotation and flexure - are not clearly understood. Using a high-resolution numerical model, we explore the exhumation kinematics in the footwall beneath an emergent ODF/OCC. A key feature of the models is that footwall motion is dominated by solid rotation, accommodated by the concave-down ODF. This is attributed to a system behaviour in which the accumulation of distributed plastic strain is minimized. A consequence of these kinematics is that curvature measured along the ODF is representative of a neutral stress conﬁguration, rather than a “bent” one. Instead, it is in the subsequent process of `apparent unbending’ that signiﬁcant ﬂexural stresses are developed in the model footwall. The brittle strain associated with apparent unbending is produced dominantly in extension, beneath the OCC, consistent with earthquake clustering observed in the Trans-Atlantic Geotraverse at the Mid-Atlantic Ridge.}
+abstract = {Seafloor spreading at slow rates can be accommodated on large-offset oceanic detachment faults (ODFs), that exhume lower crustal and mantle rocks in footwall domes termed oceanic core complexes (OCCs). Footwall rock experiences large rotation during exhumation, yet important aspects of the kinematics - particularly the relative roles of rigid block rotation and flexure - are not clearly understood. Using a high-resolution numerical model, we explore the exhumation kinematics in the footwall beneath an emergent ODF/OCC. A key feature of the models is that footwall motion is dominated by solid rotation, accommodated by the concave-down ODF. This is attributed to a system behaviour in which the accumulation of distributed plastic strain is minimized. A consequence of these kinematics is that curvature measured along the ODF is representative of a neutral stress conﬁguration, rather than a “bent” one. Instead, it is in the subsequent process of `apparent unbending’ that signiﬁcant ﬂexural stresses are developed in the model footwall. The brittle strain associated with apparent unbending is produced dominantly in extension, beneath the OCC, consistent with earthquake clustering observed in the Trans-Atlantic Geotraverse at the Mid-Atlantic Ridge.}
 }
 
 @article{FACCENNA2021116905,


### PR DESCRIPTION
We have quite a number of references that cite ASPECT that have non-standard fields `abstract`, `notes`, etc. I've removed them from some since bibtex doesn't actually do anything with them. I've also cleaned up inconsistent use of abbreviated first names.

/rebuild