### PR TITLE
Rework the gravity postprocessor

### DIFF
--- a/include/aspect/postprocess/gravity_point_values.h
+++ b/include/aspect/postprocess/gravity_point_values.h
@@ -277,7 +277,7 @@ namespace aspect
         double model_outer_radius;
         double model_inner_radius;
 
-        std::vector<Point<dim>> satellites_coordinate;
+        std::vector<std::array<double,dim>> satellites_coordinate;
     };
   }
 }

--- a/include/aspect/postprocess/gravity_point_values.h
+++ b/include/aspect/postprocess/gravity_point_values.h
@@ -277,7 +277,12 @@ namespace aspect
         double model_outer_radius;
         double model_inner_radius;
 
-        std::vector<std::array<double,dim>> satellites_coordinate;
+        /**
+         * The positions of all satellite positions in spherical and
+         * Cartesian coordinate systems.
+         */
+        std::vector<std::array<double,dim>> satellite_positions_spherical;
+        std::vector<Point<dim>>             satellite_positions_cartesian;
     };
   }
 }

--- a/include/aspect/postprocess/gravity_point_values.h
+++ b/include/aspect/postprocess/gravity_point_values.h
@@ -63,6 +63,11 @@ namespace aspect
         GravityPointValues ();
 
         /**
+         * @copydoc Interface::initialize().
+         */
+        void initialize();
+
+        /**
          * Specify the creation of output_gravity.txt.
          */
         std::pair<std::string,std::string> execute (TableHandler &) override;
@@ -266,6 +271,13 @@ namespace aspect
          */
         std::vector<double> latitude_list;
 
+        // ------------ the following variables are not set from parameters,
+        //              but are instead computed up front from input
+        //              parameters and other parts of the overall model
+        double model_outer_radius;
+        double model_inner_radius;
+
+        std::vector<Point<dim>> satellites_coordinate;
     };
   }
 }

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -326,17 +326,17 @@ namespace aspect
       std::vector<Tensor<1,dim>>          local_g_anomaly (n_satellites);
       std::vector<SymmetricTensor<2,dim>> local_g_gradient (n_satellites);
 
