### PR TITLE
Use fast path for particle advection in box

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1357,7 +1357,16 @@ namespace aspect
               if (particles_in_cell.begin() != particles_in_cell.end())
                 {
                   // Only use deal.II FEPointEvaluation if it's fast path is used
-                  const bool use_fast_path = dynamic_cast<const MappingQGeneric<dim> *>(&this->get_mapping()) != nullptr;
+                  bool use_fast_path = false;
+#if DEAL_II_VERSION_GTE(10,0,0)
+                  if (dynamic_cast<const MappingQGeneric<dim> *>(&this->get_mapping()) != nullptr ||
+                      dynamic_cast<const MappingCartesian<dim> *>(&this->get_mapping()) != nullptr)
+                    use_fast_path = true;
+#else
+                  if (dynamic_cast<const MappingQGeneric<dim> *>(&this->get_mapping()) != nullptr)
+                    use_fast_path = true;
+#endif
+
                   if (use_fast_path)
                     local_advect_particles(cell,
                                            particles_in_cell.begin(),


### PR DESCRIPTION
This PR optimizes the particle advection in box models without mesh deformation by using the FEPointEvaluation class with MappingCartesian mappings. This was made possible by #dealii/dealii#12773 and results in a speedup of around 3x for particle advection. Non-box models and box models with mesh deformation had this speedup already before.