### PR TITLE
Prescribed temperature field with diffusion

### DIFF
--- a/doc/modules/changes/20220328_jdannberg
+++ b/doc/modules/changes/20220328_jdannberg
@@ -1,0 +1,6 @@
+New: There is now a new advection method for the temperature
+called 'prescribed field with diffusion', which works in the
+same way as the corresponding advection field method for
+compositional fields. 
+<br>
+(Juliane Dannberg, 2022/03/28)

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -317,6 +317,12 @@ namespace aspect
       IndexSets index_sets;
 
       /**
+       * A variable that contains the field method for the temperature field
+       * and is used to determine how to solve it when solving a timestep.
+       */
+      typename Parameters<dim>::AdvectionFieldMethod::Kind temperature_method;
+
+      /**
        * A vector that contains a field method for every compositional
        * field and is used to determine how to solve a particular field when
        * solving a timestep.

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -79,7 +79,7 @@ namespace aspect
 
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
 
-      if (!advection_field_is_temperature && advection_field.advection_method (introspection)
+      if (advection_field.advection_method (introspection)
           == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
         return;
 
@@ -327,7 +327,7 @@ namespace aspect
 
       const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
 
-      if (advection_field.is_temperature() || advection_field.advection_method(introspection)
+      if (advection_field.advection_method(introspection)
           != Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
         return;
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -201,7 +201,8 @@ namespace aspect
 
     // add the diffusion assemblers if we have fields that use this method
     if (std::find(parameters.compositional_field_methods.begin(), parameters.compositional_field_methods.end(),
-                  Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion) != parameters.compositional_field_methods.end())
+                  Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion) != parameters.compositional_field_methods.end()
+        || parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
       assemblers->advection_system.push_back(
         std::make_unique<aspect::Assemblers::DiffusionSystem<dim>>());
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -119,7 +119,13 @@ namespace aspect
   typename Parameters<dim>::AdvectionFieldMethod::Kind
   Simulator<dim>::AdvectionField::advection_method(const Introspection<dim> &introspection) const
   {
-    return introspection.compositional_field_methods[compositional_variable];
+    if (field_type == temperature_field)
+      return introspection.temperature_method;
+    else if (field_type == compositional_field)
+      return introspection.compositional_field_methods[compositional_variable];
+
+    Assert (false, ExcInternalError());
+    return Parameters<dim>::AdvectionFieldMethod::fem_field;
   }
 
   template <int dim>

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -200,6 +200,7 @@ namespace aspect
     polynomial_degree (internal::setup_polynomial_degree<dim>(parameters)),
     component_masks (*this),
     system_dofs_per_block (n_blocks),
+    temperature_method(parameters.temperature_method),
     compositional_field_methods(parameters.compositional_field_methods),
     composition_names(parameters.names_of_compositional_fields),
     composition_descriptions(parameters.composition_descriptions)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -567,7 +567,7 @@ namespace aspect
       {
         prm.declare_entry ("Diffusion length scale", "1.e4",
                            Patterns::Double (0.),
-                           "Set a length scale for the diffusion of compositional fields if the "
+                           "Set a length scale for the diffusion of advection fields if the "
                            "``prescribed field with diffusion'' method is selected for a field. "
                            "More precisely, this length scale represents the square root of the "
                            "product of diffusivity and time in the diffusion equation, and controls "
@@ -1176,11 +1176,11 @@ namespace aspect
                          "\n"
                          "\\item ``prescribed field with diffusion'': If the temperature field is "
                          "marked this way, the value of a specific additional material model output, "
-                         "called the `PrescribedFieldOutputs' is interpolated onto the field, as in "
+                         "called the `PrescribedTemperatureOutputs' is interpolated onto the field, as in "
                          "the ``prescribed field'' method. Afterwards, the field is diffused based on "
                          "a solver parameter, the diffusion length scale, smoothing the field. "
                          "Specifically, the field is updated by solving the equation "
-                         "$(I-l^2 \\Delta) C_\\text{smoothed} = C_\\text{prescribed}$, "
+                         "$(I-l^2 \\Delta) T_\\text{smoothed} = T_\\text{prescribed}$, "
                          "where $l$ is the diffusion length scale. Note that this means that the amount "
                          "of diffusion is independent of the time step size, and that the field is not "
                          "advected with the flow."

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1154,7 +1154,7 @@ namespace aspect
     prm.enter_subsection ("Temperature field");
     {
       prm.declare_entry ("Temperature method", "field",
-                         Patterns::Selection("field|prescribed field|static"),
+                         Patterns::Selection("field|prescribed field|prescribed field with diffusion|static"),
                          "A comma separated list denoting the solution method of the "
                          "temperature field. Each entry of the list must be "
                          "one of the currently implemented field types."
@@ -1173,6 +1173,17 @@ namespace aspect
                          "model output, called the `PrescribedTemperatureOutputs' is interpolated "
                          "onto the temperature. This field does not change otherwise, it is not "
                          "advected with the flow. "
+                         "\n"
+                         "\\item ``prescribed field with diffusion'': If the temperature field is "
+                         "marked this way, the value of a specific additional material model output, "
+                         "called the `PrescribedFieldOutputs' is interpolated onto the field, as in "
+                         "the ``prescribed field'' method. Afterwards, the field is diffused based on "
+                         "a solver parameter, the diffusion length scale, smoothing the field. "
+                         "Specifically, the field is updated by solving the equation "
+                         "$(I-l^2 \\Delta) C_\\text{smoothed} = C_\\text{prescribed}$, "
+                         "where $l$ is the diffusion length scale. Note that this means that the amount "
+                         "of diffusion is independent of the time step size, and that the field is not "
+                         "advected with the flow."
                          "\n"
                          "\\item ``static'': If a temperature field is marked "
                          "this way, then it does not evolve at all. Its values are "
@@ -1761,6 +1772,8 @@ namespace aspect
         temperature_method = AdvectionFieldMethod::fem_field;
       else if (x_temperature_method == "prescribed field")
         temperature_method = AdvectionFieldMethod::prescribed_field;
+      else if (x_temperature_method == "prescribed field with diffusion")
+        temperature_method = AdvectionFieldMethod::prescribed_field_with_diffusion;
       else if (x_temperature_method == "static")
         temperature_method = AdvectionFieldMethod::static_field;
       else

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -145,8 +145,25 @@ namespace aspect
     switch (parameters.temperature_method)
       {
         case Parameters<dim>::AdvectionFieldMethod::fem_field:
+        case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
         {
-          assemble_advection_system (AdvectionField::temperature());
+          const AdvectionField adv_field (AdvectionField::temperature());
+
+          // if this is a prescribed field with diffusion, we first have to copy the material model
+          // outputs into the prescribed field before we assemble and solve the equation
+          if (parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
+            {
+              TimerOutput::Scope timer (computing_timer, "Interpolate prescribed temperature");
+
+              interpolate_material_output_into_advection_field(adv_field);
+
+              // Also set the old_solution block to the prescribed field. The old
+              // solution is the one that is used to assemble the diffusion system in
+              // assemble_advection_system() for this solver scheme.
+              old_solution.block(adv_field.block_index(introspection)) = solution.block(adv_field.block_index(introspection));
+            }
+
+          assemble_advection_system (adv_field);
 
           if (compute_initial_residual)
             {
@@ -154,7 +171,7 @@ namespace aspect
               *initial_residual = system_rhs.block(introspection.block_indices.temperature).l2_norm();
             }
 
-          const double current_residual = solve_advection(AdvectionField::temperature());
+          const double current_residual = solve_advection(adv_field);
 
           current_linearization_point.block(introspection.block_indices.temperature)
             = solution.block(introspection.block_indices.temperature);

--- a/tests/prescribed_temperature_with_diffusion.cc
+++ b/tests/prescribed_temperature_with_diffusion.cc
@@ -1,0 +1,75 @@
+#include <aspect/material_model/simple.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    using namespace dealii;
+
+    template <int dim>
+    class PrescribedTemperatureMaterial : public MaterialModel::Simple<dim>
+    {
+      public:
+
+        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+        virtual
+        void
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+    };
+
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+
+    template <int dim>
+    void
+    PrescribedTemperatureMaterial<dim>::
+    evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+             MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      Simple<dim>::evaluate(in, out);
+
+      // set up variable to interpolate prescribed field outputs onto compositional fields
+      PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim> >();
+
+      if (prescribed_temperature_out != NULL)
+        for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
+          {
+            const double y = in.position[i](1);
+            prescribed_temperature_out->prescribed_temperature_outputs[i] = std::exp(-y*y/2.0);
+          }
+    }
+
+
+    template <int dim>
+    void
+    PrescribedTemperatureMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
+    {
+      if (out.template get_additional_output<PrescribedTemperatureOutputs<dim> >() == NULL)
+        {
+          const unsigned int n_points = out.n_evaluation_points();
+          out.additional_outputs.push_back(
+            std::make_unique<MaterialModel::PrescribedTemperatureOutputs<dim>> (n_points));
+        }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    ASPECT_REGISTER_MATERIAL_MODEL(PrescribedTemperatureMaterial,
+                                   "prescribed temperature material",
+                                   "A simple material model that is like the "
+                                   "'Simple' model, but creates prescribed temperature outputs.")
+  }
+}

--- a/tests/prescribed_temperature_with_diffusion.prm
+++ b/tests/prescribed_temperature_with_diffusion.prm
@@ -1,0 +1,91 @@
+# A testcase that demonstrates that interpolating material model
+# outputs into the temperature field and diffusing it works.
+#
+# The property copied into the temperature field
+# is a Gaussian with an amplitude of 1, namely exp(-0.5*x*x).
+# We choose the diffusion length scale in a way that its amplitude
+# should be reduced to 0.95 when the diffusion equation is solved.
+
+set Dimension = 2
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false
+
+subsection Solver parameters
+  subsection Diffusion solver parameters
+    set Diffusion length scale = 0.23241476
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 0.1
+    set Y extent = 10
+    set Y repetitions = 100
+  end
+end
+
+subsection Temperature field
+  set Temperature method = prescribed field with diffusion
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 0.0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 1.0
+  end
+end
+
+
+subsection Material model
+  set Model name = prescribed temperature material
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1e-6
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, temperature statistics
+
+  subsection Visualization
+    set Interpolate output = false
+
+    set List of output variables      = named additional outputs
+    set Number of grouped files       = 0
+    set Output format                 = vtu
+    set Time between graphical output = 0
+  end
+end

--- a/tests/prescribed_temperature_with_diffusion/screen-output
+++ b/tests/prescribed_temperature_with_diffusion/screen-output
@@ -1,0 +1,29 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libprescribed_temperature_with_diffusion.so>
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 400 (on 2 levels)
+Number of degrees of freedom: 6,618 (4,010+603+2,005)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Copying properties into prescribed temperature field.
+   Solving temperature system... 152 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 35+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-prescribed_temperature_with_diffusion/solution/solution-00000
+     Temperature min/avg/max:  1.906e-14 K, 0.1253 K, 0.953 K
+
+Termination requested by criterion: end time
+
+
++------------------------------------------------+------------+------------+
++------------------------------------+-----------+------------+------------+
++------------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/prescribed_temperature_with_diffusion/statistics
+++ b/tests/prescribed_temperature_with_diffusion/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 400 4613 2005 152 34 36 35 output-prescribed_temperature_with_diffusion/solution/solution-00000 1.90639024e-14 1.25331414e-01 9.52987448e-01 


### PR DESCRIPTION
The pull request adds a new advection method for the temperature field called 'prescribed field with diffusion', analogous to the same method that already exists for compositional fields. This is useful for models with prescribed temperature outputs (such as when solving the energy equation for entropy instead of temperature as in the entropy_adiabat benchmark) because it allows for diffusion of the temperature field without applying any of the other terms in the equation. 

I have a follow-up pull request that applies this method using the entropy_adiabat benchmark. 

* [x] I have followed the [instructions for indenting my code](../blob/master/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/master/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/master/doc/modules/changes) directory that will inform other users of my change.
