### PR TITLE
Get rid of a bunch of GeometryInfo related things.

### DIFF
--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -419,15 +419,16 @@ namespace aspect
            */
           FullMatrix<double>          local_matrix;
 
-          /** Local contributions to the global matrix from the face terms in the
-           * discontinuous Galerkin method. The vectors are of length
-           * GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell
-           * so as to hold one matrix for each possible face or subface of the cell.
-           * The discontinuous Galerkin bilinear form contains terms arising from internal
-           * (to the cell) values and external (to the cell) values.
-           * _int_ext and ext_int hold the terms arising from the pairing between a cell
-           * and its neighbor, while _ext_ext is the pairing of the neighbor's dofs with
-           * themselves. In the continuous Galerkin case, these are unused, and set to size zero.
+          /**
+           * Local contributions to the global matrix from the face terms in the
+           * discontinuous Galerkin method. These arrays are of a length sufficient
+           * to hold one matrix for each possible face or subface of the cell.
+           * The discontinuous Galerkin bilinear form contains terms arising from
+           * internal (to the cell) values and external (to the cell) values.
+           * `_int_ext` and `_ext_int` hold the terms arising from the pairing
+           * between a cell and its neighbor, while `_ext_ext` is the pairing
+           * of the neighbor's dofs with themselves. In the continuous
+           * Galerkin case, these are unused, and set to size zero.
            */
           std::vector<FullMatrix<double>>         local_matrices_int_ext;
           std::vector<FullMatrix<double>>         local_matrices_ext_int;
@@ -460,8 +461,9 @@ namespace aspect
           /**
            * Indices of the degrees of freedom corresponding to the temperature
            * or composition field on all possible neighboring cells. This is used
-           * in the discontinuous Galerkin method. The outer std::vector has
-           * length GeometryInfo<dim>::max_children_per_face * GeometryInfo<dim>::faces_per_cell,
+           * in the discontinuous Galerkin method. The outer array has a
+           * length sufficient to hold one element for each possible face
+           * and sub-face of the current cell. The object is not used
            * and has size zero if in the continuous Galerkin case.
            */
           std::vector<std::vector<types::global_dof_index>>   neighbor_dof_indices;
@@ -476,6 +478,38 @@ namespace aspect
    */
   namespace Assemblers
   {
+
+    /**
+     * For a reference cell (which is typically obtained by asking the finite
+     * element to be used), determine how many interface matrices are needed.
+     * Since interface matrices are needed for as many neighbors as each
+     * cell can have, this is the number of faces for the given reference cell
+     * times the number of children each of these faces can have. This
+     * accommodates the fact that the neighbors of a cell can all be refined,
+     * though they can only be refined once.
+     */
+    unsigned int
+    n_interface_matrices (const ReferenceCell &reference_cell);
+
+    /**
+     * For a given reference cell, and a given face we are currently
+     * assembling on, return which element of an array of size
+     * `n_interface_matrices(reference_cell)` to use.
+     */
+    unsigned int
+    nth_interface_matrix (const ReferenceCell &reference_cell,
+                          const unsigned int face);
+
+    /**
+     * For a given reference cell, and a given face and sub-face we are
+     * currently assembling on, return which element of an array of size
+     * `n_interface_matrices(reference_cell)` to use.
+     */
+    unsigned int
+    nth_interface_matrix (const ReferenceCell &reference_cell,
+                          const unsigned int face,
+                          const unsigned int sub_face);
+
     /**
      * A base class for objects that implement assembly
      * operations.

--- a/include/aspect/volume_of_fluid/assembly.h
+++ b/include/aspect/volume_of_fluid/assembly.h
@@ -135,23 +135,23 @@ namespace aspect
           /**
            * Local contributions to the global rhs from the face terms in the
            * discontinuous Galerkin interpretation of the VolumeOfFluid method.
+           *
+           * The array has a length sufficient to hold one element for each
+           * possible face and sub-face of a cell.
            */
-          std::array<Vector<double>,
-              GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
-              local_face_rhs;
-          std::array<FullMatrix<double>,
-              GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
-              local_face_matrices_ext_ext;
+          std::vector<Vector<double>> local_face_rhs;
+          std::vector<FullMatrix<double>> local_face_matrices_ext_ext;
 
           /**
            * Denotes which face's rhs have actually been assembled in the DG
            * field assembly. Entries not used (for example, those corresponding
            * to non-existent subfaces; or faces being assembled by the
            * neighboring cell) are set to false.
+           *
+           * The array has a length sufficient to hold one element for each
+           * possible face and sub-face of a cell.
            */
-          std::array<bool,
-              GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
-              face_contributions_mask;
+          std::vector<bool> face_contributions_mask;
 
           /**
            * Indices of those degrees of freedom that actually correspond to
@@ -168,10 +168,11 @@ namespace aspect
            * Indices of the degrees of freedom corresponding to the volume_of_fluid field
            * on all possible neighboring cells. This is used in the
            * discontinuous Galerkin interpretation of the VolumeOfFluid method.
+           *
+           * The array has a length sufficient to hold one element for each
+           * possible face and sub-face of a cell.
            */
-          std::array<std::vector<types::global_dof_index>,
-              GeometryInfo<dim>::max_children_per_face *GeometryInfo<dim>::faces_per_cell>
-              neighbor_dof_indices;
+          std::vector<std::vector<types::global_dof_index>> neighbor_dof_indices;
         };
       }
     }

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -781,12 +781,12 @@ namespace aspect
                 {
                   if (fe.system_to_component_index(i).first == solution_component)
                     {
-                      data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face][i_advection] = neighbor_dof_indices[i];
+                      data.neighbor_dof_indices[nth_interface_matrix(fe.reference_cell(), face_no)][i_advection] = neighbor_dof_indices[i];
                       ++i_advection;
                     }
                   ++i;
                 }
