### PR TITLE
Adjust max_visc and min_visc in the visco_plastic module to vectors of phases

### DIFF
--- a/doc/modules/changes/20211221_haoyuanli
+++ b/doc/modules/changes/20211221_haoyuanli
@@ -1,0 +1,3 @@
+New: The variables "minimum viscosity" and "maximum viscosity" in the visco plastic material model can now have different values for different phases. This is useful in assigning shear zone viscosity in a subduction model.
+<br>
+(Haoyuan Li, 2021/12/21)

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -121,8 +121,8 @@ namespace aspect
          * which involves a division by the strain rate. Units: 1/s.
          */
         double min_strain_rate;
-        double min_visc;
-        double max_visc;
+        double minimum_viscosity;
+        double maximum_viscosity;
         double veff_coefficient;
         double ref_visc;
 

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -111,8 +111,8 @@ namespace aspect
         double thermal_alpha;
         double reference_specific_heat;
         double reference_compressibility;
-        double max_viscosity;
-        double min_viscosity;
+        double maximum_viscosity;
+        double minimum_viscosity;
 
         /**
          * The thermal conductivity.

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -138,8 +138,8 @@ namespace aspect
           DruckerPragerParameters drucker_prager_parameters;
 
           unsigned int number_of_compositions;
-          double min_viscosity;
-          double max_viscosity;
+          double minimum_viscosity;
+          double maximum_viscosity;
 
           double min_strain_rate;
           double strain_rate_residual_threshold;

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -219,9 +219,10 @@ namespace aspect
           /**
            * Minimum and maximum viscosities used to improve the
            * stability of the rheology model.
+           * These parameters contain one value per composition and phase (potentially the same value).
            */
