### PR TITLE
More GeometryInfo work, the questionable part.

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -266,21 +266,25 @@ namespace aspect
         // center is less than 1.e-5 of the distance between vertices (as
         // measured by the minimum distance from any of the other vertices
         // to the first vertex), then we call this a horizontal face.
-        constexpr unsigned int n_vertices = GeometryInfo<dim>::vertices_per_face;
-        std::array<double, n_vertices>     distances_to_center;
-        std::array<double, n_vertices - 1> distances_to_first_vertex;
+        constexpr unsigned int max_n_vertices_per_face = (dim==2 ? 2 : 4);
+        std::array<double, max_n_vertices_per_face>     distances_to_center;
+        std::array<double, max_n_vertices_per_face - 1> distances_to_first_vertex;
         distances_to_center[0] = face->vertex(0).norm_square();
-        for (unsigned int i = 1; i < n_vertices; ++i)
+        for (unsigned int i = 1; i < face->n_vertices(); ++i)
           {
+            AssertIndexRange (i, distances_to_center.size());
+            AssertIndexRange (i-1, distances_to_first_vertex.size());
+
             distances_to_center[i] = face->vertex(i).norm_square();
             distances_to_first_vertex[i - 1] =
               (face->vertex(i) - face->vertex(0)).norm_square();
           }
         const auto minmax_distance =
-          std::minmax_element(distances_to_center.begin(), distances_to_center.end());
+          std::minmax_element(distances_to_center.begin(),
+                              distances_to_center.begin()+face->n_vertices());
         const auto min_distance_to_first_vertex =
           std::min_element(distances_to_first_vertex.begin(),
-                           distances_to_first_vertex.end());
+                           distances_to_first_vertex.begin()+face->n_vertices());
 
         // So, if this is a "horizontal" face, then just compute the normal
         // vector as the one from the center to the point 'p', adequately

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -284,7 +284,7 @@ namespace aspect
                               distances_to_center.begin()+face->n_vertices());
         const auto min_distance_to_first_vertex =
           std::min_element(distances_to_first_vertex.begin(),
-                           distances_to_first_vertex.begin()+face->n_vertices());
+                           distances_to_first_vertex.begin()+face->n_vertices()-1);
 
         // So, if this is a "horizontal" face, then just compute the normal
         // vector as the one from the center to the point 'p', adequately


### PR DESCRIPTION
This is the part of #4425 that didn't work yesterday. I checked that at least on my system, there is no difference between the before/after outputs of the `merged_chunks_2D` test that failed yesterday, though the output is (expectedly) slightly different than what's stored.

/rebuild