### PR TITLE
fix radiogenic heating assert

### DIFF
--- a/doc/modules/changes/20220103_ekendall
+++ b/doc/modules/changes/20220103_ekendall
@@ -1,0 +1,3 @@
+Fixed: Change assert throw for radiogenic heating such that it should only be evaluated if crust is defined by compostion.
+<br>
+(Elodie Kendall, 2022/01/03)

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -40,8 +40,11 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      AssertThrow(crust_composition_num < material_model_inputs.composition[0].size(),
-                  ExcMessage("The composition number of crust is larger than number of composition fields."));
+      if (is_crust_defined_by_composition)
+        {
+          AssertThrow(crust_composition_num < material_model_inputs.composition[0].size(),
+                      ExcMessage("The composition number of crust is larger than number of composition fields."));
+        }
 
       for (unsigned int q = 0; q < heating_model_outputs.heating_source_terms.size(); ++q)
         {


### PR DESCRIPTION
*Describe what you did in this PR and why you did it.*
In response to issue #4412 I changed the assert throw for radiogenic heating such that it should only be evaluated if crust is defined by composition.

### Before your first pull request:

* [ X] I have read the guidelines in our [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) document.

### For all pull requests:

* [ X] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [X ] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
