### PR TITLE
use new "density" field type for density fields

### DIFF
--- a/benchmarks/compressibility_formulations/lateral_pipe/lateral_pipe.prm
+++ b/benchmarks/compressibility_formulations/lateral_pipe/lateral_pipe.prm
@@ -40,6 +40,7 @@ subsection Compositional fields
   set Number of fields = 1
   set Names of fields = density_field
   set Compositional field methods = prescribed field
+  set Types of fields             = density
 end
 
 subsection Initial composition model

--- a/benchmarks/compressibility_formulations/lateral_pipe_advect/lateral_pipe.prm
+++ b/benchmarks/compressibility_formulations/lateral_pipe_advect/lateral_pipe.prm
@@ -51,6 +51,7 @@ subsection Compositional fields
   set Number of fields = 1
   set Names of fields = density_field
   set Compositional field methods = prescribed field
+  set Types of fields             = density
 end
 
 subsection Initial composition model

--- a/benchmarks/compressibility_formulations/lateral_pipe_increase_pressure/lateral_pipe.prm
+++ b/benchmarks/compressibility_formulations/lateral_pipe_increase_pressure/lateral_pipe.prm
@@ -50,6 +50,7 @@ subsection Compositional fields
   set Number of fields = 1
   set Names of fields = density_field
   set Compositional field methods = prescribed field
+  set Types of fields             = density
 end
 
 subsection Initial composition model

--- a/benchmarks/compressibility_formulations/lateral_pipe_transient/lateral_pipe.prm
+++ b/benchmarks/compressibility_formulations/lateral_pipe_transient/lateral_pipe.prm
@@ -48,6 +48,7 @@ subsection Compositional fields
   set Number of fields = 1
   set Names of fields = density_field
   set Compositional field methods = prescribed field
+  set Types of fields             = density
 end
 
 subsection Initial composition model

--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -31,8 +31,8 @@ namespace aspect
   {
     /**
      * A material model that is identical to the simple compressible model,
-     * except that the density is tracked in a compositional field named
-     * 'density_field' using the prescribed field advection method. It also
+     * except that the density is tracked in a compositional field of type
+     * 'density' using the prescribed field advection method. It also
      * allows some modification to the density and thermal expansivity
      * calculation for the compressibility benchmarks.
      *
@@ -145,7 +145,7 @@ namespace aspect
     {
       base_model->evaluate(in,out);
 
-      const unsigned int density_field_index = this->introspection().compositional_index_for_name("density_field");
+      const unsigned int density_field_index = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
@@ -275,9 +275,9 @@ namespace aspect
     ASPECT_REGISTER_MATERIAL_MODEL(CompressibilityFormulations,
                                    "compressibility formulations",
                                    "A material model that is identical to the simple compressible model, "
-                                   " except that the density is tracked in a compositional field named "
-                                   " 'density_field' using the prescribed field advection method. It also "
-                                   " allows some modification to the density and thermal expansivity "
-                                   " calculation for the compressibility benchmarks.")
+                                   "except that the density is tracked in a compositional field of type "
+                                   "'density' using the prescribed field advection method. It also "
+                                   "allows some modification to the density and thermal expansivity "
+                                   "calculation for the compressibility benchmarks.")
   }
 }

--- a/benchmarks/compressibility_formulations/vertical_pipe/vertical_pipe.prm
+++ b/benchmarks/compressibility_formulations/vertical_pipe/vertical_pipe.prm
@@ -45,6 +45,7 @@ subsection Compositional fields
   set Number of fields = 1
   set Names of fields = density_field
   set Compositional field methods = prescribed field
+  set Types of fields             = density
 end
 
 

--- a/include/aspect/initial_composition/adiabatic_density.h
+++ b/include/aspect/initial_composition/adiabatic_density.h
@@ -35,7 +35,7 @@ namespace aspect
     /**
      * A class that implements initial conditions for the compositional fields
      * based on the adiabatic density profile. Note that only the field
-     * with the name 'density_field' will be filled, for all other fields
+     * of the type 'density' will be filled, for all other fields
      * this plugin returns 0.0.
      *
      * @ingroup InitialCompositionModels

--- a/include/aspect/simulator/assemblers/stokes.h
+++ b/include/aspect/simulator/assemblers/stokes.h
@@ -152,7 +152,7 @@ namespace aspect
      * This class approximates this term as
      * $ - \nabla \cdot \mathbf{u} = \frac{1}{\rho} \frac{\partial \rho}{\partial t} + \frac{1}{\rho} \nabla \rho \cdot \mathbf{u}$
      * where the right-hand side velocity is explicitly taken from the last timestep,
-     * and the density is taken from a compositional field called 'density_field'.
+     * and the density is taken from a compositional field of the type 'density'.
      */
     template <int dim>
     class StokesProjectedDensityFieldTerm : public Assemblers::Interface<dim>,

--- a/source/initial_composition/adiabatic_density.cc
+++ b/source/initial_composition/adiabatic_density.cc
@@ -32,7 +32,7 @@ namespace aspect
     AdiabaticDensity<dim>::
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
-      if (n_comp == this->introspection().compositional_index_for_name("density_field"))
+      if (n_comp == this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density))
         return this->get_adiabatic_conditions().density(position);
 
       return 0.0;
