### PR TITLE
fix periodic boundary conditions in compressible models

### DIFF
--- a/doc/modules/changes/20220126_jdannberg
+++ b/doc/modules/changes/20220126_jdannberg
@@ -1,3 +1,9 @@
-Fixed: Periodic boundaries now work correctly in compressible models.
+Fixed: Compressible models with periodic boundaries that did not also
+have one or more open boundaries did not correctly apply the necessary
+pressure right-hand side compatibility modification when solving the
+Stokes equations. This generally caused the linear solver to fail or to
+take many more iterations than necessary. The right-hand side pressure
+compatibility modification is now applied correctly, fixing this problem
+and allowing it to use periodic boudaries in compressible models.
 <br>
 (Juliane Dannberg, 2022/01/26)

--- a/doc/modules/changes/20220126_jdannberg
+++ b/doc/modules/changes/20220126_jdannberg
@@ -1,0 +1,3 @@
+Fixed: Periodic boundaries now work correctly in compressible models.
+<br>
+(Juliane Dannberg, 2022/01/26)

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -475,6 +475,16 @@ namespace aspect
     for (const auto p : boundary_velocity_manager.get_tangential_boundary_velocity_indicators())
       open_velocity_boundary_indicators.erase (p);
 
+    // Make sure that we do the pressure right-hand side modification correctly for periodic boundaries
+    using periodic_boundary_set
+      = std::set< std::pair< std::pair< types::boundary_id, types::boundary_id>, unsigned int>>;
+    periodic_boundary_set pbs = geometry_model->get_periodic_boundary_pairs();
+    for (periodic_boundary_set::iterator p = pbs.begin(); p != pbs.end(); ++p)
+      {
+        open_velocity_boundary_indicators.erase ((*p).first.first);
+        open_velocity_boundary_indicators.erase ((*p).first.second);
+      }
+
     // We need to do the RHS compatibility modification, if the model is
     // compressible or compatible (in the case of melt transport), and
     // there is no open boundary to balance the pressure.

--- a/tests/periodic_compressible.prm
+++ b/tests/periodic_compressible.prm
@@ -1,0 +1,90 @@
+# This is a test case for periodic boundary conditions in a model
+# with a compressible material model.
+
+set Dimension                              = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Adiabatic surface temperature          = 1613.0
+set Output directory                       = periodic
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = iterated Advection and Stokes
+set Max nonlinear iterations               = 3
+
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent   = 2900000
+    set Y extent   = 2900000
+    set X periodic = true
+  end
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = top, bottom
+  set List of model names = box
+
+  subsection Box
+    set Bottom temperature = 3773
+    set Top temperature = 273
+  end
+end
+
+
+subsection Initial temperature model
+  set List of model names = adiabatic, function
+
+  subsection Function
+    set Coordinate system   = cartesian
+    set Variable names      = x, y
+    set Function constants  = d = 2900000
+    set Function expression = 50 * sin(2*x/d*pi)*sin(2*y/d*pi)
+  end
+
+  subsection Adiabatic
+    set Age top boundary layer = 1e8
+    set Age bottom boundary layer = 1e8
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple compressible
+
+  subsection Simple compressible model
+    set Viscosity                     = 1e22
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 5
+  set Time steps between mesh refinement = 0
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = top
+  set Zero velocity boundary indicators = bottom
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization,velocity statistics,temperature statistics,heat flux statistics
+
+  subsection Visualization
+    set Output format                 = vtu
+    set List of output variables      = viscosity, density, thermal expansivity, specific heat, nonadiabatic temperature #, named additional outputs
+    set Time between graphical output = 1e6
+  end
+end

--- a/tests/periodic_compressible/screen-output
+++ b/tests/periodic_compressible/screen-output
@@ -1,0 +1,41 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58886e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 31+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.55733e-16, 0.0690827
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0690827
+
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 28+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58304e-16, 0.0147308
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0147308
+
+
+   Postprocessing:
+     Writing graphical output:           output-periodic_compressible/solution/solution-00000
+     RMS, max velocity:                  0.00413 m/year, 0.00624 m/year
+     Temperature min/avg/max:            273 K, 1622 K, 3773 K
+     Heat fluxes through boundary parts: 4.285e+04 W, -4.285e+04 W, -3.299e+05 W, 1.697e+05 W
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/periodic_compressible/statistics
+++ b/tests/periodic_compressible/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Average nondimensional temperature (K)
+# 19: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 20: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 21: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 22: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 3 0 86 92 273 output-periodic_compressible/solution/solution-00000 4.12865921e-03 6.23699087e-03 2.73000000e+02 1.62186269e+03 3.77300000e+03 3.85389341e-01 4.28501304e+04 -4.28501304e+04 -3.29934227e+05 1.69745572e+05 


### PR DESCRIPTION
Compressible models with periodic boundaries did not work before. The ones I tried always crashed in the Stokes solver or had very large iteration counts. The problem was that we did not do the pressure right-hand side compatibility modification in case a model had periodic boundaries. This PR fixes this. 
I added a very simple test case, but I also tested this with a more complex model (spherical geometry, nullspace removal, strong viscosity contrast, material properties read in from a look-up table) and it worked as well. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
