### PR TITLE
only average viscosity if the viscosity is computed in the material model

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -741,6 +741,7 @@ namespace aspect
                     const typename DoFHandler<dim>::active_cell_iterator &cell,
                     const Quadrature<dim>         &quadrature_formula,
                     const Mapping<dim>            &mapping,
+                    const MaterialProperties::Property &requested_properties,
                     MaterialModelOutputs<dim>     &values_out);
 
       /**

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -304,6 +304,7 @@ namespace aspect
                                            in.current_cell,
                                            this->introspection().quadratures.velocities,
                                            this->get_mapping(),
+                                           in.requested_properties,
                                            out_copy);
 
                 effective_creep_viscosities = out_copy.viscosities;
@@ -382,6 +383,7 @@ namespace aspect
                                            in.current_cell,
                                            this->introspection().quadratures.compositional_fields,
                                            this->get_mapping(),
+                                           in.requested_properties,
                                            out_copy);
 
                 effective_creep_viscosities = out_copy.viscosities;

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -146,6 +146,7 @@ namespace aspect
                                                          cell,
                                                          fe_volume_values.get_quadrature(),
                                                          fe_volume_values.get_mapping(),
+                                                         in.requested_properties,
                                                          out);
 
               simulator_access.get_heating_model_manager().evaluate(in, out, heating_out);

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -142,6 +142,7 @@ namespace aspect
                                                      input_data.template get_cell<dim>(),
                                                      Quadrature<dim>(),
                                                      this->get_mapping(),
+                                                     in.requested_properties,
                                                      out);
 
         std::vector<double> melt_fractions(n_quadrature_points);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -316,6 +316,7 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
+                                               scratch.material_model_inputs.requested_properties,
                                                scratch.material_model_outputs);
 
     for (unsigned int i=0; i<assemblers->stokes_preconditioner.size(); ++i)
@@ -565,6 +566,7 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
+                                               scratch.material_model_inputs.requested_properties,
                                                scratch.material_model_outputs);
 
     scratch.finite_element_values[introspection.extractors.velocities].get_function_values(current_linearization_point,
@@ -949,6 +951,7 @@ namespace aspect
                                                cell,
                                                scratch.finite_element_values.get_quadrature(),
                                                scratch.finite_element_values.get_mapping(),
+                                               scratch.material_model_inputs.requested_properties,
                                                scratch.material_model_outputs);
 
     heating_model_manager.evaluate(scratch.material_model_inputs,

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -584,6 +584,7 @@ namespace aspect
                                                    cell,
                                                    scratch.finite_element_values.get_quadrature(),
                                                    scratch.finite_element_values.get_mapping(),
+                                                   scratch.material_model_inputs.requested_properties,
                                                    scratch.material_model_outputs);
 
         if (parameters.advection_stabilization_method == Parameters<dim>::AdvectionStabilizationMethod::entropy_viscosity)

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1165,6 +1165,7 @@ namespace aspect
           FEQ_cell,
           quadrature_formula,
           *sim.mapping,
+          in.requested_properties,
           out);
 
         for (unsigned int i=0; i<values.size(); ++i)
@@ -1417,6 +1418,7 @@ namespace aspect
                                                             in.current_cell,
                                                             fe_values.get_quadrature(),
                                                             *sim.mapping,
+                                                            in.requested_properties,
                                                             out);
 
                   Assert(std::isfinite(in.strain_rate[0].norm()),


### PR DESCRIPTION
This pull request makes sure that the cell-wise averaging of material properties only averages the viscosity if the viscosity is actually computed in the material model (as indicted by `in.requests_property(MaterialModel::MaterialProperties::viscosity)`). Before this change, models with geometric averaging would crash in debug mode in case a material model did not compute the viscosity (for me, this happened with the steinberger model). This is because the viscosity is initialized with NaNs. But the `average_property` function only checks if `values_out.size() == 0` (It has a comment that says: "if an output field has not been filled (because it was not requested), then simply do nothing -- no harm no foul", but that's not what happens in the other parts of the code, the size of in.viscosities is not actually zero if the viscosity is not requested). 

I am not sure what I did is the best solution for this problem (I had to add a new argument to the average function, which needs to be handed over in many places in the code), so let me know if you have a better idea. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
