### PR TITLE
Optimize elasticity evaluation in material model

### DIFF
--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -192,7 +192,7 @@ namespace aspect
            * By caching the evaluator, we can avoid recreating it every time we
            * need it.
            */
-          std::unique_ptr<FEPointEvaluation<dim, dim>> evaluator;
+          mutable std::unique_ptr<FEPointEvaluation<dim, dim>> evaluator;
       };
     }
   }

--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -25,6 +25,8 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
 
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+
 namespace aspect
 {
   namespace MaterialModel
@@ -182,6 +184,15 @@ namespace aspect
            * time step to create a time scale.
            */
           double stabilization_time_scale_factor;
+
+          /**
+           * We cache the evaluator that is necessary to evaluate the old velocity
+           * gradients. They are required to compute the elastic stresses, but
+           * are not provided by the material model.
+           * By caching the evaluator, we can avoid recreating it every time we
+           * need it.
+           */
+          std::unique_ptr<FEPointEvaluation<dim, dim>> evaluator;
       };
     }
   }

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -490,9 +490,9 @@ namespace aspect
       get_dof_handler () const;
 
       /**
-       * Return a reference to the finite element that the DoFHandler that is
-       * used to discretize the variables at the current time step is built
-       * on. This is the finite element for the entire, couple problem, i.e.,
+       * Return a reference to the finite element that is
+       * used to discretize the variables at the current time step.
+       * This is the finite element for the entire, coupled problem, i.e.,
        * it contains sub-elements for velocity, pressure, temperature and all
        * other variables in this problem (e.g., compositional variables, if
        * used in this simulation).

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -213,12 +213,6 @@ namespace aspect
                                "averaging schemes 'none', 'harmonic average only viscosity', and "
                                "project to Q1 only viscosity'. This parameter ('Material averaging') "
                                "is located within the 'Material model' subsection."));
-
-        // Initialize the evaluator for the old velocity gradients
-        evaluator = std::make_unique<FEPointEvaluation<dim,dim>>(this->get_mapping(),
-                                                                 this->get_fe(),
-                                                                 update_gradients,
-                                                                 this->introspection().component_indices.velocities[0]);
       }
 
 
@@ -293,6 +287,14 @@ namespace aspect
                                             solution_values.begin(),
                                             solution_values.end());
 
+            // Only create the evaluator the first time we get here
+            if (!evaluator)
+              evaluator.reset(new FEPointEvaluation<dim,dim>(this->get_mapping(),
+                                                             this->get_fe(),
+                                                             update_gradients,
+                                                             this->introspection().component_indices.velocities[0]));
+
+            // Initialize the evaluator for the old velocity gradients
             evaluator->reinit(in.current_cell, quadrature_positions);
             evaluator->evaluate(solution_values,
                                 EvaluationFlags::gradients);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -373,12 +373,7 @@ namespace aspect
   const FiniteElement<dim> &
   SimulatorAccess<dim>::get_fe () const
   {
-    Assert (simulator->dof_handler.n_dofs() > 0,
-            ExcMessage("You are trying to access the FiniteElement before the DOFs have been "
-                       "initialized. This may happen when accessing the Simulator from a plugin "
-                       "that gets executed early in some cases (like material models) or from "
-                       "an early point in the core code."));
-    return simulator->dof_handler.get_fe();
+    return simulator->finite_element;
   }
 
 


### PR DESCRIPTION
This is another seemingly small change that drastically improves the speed of computing the reaction terms for elasticity, in particular for particles. By using the deal.II class `FEPointEvaluation` instead of `FEValues` we no longer need to create a new `FEValues` object for every evaluation (which in case of particles was for every particles). The new implementation is fully equivalent and gives the following speedups for the bending beam benchmark with particles. I benchmarked this in reduced resolution on a 25x10 grid and with 1e3 particles for 2 timesteps, I used aspect from PR #4415 and dealii from PR #12983, all in optimized mode:

- Particle Update -> from 0.131s (19%) to 0.00818s (1.7%) runtime, 16X speedup
- Stokes assembly -> from 0.038s (5.5%) to 0.0225s (4.7%), 1.7X speedup
- Temperature assembly ->  from 0.0542s (7.9%) to 0.0285s (6%), 1.9X speedup


@naliboff and @anne-glerum FYI. 