-      for (unsigned int p=0; p < n_satellites; ++p)
-        {
-          const Point<dim> satellite_position = satellite_positions_cartesian[p];
-
-          // For each point (i.e. satellite), the fourth integral goes over cells and
-          // quadrature points to get the unique distance between those, to calculate
-          // gravity vector components x,y,z (in tensor), potential and gradients.
-          local_cell_number = 0;
-          for (const auto &cell : this->get_dof_handler().active_cell_iterators())
-            if (cell->is_locally_owned())
+      // For each point (i.e. satellite), the fourth integral goes over cells and
+      // quadrature points to get the unique distance between those, to calculate
+      // gravity vector components x,y,z (in tensor), potential and gradients.
+      local_cell_number = 0;
+      for (const auto &cell : this->get_dof_handler().active_cell_iterators())
+        if (cell->is_locally_owned())
+          {
+            for (unsigned int p=0; p < n_satellites; ++p)
               {
+                const Point<dim> satellite_position = satellite_positions_cartesian[p];
+
                 for (unsigned int q = 0; q < n_quadrature_points_per_cell; ++q)
                   {
                     const unsigned int array_index = local_cell_number * n_quadrature_points_per_cell + q;
@@ -365,9 +365,10 @@ namespace aspect
                                                                 * r_vector[e] * r_vector[f]
                                                                 - (e==f ? r_squared : 0));
                   }
-                ++local_cell_number;
               }
-        }
+
+            ++local_cell_number;
+          }
 
       for (unsigned int p=0; p < n_satellites; ++p)
         {

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -373,12 +373,10 @@ namespace aspect
 
 
       // open the file on rank 0 and write the headers
-      std::ofstream output;
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
         {
-          output.open(filename.c_str());
-          AssertThrow(output,
-                      ExcMessage("Unable to open file for writing: " + filename +"."));
+          // First put all of our output into a string buffer:
+          std::ostringstream output;
           output << "# 1: position_satellite_r" << '\n'
                  << "# 2: position_satellite_phi" << '\n'
                  << "# 3: position_satellite_theta" << '\n'
@@ -494,6 +492,12 @@ namespace aspect
                      << g_gradient_theory[1][2] *1e9 << ' '
                      << '\n';
             }
+
+          // Now push the entire buffer into the output file in one swoop fell:
+          std::ofstream output_file(filename);
+          AssertThrow(output_file,
+                      ExcMessage("Unable to open file for writing: " + filename +"."));
+          output_file << output.str();
         }
 
       // write quantities in the statistic file

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -321,7 +321,7 @@ namespace aspect
       const unsigned int n_satellites = satellite_positions_spherical.size();
       for (unsigned int p=0; p < n_satellites; ++p)
         {
-          const Point<dim> position_satellite = satellite_positions_cartesian[p];
+          const Point<dim> satellite_position = satellite_positions_cartesian[p];
 
           // For each point (i.e. satellite), the fourth integral goes over cells and
           // quadrature points to get the unique distance between those, to calculate
@@ -338,7 +338,7 @@ namespace aspect
                   {
                     const unsigned int array_index = local_cell_number * n_quadrature_points_per_cell + q;
 
-                    const Tensor<1,dim> r_vector = position_satellite - position_point[array_index];
+                    const Tensor<1,dim> r_vector = satellite_position - position_point[array_index];
 
                     const double r_squared = r_vector.norm_square();
                     const double r = std::sqrt(r_squared);
@@ -428,7 +428,7 @@ namespace aspect
               // Then do the off-diagonal elements:
               for (unsigned int e=0; e<dim; ++e)
                 for (unsigned int f=e; f<dim; ++f)
-                  g_gradient_theory[e][f] += -(- 3.0 * position_satellite[e] * position_satellite[f])
+                  g_gradient_theory[e][f] += -(- 3.0 * satellite_position[e] * satellite_position[f])
                                              /  std::pow(r,5);
               g_gradient_theory *= common_factor;
             }
@@ -440,9 +440,9 @@ namespace aspect
               output << satellite_positions_spherical[p][0] << ' '
                      << satellite_positions_spherical[p][1] *180. / numbers::PI << ' '
                      << satellite_positions_spherical[p][2] *180. / numbers::PI << ' '
-                     << position_satellite[0] << ' '
-                     << position_satellite[1] << ' '
-                     << position_satellite[2] << ' '
+                     << satellite_position[0] << ' '
+                     << satellite_position[1] << ' '
+                     << satellite_position[2] << ' '
                      << std::setprecision(precision)
                      << g << ' '
                      << g.norm() << ' '

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -326,9 +326,9 @@ namespace aspect
           // For each point (i.e. satellite), the fourth integral goes over cells and
           // quadrature points to get the unique distance between those, to calculate
           // gravity vector components x,y,z (in tensor), potential and gradients.
-          Tensor<1,dim> local_g;
-          Tensor<1,dim> local_g_anomaly;
-          Tensor<2,dim> local_g_gradient;
+          Tensor<1,dim>          local_g;
+          Tensor<1,dim>          local_g_anomaly;
+          SymmetricTensor<2,dim> local_g_gradient;
           double local_g_potential = 0;
           local_cell_number = 0;
           for (const auto &cell : this->get_dof_handler().active_cell_iterators())
@@ -366,10 +366,10 @@ namespace aspect
               }
 
           // Sum local gravity components over global domain:
-          const Tensor<1,dim> g          = Utilities::MPI::sum (local_g, this->get_mpi_communicator());
-          const Tensor<1,dim> g_anomaly  = Utilities::MPI::sum (local_g_anomaly, this->get_mpi_communicator());
-          const Tensor<2,dim> g_gradient = Utilities::MPI::sum (local_g_gradient, this->get_mpi_communicator());
-          const double g_potential       = Utilities::MPI::sum (local_g_potential, this->get_mpi_communicator());
+          const Tensor<1,dim>          g          = Utilities::MPI::sum (local_g, this->get_mpi_communicator());
+          const Tensor<1,dim>          g_anomaly  = Utilities::MPI::sum (local_g_anomaly, this->get_mpi_communicator());
+          const SymmetricTensor<2,dim> g_gradient = Utilities::MPI::sum (local_g_gradient, this->get_mpi_communicator());
+          const double                 g_potential= Utilities::MPI::sum (local_g_potential, this->get_mpi_communicator());
 
           // sum gravity components for all n_satellites:
           sum_g += g.norm();

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -270,8 +270,6 @@ namespace aspect
             ++local_cell_number;
           }
 
