### PR TITLE
fix GMG mesh deformation missing ghost entries

### DIFF
--- a/tests/gmg_mesh_deform_ghost_entries.prm
+++ b/tests/gmg_mesh_deform_ghost_entries.prm
@@ -1,0 +1,42 @@
+# Based on viscoelastic free surface benchmark (with free surface
+# disabled) to show a bug, where we did not include the correct ghost
+# entries for the MappingQEulerian
+# MPI: 3
+
+include $ASPECT_SOURCE_DIR/benchmarks/free_surface_tractions/viscoelastic/free_surface_VE_cylinder_2D_loading.prm
+
+set Dimension                              = 2
+set End time = 10
+
+subsection Material model
+  set Model name = viscoelastic
+
+  subsection Viscoelastic
+    set Use fixed elastic time step = true
+    set Fixed elastic time step     = 1e2
+    set Use stress averaging        = true
+    set Viscosity averaging scheme  = harmonic
+  end
+
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Linear solver tolerance = 1.e-7
+    set Number of cheap Stokes solver steps = 200
+  end
+end
+
+subsection Material model
+  set Material averaging = project to Q1 only viscosity
+end
+
+subsection Mesh deformation
+  set Additional tangential mesh velocity boundary indicators = left,right
+  set Mesh deformation boundary indicators = top: boundary function
+  subsection Boundary function
+    set Variable names      = x,y,t
+    set Function expression = 0;  -3.168808781e-16*(x-1e5)
+  end
+end

--- a/tests/gmg_mesh_deform_ghost_entries/screen-output
+++ b/tests/gmg_mesh_deform_ghost_entries/screen-output
@@ -1,0 +1,40 @@
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/box_3d_top.0.txt.
+
+
+   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
+   This is either because ASPECT has already read all the files necessary to impose
+   the requested boundary condition, or that the last available file has been read.
+   If the Ascii data represented a time-dependent boundary condition,
+   that time-dependence ends at this timestep  (i.e. the boundary condition
+   will continue unchanged from the last known state into the future).
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+Number of active cells: 8 (on 2 levels)
+Number of degrees of freedom: 527 (375+27+125)
+
+Number of mesh deformation degrees of freedom: 81
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 10+0 iterations.
+
+Number of active cells: 36 (on 3 levels)
+Number of degrees of freedom: 1,968 (1,413+84+471)
+
+Number of mesh deformation degrees of freedom: 252
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh velocity system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 14+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-gmg_mesh_deform/solution/solution-00000
+     RMS, max velocity:        0.474 m/year, 1.45 m/year
+     Topography min/max:       2e+04 m, 5.5e+04 m
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/gmg_mesh_deform_ghost_entries/statistics
+++ b/tests/gmg_mesh_deform_ghost_entries/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimum topography (m)
+# 15: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 36 1497 471 0 13 15 15 output-gmg_mesh_deform/solution/solution-00000 4.73519596e-01 1.44934450e+00 2.00000000e+04 5.50000000e+04 


### PR DESCRIPTION
Without adding additional ghost entries to the level displacement vectors used by the ``MappingQEulerian``, we run into crashes like
```
An error occurred in line <1627> of file </ssd/candi-v9.3.1-r1/tmp/unpack/deal.II-v9.3.1/include/deal.II/lac/la_parallel_vector.h> in function
    Number dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>::operator()(dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>::size_type) const [with Number = double; MemorySpace = dealii::MemorySpace::Host; dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>::size_type = unsigned int]
The violated condition was: 
    partitioner->in_local_range(global_index) || partitioner->ghost_indices().is_element(global_index)
```
when running in parallel.