### PR TITLE
Correct the computation of e_dot_ii.

### DIFF
--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -41,7 +41,7 @@ namespace aspect
       // to prevent a division-by-zero, and a floating point exception.
       // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
       // strain rate (often simplified as epsilondot_ii)
-      const double edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
+      const double edot_ii = std::max(std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.)),
                                       min_strain_rate);
 
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -184,7 +184,7 @@ namespace aspect
       // get grain size and limit it to a global minimum
       const unsigned int grain_size_index = this->introspection().compositional_index_for_name("grain_size");
       double grain_size = composition[grain_size_index];
-      grain_size = std::max(std::exp(-grain_size),min_grain_size);
+      grain_size = std::max(std::exp(-grain_size), min_grain_size);
 
       composition[grain_size_index] = grain_size;
     }
@@ -246,7 +246,7 @@ namespace aspect
 
           // grain size reduction in dislocation creep regime
           const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
-          const double second_strain_rate_invariant = std::sqrt(std::abs(second_invariant(shear_strain_rate)));
+          const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
           const double current_diffusion_viscosity   = diffusion_viscosity(temperature, pressure, current_composition, strain_rate, position);
           current_dislocation_viscosity              = dislocation_viscosity(temperature, pressure, current_composition, strain_rate, position, current_dislocation_viscosity);
@@ -336,7 +336,7 @@ namespace aspect
                          const Point<dim>             &position) const
     {
       const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
-      const double second_strain_rate_invariant = std::sqrt(std::abs(second_invariant(shear_strain_rate)));
+      const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
       const double grain_size = composition[this->introspection().compositional_index_for_name("grain_size")];
 
@@ -430,7 +430,7 @@ namespace aspect
                                              const Point<dim> &position) const
     {
       const SymmetricTensor<2,dim> shear_strain_rate = dislocation_strain_rate - 1./dim * trace(dislocation_strain_rate) * unit_symmetric_tensor<dim>();
-      const double second_strain_rate_invariant = std::sqrt(std::abs(second_invariant(shear_strain_rate)));
+      const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
       // Currently this will never be called without adiabatic_conditions initialized, but just in case
       const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
@@ -479,7 +479,7 @@ namespace aspect
                const Point<dim> &position) const
     {
       const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
-      const double second_strain_rate_invariant = std::sqrt(std::abs(second_invariant(shear_strain_rate)));
+      const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
       const double diff_viscosity = diffusion_viscosity(temperature, pressure, composition, strain_rate, position);
 
@@ -846,7 +846,7 @@ namespace aspect
               double disl_viscosity = std::numeric_limits<double>::max();
 
               const SymmetricTensor<2,dim> shear_strain_rate = in.strain_rate[i] - 1./dim * trace(in.strain_rate[i]) * unit_symmetric_tensor<dim>();
-              const double second_strain_rate_invariant = std::sqrt(std::abs(second_invariant(shear_strain_rate)));
+              const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
               const double diff_viscosity = diffusion_viscosity(in.temperature[i], pressure, composition, in.strain_rate[i], in.position[i]);
 

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -130,7 +130,7 @@ namespace aspect
         // to prevent a division-by-zero, and a floating point exception.
         // Otherwise, calculate the square-root of the norm of the second invariant of the deviatoric-
         // strain rate (often simplified as epsilondot_ii)
-        const double edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(strain_rate)))),
+        const double edot_ii = std::max(std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.)),
                                         min_strain_rate);
 
         Rheology::DiffusionCreepParameters diffusion_creep_parameters;

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -423,7 +423,7 @@ namespace aspect
         const SymmetricTensor<2,dim> edot_deviator = deviator(strain_rate) + 0.5*stress /
                                                      calculate_elastic_viscosity(shear_modulus);
 
-        return std::sqrt(std::fabs(second_invariant(edot_deviator)));
+        return std::sqrt(std::max(-second_invariant(edot_deviator), 0.));
       }
     }
   }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -498,7 +498,8 @@ namespace aspect
         // Calculate changes in strain and update the reaction terms
         if  (this->simulator_is_past_initialization() && this->get_timestep_number() > 0 && in.requests_property(MaterialProperties::reaction_terms))
           {
-            const double edot_ii = std::max(sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),min_strain_rate);
+            const double edot_ii = std::max(std::sqrt(std::max(-second_invariant(deviator(in.strain_rate[i])), 0.)),
+                                            min_strain_rate);
             double delta_e_ii = edot_ii*this->get_timestep();
 
             // Adjusting strain values to account for strain healing without exceeding an unreasonable range

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -126,7 +126,7 @@ namespace aspect
           edot_ii = ref_strain_rate;
         else
           // Calculate the square root of the second moment invariant for the deviatoric strain rate tensor.
-          edot_ii = std::max(std::sqrt(std::fabs(second_invariant(deviator(in.strain_rate[i])))),
+          edot_ii = std::max(std::sqrt(std::max(-second_invariant(deviator(in.strain_rate[i])), 0.)),
                              min_strain_rate);
 
         // Calculate viscosities for each of the individual compositional phases

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -59,7 +59,7 @@ namespace aspect
         const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
 
         // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::fabs(second_invariant(deviator(strain_rate))));
+        const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.));
 
         // New strain is the old strain plus dt*edot_ii
         const double new_strain = old_strain + dt*edot_ii;

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -137,7 +137,7 @@ namespace aspect
 
 
         // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::fabs(second_invariant(deviator(material_inputs.strain_rate[0]))));
+        const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(material_inputs.strain_rate[0])), 0.));
 
         // New strain is the old strain plus dt*edot_ii
         const double new_strain = old_strain + dt*edot_ii;

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -58,7 +58,7 @@ namespace aspect
               grad_u[d] = input_data.solution_gradients[q][d];
 
             const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
-            computed_quantities[q](0) = std::sqrt(std::fabs(second_invariant(deviator(strain_rate))));
+            computed_quantities[q](0) = std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.));
           }
 
         // average the values if requested

--- a/source/postprocess/visualization/stress_second_invariant.cc
+++ b/source/postprocess/visualization/stress_second_invariant.cc
@@ -103,7 +103,7 @@ namespace aspect
             // in the same way as the second moment invariant of the deviatoric
             // strain rate is computed in the viscoplastic material model.
             // TODO check that this is valid for the compressible case.
-            const double stress_invariant = std::sqrt(std::fabs(second_invariant(deviatoric_stress)));
+            const double stress_invariant = std::sqrt(std::max(-second_invariant(deviatoric_stress), 0.));
 
             computed_quantities[q](0) = stress_invariant;
           }


### PR DESCRIPTION
#3755 made me think about the computation of e_dot_ii. In quite a number of places, we compute it as
```
  sqrt( abs( second_invariant( deviator( eps ) ) ) )
```
but that seems wrong. I don't think we should be taking the absolute value -- the second invariant of a deviator should probably already be non-negative (I haven't tried to prove this, though).

This patch fixes this, but I imagine that it won't work because there will likely be cases where numerical round-off means that the second invariant is `-1e-16` or some such, and the square root will not be happy. I just want to try this out.

The "correct" patch -- should the current patch fail because of the anticipated issue with round off -- would be to treat everything negative as zero. I'll do that instead if the patch fails.

/rebuild