-      // Pre-Assign the coordinates of all satellites in a vector point:
-
       // open the file on rank 0 and write the headers
       std::ofstream output;
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
@@ -338,35 +336,38 @@ namespace aspect
               {
                 for (unsigned int q = 0; q < n_quadrature_points_per_cell; ++q)
                   {
-                    const double dist = (position_satellite - position_point[local_cell_number * n_quadrature_points_per_cell + q]).norm();
+                    const unsigned int array_index = local_cell_number * n_quadrature_points_per_cell + q;
+
+                    const double dist = (position_satellite - position_point[array_index]).norm();
+
                     // For gravity acceleration:
-                    const double KK = - G * density_JxW[local_cell_number * n_quadrature_points_per_cell + q] / std::pow(dist,3);
-                    local_g += KK * (position_satellite - position_point[local_cell_number * n_quadrature_points_per_cell + q]);
+                    const double KK = - G * density_JxW[array_index] / std::pow(dist,3);
+                    local_g += KK * (position_satellite - position_point[array_index]);
                     // For gravity anomalies:
-                    const double KK_anomalies = - G * density_anomalies_JxW[local_cell_number * n_quadrature_points_per_cell + q] / std::pow(dist,3);
-                    local_g_anomaly += KK_anomalies * (position_satellite - position_point[local_cell_number * n_quadrature_points_per_cell + q]);
+                    const double KK_anomalies = - G * density_anomalies_JxW[array_index] / std::pow(dist,3);
+                    local_g_anomaly += KK_anomalies * (position_satellite - position_point[array_index]);
                     // For gravity potential:
-                    local_g_potential -= G * density_JxW[local_cell_number * n_quadrature_points_per_cell + q] / dist;
+                    local_g_potential -= G * density_JxW[array_index] / dist;
                     // For gravity gradient:
-                    const double grad_KK = G * density_JxW[local_cell_number * n_quadrature_points_per_cell + q] / std::pow(dist,5);
+                    const double grad_KK = G * density_JxW[array_index] / std::pow(dist,5);
                     local_g_gradient[0][0] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[0] - position_point[local_cell_number * n_quadrature_points_per_cell + q][0]),2)
+                                                         * std::pow((position_satellite[0] - position_point[array_index][0]),2)
                                                          - std::pow(dist,2));
                     local_g_gradient[1][1] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[1] - position_point[local_cell_number * n_quadrature_points_per_cell + q][1]),2)
+                                                         * std::pow((position_satellite[1] - position_point[array_index][1]),2)
                                                          - std::pow(dist,2));
                     local_g_gradient[2][2] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[2] - position_point[local_cell_number * n_quadrature_points_per_cell + q][2]),2)