-              data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face] = true;
+              data.assembled_matrices[nth_interface_matrix(fe.reference_cell(), face_no)] = true;
 
               for (unsigned int q=0; q<n_q_points; ++q)
                 {
@@ -945,7 +945,7 @@ namespace aspect
                              )
                              * scratch.face_finite_element_values->JxW(q);
 
-                          data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                          data.local_matrices_int_ext[nth_interface_matrix(fe.reference_cell(), face_no)](i,j)
                           += (- 0.5 * time_step * neighbor_conductivity
                               * scratch.neighbor_face_grad_phi_field[j]
                               * scratch.face_finite_element_values->normal_vector(q)
@@ -975,7 +975,7 @@ namespace aspect
                              )
                              * scratch.face_finite_element_values->JxW(q);
 
-                          data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                          data.local_matrices_ext_int[nth_interface_matrix(fe.reference_cell(), face_no)](i,j)
                           += (+ 0.5 * time_step * conductivity
                               * scratch.face_grad_phi_field[j]
                               * scratch.face_finite_element_values->normal_vector(q)
@@ -1005,7 +1005,7 @@ namespace aspect
                              )
                              * scratch.face_finite_element_values->JxW(q);
 
-                          data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face](i,j)
+                          data.local_matrices_ext_ext[nth_interface_matrix(fe.reference_cell(), face_no)](i,j)
                           += (+ 0.5 * time_step * neighbor_conductivity
                               * scratch.neighbor_face_grad_phi_field[i]
                               * scratch.face_finite_element_values->normal_vector(q)
@@ -1137,12 +1137,12 @@ namespace aspect
                 {
                   if (fe.system_to_component_index(i).first == solution_component)
                     {
-                      data.neighbor_dof_indices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no][i_advection] = neighbor_dof_indices[i];
+                      data.neighbor_dof_indices[nth_interface_matrix(fe.reference_cell(), face_no, subface_no)][i_advection] = neighbor_dof_indices[i];
                       ++i_advection;
                     }
                   ++i;
                 }
-              data.assembled_matrices[face_no * GeometryInfo<dim>::max_children_per_face + subface_no] = true;
+              data.assembled_matrices[nth_interface_matrix(fe.reference_cell(), face_no, subface_no)] = true;
 
               for (unsigned int q=0; q<n_q_points; ++q)
                 {
@@ -1301,7 +1301,7 @@ namespace aspect
                              )
                              * scratch.subface_finite_element_values->JxW(q);
 
-                          data.local_matrices_int_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                          data.local_matrices_int_ext[nth_interface_matrix(fe.reference_cell(), face_no, subface_no)](i,j)
                           += (- 0.5 * time_step * neighbor_conductivity
                               * scratch.neighbor_face_grad_phi_field[j]
                               * scratch.subface_finite_element_values->normal_vector(q)
@@ -1331,7 +1331,7 @@ namespace aspect
                              )
                              * scratch.subface_finite_element_values->JxW(q);
 
