### PR TITLE
support reading larger than 2GB data files

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -35,15 +35,7 @@ namespace big_mpi
 
 #if DEAL_II_VERSION_GTE(10,0,0)
 
-  template <typename T>
-  void
-  broadcast(T                 *buffer,
-            const size_t       count,
-            const unsigned int root,
-            const MPI_Comm    &comm)
-  {
-    dealii::Utilities::MPI::broadcast(buffer, count, root, comm);
-  }
+  using dealii::Utilities::MPI::broadcast;
 
 #else
 
@@ -54,12 +46,9 @@ namespace big_mpi
   }
 
   /**
-       * Broadcast the information in @p buffer from @p root to all
-       * other ranks.
-       *
-       * This will be in deal.II 10.0-pre after https://github.com/dealii/dealii/pull/13368
-       * is merged under the name Utilities::MPI::broadcast().
-       */
+   * Broadcast the information in @p buffer from @p root to all
+   * other ranks.
+   */
   template <typename T>
   void
   broadcast(T                 *buffer,

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1388,12 +1388,7 @@ namespace aspect
           int ierr = MPI_Bcast(&filesize, 1, Utilities::internal::MPI::mpi_type_id(&filesize), 0, comm);
           AssertThrowMPI(ierr);
 
-          AssertThrow (filesize < static_cast<std::size_t>(std::numeric_limits<signed int>::max()),
-                       ExcMessage ("You are trying to broadcast a file that is larger than what "
-                                   "MPI can handle in a single MPI_Bcast call. This is not currently "
-                                   "supported"));
-          ierr = MPI_Bcast(&data_string[0], filesize, MPI_CHAR, 0, comm);
-          AssertThrowMPI(ierr);
+          big_mpi::broadcast<>(&data_string[0], filesize, 0, comm);
         }
       else
         {
@@ -1414,8 +1409,7 @@ namespace aspect
             throw QuietException();
 
           // Receive and store data
-          ierr = MPI_Bcast(&data_string[0], filesize, MPI_CHAR, 0, comm);
-          AssertThrowMPI(ierr);
+          big_mpi::broadcast<>(&data_string[0], filesize, 0, comm);
         }
 
       return data_string;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1388,7 +1388,7 @@ namespace aspect
           int ierr = MPI_Bcast(&filesize, 1, Utilities::internal::MPI::mpi_type_id(&filesize), 0, comm);
           AssertThrowMPI(ierr);
 
-          big_mpi::broadcast<>(&data_string[0], filesize, 0, comm);
+          big_mpi::broadcast(&data_string[0], filesize, 0, comm);
         }
       else
         {
@@ -1402,7 +1402,7 @@ namespace aspect
           data_string.resize(filesize);
 
           // Receive and store data
-          big_mpi::broadcast<>(&data_string[0], filesize, 0, comm);
+          big_mpi::broadcast(&data_string[0], filesize, 0, comm);
         }
 
       return data_string;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1401,13 +1401,6 @@ namespace aspect
 
           data_string.resize(filesize);
 
-          // Check whether the size is small enough to be handled in a single Bcast call.
-          // If not, error out for now. We may fix this later. (We error out by throwing
-          // a quiet exception; the root rank will throw a more information exception,
-          // see above.)
-          if (filesize >= static_cast<std::size_t>(std::numeric_limits<signed int>::max()))
-            throw QuietException();
-
           // Receive and store data
           big_mpi::broadcast<>(&data_string[0], filesize, 0, comm);
         }


### PR DESCRIPTION
This is the minimum implementation taken from deal.II to broadcast >2GB
of data (ascii data, etc.).
