### PR TITLE
add sheared torsion BM after Farrington et al. 2014

### DIFF
--- a/benchmarks/viscoelastic_sheared_torsion/viscoelastic_sheared_torsion.prm
+++ b/benchmarks/viscoelastic_sheared_torsion/viscoelastic_sheared_torsion.prm
@@ -1,0 +1,177 @@
+# This parameter file constructs a 3D cube which is rotated around its vertical axis and sheared in the
+# xz-plane. It is adapted from Farrington et al. 2014 (Geophysics, Geochemistry, Geosystems), section "3.4.
+# Torsion Test in 3-D". According to the authors this is essentially an extension of the simple shear test
+# (see the viscoelastic_plastic_simple_shear benchmark prm file) into the third dimension.
+# While the model always rotates with a constant rate of 42/360 per unit time, shearing is only applied until
+# t = 0.5. At this point the shearing velocity is reduced to zero, and elastic stresses relax.
+# For t < 0.5 the analytical expression of the stress is given by:
+#   tau = exp(-mu/eta*t)*(C2*cos(V*t/h)-C1*sin(V*t/h))-C2
+# and for t >= 0.5:
+#   tau = exp(-mu/eta*tmax)*(C2*cos(V*tmax/h)-C1*sin(V*tmax/h))-C2)*exp(-mu/eta*(t-tmax))
+# with:
+#   tmax = 0.5 [s]     # time at which shearing stops
+#   eta = 100  [Pa s]  # the shear viscosity
+#   mu  = 100  [Pa]    # the shear modulus
+#   V = 0.3    [m/s]   # the shearing velocity
+#   h = 1      [m]     # the height of the box
+#   omega = 42 [deg/s] # the rotation rate
+#   C1 = -(V^2*eta^2*mu)/(mu^2*h^2+V^2*eta^2)
+#   C2 = -(V*h*eta*mu^2)/(mu^2*h^2+V^2*eta^2)
+#
+# These analytical stresses can be directly compared to the xz-component of the stress output (in the composition
+# statistics) from this parameter file.
+# Farrington et al., however, look at the stresses in an unrotated frame (their Fig. 1b), in which case both
+# the analytical stress and the ASPECT stress component need to be multiplied with cos(omega*t). Note that in the
+# Farrington paper the vertical axis is the y-axis, such that their stress component xy is ASPECT's stress
+# component xz.
+# With the time step size given in this parameter file, stresses are underestimated compared to the analytical
+# solution by about 0.9% for t < 0.5 and about 2% for t > 0.5. The fit of the numerical stress to the analytical
+# solution can be enhanced by choosing a smaller time step size.
+
+
+# Global parameters
+set Dimension                                  = 3
+set Start time                                 = 0
+set End time                                   = 2
+set Use years in output instead of seconds     = false
+# This will limit all time steps sizes to equal the "maximum time step" size
+set Maximum time step                          = 0.01
+set Output directory                           = output-viscoelastic_sheared_torsion
+set Pressure normalization                     = surface
+set Surface pressure                           = 0.
+set Nonlinear solver scheme                    = single Advection, iterated Stokes
+set Max nonlinear iterations                   = 30
+set Nonlinear solver tolerance                 = 1e-5
+set Max nonlinear iterations in pre-refinement = 0
+
+# Solver settings
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance                = 1e-6
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 1.0
+    set Y extent  = 1.0
+    set Z extent  = 1.0
+    set X repetitions = 5
+    set Y repetitions = 5
+    set Z repetitions = 5
+
+    # The axes' origins are offset such that the vertical axis runs through the middle of
+    # the box. This facilitates the velocity boundary condition of the rotational movement.
+    set Box origin X coordinate = -0.5
+    set Box origin Y coordinate = -0.5
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 0
+end
+
+
+# Velocity boundary conditions
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = 0:function, 1:function, 2:function, 3:function, 4:function, 5:function
+  subsection Function
+  # circular rotation plus shearing until t=0.5
+  set Function expression = if(t<0.5, -sin(atan2(y,x))*sqrt(y*y+x*x)*42/360 + 0.3*z, -sin(atan2(y,x))*sqrt(y*y+x*x)*42/360) ;\
+                            cos(atan2(y,x))*sqrt(y*y+x*x)*42/360 ;\
+                            0
+  end
+end
+
+# Formulation classification
+subsection Formulation
+  set Enable elasticity = true
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name  = vertical
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+# Number and name of compositional fields
+subsection Compositional fields
+  set Number of fields = 6
+  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_zz, ve_stress_xy, ve_stress_xz, ve_stress_yz
+end
+
+# Composition boundary conditions
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+# Spatial domain of different compositional fields.
+# The elastic stress tensor components are set to 0 initially.
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0;0.0;0.0;0.0;0.0;0.0
+  end
+end
+
+# Material model
+subsection Material model
+  set Model name = visco plastic
+
+  subsection Visco Plastic
+
+    # We use the dislocation creep law to prescribe a constant viscous viscosity.
+    # Because we set the stress exponent n=1, the strain rate term of the dislocation creep
+    # equation becomes 1 as it is set to the power of 0. Furthermore E=0 and P=0 so the exponential
+    # term equals 1 as well. This leads to a simplification of the dislocation creep equation to:
+    # eta = 1/2*prefactor^(-1/stress_exponent)
+    # So this parameter file gives a viscosity eta = 1/2*0.005(-1/1) = 100
+    set Prefactors for dislocation creep          = 0.005
+    set Stress exponents for dislocation creep    = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep  = 0.
+
+    set Viscous flow law = dislocation
+
+    set Include viscoelasticity = true
+
+    set Densities                   =  1
+
+    set Elastic shear moduli        = 1.e2
+
+    # Even though we do not use a fixed elastic time step,
+    # this parameters needs to be set equal to the "maximum time step"
+    # as it is used to compute the elastic time step during time step 0.
+    set Fixed elastic time step     = 0.01
+    set Use fixed elastic time step = false
+    set Use stress averaging        = false
+    set Viscosity averaging scheme  = maximum composition
+
+    # Cohesion is set higher than the maximum stress expected in this benchmark,
+    # such that yielding does not occur
+    set Cohesions                   = 15
+    set Angles of internal friction = 0.
+
+    set Minimum viscosity           = 1e-3
+    set Maximum viscosity           = 1e3
+
+  end
+end
+
+
+# The temperature plays no role in this model
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 293
+  end
+end
+
+# Postprocessing
+subsection Postprocess
+  set List of postprocessors = composition statistics
+end

