### PR TITLE
CI: dealii-dev, show details

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,6 +94,8 @@ jobs:
         -D ASPECT_UNITY_BUILD=ON \
         ..
         ninja
+        cat detailed.log
+        ./aspect -v
         ./aspect --test
 
   tests:


### PR DESCRIPTION
It is convenient to see detailed.log and version info, to confirm what
deal.II sha1 was used.
