### PR TITLE
Fix deprecation warnings and incompatibility with deal.II

### DIFF
--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -388,6 +388,10 @@ namespace aspect
 
           return n_particles_in_cell * particle_weight;
         }
+      else if (status == parallel::distributed::Triangulation<dim>::CELL_INVALID)
+        {
+          return 0;
+        }
 
       Assert (false, ExcInternalError());
       return 0;


### PR DESCRIPTION
This PR supersedes #4565. It fixes a number of deprecation warnings and uses a new version of a deal.II signal. In the process it also fixes a crash in current master with a current deal.II dev. Because this PR has a different implementation of the `cell_weight` function than #4565 for deal.II 9.4 the fix in the earlier PR is no longer necessary.