### PR TITLE
remove empty list items in changelog

### DIFF
--- a/doc/modules/changes/20210707_bobmyhill
+++ b/doc/modules/changes/20210707_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: Added a new input parameter Elastic damper viscosity to Rheology::Elasticity.
+New: Added a new input parameter Elastic damper viscosity to Rheology::Elasticity.
 This parameter corresponds to the viscosity of a viscous damper which deforms
 at the same strain rate as the elastic element.
 The default value of 0 Pas corresponds to purely elastic deformation.

--- a/doc/modules/changes/20210712_mfmweerdesteijn
+++ b/doc/modules/changes/20210712_mfmweerdesteijn
@@ -1,3 +1,3 @@
-<li> New: The geoid postprocessor can now handle a deforming mesh (free surface), next to the already existing option from the dynamic topography postprocessor output.
+New: The geoid postprocessor can now handle a deforming mesh (free surface), next to the already existing option from the dynamic topography postprocessor output.
 <br>
 (Maaike Weerdesteijn, Rene Gassmoeller, Jacky Austermann, 2021/07/12)

--- a/doc/modules/changes/20210713_bobmyhill
+++ b/doc/modules/changes/20210713_bobmyhill
@@ -1,4 +1,4 @@
-<li> New: ASPECT now has a cookbook which shows how velocities can be
+New: ASPECT now has a cookbook which shows how velocities can be
 prescribed at positions specified by an ASCII input file.
 <br>
 (Bob Myhill, 2021/07/13)


### PR DESCRIPTION
This should remove the empty items in the list of changes: https://aspect.geodynamics.org/doc/doxygen/changes_current.html. 