--- a/tests/viscoelastic_sheared_torsion.prm
+++ b/tests/viscoelastic_sheared_torsion.prm
@@ -1,0 +1,177 @@
+# This parameter file constructs a 3D cube which is rotated around its vertical axis and sheared in the
+# xz-plane. It is adapted from Farrington et al. 2014 (Geophysics, Geochemistry, Geosystems), section "3.4.
+# Torsion Test in 3-D". According to the authors this is essentially an extension of the simple shear test
+# (see the viscoelastic_plastic_simple_shear benchmark prm file) into the third dimension.
+# While the model always rotates with a constant rate of 42/360 per unit time, shearing is only applied until
+# t = 0.5. At this point the shearing velocity is reduced to zero, and elastic stresses relax.
+# For t < 0.5 the analytical expression of the stress is given by:
+#   tau = exp(-mu/eta*t)*(C2*cos(V*t/h)-C1*sin(V*t/h))-C2
+# and for t >= 0.5:
+#   tau = exp(-mu/eta*tmax)*(C2*cos(V*tmax/h)-C1*sin(V*tmax/h))-C2)*exp(-mu/eta*(t-tmax))
+# with:
+#   tmax = 0.5 [s]     # time at which shearing stops
+#   eta = 100  [Pa s]  # the shear viscosity
+#   mu  = 100  [Pa]    # the shear modulus
+#   V = 0.3    [m/s]   # the shearing velocity
+#   h = 1      [m]     # the height of the box
+#   omega = 42 [deg/s] # the rotation rate
+#   C1 = -(V^2*eta^2*mu)/(mu^2*h^2+V^2*eta^2)
+#   C2 = -(V*h*eta*mu^2)/(mu^2*h^2+V^2*eta^2)
+#
+# These analytical stresses can be directly compared to the xz-component of the stress output (in the composition
+# statistics) from this parameter file.
+# Farrington et al., however, look at the stresses in an unrotated frame (their Fig. 1b), in which case both
+# the analytical stress and the ASPECT stress component need to be multiplied with cos(omega*t). Note that in the
+# Farrington paper the vertical axis is the y-axis, such that their stress component xy is ASPECT's stress
+# component xz.
+# With the time step size given in this parameter file, stresses are underestimated compared to the analytical
+# solution by about 0.9% for t < 0.5 and about 2% for t > 0.5. The fit of the numerical stress to the analytical
+# solution can be enhanced by choosing a smaller time step size.
+
+
+# Global parameters
+set Dimension                                  = 3
+set Start time                                 = 0
+set End time                                   = 0.02
+set Use years in output instead of seconds     = false
+# This will limit all time steps sizes to equal the "maximum time step" size
+set Maximum time step                          = 0.01
+set Output directory                           = viscoelastic_sheared_torsion
+set Pressure normalization                     = surface
+set Surface pressure                           = 0.
+set Nonlinear solver scheme                    = single Advection, iterated Stokes
+set Max nonlinear iterations                   = 30
+set Nonlinear solver tolerance                 = 1e-5
+set Max nonlinear iterations in pre-refinement = 0
+
+# Solver settings
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Linear solver tolerance                = 1e-6
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X extent  = 1.0
+    set Y extent  = 1.0
+    set Z extent  = 1.0
+    set X repetitions = 5
+    set Y repetitions = 5
+    set Z repetitions = 5
+
+    # The axes' origins are offset such that the vertical axis runs through the middle of
+    # the box. This facilitates the velocity boundary condition of the rotational movement.
+    set Box origin X coordinate = -0.5
+    set Box origin Y coordinate = -0.5
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 0
+end
+
+
+# Velocity boundary conditions
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = 0:function, 1:function, 2:function, 3:function, 4:function, 5:function
+  subsection Function
+  # circular rotation plus shearing until t=0.5
+  set Function expression = if(t<0.5, -sin(atan2(y,x))*sqrt(y*y+x*x)*42/360 + 0.3*z, -sin(atan2(y,x))*sqrt(y*y+x*x)*42/360) ;\
+                            cos(atan2(y,x))*sqrt(y*y+x*x)*42/360 ;\
+                            0
+  end
+end
+
+# Formulation classification
+subsection Formulation
+  set Enable elasticity = true
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name  = vertical
+  subsection Vertical
+    set Magnitude = 1
+  end
+end
+
+# Number and name of compositional fields
+subsection Compositional fields
+  set Number of fields = 6
+  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_zz, ve_stress_xy, ve_stress_xz, ve_stress_yz
+end
+
+# Composition boundary conditions
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+# Spatial domain of different compositional fields.
+# The elastic stress tensor components are set to 0 initially.
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0;0.0;0.0;0.0;0.0;0.0
+  end
+end
+
+# Material model
+subsection Material model
+  set Model name = visco plastic
+
+  subsection Visco Plastic
+
+    # We use the dislocation creep law to prescribe a constant viscous viscosity.
+    # Because we set the stress exponent n=1, the strain rate term of the dislocation creep
+    # equation becomes 1 as it is set to the power of 0. Furthermore E=0 and P=0 so the exponential
+    # term equals 1 as well. This leads to a simplification of the dislocation creep equation to:
+    # eta = 1/2*prefactor^(-1/stress_exponent)
+    # So this parameter file gives a viscosity eta = 1/2*0.005(-1/1) = 100
+    set Prefactors for dislocation creep          = 0.005
+    set Stress exponents for dislocation creep    = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep  = 0.
+
+    set Viscous flow law = dislocation
+
+    set Include viscoelasticity = true
+
+    set Densities                   =  1
+
+    set Elastic shear moduli        = 1.e2
+
+    # Even though we do not use a fixed elastic time step,
+    # this parameters needs to be set equal to the "maximum time step"
+    # as it is used to compute the elastic time step during time step 0.
+    set Fixed elastic time step     = 0.01
+    set Use fixed elastic time step = false
+    set Use stress averaging        = false
+    set Viscosity averaging scheme  = maximum composition
+
+    # Cohesion is set higher than the maximum stress expected in this benchmark,
+    # such that yielding does not occur
+    set Cohesions                   = 15
+    set Angles of internal friction = 0.
+
+    set Minimum viscosity           = 1e-3
+    set Maximum viscosity           = 1e3
+
+  end
+end
+
+
+# The temperature plays no role in this model
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 293
+  end
+end
+
+# Postprocessing
+subsection Postprocess
+  set List of postprocessors = composition statistics
+end

