### PR TITLE
Fix tester results

### DIFF
--- a/tests/gmg_mesh_deform_adaptive_bug/screen-output
+++ b/tests/gmg_mesh_deform_adaptive_bug/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 6,996 (4,290+561+2,145)
 Number of mesh deformation degrees of freedom: 1122
    Solving mesh displacement system... 0 iterations.
 *** Timestep 0:  t=0 years, dt=0 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 0 iterations.
    Solving Stokes system... 11+0 iterations.
 
@@ -14,7 +14,7 @@ Number of mesh deformation degrees of freedom: 1122
      Topography min/max: 0 m, 0 m
 
 *** Timestep 1:  t=10000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 10 iterations.
    Solving Stokes system... 24+0 iterations.
 
@@ -22,7 +22,7 @@ Number of mesh deformation degrees of freedom: 1122
      Topography min/max: -10 m, 10 m
 
 *** Timestep 2:  t=20000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -30,7 +30,7 @@ Number of mesh deformation degrees of freedom: 1122
      Topography min/max: -20 m, 20 m
 
 *** Timestep 3:  t=30000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -38,7 +38,7 @@ Number of mesh deformation degrees of freedom: 1122
      Topography min/max: -30 m, 30 m
 
 *** Timestep 4:  t=40000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -46,7 +46,7 @@ Number of mesh deformation degrees of freedom: 1122
      Topography min/max: -40 m, 40 m
 
 *** Timestep 5:  t=50000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 4 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -58,7 +58,7 @@ Number of degrees of freedom: 6,467 (3,966+518+1,983)
 
 Number of mesh deformation degrees of freedom: 1036
 *** Timestep 6:  t=60000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 27+0 iterations.
 
@@ -66,7 +66,7 @@ Number of mesh deformation degrees of freedom: 1036
      Topography min/max: -60 m, 60 m
 
 *** Timestep 7:  t=70000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 27+0 iterations.
 
@@ -74,7 +74,7 @@ Number of mesh deformation degrees of freedom: 1036
      Topography min/max: -70 m, 70 m
 
 *** Timestep 8:  t=80000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 26+0 iterations.
 
@@ -82,7 +82,7 @@ Number of mesh deformation degrees of freedom: 1036
      Topography min/max: -80 m, 80 m
 
 *** Timestep 9:  t=90000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 26+0 iterations.
 
@@ -90,7 +90,7 @@ Number of mesh deformation degrees of freedom: 1036
      Topography min/max: -90 m, 90 m
 
 *** Timestep 10:  t=100000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 26+0 iterations.
 
@@ -102,7 +102,7 @@ Number of degrees of freedom: 6,317 (3,874+506+1,937)
 
 Number of mesh deformation degrees of freedom: 1012
 *** Timestep 11:  t=110000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 25+0 iterations.
 
@@ -110,7 +110,7 @@ Number of mesh deformation degrees of freedom: 1012
      Topography min/max: -110 m, 110 m
 
 *** Timestep 12:  t=120000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 25+0 iterations.
 
@@ -118,7 +118,7 @@ Number of mesh deformation degrees of freedom: 1012
      Topography min/max: -120 m, 120 m
 
 *** Timestep 13:  t=130000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 25+0 iterations.
 
@@ -126,7 +126,7 @@ Number of mesh deformation degrees of freedom: 1012
      Topography min/max: -130 m, 130 m
 
 *** Timestep 14:  t=140000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 25+0 iterations.
 
@@ -134,7 +134,7 @@ Number of mesh deformation degrees of freedom: 1012
      Topography min/max: -140 m, 140 m
 
 *** Timestep 15:  t=150000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 25+0 iterations.
 
@@ -146,7 +146,7 @@ Number of degrees of freedom: 6,353 (3,896+509+1,948)
 
 Number of mesh deformation degrees of freedom: 1018
 *** Timestep 16:  t=160000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 24+0 iterations.
 
@@ -154,7 +154,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -160 m, 160 m
 
 *** Timestep 17:  t=170000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 24+0 iterations.
 
@@ -162,7 +162,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -170 m, 170 m
 
 *** Timestep 18:  t=180000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -170,7 +170,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -180 m, 180 m
 
 *** Timestep 19:  t=190000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -178,7 +178,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -190 m, 190 m
 
 *** Timestep 20:  t=200000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -190,7 +190,7 @@ Number of degrees of freedom: 6,281 (3,852+503+1,926)
 
 Number of mesh deformation degrees of freedom: 1006
 *** Timestep 21:  t=210000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 24+0 iterations.
 
