### PR TITLE
Fix override warnings

### DIFF
--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -161,10 +161,9 @@ namespace aspect
          * Apply a translation to all points outside of the domain
          * to account for periodicity.
          */
-        virtual
         void
         adjust_positions_for_periodicity (Point<dim> &position,
-                                          const ArrayView<Point<dim>> &connected_positions = {}) const;
+                                          const ArrayView<Point<dim>> &connected_positions = {}) const override;
 
         /**
          * @copydoc Interface::has_curved_elements()

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -142,10 +142,9 @@ namespace aspect
          * Apply a rotation to all points outside of the domain
          * to account for periodicity.
          */
-        virtual
         void
         adjust_positions_for_periodicity (Point<dim> &position,
-                                          const ArrayView<Point<dim>> &connected_positions = {}) const;
+                                          const ArrayView<Point<dim>> &connected_positions = {}) const override;
 
         /**
          * @copydoc Interface::has_curved_elements()

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -141,10 +141,9 @@ namespace aspect
          * Apply a translation to all points outside of the domain
          * to account for periodicity.
          */
-        virtual
         void
         adjust_positions_for_periodicity (Point<dim> &position,
-                                          const ArrayView<Point<dim>> &connected_positions = {}) const;
+                                          const ArrayView<Point<dim>> &connected_positions = {}) const override;
 
         /**
          * @copydoc Interface::has_curved_elements()

--- a/include/aspect/postprocess/gravity_point_values.h
+++ b/include/aspect/postprocess/gravity_point_values.h
@@ -65,7 +65,7 @@ namespace aspect
         /**
          * @copydoc Interface::initialize().
          */
-        void initialize();
+        void initialize() override;
 
         /**
          * Specify the creation of output_gravity.txt.


### PR DESCRIPTION
Fix compiler warnings about functions that override member functions but are not marked as such.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