--- a/tests/viscoelastic_sheared_torsion/screen-output
+++ b/tests/viscoelastic_sheared_torsion/screen-output
@@ -1,0 +1,99 @@
+-----------------------------------------------------------------------------
+-- This is ASPECT, the Advanced Solver for Problems in Earth's ConvecTion.
+--     . version 2.4.0-pre (add_vep_torsion_BM, 4a8ed33c8)
+--     . using deal.II 9.3.1
+--     .       with 32 bit indices and vectorization level 1 (128 bits)
+--     . using Trilinos 12.18.1
+--     . using p4est 2.2.0
+--     . running in OPTIMIZED mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.4.0-pre&sha=4a8ed33c8&src=code
+-----------------------------------------------------------------------------
+Number of active cells: 125 (on 1 levels)
+Number of degrees of freedom: 13,526 (3,993+216+1,331+1,331+1,331+1,331+1,331+1,331+1,331)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Skipping ve_stress_xx composition solve because RHS is zero.
+   Skipping ve_stress_yy composition solve because RHS is zero.
+   Skipping ve_stress_zz composition solve because RHS is zero.
+   Skipping ve_stress_xy composition solve because RHS is zero.
+   Skipping ve_stress_xz composition solve because RHS is zero.
+   Skipping ve_stress_yz composition solve because RHS is zero.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 9.66645e-07
+
+
+   Postprocessing:
+     Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0
+
+*** Timestep 1:  t=0.01 seconds, dt=0.01 seconds
+   Solving temperature system... 0 iterations.
+   Solving ve_stress_xx system ... 13 iterations.
+   Solving ve_stress_yy system ... 13 iterations.
+   Solving ve_stress_zz system ... 13 iterations.
+   Solving ve_stress_xy system ... 13 iterations.
+   Solving ve_stress_xz system ... 12 iterations.
+   Solving ve_stress_yz system ... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.51536e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: -1.64e-05/1.511e-05/-1.455e-10 // -1.636e-05/1.622e-05/1.445e-10 // -1.337e-05/1.286e-05/9.515e-13 // -1.871e-05/1.917e-05/-5.239e-10 // 0.297/0.297/0.297 // -1.691e-05/1.689e-05/-4.805e-10
+
+*** Timestep 2:  t=0.02 seconds, dt=0.01 seconds
+   Solving temperature system... 0 iterations.
+   Solving ve_stress_xx system ... 13 iterations.
+   Solving ve_stress_yy system ... 14 iterations.
+   Solving ve_stress_zz system ... 13 iterations.
+   Solving ve_stress_xy system ... 14 iterations.
+   Solving ve_stress_xz system ... 10 iterations.
+   Solving ve_stress_yz system ... 13 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.70271e-06
+
+
+   Postprocessing:
+     Compositions min/max/mass: 0.001159/0.001192/0.001176 // -1.546e-05/1.458e-05/7.847e-10 // -0.001191/-0.001163/-0.001176 // -1.765e-05/1.853e-05/-3.825e-10 // 0.5901/0.5902/0.5901 // 0.0004411/0.0004733/0.0004575
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start     |      3.82s |            |
+|                                              |            |            |
+| Section                          | no. calls |  wall time | % of total |
++----------------------------------+-----------+------------+------------+
+| Assemble Stokes system           |         4 |     0.651s |        17% |
+| Assemble composition system      |        18 |      1.86s |        49% |
+| Assemble temperature system      |         3 |     0.348s |       9.1% |
+| Build Stokes preconditioner      |         4 |     0.384s |        10% |
+| Build composition preconditioner |        12 |    0.0655s |       1.7% |
+| Build temperature preconditioner |         3 |    0.0173s |      0.45% |
+| Initialization                   |         1 |     0.122s |       3.2% |
+| Postprocessing                   |         3 |    0.0166s |      0.44% |
+| Setup dof systems                |         1 |   0.00544s |      0.14% |
+| Setup initial conditions         |         1 |    0.0665s |       1.7% |
+| Setup matrices                   |         1 |    0.0371s |      0.97% |
+| Solve Stokes system              |         4 |    0.0584s |       1.5% |
+| Solve composition system         |        12 |    0.0281s |      0.74% |
+| Solve temperature system         |         3 |   0.00137s |         0% |
++----------------------------------+-----------+------------+------------+
+
+-- Total wallclock time elapsed including restarts:4s
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=2.4.0-pre&sha=4a8ed33c8&src=code
+-----------------------------------------------------------------------------