+                                                         * std::pow((position_satellite[2] - position_point[array_index][2]),2)
                                                          - std::pow(dist,2));
                     local_g_gradient[0][1] += grad_KK * (3.0
-                                                         * (position_satellite[0] - position_point[local_cell_number * n_quadrature_points_per_cell + q][0])
-                                                         * (position_satellite[1] - position_point[local_cell_number * n_quadrature_points_per_cell + q][1]));
+                                                         * (position_satellite[0] - position_point[array_index][0])
+                                                         * (position_satellite[1] - position_point[array_index][1]));
                     local_g_gradient[0][2] += grad_KK * (3.0
-                                                         * (position_satellite[0] - position_point[local_cell_number * n_quadrature_points_per_cell + q][0])
-                                                         * (position_satellite[2] - position_point[local_cell_number * n_quadrature_points_per_cell + q][2]));
+                                                         * (position_satellite[0] - position_point[array_index][0])
+                                                         * (position_satellite[2] - position_point[array_index][2]));
                     local_g_gradient[1][2] += grad_KK * (3.0
-                                                         * (position_satellite[1] - position_point[local_cell_number * n_quadrature_points_per_cell + q][1])
-                                                         * (position_satellite[2] - position_point[local_cell_number * n_quadrature_points_per_cell + q][2]));
+                                                         * (position_satellite[1] - position_point[array_index][1])
+                                                         * (position_satellite[2] - position_point[array_index][2]));
                   }
                 ++local_cell_number;
               }

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -338,40 +338,29 @@ namespace aspect
                   {
                     const unsigned int array_index = local_cell_number * n_quadrature_points_per_cell + q;
 
-                    const double r_squared = (position_satellite - position_point[array_index]).norm_square();
+                    const Tensor<1,dim> r_vector = position_satellite - position_point[array_index];
+
+                    const double r_squared = r_vector.norm_square();
                     const double r = std::sqrt(r_squared);
 
                     // For gravity acceleration:
                     const double KK = - G * density_JxW[array_index] / std::pow(r,3);
-                    local_g += KK * (position_satellite - position_point[array_index]);
+                    local_g += KK * r_vector;
 
                     // For gravity anomalies:
                     const double KK_anomalies = - G * density_anomalies_JxW[array_index] / std::pow(r,3);
-                    local_g_anomaly += KK_anomalies * (position_satellite - position_point[array_index]);
+                    local_g_anomaly += KK_anomalies * r_vector;
 
                     // For gravity potential:
                     local_g_potential -= G * density_JxW[array_index] / r;
 
                     // For gravity gradient:
                     const double grad_KK = G * density_JxW[array_index] / std::pow(r,5);
-                    local_g_gradient[0][0] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[0] - position_point[array_index][0]),2)
-                                                         - r_squared);
-                    local_g_gradient[1][1] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[1] - position_point[array_index][1]),2)
-                                                         - r_squared);
-                    local_g_gradient[2][2] += grad_KK * (3.0
-                                                         * std::pow((position_satellite[2] - position_point[array_index][2]),2)
-                                                         - r_squared);
-                    local_g_gradient[0][1] += grad_KK * (3.0
-                                                         * (position_satellite[0] - position_point[array_index][0])
-                                                         * (position_satellite[1] - position_point[array_index][1]));
-                    local_g_gradient[0][2] += grad_KK * (3.0
-                                                         * (position_satellite[0] - position_point[array_index][0])
-                                                         * (position_satellite[2] - position_point[array_index][2]));
-                    local_g_gradient[1][2] += grad_KK * (3.0
-                                                         * (position_satellite[1] - position_point[array_index][1])
-                                                         * (position_satellite[2] - position_point[array_index][2]));
+                    for (unsigned int e=0; e<dim; ++e)
+                      for (unsigned int f=e; f<dim; ++f)
+                        local_g_gradient[e][f] += grad_KK * (3.0
+                                                             * r_vector[e] * r_vector[f]
+                                                             - (e==f ? r_squared : 0));
                   }
                 ++local_cell_number;
               }

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -391,15 +391,11 @@ namespace aspect
                  << "# 28: gravity_gradient_theory_xz" << '\n'
                  << "# 29: gravity_gradient_theory_yz" << '\n'
                  << '\n';
-        }
 
