### PR TITLE
Fix incompatibility with deal.II master

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -388,6 +388,10 @@ namespace aspect
 
           return n_particles_in_cell * particle_weight;
         }
+      else if (status == parallel::distributed::Triangulation<dim>::CELL_INVALID)
+        {
+          return 0;
+        }
 
       Assert (false, ExcInternalError());
       return 0;


### PR DESCRIPTION
This fixes an incompatibility introduced in deal.II in dealii/dealii#13451. I need to make some further changes to remove deprecation warnings, but the current change at least fixes the crash that we currently get for all particle models running a relatively new deal.II dev version (because the `cell_weight` function is now occasionally called with a `CELL_INVALID` cell status, which it did not do before that change).