--- a/tests/viscoelastic_sheared_torsion/statistics
+++ b/tests/viscoelastic_sheared_torsion/statistics
@@ -1,0 +1,39 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for composition solver 3
+# 13: Iterations for composition solver 4
+# 14: Iterations for composition solver 5
+# 15: Iterations for composition solver 6
+# 16: Iterations for Stokes solver
+# 17: Velocity iterations in Stokes preconditioner
+# 18: Schur complement iterations in Stokes preconditioner
+# 19: Minimal value for composition ve_stress_xx
+# 20: Maximal value for composition ve_stress_xx
+# 21: Global mass for composition ve_stress_xx
+# 22: Minimal value for composition ve_stress_yy
+# 23: Maximal value for composition ve_stress_yy
+# 24: Global mass for composition ve_stress_yy
+# 25: Minimal value for composition ve_stress_zz
+# 26: Maximal value for composition ve_stress_zz
+# 27: Global mass for composition ve_stress_zz
+# 28: Minimal value for composition ve_stress_xy
+# 29: Maximal value for composition ve_stress_xy
+# 30: Global mass for composition ve_stress_xy
+# 31: Minimal value for composition ve_stress_xz
+# 32: Maximal value for composition ve_stress_xz
+# 33: Global mass for composition ve_stress_xz
+# 34: Minimal value for composition ve_stress_yz
+# 35: Maximal value for composition ve_stress_yz
+# 36: Global mass for composition ve_stress_yz
+0 0.000000000000e+00 0.000000000000e+00 125 4209 1331 7986 2 0  0  0  0  0  0  0 34 37 37  0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00  0.00000000e+00 0.00000000e+00  0.00000000e+00 
+1 1.000000000000e-02 1.000000000000e-02 125 4209 1331 7986 1 0 13 13 13 13 12 13  1  3  3 -1.64045049e-05 1.51094339e-05 -1.45481533e-10 -1.63641477e-05 1.62204396e-05 1.44529992e-10 -1.33656488e-05  1.28570993e-05  9.51541381e-13 -1.87149041e-05 1.91691073e-05 -5.23909963e-10 2.97016492e-01 2.97047039e-01 2.97029703e-01 -1.69132935e-05 1.68897863e-05 -4.80495479e-10 
+2 2.000000000000e-02 1.000000000000e-02 125 4209 1331 7986 1 0 13 14 13 14 10 13  1  3  3  1.15947587e-03 1.19182138e-03  1.17635419e-03 -1.54593913e-05 1.45834494e-05 7.84725063e-10 -1.19083698e-03 -1.16269489e-03 -1.17635497e-03 -1.76469791e-05 1.85266531e-05 -3.82470017e-10 5.90127395e-01 5.90155343e-01 5.90138222e-01  4.41079644e-04 4.73345451e-04  4.57470446e-04 


### PR DESCRIPTION
This adds the input file for a 3D torsion plus shearing benchmark after Farrington et al. 2014.  

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
