### PR TITLE
Fix pressure depth derivative in latent heat material model

### DIFF
--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -83,7 +83,7 @@ namespace aspect
           // Prepare some values for phase dependent properties
           const double depth = this->get_geometry_model().depth(in.position[i]);
           const double adiabatic_pressure = this->get_adiabatic_conditions().pressure(in.position[i]);
-          const double pressure_depth_derivative = (depth > 0.0 && adiabatic_pressure > 0.0)
+          const double pressure_depth_derivative = (depth > 0.0)
                                                    ?
                                                    adiabatic_pressure / depth
                                                    :

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -177,11 +177,11 @@ namespace aspect
               for (unsigned int phase=0; phase<phase_function.n_phase_transitions(); ++phase)
                 {
                   const double depth = this->get_geometry_model().depth(in.position[i]);
-                  const double pressure_depth_derivative = (this->get_adiabatic_conditions().pressure(position) > 0)
+                  const double pressure_depth_derivative = (depth > 0.0)
                                                            ?
-                                                           depth / this->get_adiabatic_conditions().pressure(position)
+                                                           this->get_adiabatic_conditions().pressure(position) / depth
                                                            :
-                                                           this->get_gravity_model().gravity_vector(in.position[i]).norm() * reference_rho;
+                                                           this->get_gravity_model().gravity_vector(position).norm() * reference_rho;
 
                   const MaterialUtilities::PhaseFunctionInputs<dim> phase_in(temperature,
                                                                              pressure,


### PR DESCRIPTION
I think this fixes a bug in the latent heat material model. If you compare this way to compute the pressure_depth_derivative with the one in line 114 in the same file you notice that we actually compute the inverse here (the depth_pressure_derivative). This PR unifies the way to compute this derivative. 

The fix likely leads to a displacement of the latent heat that is generated at the phase transition. In the old version the density change of the phase transition would take place at the correct location (one that is displaced from the standard phase transition location considering the current temperature and clapeyron slope), but the latent heat change would be added at a different depth, one that is computed with a wrong Clapeyron slope of nearly 0 (the pressure_depth_derivative is large, so the inverse is small). All of this would only happen if the phase transition is defined in terms of depth instead of pressure, because otherwise the pressure_depth_derivative is not needed to compute the offset of the phase transition.

I first want to check what this changes in the tests, I will add a second commit later that refactors the whole computation to avoid having to compute the same value twice.

@jdannberg can you take a look?