### PR TITLE
Provide a 'const' version of NaturalCoordinate::get_coordinates().

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -757,6 +757,12 @@ namespace aspect
         std::array<double,dim> &get_coordinates();
 
         /**
+         * Returns the coordinates in the given coordinate system, which may
+         * not be Cartesian.
+         */
+        const std::array<double,dim> &get_coordinates() const;
+
+        /**
          * The coordinate that represents the 'surface' directions in the
          * chosen coordinate system.
          */

--- a/source/boundary_composition/function.cc
+++ b/source/boundary_composition/function.cc
@@ -35,7 +35,7 @@ namespace aspect
                           const Point<dim> &position,
                           const unsigned int compositional_field) const
     {
-      Utilities::NaturalCoordinate<dim> point =
+      const Utilities::NaturalCoordinate<dim> point =
         this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
       return function->value(Utilities::convert_array_to_point<dim>(point.get_coordinates()), compositional_field);
     }

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -41,7 +41,7 @@ namespace aspect
     boundary_temperature (const types::boundary_id /*boundary_indicator*/,
                           const Point<dim> &position) const
     {
-      Utilities::NaturalCoordinate<dim> point =
+      const Utilities::NaturalCoordinate<dim> point =
         this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
       return boundary_temperature_function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));
     }

--- a/source/boundary_velocity/function.cc
+++ b/source/boundary_velocity/function.cc
@@ -44,7 +44,7 @@ namespace aspect
     {
       Tensor<1,dim> velocity;
 
-      Utilities::NaturalCoordinate<dim> point =
+      const Utilities::NaturalCoordinate<dim> point =
         this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
 
       for (unsigned int d=0; d<dim; ++d)

--- a/source/initial_composition/function.cc
+++ b/source/initial_composition/function.cc
@@ -34,7 +34,7 @@ namespace aspect
     Function<dim>::
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
-      Utilities::NaturalCoordinate<dim> point =
+      const Utilities::NaturalCoordinate<dim> point =
         this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
 
       return function->value(Utilities::convert_array_to_point<dim>(point.get_coordinates()),n_comp);

--- a/source/initial_temperature/function.cc
+++ b/source/initial_temperature/function.cc
@@ -41,7 +41,7 @@ namespace aspect
     Function<dim>::
     initial_temperature (const Point<dim> &position) const
     {
-      Utilities::NaturalCoordinate<dim> point =
+      const Utilities::NaturalCoordinate<dim> point =
         this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
 
       return function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -60,7 +60,7 @@ namespace aspect
               for ( unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;  ++v)
                 {
                   const Point<dim> vertex = cell->vertex(v);
-                  Utilities::NaturalCoordinate<dim> point =
+                  const Utilities::NaturalCoordinate<dim> point =
                     this->get_geometry_model().cartesian_to_other_coordinates(vertex, coordinate_system);
 
                   const double maximum_refinement_level = max_refinement_level.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -60,7 +60,7 @@ namespace aspect
               for ( unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;  ++v)
                 {
                   const Point<dim> vertex = cell->vertex(v);
-                  Utilities::NaturalCoordinate<dim> point =
+                  const Utilities::NaturalCoordinate<dim> point =
                     this->get_geometry_model().cartesian_to_other_coordinates(vertex, coordinate_system);
 
                   const double minimum_refinement_level = min_refinement_level.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2157,6 +2157,16 @@ namespace aspect
       return coordinates;
     }
 
+
+
+    template <int dim>
+    const std::array<double,dim> &NaturalCoordinate<dim>::get_coordinates() const
+    {
+      return coordinates;
+    }
+
+
+
     template <>
     std::array<double,1> NaturalCoordinate<2>::get_surface_coordinates() const
     {


### PR DESCRIPTION
Previously, there was only a non-const version that returned a non-const reference to
a member variable. This isn't usable when the object it is called on is 'const'. So
provide a 'const' version that returns a 'const' reference.

/rebuild