@@ -198,7 +198,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -210 m, 210 m
 
 *** Timestep 22:  t=220000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -206,7 +206,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -220 m, 220 m
 
 *** Timestep 23:  t=230000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -214,7 +214,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -230 m, 230 m
 
 *** Timestep 24:  t=240000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -222,7 +222,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -240 m, 240 m
 
 *** Timestep 25:  t=250000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -234,7 +234,7 @@ Number of degrees of freedom: 6,353 (3,896+509+1,948)
 
 Number of mesh deformation degrees of freedom: 1018
 *** Timestep 26:  t=260000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -242,7 +242,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -260 m, 260 m
 
 *** Timestep 27:  t=270000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -250,7 +250,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -270 m, 270 m
 
 *** Timestep 28:  t=280000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -258,7 +258,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -280 m, 280 m
 
 *** Timestep 29:  t=290000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -266,7 +266,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -290 m, 290 m
 
 *** Timestep 30:  t=300000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -278,7 +278,7 @@ Number of degrees of freedom: 6,281 (3,852+503+1,926)
 
 Number of mesh deformation degrees of freedom: 1006
 *** Timestep 31:  t=310000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -286,7 +286,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -310 m, 310 m
 
 *** Timestep 32:  t=320000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
 
@@ -294,7 +294,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -320 m, 320 m
 
 *** Timestep 33:  t=330000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -302,7 +302,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -330 m, 330 m
 
 *** Timestep 34:  t=340000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -310,7 +310,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -340 m, 340 m
 
 *** Timestep 35:  t=350000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -322,7 +322,7 @@ Number of degrees of freedom: 6,353 (3,896+509+1,948)
 
 Number of mesh deformation degrees of freedom: 1018
 *** Timestep 36:  t=360000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -330,7 +330,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -360 m, 360 m
 
 *** Timestep 37:  t=370000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -338,7 +338,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -370 m, 370 m
 
 *** Timestep 38:  t=380000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -346,7 +346,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -380 m, 380 m
 
 *** Timestep 39:  t=390000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -354,7 +354,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -390 m, 390 m
 
 *** Timestep 40:  t=400000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -366,7 +366,7 @@ Number of degrees of freedom: 6,281 (3,852+503+1,926)
 
 Number of mesh deformation degrees of freedom: 1006
 *** Timestep 41:  t=410000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -374,7 +374,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -410 m, 410 m
 
 *** Timestep 42:  t=420000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
 
@@ -382,7 +382,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -420 m, 420 m
 
 *** Timestep 43:  t=430000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -390,7 +390,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -430 m, 430 m
 
 *** Timestep 44:  t=440000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -398,7 +398,7 @@ Number of mesh deformation degrees of freedom: 1006
      Topography min/max: -440 m, 440 m
 
 *** Timestep 45:  t=450000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -410,7 +410,7 @@ Number of degrees of freedom: 6,353 (3,896+509+1,948)
 
 Number of mesh deformation degrees of freedom: 1018
 *** Timestep 46:  t=460000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -418,7 +418,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -460 m, 460 m
 
 *** Timestep 47:  t=470000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -426,7 +426,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -470 m, 470 m
 
 *** Timestep 48:  t=480000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -434,7 +434,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -480 m, 480 m
 
 *** Timestep 49:  t=490000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
 
@@ -442,7 +442,7 @@ Number of mesh deformation degrees of freedom: 1018
      Topography min/max: -490 m, 490 m
 
 *** Timestep 50:  t=500000 years, dt=10000 years
-   Solving mesh displacement system... 1 iterations.
+   Solving mesh displacement system... 5 iterations.
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
 


### PR DESCRIPTION
https://github.com/geodynamics/aspect/pull/4528 was merged with test results that were correct before https://github.com/geodynamics/aspect/pull/4495 was merged, but wrong afterwards. Due to the overlap the results were not correctly updated (I didnt notice that during reviewing) so the tester currently fails on `main`. This applies the fix and is identical to the changes that #4495 caused in the test `gmg_mesh_deform_adaptive`.