-                          data.local_matrices_ext_int[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                          data.local_matrices_ext_int[nth_interface_matrix(fe.reference_cell(), face_no, subface_no)](i,j)
                           += (+ 0.5 * time_step * conductivity
                               * scratch.face_grad_phi_field[j]
                               * scratch.subface_finite_element_values->normal_vector(q)
@@ -1361,7 +1361,7 @@ namespace aspect
                              )
                              * scratch.subface_finite_element_values->JxW(q);
 
-                          data.local_matrices_ext_ext[face_no * GeometryInfo<dim>::max_children_per_face + subface_no](i,j)
+                          data.local_matrices_ext_ext[nth_interface_matrix(fe.reference_cell(), face_no, subface_no)](i,j)
                           += (+ 0.5 * time_step * neighbor_conductivity
                               * scratch.neighbor_face_grad_phi_field[i]
                               * scratch.subface_finite_element_values->normal_vector(q)

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -1092,35 +1092,31 @@ namespace aspect
                                                     system_matrix,
                                                     system_rhs);
 
-    /* In the following, we copy DG contributions element by element. This
-     * is allowed since there are no constraints imposed on discontinuous fields.
-     */
+    // In the following, we copy DG contributions entry by entry. This
+    // is allowed since there are no constraints imposed on discontinuous fields.
     if (!assemblers->advection_system_on_interior_face.empty() &&
         assemblers->advection_system_assembler_on_face_properties[advection_field.field_index()].need_face_finite_element_evaluation)
       {
-        for (unsigned int f=0; f<GeometryInfo<dim>::max_children_per_face
-             * GeometryInfo<dim>::faces_per_cell; ++f)
-          {
-            if (data.assembled_matrices[f])
-              {
-                for (unsigned int i=0; i<data.local_dof_indices.size(); ++i)
-                  for (unsigned int j=0; j<data.neighbor_dof_indices[f].size(); ++j)
-                    {
-                      system_matrix.add (data.local_dof_indices[i],
-                                         data.neighbor_dof_indices[f][j],
-                                         data.local_matrices_int_ext[f](i,j));
-                      system_matrix.add (data.neighbor_dof_indices[f][j],
-                                         data.local_dof_indices[i],
-                                         data.local_matrices_ext_int[f](j,i));
-                    }
-
-                for (unsigned int i=0; i<data.neighbor_dof_indices[f].size(); ++i)
-                  for (unsigned int j=0; j<data.neighbor_dof_indices[f].size(); ++j)
-                    system_matrix.add (data.neighbor_dof_indices[f][i],
+        for (unsigned int f=0; f<data.assembled_matrices.size(); ++f)
+          if (data.assembled_matrices[f])
+            {
+              for (unsigned int i=0; i<data.local_dof_indices.size(); ++i)
+                for (unsigned int j=0; j<data.neighbor_dof_indices[f].size(); ++j)
+                  {
+                    system_matrix.add (data.local_dof_indices[i],
                                        data.neighbor_dof_indices[f][j],
-                                       data.local_matrices_ext_ext[f](i,j));
-              }
-          }
+                                       data.local_matrices_int_ext[f](i,j));
+                    system_matrix.add (data.neighbor_dof_indices[f][j],
+                                       data.local_dof_indices[i],
+                                       data.local_matrices_ext_int[f](j,i));
+                  }
+
+              for (unsigned int i=0; i<data.neighbor_dof_indices[f].size(); ++i)
+                for (unsigned int j=0; j<data.neighbor_dof_indices[f].size(); ++j)
+                  system_matrix.add (data.neighbor_dof_indices[f][i],
+                                     data.neighbor_dof_indices[f][j],
+                                     data.local_matrices_ext_ext[f](i,j));
+            }
       }
   }
 

--- a/source/volume_of_fluid/assembler.cc
+++ b/source/volume_of_fluid/assembler.cc
@@ -20,6 +20,7 @@
 
 #include <aspect/simulator_access.h>
 #include <aspect/utilities.h>
+#include <aspect/simulator/assemblers/interface.h>
 #include <aspect/volume_of_fluid/utilities.h>
 #include <aspect/volume_of_fluid/handler.h>
 #include <aspect/volume_of_fluid/field.h>
@@ -491,7 +492,7 @@ namespace aspect
               // that correspond to the solution_field we are interested in
               neighbor->get_dof_indices (neighbor_dof_indices);
 
-              const unsigned int f_rhs_ind = face_no * GeometryInfo<dim>::max_children_per_face;
+              const unsigned int f_rhs_ind = Assemblers::nth_interface_matrix(cell->reference_cell(), face_no);
 
               for (unsigned int i=0; i<volume_of_fluid_dofs_per_cell; ++i)
                 data.neighbor_dof_indices[f_rhs_ind][i]
@@ -587,7 +588,7 @@ namespace aspect
               std::vector<types::global_dof_index> neighbor_dof_indices (scratch.subface_finite_element_values.get_fe().dofs_per_cell);
               neighbor_child->get_dof_indices (neighbor_dof_indices);
 
-              const unsigned int f_rhs_ind = face_no * GeometryInfo<dim>::max_children_per_face+subface_no;
+              const unsigned int f_rhs_ind = Assemblers::nth_interface_matrix(cell->reference_cell(), face_no, subface_no);
 
               for (unsigned int i=0; i<volume_of_fluid_dofs_per_cell; ++i)
                 data.neighbor_dof_indices[f_rhs_ind][i]


### PR DESCRIPTION
This continues my quest to get rid of places that use `GeometryInfo`. `GeometryInfo` is used widely in all places where we do assembly for DG elements because we need to allocate and then access vectors and matrices for all faces and subfaces. Counting how many of these there are, and then what index to use was previously done via `GeometryInfo::faces_per_cell` and `GeometryInfo::subfaces_per_face`. 

This patch introduces two new functions, `n_interface_matrices(...)` and `nth_interface_matrix(...)` that tell us the number of matrices we need to provision, and the index within such arrays that we want to access for a given face (and subface, if so relevant). The places where this is relevant are in the advection assemblers (where we sometimes use DG elements) and in the volume-of-fluid assemblers.

I'd be surprised if this patch doesn't break something, so let's see what happens.

/rebuild