### PR TITLE
use round() and convert to int

### DIFF
--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -60,9 +60,10 @@ namespace aspect
 
               const double maximum_refinement_level = max_refinement_level.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));
 
-              if (cell->level() >= rint(maximum_refinement_level))
+              if (cell->level() >= static_cast<int>(std::round(maximum_refinement_level)))
                 cell->clear_refine_flag ();
-              if (cell->level() >  rint(maximum_refinement_level))
+
+              if (cell->level() > static_cast<int>(std::round(maximum_refinement_level)))
                 cell->set_coarsen_flag ();
             }
         }

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -60,9 +60,9 @@ namespace aspect
 
               const double minimum_refinement_level = min_refinement_level.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));
 
-              if (cell->level() <= rint(minimum_refinement_level))
+              if (cell->level() <= static_cast<int>(std::round(minimum_refinement_level)))
                 cell->clear_coarsen_flag ();
-              if (cell->level() <  rint(minimum_refinement_level))
+              if (cell->level() < static_cast<int>(std::round(minimum_refinement_level)))
                 cell->set_refine_flag ();
             }
         }


### PR DESCRIPTION
I don't think using rint() makes a lot of sense as its rounding depends on some floating point setting, instead use round()
followed by a cast.