-      for (unsigned int p=0; p < n_satellites; ++p)
-        {
-          const Point<dim> satellite_position = satellite_positions_cartesian[p];
-
-          // On processor 0, compute analytical solutions and write output
-          if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+          for (unsigned int p=0; p < n_satellites; ++p)
             {
+              const Point<dim> satellite_position = satellite_positions_cartesian[p];
+
               // analytical solution to calculate the theoretical gravity and its derivatives
               // from a uniform density model. Can only be used if concentric density profile.
               double g_theory = 0;

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -319,11 +319,8 @@ namespace aspect
 
           // The spherical coordinates are shifted into cartesian to allow simplification
           // in the mathematical equation.
-          std::array<double,dim> satellite_point_coordinate;
-          satellite_point_coordinate[0] = satellites_coordinate[p][0];
-          satellite_point_coordinate[1] = satellites_coordinate[p][1];
-          satellite_point_coordinate[2] = satellites_coordinate[p][2];
-          const Point<dim> position_satellite = Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(satellite_point_coordinate);
+          const Point<dim> position_satellite
+            = Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(satellites_coordinate[p]);
 
           // For each point (i.e. satellite), the fourth integral goes over cells and
           // quadrature points to get the unique distance between those, to calculate

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -285,23 +285,25 @@ namespace aspect
 
                     const double r_squared = r_vector.norm_square();
                     const double r = std::sqrt(r_squared);
+                    const double r_cubed = r * r_squared;
+                    const double one_over_r_cubed = 1. / r_cubed;
+                    const double r_to_the_5 = r_squared * r_cubed;
 
                     const double G_density_JxW = G_times_density_times_JxW[q];
 
                     // For gravity acceleration:
-                    const double KK = - G_density_JxW / std::pow(r,3);
+                    const double KK = - G_density_JxW * one_over_r_cubed;
                     local_g[p] += KK * r_vector;
 
                     // For gravity anomalies:
-                    const double KK_anomalies = - G_times_density_anomaly_times_JxW[q] /
-                                                std::pow(r,3);
+                    const double KK_anomalies = - G_times_density_anomaly_times_JxW[q] * one_over_r_cubed;
                     local_g_anomaly[p] += KK_anomalies * r_vector;
 
                     // For gravity potential:
                     local_g_potential[p] -= G_density_JxW / r;
 
                     // For gravity gradient:
-                    const double grad_KK = G_density_JxW / std::pow(r,5);
+                    const double grad_KK = G_density_JxW / r_to_the_5;
                     for (unsigned int e=0; e<dim; ++e)
                       for (unsigned int f=e; f<dim; ++f)
                         local_g_gradient[p][e][f] += grad_KK * (3.0

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -374,14 +374,10 @@ namespace aspect
           // sum gravity components for all n_satellites:
           sum_g += g.norm();
           sum_g_potential += g_potential;
-          if (g.norm() > max_g)
-            max_g = g.norm();
-          if (g.norm() < min_g)
-            min_g = g.norm();
-          if (g_potential > max_g_potential)
-            max_g_potential = g_potential;
-          if (g_potential < min_g_potential)
-            min_g_potential = g_potential;
+          max_g = std::max(g.norm(), max_g);
+          min_g = std::min(g.norm(), min_g);
+          max_g_potential = std::max(g_potential, max_g_potential);
+          min_g_potential = std::min(g_potential, min_g_potential);
 
           // On processor 0, compute analytical solutions and write output
           if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -338,27 +338,31 @@ namespace aspect
                   {
                     const unsigned int array_index = local_cell_number * n_quadrature_points_per_cell + q;
 
-                    const double dist = (position_satellite - position_point[array_index]).norm();
+                    const double r_squared = (position_satellite - position_point[array_index]).norm_square();
+                    const double r = std::sqrt(r_squared);
 
                     // For gravity acceleration:
-                    const double KK = - G * density_JxW[array_index] / std::pow(dist,3);
+                    const double KK = - G * density_JxW[array_index] / std::pow(r,3);
                     local_g += KK * (position_satellite - position_point[array_index]);
+
                     // For gravity anomalies:
-                    const double KK_anomalies = - G * density_anomalies_JxW[array_index] / std::pow(dist,3);
+                    const double KK_anomalies = - G * density_anomalies_JxW[array_index] / std::pow(r,3);
                     local_g_anomaly += KK_anomalies * (position_satellite - position_point[array_index]);
+
                     // For gravity potential:
-                    local_g_potential -= G * density_JxW[array_index] / dist;
+                    local_g_potential -= G * density_JxW[array_index] / r;
+
                     // For gravity gradient:
-                    const double grad_KK = G * density_JxW[array_index] / std::pow(dist,5);
+                    const double grad_KK = G * density_JxW[array_index] / std::pow(r,5);
                     local_g_gradient[0][0] += grad_KK * (3.0
                                                          * std::pow((position_satellite[0] - position_point[array_index][0]),2)
-                                                         - std::pow(dist,2));
+                                                         - r_squared);
                     local_g_gradient[1][1] += grad_KK * (3.0
                                                          * std::pow((position_satellite[1] - position_point[array_index][1]),2)
-                                                         - std::pow(dist,2));
+                                                         - r_squared);
                     local_g_gradient[2][2] += grad_KK * (3.0
                                                          * std::pow((position_satellite[2] - position_point[array_index][2]),2)
-                                                         - std::pow(dist,2));
+                                                         - r_squared);
                     local_g_gradient[0][1] += grad_KK * (3.0
                                                          * (position_satellite[0] - position_point[array_index][0])
                                                          * (position_satellite[1] - position_point[array_index][1]));


### PR DESCRIPTION
@cedrict complained that the gravity postprocessor is slow. This patch reworks a good bit of it to make it a bit easier to read and (slightly) more efficient. I have more work to do regarding efficiency, but thought I'd get this out of the way already. It's probably easiest to read side-by-side.

I've broken the work into self-contained commits that I've individually tested. I think that also makes it easier to follow the flow of the transformations I've applied.

/rebuild