### PR TITLE
remove nullspace for cookbooks/S20RTS.prm 

### DIFF
--- a/cookbooks/S20RTS.prm
+++ b/cookbooks/S20RTS.prm
@@ -142,3 +142,7 @@ subsection Postprocess
     set Also output the gravity anomaly  = true
   end
 end
+
+subsection Nullspace removal
+  set Remove nullspace = net rotation
+end


### PR DESCRIPTION
Remove the nullspace so that the velocity field is uniquely determined. @tjhei 