### PR TITLE
Mesh deformation: get the free surface stabilization parameter

### DIFF
--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -108,6 +108,11 @@ namespace aspect
          */
         void parse_parameters (ParameterHandler &prm) override;
 
+        /**
+         * Return the stabilization parameter for the free surface.
+         */
+        double get_free_surface_theta () const;
+
       private:
         /**
          * Project the Stokes velocity solution onto the

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -208,6 +208,14 @@ namespace aspect
 
 
     template <int dim>
+    double FreeSurface<dim>::get_free_surface_theta()const
+    {
+      return free_surface_theta;
+    }
+
+
+
+    template <int dim>
     void FreeSurface<dim>::project_velocity_onto_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                           const IndexSet &mesh_locally_owned,
                                                           const IndexSet &mesh_locally_relevant,


### PR DESCRIPTION
Add a function to get the stabilization parameter for the free surface, which is required by the matrix-free implementation. @tjhei 