### PR TITLE
Remove uses of GeometryInfo.

### DIFF
--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -688,7 +688,7 @@ namespace aspect
 
         for (const auto &cell : this->get_dof_handler().active_cell_iterators())
           if (cell->is_locally_owned())
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               if (cell->at_boundary(f))
                 if (cell->face(f)->boundary_id() == CMB_id)
                   {

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -43,7 +43,7 @@ namespace aspect
         {
 
           // first set the default boundary indicators
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->face(f)->at_boundary())
               cell->face(f)->set_boundary_id (f);
 

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -128,7 +128,7 @@ namespace aspect
            ++cell)
         {
           // First set the default boundary indicators.
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->face(f)->at_boundary())
               cell->face(f)->set_boundary_id (f);
 

--- a/source/mesh_refinement/volume_of_fluid_interface.cc
+++ b/source/mesh_refinement/volume_of_fluid_interface.cc
@@ -111,7 +111,7 @@ namespace aspect
 
                 if (!refine_current_cell)
                   {
-                    for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+                    for (const unsigned int f : cell->face_indices())
                       {
                         const bool cell_has_periodic_neighbor = cell->has_periodic_neighbor(f);
                         const typename DoFHandler<dim>::face_iterator face = cell->face(f);
@@ -255,7 +255,7 @@ namespace aspect
             }
 
           // Check for periodic neighbors, and refine if existing
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : mcell->face_indices())
             {
               if (mcell->has_periodic_neighbor(f))
                 {

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -500,7 +500,7 @@ namespace aspect
                   bool cell_at_fixed_boundary = false;
                   unsigned int boundary_face = numbers::invalid_unsigned_int;
                   double minimum_face_distance = std::numeric_limits<double>::max();
-                  for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+                  for (const unsigned int f : cell->face_indices())
                     if (cell->at_boundary(f) && fixed_boundaries.count(cell->face(f)->boundary_id()) == 1)
                       {
                         const double face_center_distance = particle_location.distance_square(cell->face(f)->center(true));

--- a/source/postprocess/boundary_densities.cc
+++ b/source/postprocess/boundary_densities.cc
@@ -61,7 +61,7 @@ namespace aspect
       // the top or bottom surface, evaluate the density on that face
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned() && cell->at_boundary())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             {
               bool cell_at_top = false;
               bool cell_at_bottom = false;

--- a/source/postprocess/boundary_pressures.cc
+++ b/source/postprocess/boundary_pressures.cc
@@ -59,7 +59,7 @@ namespace aspect
       // the top or bottom surface, evaluate the pressure on that face
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned() && cell->at_boundary())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             {
               bool cell_at_top = false;
               bool cell_at_bottom = false;

--- a/source/postprocess/boundary_velocity_residual_statistics.cc
+++ b/source/postprocess/boundary_velocity_residual_statistics.cc
@@ -133,7 +133,7 @@ namespace aspect
       // magnitude and the face area.
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             for (const auto current_boundary_id : boundary_indicators)
               if (cell->face(f)->at_boundary() && cell->face(f)->boundary_id() == current_boundary_id)
                 {

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -119,7 +119,7 @@ namespace aspect
           {
             // see if the cell is at the *top* or *bottom* boundary, not just any boundary
             unsigned int face_idx = numbers::invalid_unsigned_int;
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               {
                 if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                   {
@@ -241,7 +241,7 @@ namespace aspect
             // is true and will be changed to false if it's at the lower boundary. If the
             // cell is at neither boundary the loop will continue to the next cell.
             bool at_upper_surface = true;
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               {
                 if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                   {

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -210,7 +210,7 @@ namespace aspect
             unsigned int face_idx = numbers::invalid_unsigned_int;
             bool at_upper_surface = false;
             {
-              for (unsigned int f=0; f<GeometryInfo<3>::faces_per_cell; ++f)
+              for (const unsigned int f : cell->face_indices())
                 {
                   if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                     {
@@ -515,7 +515,7 @@ namespace aspect
         if (cell->is_locally_owned() && cell->at_boundary())
           {
             // If the cell is at the top boundary, store the cell's upper face midpoint location.
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               if (cell->at_boundary(f) && cell->face(f)->boundary_id() == top_boundary_id)
                 {
                   fe_face_center_values.reinit(cell,f);

--- a/source/postprocess/heat_flux_densities.cc
+++ b/source/postprocess/heat_flux_densities.cc
@@ -49,7 +49,7 @@ namespace aspect
       // Finally, sum over the processors and compute the ratio between the
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->at_boundary(f))
               {
                 const types::boundary_id boundary_indicator

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -224,7 +224,7 @@ namespace aspect
                     }
                 }
 
-              for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+              for (const unsigned int f : cell->face_indices())
                 {
                   if (!cell->at_boundary(f))
                     continue;
@@ -357,7 +357,7 @@ namespace aspect
         for (const auto &cell : simulator_access.get_dof_handler().active_cell_iterators())
           if (cell->is_locally_owned() && cell->at_boundary())
             {
-              for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+              for (const unsigned int f : cell->face_indices())
                 if (cell->at_boundary(f))
                   {
                     // Determine the type of boundary
@@ -454,7 +454,7 @@ namespace aspect
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->at_boundary(f) &&
                 (cell->face(f)->boundary_id() == top_boundary_id ||
                  cell->face(f)->boundary_id() == bottom_boundary_id))

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -44,7 +44,7 @@ namespace aspect
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->at_boundary(f))
               {
                 const types::boundary_id boundary_indicator

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -70,7 +70,7 @@ namespace aspect
       //   j =  \rho * v * n
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->at_boundary(f))
               {
                 fe_face_values.reinit (cell, f);

--- a/source/postprocess/velocity_boundary_statistics.cc
+++ b/source/postprocess/velocity_boundary_statistics.cc
@@ -68,7 +68,7 @@ namespace aspect
       // and the face area.
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->face(f)->at_boundary())
               {
                 fe_face_values.reinit (cell, f);

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -51,7 +51,7 @@ namespace aspect
               if (cell->at_boundary())
                 {
                   types::boundary_id boundary_id = largest_boundary_id_plus_one;
-                  for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+                  for (const unsigned int f : cell->face_indices())
                     {
                       if (cell->face(f)->at_boundary())
                         {

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -60,7 +60,7 @@ namespace aspect
         // We only want the output at the top boundary, so only compute it if the current cell
         // has a face at the top boundary.
         bool cell_at_top_boundary = false;
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : cell->face_indices())
           if (cell->at_boundary(f) &&
               (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top"))
             cell_at_top_boundary = true;

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -57,7 +57,7 @@ namespace aspect
         // boundary, so only compute it if the current cell has
         // a face at the top or bottom boundary.
         bool cell_at_top_or_bottom_boundary = false;
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : cell->face_indices())
           if (cell->at_boundary(f) &&
               (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -68,7 +68,7 @@ namespace aspect
         auto cell = input_data.template get_cell<dim>();
 
         bool cell_at_top_boundary = false;
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : cell->face_indices())
           if (cell->at_boundary(f) &&
               this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top")
             cell_at_top_boundary = true;

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -69,7 +69,7 @@ namespace aspect
         if (output_point_wise_heat_flux)
           {
             bool cell_at_top_or_bottom_boundary = false;
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               if (cell->at_boundary(f) &&
                   (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                    this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))
@@ -101,7 +101,7 @@ namespace aspect
           {
             double heat_flux = 0.0;
 
-            for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : cell->face_indices())
               if (cell->at_boundary(f) &&
                   (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                    this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -55,7 +55,7 @@ namespace aspect
         // boundary, so only compute it if the current cell has
         // a face at the top or bottom boundary.
         bool cell_at_top_or_bottom_boundary = false;
-        for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : cell->face_indices())
           if (cell->at_boundary(f) &&
               (this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top" ||
                this->get_geometry_model().translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "bottom"))

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -613,7 +613,7 @@ namespace aspect
       {
         // then also work on possible face terms. if necessary, initialize
         // the material model data on faces
-        for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
+        for (const unsigned int face_number : cell->face_indices())
           if (cell->at_boundary(face_number) && !cell->has_periodic_neighbor(face_number))
             {
               scratch.reinit(cell, face_number);
@@ -999,9 +999,9 @@ namespace aspect
           }
       }
 
-    for (scratch.face_number=0; scratch.face_number<GeometryInfo<dim>::faces_per_cell; ++scratch.face_number)
+    for (scratch.face_number=0; scratch.face_number<cell->n_faces(); ++scratch.face_number)
       {
-        typename DoFHandler<dim>::face_iterator face = cell->face (scratch.face_number);
+        const typename DoFHandler<dim>::face_iterator face = cell->face (scratch.face_number);
 
         if ((has_boundary_face_assemblers && face->at_boundary()) ||
             (has_interior_face_assemblers && !face->at_boundary()))

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2037,9 +2037,9 @@ namespace aspect
     // Loop over all of the boundary faces, ...
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (!cell->is_artificial())
-        for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
+        for (const unsigned int face_number : cell->face_indices())
           {
-            typename DoFHandler<dim>::face_iterator face = cell->face(face_number);
+            const typename DoFHandler<dim>::face_iterator face = cell->face(face_number);
             if (face->at_boundary())
               {
                 Assert(face->boundary_id() <= offset,
@@ -2074,9 +2074,9 @@ namespace aspect
     // Loop over all of the boundary faces...
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (!cell->is_artificial())
-        for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
+        for (const unsigned int face_number : cell->face_indices())
           {
-            typename DoFHandler<dim>::face_iterator face = cell->face(face_number);
+            const typename DoFHandler<dim>::face_iterator face = cell->face(face_number);
             if (face->at_boundary())
               {
                 // ... and reset all of the boundary ids we changed in replace_outflow_boundary_ids above.

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1008,7 +1008,7 @@ namespace aspect
                                                                  &this->get_dof_handler());
 
       unsigned int face_no = numbers::invalid_unsigned_int;
-      for (face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+      for (face_no=0; face_no<cell->n_faces(); ++face_no)
         if (scratch.face_finite_element_values.get_face_index() == cell->face_index(face_no))
           break;
       Assert(face_no != numbers::invalid_unsigned_int,ExcInternalError());

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -403,7 +403,7 @@ namespace aspect
               // We only want the output at the top boundary, so only compute it if the current cell
               // has a face at the top boundary.
               bool cell_at_top_boundary = false;
-              for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+              for (const unsigned int f : cell->face_indices())
                 if (cell->at_boundary(f) &&
                     (geometry_model->translate_id_to_symbol_name (cell->face(f)->boundary_id()) == "top"))
                   {

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -258,9 +258,7 @@ namespace aspect
           if (cell->level_subdomain_id() != numbers::artificial_subdomain_id
               &&
               cell->level_subdomain_id() != numbers::invalid_subdomain_id)
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : cell->face_indices())
               if ((b_id = boundary_ids.find(cell->face(face_no)->boundary_id())) !=
                   boundary_ids.end())
                 {

--- a/source/termination_criteria/steady_heat_flux.cc
+++ b/source/termination_criteria/steady_heat_flux.cc
@@ -60,7 +60,7 @@ namespace aspect
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())
-          for (unsigned int f=0; f<GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : cell->face_indices())
             if (cell->at_boundary(f))
               {
                 const types::boundary_id boundary_indicator


### PR DESCRIPTION
GeometryInfo is quad/hex-specific, and so will have to be removed from deal.II at some point
in the near future. This patch removes a whole bunch of uses of that class and replaces
them by querying this information from the cell we are working on.

/rebuild