### PR TITLE
Provide the infrastructure for face quadratures.

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -246,6 +246,27 @@ namespace aspect
       const Quadratures quadratures;
 
       /**
+       * A structure that contains appropriate face quadrature formulas for the
+       * finite elements that correspond to each of the variables in this problem,
+       * as well as for the complete system (the `system` variable).
+       *
+       * This structure corresponds to the Quadratures structure above, but for
+       * face integration.
+       */
+      struct FaceQuadratures
+      {
+        Quadrature<dim-1>       velocities;
+        Quadrature<dim-1>       temperature;
+        Quadrature<dim-1>       compositional_fields;
+        Quadrature<dim-1>       system;
+      };
+      /**
+       * A variable that enumerates the polynomial degree of the finite element
+       * that correspond to each of the variables in this problem.
+       */
+      const FaceQuadratures face_quadratures;
+
+      /**
        * A structure that contains component masks for each of the variables
        * in this problem. Component masks are a deal.II concept, see the
        * deal.II glossary.

--- a/source/postprocess/boundary_velocity_residual_statistics.cc
+++ b/source/postprocess/boundary_velocity_residual_statistics.cc
@@ -97,7 +97,7 @@ namespace aspect
     BoundaryVelocityResidualStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula for the velocity.
-      const QGauss<dim-1> quadrature_formula (this->introspection().polynomial_degree.velocities+1);
+      const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.velocities;
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                         this->get_fe(),

--- a/source/postprocess/mobility_statistics.cc
+++ b/source/postprocess/mobility_statistics.cc
@@ -39,8 +39,7 @@ namespace aspect
     MobilityStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula for the velocity for the volume of cells
-      const QGauss<dim> quadrature_formula (this->get_fe()
-                                            .base_element(this->introspection().base_elements.velocities).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.velocities;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),
@@ -53,7 +52,8 @@ namespace aspect
       std::vector<Tensor<1,dim>> velocity_values(n_q_points);
 
       // create a quadrature formula for the velocity for the surface of cells
-      const QGauss<dim-1> quadrature_formula_face (this->introspection().polynomial_degree.velocities+1);
+      const Quadrature<dim-1> &quadrature_formula_face
+        = this->introspection().face_quadratures.velocities;
       const unsigned int n_q_points_face = quadrature_formula_face.size();
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -125,6 +125,26 @@ namespace aspect
 
 
     template <int dim>
+    typename Introspection<dim>::FaceQuadratures
+    setup_face_quadratures (const Parameters<dim> &parameters,
+                            const ReferenceCell reference_cell)
+    {
+      typename Introspection<dim>::FaceQuadratures quadratures;
+
+      quadratures.velocities = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.stokes_velocity_degree+1);
+      quadratures.temperature = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.temperature_degree+1);
+      quadratures.compositional_fields = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.composition_degree+1);
+      quadratures.system = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(std::max({parameters.stokes_velocity_degree,
+                           parameters.temperature_degree,
+                           parameters.composition_degree
+                                                                                                           }) + 1);
+
+      return quadratures;
+    }
+
+
+
+    template <int dim>
     std::shared_ptr<FiniteElement<dim>>
                                      new_FE_Q_or_DGP(const bool discontinuous,
                                                      const unsigned int degree)
@@ -219,6 +239,7 @@ namespace aspect
     base_elements (internal::setup_base_elements<dim>(*this)),
     polynomial_degree (internal::setup_polynomial_degree<dim>(parameters)),
     quadratures (internal::setup_quadratures<dim>(parameters, ReferenceCells::get_hypercube<dim>())),
+    face_quadratures (internal::setup_face_quadratures<dim>(parameters, ReferenceCells::get_hypercube<dim>())),
     component_masks (*this),
     system_dofs_per_block (n_blocks),
     temperature_method(parameters.temperature_method),


### PR DESCRIPTION
This is the face equivalent of the patch that introduced quadrature formula objects to `Introspection`, #4536 . The second commit uses this in a couple of places as an example.

/rebuild