### PR TITLE
Provide centralized facilities for quadrature formulas.

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -23,6 +23,7 @@
 #define _aspect_introspection_h
 
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/quadrature.h>
 #include <deal.II/fe/component_mask.h>
 #include <deal.II/fe/fe_values_extractors.h>
 #include <deal.II/fe/fe.h>
@@ -213,6 +214,38 @@ namespace aspect
       const PolynomialDegree polynomial_degree;
 
       /**
+       * A structure that contains appropriate quadrature formulas for the
+       * finite elements that correspond to each of the variables in this problem,
+       * as well as for the complete system (the `system` variable).
+       *
+       * If there are compositional fields, they are all discretized with the
+       * same polynomial degree and, consequently, we only need a single formula.
+       *
+       * The quadrature formulas provided here are chosen such that the
+       * compute integrals with sufficient accuracy. For hypercube cells,
+       * this means in particular that they are of Gauss type with a
+       * number of Gauss points per coordinate direction that is one larger than
+       * the polynomial degree of the finite element per direction. For
+       * example, when using quadratic elements for the velocity, the
+       * corresponding quadrature formula will have three Gauss points per
+       * direction. If the mesh is based on triangles or tetrahedra, the
+       * quadrature formula is not of tensor-product Gauss type, but the
+       * corresponding analog for simplex cells.
+       */
+      struct Quadratures
+      {
+        Quadrature<dim>       velocities;
+        Quadrature<dim>       temperature;
+        Quadrature<dim>       compositional_fields;
+        Quadrature<dim>       system;
+      };
+      /**
+       * A variable that enumerates the polynomial degree of the finite element
+       * that correspond to each of the variables in this problem.
+       */
+      const Quadratures quadratures;
+
+      /**
        * A structure that contains component masks for each of the variables
        * in this problem. Component masks are a deal.II concept, see the
        * deal.II glossary.
@@ -379,7 +412,6 @@ namespace aspect
       composition_type_exists (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
 
 
-
       /**
        * A function that gets the type of a compositional field as an input
        * parameter and returns the index of the first compositional field of
@@ -391,8 +423,6 @@ namespace aspect
        */
       unsigned int
       find_composition_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
-
-
 
 
       /**

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -105,6 +105,26 @@ namespace aspect
 
 
     template <int dim>
+    typename Introspection<dim>::Quadratures
+    setup_quadratures (const Parameters<dim> &parameters,
+                       const ReferenceCell reference_cell)
+    {
+      typename Introspection<dim>::Quadratures quadratures;
+
+      quadratures.velocities = reference_cell.get_gauss_type_quadrature<dim>(parameters.stokes_velocity_degree+1);
+      quadratures.temperature = reference_cell.get_gauss_type_quadrature<dim>(parameters.temperature_degree+1);
+      quadratures.compositional_fields = reference_cell.get_gauss_type_quadrature<dim>(parameters.composition_degree+1);
+      quadratures.system = reference_cell.get_gauss_type_quadrature<dim>(std::max({parameters.stokes_velocity_degree,
+                                                                                   parameters.temperature_degree,
+                                                                                   parameters.composition_degree
+                                                                                  }) + 1);
+
+      return quadratures;
+    }
+
+
+
+    template <int dim>
     std::shared_ptr<FiniteElement<dim>>
                                      new_FE_Q_or_DGP(const bool discontinuous,
                                                      const unsigned int degree)
@@ -198,6 +218,7 @@ namespace aspect
     extractors (component_indices),
     base_elements (internal::setup_base_elements<dim>(*this)),
     polynomial_degree (internal::setup_polynomial_degree<dim>(parameters)),
+    quadratures (internal::setup_quadratures<dim>(parameters, ReferenceCells::get_hypercube<dim>())),
     component_masks (*this),
     system_dofs_per_block (n_blocks),
     temperature_method(parameters.temperature_method),

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1445,7 +1445,7 @@ namespace aspect
     dealii::LinearAlgebra::distributed::Vector<double> active_viscosity_vector(dof_handler_projection.locally_owned_dofs(),
                                                                                sim.triangulation.get_communicator());
 
-    const QGauss<dim> quadrature_formula (sim.parameters.stokes_velocity_degree+1);
+    const Quadrature<dim> &quadrature_formula = sim.introspection.quadratures.velocities;
 
     double minimum_viscosity_local = std::numeric_limits<double>::max();
     double maximum_viscosity_local = std::numeric_limits<double>::lowest();
@@ -2957,7 +2957,7 @@ namespace aspect
                                    locally_relevant_dofs,
                                    sim.mpi_communicator);
 
-            QGauss<dim>  quadrature_formula(sim.parameters.stokes_velocity_degree+1);
+            const Quadrature<dim> &quadrature_formula = sim.introspection.quadratures.velocities;
             FEValues<dim> fe_values (*(sim.mapping), fe_v, quadrature_formula,
                                      update_values   | update_gradients |
                                      update_quadrature_points | update_JxW_values);


### PR DESCRIPTION
If we ever want to use anything other than hypercube cells, then we must also switch quadrature formulas. In other words, every occurrence of `QGauss` has to be replaced by something that depends on the cell type.

Rather than having lots of `if` or `?:` statements in the code, I thought I'd use this as an opportunity to provide centralized infrastructure for these cases. That's what the first commit does. I think it makes the code easier to read in general because one no longer has to know that adding one to the polynomial degree is what one should be doing to get an appropriate quadrature formula.

The second commit shows how this can be used. There are some 30 places left that need to be looked at, but I thought I'd put this patch out already for comment, and then just work through the remaining places by hand.

(Right now, I set quadrature objects up in a way that only works for hypercubes. That's because it's not trivial to know up front what kind of cell a mesh is going to use, and the introspection object is set up pretty early. I will have to think about how to address this, but at least it will have to be addressed in only one place, rather than at every location where we currently set up quadrature formulas.)

/rebuild