### PR TITLE
Make sure environment variable is respected when searching for deal.II

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ LIST(APPEND CMAKE_MODULE_PATH
   )
 
 FIND_PACKAGE(deal.II 9.3.0 QUIET
-  HINTS ${deal.II_DIR} ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
+  HINTS ${deal.II_DIR} ${DEAL_II_DIR} $ENV{DEAL_II_DIR} ../ ../../
   )
 IF(NOT ${deal.II_FOUND})
   MESSAGE(FATAL_ERROR "\n*** Could not find a suitably recent version of deal.II. ***\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ LIST(APPEND CMAKE_MODULE_PATH
   )
 
 FIND_PACKAGE(deal.II 9.3.0 QUIET
-  HINTS ${deal.II_DIR} ${DEAL_II_DIR} $ENV{DEAL_II_DIR} ../ ../../
+  HINTS ${deal.II_DIR} ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
 IF(NOT ${deal.II_FOUND})
   MESSAGE(FATAL_ERROR "\n*** Could not find a suitably recent version of deal.II. ***\n"


### PR DESCRIPTION
This PR fixes annoying behavior that happens if you have multiple deal.II versions installed and at least one of them is one or two directory levels above your build folder. In such configurations it is impossible to specify the used deal.II version via an environment variable, because the first deal.II found in the level above will be used instead. deal.II paths directly specified as cmake parameters are respected, but environment variables are not. This patch unifies the behavior for cmake variables and environment variables. deal.II versions in the levels above are still found, but only if there are no cmake or environment variables set.