### PR TITLE
More using of centralized quadrature objects.

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -235,6 +235,7 @@ namespace aspect
       struct Quadratures
       {
         Quadrature<dim>       velocities;
+        Quadrature<dim>       pressure;
         Quadrature<dim>       temperature;
         Quadrature<dim>       compositional_fields;
         Quadrature<dim>       system;
@@ -256,6 +257,7 @@ namespace aspect
       struct FaceQuadratures
       {
         Quadrature<dim-1>       velocities;
+        Quadrature<dim-1>       pressure;
         Quadrature<dim-1>       temperature;
         Quadrature<dim-1>       compositional_fields;
         Quadrature<dim-1>       system;

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -656,7 +656,7 @@ namespace aspect
 
       // Calculate core mantle boundary heat flow
       {
-        const QGauss<dim-1> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+        const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.temperature;
         FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                           this->get_fe(),
                                           quadrature_formula,

--- a/source/postprocess/boundary_densities.cc
+++ b/source/postprocess/boundary_densities.cc
@@ -33,13 +33,11 @@ namespace aspect
     std::pair<std::string,std::string>
     BoundaryDensities<dim>::execute (TableHandler &statistics)
     {
-      const QGauss<dim-1> quadrature_formula_face (this->get_fe()
-                                                   .base_element(this->introspection().base_elements.temperature)
-                                                   .degree+1);
+      const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.temperature;
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                         this->get_fe(),
-                                        quadrature_formula_face,
+                                        quadrature_formula,
                                         update_values |
                                         update_gradients |
                                         update_quadrature_points |

--- a/source/postprocess/boundary_pressures.cc
+++ b/source/postprocess/boundary_pressures.cc
@@ -33,13 +33,11 @@ namespace aspect
     std::pair<std::string,std::string>
     BoundaryPressures<dim>::execute (TableHandler &statistics)
     {
-      const QGauss<dim-1> quadrature_formula_face (this->get_fe()
-                                                   .base_element(this->introspection().base_elements.pressure)
-                                                   .degree+1);
+      const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.pressure;
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                         this->get_fe(),
-                                        quadrature_formula_face,
+                                        quadrature_formula,
                                         update_values |
                                         update_gradients |
                                         update_quadrature_points |
@@ -50,7 +48,7 @@ namespace aspect
       double local_top_area = 0.;
       double local_bottom_area = 0.;
 
-      std::vector<double> pressure_vals( fe_face_values.n_quadrature_points );
+      std::vector<double> pressure_vals (fe_face_values.n_quadrature_points);
 
       const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
       const types::boundary_id bottom_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");

--- a/source/postprocess/composition_statistics.cc
+++ b/source/postprocess/composition_statistics.cc
@@ -41,7 +41,7 @@ namespace aspect
       AssertThrow (this->introspection().base_elements.compositional_fields
                    != numbers::invalid_unsigned_int,
                    ExcMessage("This postprocessor cannot be used without compositional fields."));
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.compositional_fields).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.compositional_fields;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/postprocess/heating_statistics.cc
+++ b/source/postprocess/heating_statistics.cc
@@ -37,7 +37,7 @@ namespace aspect
     HeatingStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.temperature;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -35,7 +35,6 @@ namespace aspect
     std::pair<std::string,std::string>
     MassFluxStatistics<dim>::execute (TableHandler &statistics)
     {
-      // First determine the units for the output
       const std::string unit = (this->convert_output_to_years())
                                ?
                                "kg/yr"
@@ -48,7 +47,7 @@ namespace aspect
                               1.0;
 
       // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim-1> quadrature_formula (this->introspection().polynomial_degree.velocities + 1);
+      const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.velocities;
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                         this->get_fe(),

--- a/source/postprocess/material_statistics.cc
+++ b/source/postprocess/material_statistics.cc
@@ -35,7 +35,7 @@ namespace aspect
     MaterialStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.temperature;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/postprocess/max_depth_field.cc
+++ b/source/postprocess/max_depth_field.cc
@@ -38,7 +38,7 @@ namespace aspect
       // be defensive about determining that a compositional field actually exists
       AssertThrow(this->introspection().base_elements.compositional_fields != numbers::invalid_unsigned_int,
                   ExcMessage("This postprocessor cannot be used without compositional fields."));
-      const QGauss<dim> quadrature_formula(this->get_fe().base_element(this->introspection().base_elements.compositional_fields).degree + 1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.compositional_fields;
 
       const unsigned int n_q_points = quadrature_formula.size();
 

--- a/source/postprocess/melt_statistics.cc
+++ b/source/postprocess/melt_statistics.cc
@@ -36,7 +36,7 @@ namespace aspect
     MeltStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.temperature;
       const unsigned int n_q_points = quadrature_formula.size();
       std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),
                                                            std::vector<double> (n_q_points));

--- a/source/postprocess/temperature_statistics.cc
+++ b/source/postprocess/temperature_statistics.cc
@@ -36,7 +36,7 @@ namespace aspect
     TemperatureStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula based on the temperature element alone.
-      const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.temperature).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.temperature;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/postprocess/velocity_boundary_statistics.cc
+++ b/source/postprocess/velocity_boundary_statistics.cc
@@ -37,7 +37,7 @@ namespace aspect
     VelocityBoundaryStatistics<dim>::execute (TableHandler &statistics)
     {
       // create a quadrature formula for the velocity.
-      const QGauss<dim-1> quadrature_formula (this->introspection().polynomial_degree.velocities+1);
+      const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.velocities;
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
                                         this->get_fe(),

--- a/source/postprocess/velocity_statistics.cc
+++ b/source/postprocess/velocity_statistics.cc
@@ -35,8 +35,7 @@ namespace aspect
     std::pair<std::string,std::string>
     VelocityStatistics<dim>::execute (TableHandler &statistics)
     {
-      const QGauss<dim> quadrature_formula (this->get_fe()
-                                            .base_element(this->introspection().base_elements.velocities).degree+1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.velocities;
       const unsigned int n_q_points = quadrature_formula.size();
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/postprocess/viscous_dissipation_statistics.cc
+++ b/source/postprocess/viscous_dissipation_statistics.cc
@@ -35,7 +35,7 @@ namespace aspect
     ViscousDissipationStatistics<dim>::execute (TableHandler &statistics)
     {
       // Create a quadrature formula based on the velocity element.
-      const QGauss<dim> quadrature_formula(this->get_fe().base_element(this->introspection().base_elements.velocities).degree + 1);
+      const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.velocities;
 
       const unsigned int n_q_points = quadrature_formula.size();
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -372,7 +372,7 @@ namespace aspect
 
     system_preconditioner_matrix = 0;
 
-    const QGauss<dim> quadrature_formula(parameters.stokes_velocity_degree+1);
+    const Quadrature<dim> &quadrature_formula = introspection.quadratures.velocities;
 
     using CellFilter = FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>;
 
@@ -731,8 +731,8 @@ namespace aspect
     if (do_pressure_rhs_compatibility_modification)
       pressure_shape_function_integrals = 0;
 
-    const QGauss<dim>   quadrature_formula(parameters.stokes_velocity_degree+1);
-    const QGauss<dim-1> face_quadrature_formula(parameters.stokes_velocity_degree+1);
+    const Quadrature<dim>   &quadrature_formula = introspection.quadratures.velocities;
+    const Quadrature<dim-1> &face_quadrature_formula = introspection.face_quadratures.velocities;
 
     using CellFilter = FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>;
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2036,7 +2036,7 @@ namespace aspect
   void
   Simulator<dim>::replace_outflow_boundary_ids(const unsigned int offset)
   {
-    const QGauss<dim-1> quadrature_formula (finite_element.base_element(introspection.base_elements.temperature).degree+1);
+    const Quadrature<dim-1> &quadrature_formula = introspection.face_quadratures.temperature;
 
     FEFaceValues<dim> fe_face_values (*mapping,
                                       finite_element,

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -411,8 +411,7 @@ namespace aspect
         LinearAlgebra::BlockVector system_tmp;
         system_tmp.reinit (system_rhs);
 
-        const QGauss<dim> quadrature(parameters.stokes_velocity_degree+1);
-
+        const Quadrature<dim> &quadrature = introspection.quadratures.velocities;
         Utilities::project_cellwise<dim,LinearAlgebra::BlockVector>(*mapping,
                                                                     dof_handler,
                                                                     introspection.component_indices.pressure,

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -112,6 +112,11 @@ namespace aspect
       typename Introspection<dim>::Quadratures quadratures;
 
       quadratures.velocities = reference_cell.get_gauss_type_quadrature<dim>(parameters.stokes_velocity_degree+1);
+      quadratures.pressure = reference_cell.get_gauss_type_quadrature<dim>(parameters.use_equal_order_interpolation_for_stokes
+                                                                           ?
+                                                                           parameters.stokes_velocity_degree+1
+                                                                           :
+                                                                           parameters.stokes_velocity_degree);
       quadratures.temperature = reference_cell.get_gauss_type_quadrature<dim>(parameters.temperature_degree+1);
       quadratures.compositional_fields = reference_cell.get_gauss_type_quadrature<dim>(parameters.composition_degree+1);
       quadratures.system = reference_cell.get_gauss_type_quadrature<dim>(std::max({parameters.stokes_velocity_degree,
@@ -132,6 +137,11 @@ namespace aspect
       typename Introspection<dim>::FaceQuadratures quadratures;
 
       quadratures.velocities = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.stokes_velocity_degree+1);
+      quadratures.pressure = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.use_equal_order_interpolation_for_stokes
+                             ?
+                             parameters.stokes_velocity_degree+1
+                             :
+                             parameters.stokes_velocity_degree);
       quadratures.temperature = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.temperature_degree+1);
       quadratures.compositional_fields = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(parameters.composition_degree+1);
       quadratures.system = reference_cell.face_reference_cell(0).get_gauss_type_quadrature<dim-1>(std::max({parameters.stokes_velocity_degree,

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -54,6 +54,7 @@ namespace aspect
     {}
 
 
+
     template <int dim>
     void MeltInputs<dim>::fill (const LinearAlgebra::BlockVector &solution,
                                 const FEValuesBase<dim>          &fe_values,
@@ -68,6 +69,8 @@ namespace aspect
       const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
       fe_values[ex_p_c].get_function_values (solution, compaction_pressures);
     }
+
+
 
     template <int dim>
     void MeltOutputs<dim>::average (const MaterialAveraging::AveragingOperation operation,
@@ -88,6 +91,8 @@ namespace aspect
       // doubles). It's also not quite clear whether these should
       // really be averaged, so avoid this for now
     }
+
+
 
     template <int dim>
     double
@@ -133,6 +138,8 @@ namespace aspect
     }
   }
 
+
+
   namespace Assemblers
   {
     namespace
@@ -158,6 +165,8 @@ namespace aspect
       }
     }
 
+
+
     template <int dim>
     void
     MeltInterface<dim>::create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
@@ -178,6 +187,7 @@ namespace aspect
              outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == n_points, ExcInternalError());
     }
+
 
 
     template <int dim>
@@ -1078,7 +1088,7 @@ namespace aspect
       system_matrix.block(block_idx, block_idx) = 0;
       system_rhs.block(block_idx) = 0;
 
-      const QGauss<dim> quadrature(this->get_parameters().stokes_velocity_degree+1);
+      const Quadrature<dim> &quadrature = this->introspection().quadratures.velocities;
       const FiniteElement<dim> &fe = this->get_fe();
 
       FEValues<dim> fe_values (this->get_mapping(),
@@ -1320,6 +1330,8 @@ namespace aspect
     }
   }
 
+
+
   template <int dim>
   bool
   MeltHandler<dim>::
@@ -1330,6 +1342,7 @@ namespace aspect
     else
       return (this->introspection().name_for_compositional_index(advection_field.compositional_variable) == "porosity");
   }
+
 
 
   namespace internal
@@ -1456,6 +1469,8 @@ namespace aspect
 
   }
 
+
+
   template <int dim>
   void
   MeltHandler<dim>::
@@ -1559,6 +1574,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   bool
   MeltHandler<dim>::
@@ -1566,6 +1582,7 @@ namespace aspect
   {
     return is_melt_cell_vector[cell->active_cell_index()];
   }
+
 
 
   template <int dim>
@@ -1579,6 +1596,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   const BoundaryFluidPressure::Interface<dim> &
   MeltHandler<dim>::
@@ -1586,6 +1604,7 @@ namespace aspect
   {
     return *boundary_fluid_pressure.get();
   }
+
 
 
   template <int dim>

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -364,7 +364,7 @@ namespace aspect
     // \int \rho r \times u =  I \cdot \omega  (3 dimensions)
 
     const Quadrature<dim> &quadrature = introspection.quadratures.velocities;
-    const QGauss<dim-1> surface_quadrature(parameters.stokes_velocity_degree+1);
+    const Quadrature<dim-1> &surface_quadrature = introspection.face_quadratures.velocities;
 
     const unsigned int n_q_points = (limit_to_top_faces == false) ? quadrature.size() : surface_quadrature.size();
     UpdateFlags flags = update_quadrature_points | update_JxW_values | update_values | update_gradients;

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1805,7 +1805,7 @@ namespace aspect
             sim.mesh_deformation->template get_matching_mesh_deformation_object<MeshDeformation::FreeSurface<dim>>()
           .get_free_surface_theta();
 
-          const QGauss<dim-1> face_quadrature_formula (sim.parameters.stokes_velocity_degree+1);
+          const Quadrature<dim-1> &face_quadrature_formula = sim.introspection.face_quadratures.velocities;
 
           const unsigned int n_face_q_points = face_quadrature_formula.size();
 


### PR DESCRIPTION
Another follow-up to #4536 and #4544. This converts most of the rest of the uses of `QGauss`, but not all. 

I needed to also create a quadrature object for the pressure, which is what the first commit does. I somehow forgot that when I created the other quadrature objects.

/rebuild