### PR TITLE
Do not create unnecessary failing assembler for compressible Newton models with full A block preconditioner

### DIFF
--- a/doc/modules/changes/20220202_gassmoeller
+++ b/doc/modules/changes/20220202_gassmoeller
@@ -1,0 +1,5 @@
+Fixed: When using the full A block as Stokes preconditioner in a compressible
+model using a Newton solver scheme we added an unnecessary assembler, which
+would throw an assertion. This is fixed now by not adding the assembler.
+<br>
+(Rene Gassmoeller, 2022/02/02)

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -53,8 +53,10 @@ namespace aspect
 
     if (this->get_material_model().is_compressible())
       {
-        assemblers.stokes_preconditioner.push_back(
-          std::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
+        // The compressible part of the preconditioner is only necessary if we use the simplified A block
+        if (this->get_parameters().use_full_A_block_preconditioner == false)
+          assemblers.stokes_preconditioner.push_back(
+            std::make_unique<aspect::Assemblers::StokesCompressiblePreconditioner<dim>>());
 
         assemblers.stokes_system.push_back(
           std::make_unique<aspect::Assemblers::NewtonStokesCompressibleStrainRateViscosityTerm<dim>>());

--- a/tests/tosi_benchmark_newton_solver_full_A.cc
+++ b/tests/tosi_benchmark_newton_solver_full_A.cc
@@ -1,0 +1,1 @@
+#include <../benchmarks/tosi_et_al_2015_gcubed/tosi.cc>

--- a/tests/tosi_benchmark_newton_solver_full_A.prm
+++ b/tests/tosi_benchmark_newton_solver_full_A.prm
@@ -1,0 +1,15 @@
+# This is a test for the Tosi benchmark using the Newton solver and the full A block
+# as preconditioner. Prior to this test there was a bug assigning the correct assemblers
+# for this case.
+
+include $ASPECT_SOURCE_DIR/benchmarks/newton_solver_benchmark_set/tosi_et_al_2015/input.prm
+
+set Additional shared libraries            = ./libnewton_solver_tosi.so
+set End time                               = 0.0021
+set Max nonlinear iterations               = 15
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Use full A block as preconditioner = true
+  end
+end

--- a/tests/tosi_benchmark_newton_solver_full_A/screen-output
+++ b/tests/tosi_benchmark_newton_solver_full_A/screen-output
@@ -1,0 +1,354 @@
+
+Loading shared library <./libtosi_benchmark_newton_solver_full_A.so>
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 3,556 (2,178+289+1,089)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Initial Newton Stokes residual = 1.97927, v = 1.97927, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 26+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.97927
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00881173, norm of the rhs: 0.0174408, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 31+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00135946, norm of the rhs: 0.00269075, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000210497, norm of the rhs: 0.00041663, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.31635e-05, norm of the rhs: 6.56396e-05, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 0 iterations.
+   Switching from defect correction form of Picard to the Newton solver scheme.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 2.44385e-05, norm of the rhs: 4.83705e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 1.436e-05, norm of the rhs: 2.84224e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 6.27573e-06, norm of the rhs: 1.24214e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 3.67085e-06, norm of the rhs: 7.26562e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 6+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.53142e-06, norm of the rhs: 3.0311e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 6+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 4.18869e-07, norm of the rhs: 8.29055e-07, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 0 iterations.
+   The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 5.09389e-08, norm of the rhs: 1.00822e-07, newton_derivative_scaling_factor: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                               3.24 m/s, 15.3 m/s
+     Temperature min/avg/max:                         0 K, 0.5 K, 1 K
+     Heat fluxes through boundary parts:              0 W, 0 W, -1 W, 1 W
+     Writing graphical output:                        output-tosi_benchmark_newton_solver_full_A/solution/solution-00000
+     Writing depth average:                           output-tosi_benchmark_newton_solver_full_A/depth_average
+     Max, min, and rms velocity along boundary parts: 4.078 m/s, 0.001682 m/s, 1.925 m/s, 3.705 m/s, 0.001647 m/s, 1.741 m/s, 15.58 m/s, 0.3344 m/s, 11.01 m/s, 0.07246 m/s, 0.00166 m/s, 0.05188 m/s
+
+*** Timestep 1:  t=0.00200722 seconds, dt=0.00200722 seconds
+   Solving temperature system... 19 iterations.
+   Initial Newton Stokes residual = 0.0421701, v = 0.0421701, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.181916, norm of the rhs: 0.00767142
+
+   Solving temperature system... 20 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0796469, norm of the rhs: 0.00335872, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 22 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0921921, norm of the rhs: 0.00388775, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 23 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.109122, norm of the rhs: 0.00460168, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 25 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 37+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.137921, norm of the rhs: 0.00581613, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 29 iterations.
+   Switching from defect correction form of Picard to the Newton solver scheme.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.474332, norm of the rhs: 0.0200026, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 29 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.540454, norm of the rhs: 0.022791, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 32 iterations.
+   The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 14+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.43636, norm of the rhs: 0.0184014, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 37 iterations.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.863575, norm of the rhs: 0.0364171, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 38 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.948113, norm of the rhs: 0.039982, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 40 iterations.
+   The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.935943, norm of the rhs: 0.0394688, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 43 iterations.
+   The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.77355, norm of the rhs: 0.0326207, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 44 iterations.
+   The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.40844, norm of the rhs: 0.017224, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 48 iterations.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.914189, norm of the rhs: 0.0385515, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 47 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.859895, norm of the rhs: 0.0362619, newton_derivative_scaling_factor: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                               84.9 m/s, 410 m/s
+     Temperature min/avg/max:                         0 K, 0.5043 K, 1 K
+     Heat fluxes through boundary parts:              0 W, 0 W, -3.128 W, 1 W
+     Max, min, and rms velocity along boundary parts: 421.2 m/s, 0.01105 m/s, 178.2 m/s, 215.5 m/s, 0.006346 m/s, 83.39 m/s, 375.3 m/s, 18.5 m/s, 235.8 m/s, 0.3302 m/s, 0.00604 m/s, 0.2397 m/s
+
+*** Timestep 2:  t=0.00208141 seconds, dt=7.41954e-05 seconds
+   Solving temperature system... 10 iterations.
+   Initial Newton Stokes residual = 0.199136, v = 0.199136, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.174222, norm of the rhs: 0.034694
+
+   Solving temperature system... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0101078, norm of the rhs: 0.00201282, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00348977, norm of the rhs: 0.000694941, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 8 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.00127419, norm of the rhs: 0.000253737, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 7 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.000484727, norm of the rhs: 9.65268e-05, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 6 iterations.
+   Switching from defect correction form of Picard to the Newton solver scheme.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.000428921, norm of the rhs: 8.54137e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 6 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 6+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.000325543, norm of the rhs: 6.48274e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 5 iterations.
+   The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.000231552, norm of the rhs: 4.61104e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 5 iterations.
+   The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.000132927, norm of the rhs: 2.64706e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 5 iterations.
+   The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.15421e-05, norm of the rhs: 8.27254e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 5 iterations.
+   The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.10933e-05, norm of the rhs: 2.20908e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 4 iterations.
+   The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 1.05113e-06, norm of the rhs: 2.09318e-07, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.00940647. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 8.12157e-08, norm of the rhs: 1.6173e-08, newton_derivative_scaling_factor: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                               93.9 m/s, 444 m/s
+     Temperature min/avg/max:                         0 K, 0.5045 K, 1 K
+     Heat fluxes through boundary parts:              0 W, 0 W, -3.239 W, 1 W
+     Max, min, and rms velocity along boundary parts: 457.6 m/s, 0.01113 m/s, 194.3 m/s, 293.1 m/s, 0.005378 m/s, 114 m/s, 391.4 m/s, 17.12 m/s, 255.5 m/s, 0.3155 m/s, 0.005362 m/s, 0.227 m/s
+
+*** Timestep 3:  t=0.0021 seconds, dt=1.8587e-05 seconds
+   Solving temperature system... 7 iterations.
+   Initial Newton Stokes residual = 0.205957, v = 0.205957, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 32+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0375195, norm of the rhs: 0.0077274
+
+   Solving temperature system... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00203865, norm of the rhs: 0.000419874, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 5 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000693454, norm of the rhs: 0.000142822, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 5 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 33+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000264699, norm of the rhs: 5.45168e-05, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 4 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 32+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.000110218, norm of the rhs: 2.27001e-05, newton_derivative_scaling_factor: 0
+
+   Solving temperature system... 4 iterations.
+   Switching from defect correction form of Picard to the Newton solver scheme.
+   The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 9.95512e-05, norm of the rhs: 2.05033e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 8.23279e-05, norm of the rhs: 1.6956e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 5.5846e-05, norm of the rhs: 1.15019e-05, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 2.70825e-05, norm of the rhs: 5.57783e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.18672e-05, norm of the rhs: 2.44413e-06, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 3 iterations.
+   The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 4+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.521e-06, norm of the rhs: 5.19218e-07, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 2 iterations.
+   The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 5+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 3.65236e-07, norm of the rhs: 7.52229e-08, newton_derivative_scaling_factor: 1
+
+   Solving temperature system... 2 iterations.
+   The linear solver tolerance is set to 0.0320063. Stabilization Preconditioner is SPD and A block is SPD.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 15+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 7.12356e-08, norm of the rhs: 1.46715e-08, newton_derivative_scaling_factor: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                               95 m/s, 450 m/s
+     Temperature min/avg/max:                         0 K, 0.5045 K, 1 K
+     Heat fluxes through boundary parts:              0 W, 0 W, -3.27 W, 1 W
+     Max, min, and rms velocity along boundary parts: 464.1 m/s, 0.01129 m/s, 197.1 m/s, 300.3 m/s, 0.00541 m/s, 116.8 m/s, 394.7 m/s, 17.38 m/s, 257.8 m/s, 0.3185 m/s, 0.005393 m/s, 0.2291 m/s
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/tosi_benchmark_newton_solver_full_A/statistics
+++ b/tests/tosi_benchmark_newton_solver_full_A/statistics
@@ -1,0 +1,38 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: RMS velocity (m/s)
+# 13: Max. velocity (m/s)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 22: Visualization file name
+# 23: Maximum velocity magnitude on boundary with indicator 0 ("left") (m/s)
+# 24: Minimum velocity magnitude on boundary with indicator 0 ("left") (m/s)
+# 25: RMS velocity on boundary with indicator 0 ("left") (m/s)
+# 26: Maximum velocity magnitude on boundary with indicator 1 ("right") (m/s)
+# 27: Minimum velocity magnitude on boundary with indicator 1 ("right") (m/s)
+# 28: RMS velocity on boundary with indicator 1 ("right") (m/s)
+# 29: Maximum velocity magnitude on boundary with indicator 2 ("bottom") (m/s)
+# 30: Minimum velocity magnitude on boundary with indicator 2 ("bottom") (m/s)
+# 31: RMS velocity on boundary with indicator 2 ("bottom") (m/s)
+# 32: Maximum velocity magnitude on boundary with indicator 3 ("top") (m/s)
+# 33: Minimum velocity magnitude on boundary with indicator 3 ("top") (m/s)
+# 34: RMS velocity on boundary with indicator 3 ("top") (m/s)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 12   0 173 197 366 3.24199594e+00 1.53236839e+01 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01 0.00000000e+00 0.00000000e+00 -1.00002689e+00 9.99999989e-01 output-tosi_benchmark_newton_solver_full_A/solution/solution-00000 4.07821249e+00 1.68193114e-03 1.92482922e+00 3.70514355e+00 1.64727429e-03 1.74147128e+00 1.55774035e+01 3.34367960e-01 1.10138895e+01 7.24640402e-02 1.66001613e-03 5.18831246e-02 
+1 2.007217537084e-03 2.007217537084e-03 256 2467 1089 15 496 291 321 660 8.48880707e+01 4.10131508e+02 0.00000000e+00 5.04288175e-01 1.00000000e+00 5.04288175e-01 0.00000000e+00 0.00000000e+00 -3.12750156e+00 1.00009559e+00                                                                 "" 4.21184998e+02 1.10509722e-02 1.78168866e+02 2.15472165e+02 6.34601960e-03 8.33913468e+01 3.75290123e+02 1.85030753e+01 2.35832766e+02 3.30219976e-01 6.03964461e-03 2.39655650e-01 
+2 2.081412962228e-03 7.419542514326e-05 256 2467 1089 13  83 214 240 674 9.38742693e+01 4.44140030e+02 0.00000000e+00 5.04454957e-01 1.00000000e+00 5.04454957e-01 0.00000000e+00 0.00000000e+00 -3.23896283e+00 1.00009991e+00                                                                 "" 4.57616033e+02 1.11346769e-02 1.94333631e+02 2.93101439e+02 5.37824428e-03 1.13974436e+02 3.91399781e+02 1.71215048e+01 2.55464003e+02 3.15477916e-01 5.36199269e-03 2.26967793e-01 
+3 2.100000000000e-03 1.858703777239e-05 256 2467 1089 13  50 194 220 616 9.50218475e+01 4.50258998e+02 0.00000000e+00 5.04497279e-01 1.00000000e+00 5.04497279e-01 0.00000000e+00 0.00000000e+00 -3.26971655e+00 1.00010079e+00                                                                 "" 4.64110233e+02 1.12860156e-02 1.97117824e+02 3.00282117e+02 5.41011664e-03 1.16759845e+02 3.94723490e+02 1.73790875e+01 2.57831713e+02 3.18545653e-01 5.39334369e-03 2.29141149e-01 


### PR DESCRIPTION
This was a bug in debug mode I noticed in one of @elodie-kendall's models. If we set up a compressible model with a Newton solver and use the full A block of the Stokes matrix for the preconditioner, then the NewtonHandler still adds an assembler for the compressible terms in the preconditioner, although the preconditioner matrix is not used (the full matrix is used instead). Additionally the added assembler will throw an assertion. This change unifies the code paths between the Newton solver and the regular solver (which does not add the assembler for these models).