### PR TITLE
Add an assert

### DIFF
--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -842,6 +842,10 @@ namespace aspect
                                   const std::vector<double> &densities,
                                   const bool return_as_fraction)
       {
+        Assert(masses.size() == densities.size(),
+               ExcMessage ("The mass fractions and densities vectors used for computing "
+                           "volumes from masses have to have the same length!"));
+
         const unsigned int n_fields = masses.size();
         std::vector<double> volumes(n_fields);
 


### PR DESCRIPTION
This is a helpful check if one wants to implement the use of the new types of compositional fields in a material model, since it's easy to make mistakes in the number of fields in the mass fractions vector. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).