@@ -48,7 +48,7 @@ namespace aspect
     ASPECT_REGISTER_INITIAL_COMPOSITION_MODEL(AdiabaticDensity,
                                               "adiabatic density",
                                               "Specify the initial composition as the adiabatic reference density at "
-                                              "each position. Note that only the field with the name 'density\\_field' "
-                                              "will be filled for all other fields this plugin returns 0.0.")
+                                              "each position. Note that only the field of the type 'density' "
+                                              "will be filled. For all other fields this plugin returns 0.0.")
   }
 }

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -726,7 +726,7 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
-      const unsigned int density_idx = this->introspection().compositional_index_for_name("density_field");
+      const unsigned int density_idx = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
 
       const double time_step = this->get_timestep();
       const double old_time_step = this->get_old_timestep();

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1924,7 +1924,7 @@ namespace aspect
     distributed_vector.block(advection_block).compress(VectorOperation::insert);
 
     if (adv_field.is_temperature() ||
-        introspection.name_for_compositional_index(adv_field.compositional_variable) != "density_field")
+        adv_field.compositional_variable != introspection.find_composition_type(Parameters<dim>::CompositionalFieldDescription::density))
       current_constraints.distribute (distributed_vector);
 
     solution.block(advection_block) = distributed_vector.block(advection_block);

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1834,12 +1834,18 @@ namespace aspect
                                "fields needs to either have one entry or have a length equal to "
                                "the number of compositional fields."));
 
-      AssertThrow (std::count(x_compositional_field_types.begin(), x_compositional_field_types.end(), "density") < 2,
-                   ExcMessage("There can only be one field of type 'density' in a simulation!"));
-
       // If only one method is specified apply this to all fields
       if (x_compositional_field_types.size() == 1)
         x_compositional_field_types = std::vector<std::string> (n_compositional_fields, x_compositional_field_types[0]);
+
+      // For backwards compatibility, convert a field named "density_field" without type to a density field
+      const unsigned int density_index = std::find(names_of_compositional_fields.begin(), names_of_compositional_fields.end(), "density_field")
+                                         - names_of_compositional_fields.begin();
+      if (density_index != n_compositional_fields && x_compositional_field_types[density_index] == "unspecified")
+        x_compositional_field_types[density_index] = "density";
+
+      AssertThrow (std::count(x_compositional_field_types.begin(), x_compositional_field_types.end(), "density") < 2,
+                   ExcMessage("There can only be one field of type 'density' in a simulation!"));
 
       composition_descriptions.resize(n_compositional_fields);
 


### PR DESCRIPTION
This is the promised follow-up to #4450 and #4451. Everywhere in the code where we were asking for a field named "density_field", we now check for the compositional field type "density" instead. I hope I found everything. 

This is also backwards compatible, since a field that is called "density_field" but has the type unspecified will be converted to type density upon reading in the parameters. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).