-          double min_visc;
-          double max_visc;
+          std::vector<double> minimum_viscosity;
+          std::vector<double> maximum_viscosity;
 
           /**
            * Enumeration for selecting which type of viscous flow law to use.

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -72,11 +72,11 @@ namespace aspect
           // Start with the assumption that all strain is accommodated by diffusion creep:
           // If the diffusion creep prefactor is very small, that means that the diffusion viscosity is very large.
           // In this case, use the maximum viscosity instead to compute the starting guess.
-          double stress_ii = (prefactor_stress_diffusion > (0.5 / max_visc)
+          double stress_ii = (prefactor_stress_diffusion > (0.5 / maximum_viscosity)
                               ?
                               edot_ii/prefactor_stress_diffusion
                               :
-                              0.5 / max_visc);
+                              0.5 / maximum_viscosity);
           double strain_rate_residual = 2*strain_rate_residual_threshold;
           double strain_rate_deriv = 0;
           unsigned int stress_iteration = 0;
@@ -128,7 +128,7 @@ namespace aspect
 
                       const double diffusion_viscosity = std::min(std::max(diffusion_prefactor * diffusion_grain_size_dependence
                                                                            * diffusion_strain_rate_dependence * diffusion_T_and_P_dependence,
-                                                                           min_visc), max_visc);
+                                                                           minimum_viscosity), maximum_viscosity);
 
                       const double dislocation_prefactor = 0.5 * std::pow(dislocation_creep_parameters.prefactor,-1.0/dislocation_creep_parameters.stress_exponent);
                       const double dislocation_strain_rate_dependence = std::pow(dislocation_strain_rate, (1.-dislocation_creep_parameters.stress_exponent)/dislocation_creep_parameters.stress_exponent);
@@ -137,7 +137,7 @@ namespace aspect
 
                       const double dislocation_viscosity = std::min(std::max(dislocation_prefactor * dislocation_strain_rate_dependence
                                                                              * dislocation_T_and_P_dependence,
-                                                                             min_visc), max_visc);
+                                                                             minimum_viscosity), maximum_viscosity);
 
                       diffusion_strain_rate = dislocation_viscosity / (diffusion_viscosity + dislocation_viscosity) * edot_ii;
                       dislocation_strain_rate = diffusion_viscosity / (diffusion_viscosity + dislocation_viscosity) * edot_ii;
@@ -161,7 +161,7 @@ namespace aspect
             }
 
           // The effective viscosity, with minimum and maximum bounds
-          composition_viscosities[j] = std::min(std::max(stress_ii/edot_ii/2, min_visc), max_visc);
+          composition_viscosities[j] = std::min(std::max(stress_ii/edot_ii/2, minimum_viscosity), maximum_viscosity);
         }
       return composition_viscosities;
     }
@@ -421,8 +421,8 @@ namespace aspect
           // Reference and minimum/maximum values
           reference_T = prm.get_double("Reference temperature");
           min_strain_rate = prm.get_double("Minimum strain rate");
-          min_visc = prm.get_double ("Minimum viscosity");
-          max_visc = prm.get_double ("Maximum viscosity");
+          minimum_viscosity = prm.get_double ("Minimum viscosity");
+          maximum_viscosity = prm.get_double ("Maximum viscosity");
           veff_coefficient = prm.get_double ("Effective viscosity coefficient");
           ref_visc = prm.get_double ("Reference viscosity");
 

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -164,7 +164,7 @@ namespace aspect
             if (this->get_parameters().formulation == Parameters<dim>::Formulation::boussinesq_approximation)
               out.densities[i] = (reference_rho * density_temperature_dependence + density_composition_dependence + phase_dependence);
 
-            out.viscosities[i] = std::max(min_viscosity, std::min(max_viscosity, out.viscosities[i] * viscosity_phase_dependence));
+            out.viscosities[i] = std::max(minimum_viscosity, std::min(maximum_viscosity, out.viscosities[i] * viscosity_phase_dependence));
           }
 
           // Calculate entropy derivative
@@ -355,8 +355,8 @@ namespace aspect
           thermal_alpha              = prm.get_double ("Thermal expansion coefficient");
           reference_compressibility  = prm.get_double ("Compressibility");
           compositional_delta_rho    = prm.get_double ("Density differential for compositional field 1");
-          min_viscosity              = prm.get_double ("Minimum viscosity");
-          max_viscosity              = prm.get_double ("Maximum viscosity");
+          minimum_viscosity              = prm.get_double ("Minimum viscosity");
+          maximum_viscosity              = prm.get_double ("Maximum viscosity");
 
           phase_function.initialize_simulator (this->get_simulator());
           phase_function.parse_parameters (prm);

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -137,9 +137,9 @@ namespace aspect
         Rheology::DislocationCreepParameters dislocation_creep_parameters;
         Rheology::PeierlsCreepParameters peierls_creep_parameters;
         Rheology::DruckerPragerParameters drucker_prager_parameters;
-        double eta_diff = max_viscosity;
-        double eta_disl = max_viscosity;
-        double eta_prls = max_viscosity;
+        double eta_diff = maximum_viscosity;
+        double eta_disl = maximum_viscosity;
+        double eta_prls = maximum_viscosity;
 
         if (use_diffusion_creep)
           {
@@ -159,7 +159,7 @@ namespace aspect
             eta_prls = peierls_creep->compute_approximate_viscosity(edot_ii, pressure, temperature, composition);
           }
         // First guess at a stress using diffusion, dislocation, and Peierls creep viscosities calculated with the total second strain rate invariant.
-        const double eta_guess = std::min(std::max(min_viscosity, eta_diff*eta_disl*eta_prls/(eta_diff*eta_disl + eta_diff*eta_prls + eta_disl*eta_prls)), max_viscosity);
+        const double eta_guess = std::min(std::max(minimum_viscosity, eta_diff*eta_disl*eta_prls/(eta_diff*eta_disl + eta_diff*eta_prls + eta_disl*eta_prls)), maximum_viscosity);
 
         double creep_stress = 2.*eta_guess*edot_ii;
 
@@ -198,8 +198,8 @@ namespace aspect
                                                                    peierls_creep_parameters,
                                                                    drucker_prager_parameters);
 
-            const double strain_rate = creep_stress/(2.*max_viscosity) + (max_viscosity/(max_viscosity - min_viscosity))*creep_edot_and_deriv.first;
-            strain_rate_deriv = 1./(2.*max_viscosity) + (max_viscosity/(max_viscosity - min_viscosity))*creep_edot_and_deriv.second;
+            const double strain_rate = creep_stress/(2.*maximum_viscosity) + (maximum_viscosity/(maximum_viscosity - minimum_viscosity))*creep_edot_and_deriv.first;
+            strain_rate_deriv = 1./(2.*maximum_viscosity) + (maximum_viscosity/(maximum_viscosity - minimum_viscosity))*creep_edot_and_deriv.second;
 
             strain_rate_residual = strain_rate - edot_ii;
 
@@ -230,8 +230,8 @@ namespace aspect
 
         // The creep stress is not the total stress, so we still need to do a little work to obtain the effective viscosity.
         // First, we compute the stress running through the strain rate limiter, and then add that to the creep stress
-        // NOTE: The viscosity of the strain rate limiter is equal to (min_visc*max_visc)/(max_visc - min_visc)
-        const double lim_stress = 2.*min_viscosity*(edot_ii - creep_stress/(2.*max_viscosity));
+        // NOTE: The viscosity of the strain rate limiter is equal to (minimum_viscosity*maximum_viscosity)/(maximum_viscosity - minimum_viscosity)
+        const double lim_stress = 2.*minimum_viscosity*(edot_ii - creep_stress/(2.*maximum_viscosity));
         const double total_stress = creep_stress + lim_stress;
 
         // Compute the strain rate experienced by the different mechanisms
@@ -263,7 +263,7 @@ namespace aspect
             partial_strain_rates[3] = drpr_edot_and_deriv.first;
           }
 
-        partial_strain_rates[4] = total_stress/(2.*max_viscosity);
+        partial_strain_rates[4] = total_stress/(2.*maximum_viscosity);
 
         // Now we return the viscosity using the total stress
         return total_stress/(2.*edot_ii);
@@ -387,8 +387,8 @@ namespace aspect
         stress_max_iteration_number = prm.get_integer ("Maximum creep strain rate iterations");
 
         // Read min and max viscosity parameters
-        min_viscosity = prm.get_double ("Minimum viscosity");
-        max_viscosity = prm.get_double ("Maximum viscosity");
+        minimum_viscosity = prm.get_double ("Minimum viscosity");
+        maximum_viscosity = prm.get_double ("Maximum viscosity");
 
         // Rheological parameters
 

--- a/source/postprocess/entropy_viscosity_statistics.cc
+++ b/source/postprocess/entropy_viscosity_statistics.cc
@@ -47,7 +47,7 @@ namespace aspect
                                quadrature_formula,
                                update_JxW_values);
 
-      double local_max_viscosity = 0.0;
+      double local_maximum_viscosity = 0.0;
       double local_integrated_viscosity = 0.0;
       double local_volume = 0.0;
 
@@ -62,7 +62,7 @@ namespace aspect
             for (unsigned int q = 0; q < n_q_points; ++q)
               {
                 const double entropy_viscosity_cell = entropy_viscosity[cell->active_cell_index()];
-                local_max_viscosity = std::max(local_max_viscosity,entropy_viscosity_cell);
+                local_maximum_viscosity = std::max(local_maximum_viscosity,entropy_viscosity_cell);
                 local_volume += fe_values.JxW(q);
                 local_integrated_viscosity += entropy_viscosity_cell * fe_values.JxW(q);
               }
@@ -72,13 +72,13 @@ namespace aspect
         = Utilities::MPI::sum (local_integrated_viscosity, this->get_mpi_communicator());
       const double global_integrated_volume
         = Utilities::MPI::sum (local_volume, this->get_mpi_communicator());
-      const double global_max_viscosity
-        = Utilities::MPI::max (local_max_viscosity, this->get_mpi_communicator());
+      const double global_maximum_viscosity
+        = Utilities::MPI::max (local_maximum_viscosity, this->get_mpi_communicator());
 
       const double average_viscosity = global_integrated_viscosity / global_integrated_volume;
 
       statistics.add_value ("Max entropy viscosity (W/(m*K))",
-                            global_max_viscosity);
+                            global_maximum_viscosity);
       statistics.add_value ("Average entropy viscosity (W/(m*K))",
                             average_viscosity);
 
@@ -95,7 +95,7 @@ namespace aspect
 
       std::ostringstream output;
       output.precision(3);
-      output << global_max_viscosity
+      output << global_maximum_viscosity
              << " W/(m*K), "
              << average_viscosity
              << " W/(m*K)";

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -203,16 +203,16 @@ namespace aspect
              max_conductivity / geometry_model->length_scale() *
              cell_diameter;
 
-    const double max_viscosity = parameters.stabilization_beta[advection_field.field_index()] *
-                                 max_advection_prefactor *
-                                 max_velocity * cell_diameter;
+    const double maximum_viscosity = parameters.stabilization_beta[advection_field.field_index()] *
+                                     max_advection_prefactor *
+                                     max_velocity * cell_diameter;
 
     if (timestep_number <= 1
         || std::abs(global_entropy_variation) < 1e-50
         || std::abs(global_field_variation) < 1e-50)
       // we don't have sensible time-steps during the first two iterations
       // and we can not divide by the entropy_variation if it is zero
-      return max_viscosity;
+      return maximum_viscosity;
     else
       {
         Assert (old_time_step > 0, ExcInternalError());
@@ -230,7 +230,7 @@ namespace aspect
                                (global_u_infty * global_field_variation));
 
 
-        return std::min (max_viscosity, entropy_viscosity);
+        return std::min (maximum_viscosity, entropy_viscosity);
       }
   }
 

--- a/tests/visco_plastic_phases_viscosity_max_min.prm
+++ b/tests/visco_plastic_phases_viscosity_max_min.prm
@@ -1,0 +1,126 @@
+# Copy of visco_plastic.prm, but include a phase transition for the EoS
+# as well as different values of minimum and a maximum viscosity on different phases.
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Output directory                       = visco_plastic
+set Timing output frequency                = 1
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top, left, right
+  set List of model names = box
+  subsection Box
+    set Bottom temperature = 273
+    set Left temperature   = 273
+    set Right temperature  = 273
+    set Top temperature    = 273
+  end
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields = right
+  set Compositional field methods = field
+end
+
+subsection Initial composition model
+  set List of model names = function
+  set List of model operators = add
+  subsection Function
+     set Coordinate system = cartesian
+     set Variable names = x, y
+     set Function constants = XMAX=100e3
+     set Function expression = (x>XMAX/2.0) ? 1.0 : 0.0
+  end
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Phase transition depths = background:50e3|75e3, right:50e3|75e3
+    set Phase transition widths = background:1e3|1e3, right:1e3|1e3
+    set Phase transition temperatures = background:273|273, right:273|273
+    set Phase transition Clapeyron slopes = background:0|0, right:0|0
+
+    set Densities = background:3300|3400|3500, right:3600|3700|3800
+    set Thermal expansivities = background:3.5e-5|2e-5|1.5e-5, right:3.5e-5|2e-5|1.5e-5
+    set Heat capacities = background:1200|1000|900, right:1200|1000|900
+
+    # Set Maximum and Minimum viscosities on phases
+    set Maximum viscosity = background: 1.e21 | 1.e19 | 1.e21, right: 1.e20
+    set Minimum viscosity = background: 1.e17 | 1.e17 | 1.e19, right: 1.e16
+    set Reference strain rate = 1.e-16
+    set Viscous flow law = dislocation
+    set Prefactors for diffusion creep = background:5.e-20|5.e-19|5.e-18, right:5.e-17|5.e-16|5.e-15
+    set Grain size exponents for diffusion creep = background:3.|3.|3., right:3.|3.|3.
+    set Activation energies for diffusion creep = background:0.|0.|0., right:0.|0.|0.
+    set Activation volumes for diffusion creep = background:0.|0.|0., right:0.|0.|0.
+    set Prefactors for dislocation creep = background:5.e-23|5.e-21|5.e-19, right:5.e-18|5.e-17|5.e-16
+    set Stress exponents for dislocation creep = background:1.0|1.0|1.0, right:1.0|1.0|1.0
+    set Activation energies for dislocation creep = background:0.|0.|0., right:0.|0.|0.
+    set Activation volumes for dislocation creep = background:0.|0.|0., right:0.|0.|0.
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics, visualization, material statistics
+
+  subsection Visualization
+    set List of output variables = material properties
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 0
+  end
+end

--- a/tests/visco_plastic_phases_viscosity_max_min/screen-output
+++ b/tests/visco_plastic_phases_viscosity_max_min/screen-output
@@ -1,0 +1,37 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,885 (882+121+441+441)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving right system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+19 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                                 1.58 m/year, 8.6 m/year
+     Mass fluxes through boundary parts:                1.688e+05 kg/yr, 1.838e+05 kg/yr, -1.823e+05 kg/yr, -1.723e+05 kg/yr
+     Writing graphical output:                          output-visco_plastic_phases_viscosity_max_min/solution/solution-00000
+     Average density / Average viscosity / Total mass:  3521 kg/m^3, 2.477e+20 Pa s, 3.521e+13 kg
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_phases_viscosity_max_min/statistics
+++ b/tests/visco_plastic_phases_viscosity_max_min/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: RMS velocity (m/year)
+# 15: Max. velocity (m/year)
+# 16: Outward mass flux through boundary with indicator 0 ("left") (kg/yr)
+# 17: Outward mass flux through boundary with indicator 1 ("right") (kg/yr)
+# 18: Outward mass flux through boundary with indicator 2 ("bottom") (kg/yr)
+# 19: Outward mass flux through boundary with indicator 3 ("top") (kg/yr)
+# 20: Visualization file name
+# 21: Average density (kg/m^3)
+# 22: Average viscosity (Pa s)
+# 23: Total mass (kg)
+0 0.000000000000e+00 0.000000000000e+00 100 1003 441 441 1 0 0 18 134 38 1.58485112e+00 8.59961564e+00 1.68837875e+05 1.83845750e+05 -1.82268290e+05 -1.72334175e+05 output-visco_plastic_phases_viscosity_max_min/solution/solution-00000 3.52110576e+03 2.47680658e+20 3.52110576e+13 


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

I adjust the way "max_visc" and "min_visc" are parsed in the first place and extend them onto compositional phases in the visco_plastic model. This is motivated by granting flexibility to assign shear zone rheology in a subduction channel. It was first discussed in this issue:
https://github.com/geodynamics/aspect/issues/4417
I'd like to ask @anne-glerum or @bobmyhill to review this as they shared their thoughts on the previous issue. Are any of you available.
Since AGU is upcoming, we can slowly but surely go through this.
Thanks for your support.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
