### PR TITLE
Improve astyle indentation

### DIFF
--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -239,7 +239,7 @@ namespace aspect
 
         virtual
         std::vector<std::pair<std::string, unsigned int>>
-                                                       get_property_information() const
+        get_property_information() const
         {
           std::vector<std::pair<std::string,unsigned int>> property_information;
 

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -578,7 +578,7 @@ namespace aspect
       // the values of the compositional fields are stored as blockvectors for each field
       // we have to extract them in this structure
       std::vector<std::vector<double>> prelim_composition_values (this->n_compositional_fields(),
-                                                                  std::vector<double> (n_q_points));
+                                                                   std::vector<double> (n_q_points));
 
       typename MaterialModel::Interface<dim>::MaterialModelInputs in(n_q_points,
                                                                      this->n_compositional_fields());

--- a/contrib/utilities/astyle.rc
+++ b/contrib/utilities/astyle.rc
@@ -32,6 +32,3 @@
 --max-instatement-indent=80
 --suffix=none
 --quiet
-
-# use "classname<dim>", not "classname< dim >" or other variations
---close-templates

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -149,8 +149,11 @@ dos_to_unix()
 {
     f=$1
     tr -d '\015' <$f >$f.tmp
-    diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
-    rm -f $f.tmp
+    if ! diff -q $f $f.tmp >/dev/null ; then
+      mv $f.tmp $f
+    else
+      rm $f.tmp
+    fi
 }
 export -f dos_to_unix
 find tests include source unit_tests cookbooks benchmarks \( -name '*.cc' -o -name '*.h' -o -name '*.prm' -o -name '*.h.in' \) -print | xargs -n 1 -P 10 -I {} bash -c 'dos_to_unix "$@"' _ {}

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -103,6 +103,11 @@ echo "--- Found astyle 2.04 at ${astyle}"
 # look-behind expression is not part of the match itself (which is only ">"
 # in the expression above) and is only used to restrict which occurrences
 # of ">" are actually matches (and consequently substituted).
+#
+# For unclear reasons, astyle insists on appending a separate empty line
+# at the end of the file. Fix this up using the last two 'sed' commands,
+# using the same logic as in the 'ensure_single_trailing_newline()'
+# function below.
 indent_file() {
   file="${1}"
   tmpfile="$(mktemp "${TMPDIR}/$(basename "$1").tmp.XXXXXXXX")"
@@ -110,7 +115,10 @@ indent_file() {
   cat ${file} \
       | perl -p -e 's/(?<=>)>/ >/g;' \
       | "${astyle}" --options=contrib/utilities/astyle.rc \
-      | perl -p -e 's/(?<=>) >/>/g;' > ${tmpfile}
+      | perl -p -e 's/(?<=>) >/>/g;' \
+      | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' \
+      | sed -e '$a\' \
+      > ${tmpfile}
 
   if ! diff -q "${file}" "${tmpfile}" >/dev/null; then
     mv "${tmpfile}" "${file}"
@@ -172,6 +180,7 @@ remove_trailing_whitespace()
 }
 export -f remove_trailing_whitespace
 find tests include source unit_tests cookbooks benchmarks \( -name '*.cc' -o -name '*.h' -o -name '*.prm' -o -name '*.h.in' -o -name 'CMakeLists.txt' -o -name '*.cmake' \) -print | xargs -n 1 -P 10 -I {} bash -c 'remove_trailing_whitespace "$@"' _ {}
+
 
 # Ensure only a single newline at end of files
 ensure_single_trailing_newline()

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -123,7 +123,7 @@ indent_file() {
   if ! diff -q "${file}" "${tmpfile}" >/dev/null; then
     mv "${tmpfile}" "${file}"
   else
-    rm ${tmpfile}
+    rm "${tmpfile}"
   fi
 }
 export -f indent_file

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -21,6 +21,14 @@
 ##
 ## ---------------------------------------------------------------------
 
+
+#
+# Mac OSX's mktemp doesn't know the --tmpdir option without argument. So,
+# let's do all of that by hand:
+#
+export TMPDIR="${TMPDIR:-/tmp}"
+
+
 find_astyle() {
   # Split $PATH variable into an array
   IFS=':' PATHS=(${PATH})
@@ -35,6 +43,7 @@ find_astyle() {
   done
 }
 
+
 if test ! -d source -o ! -d include ; then
   echo "*** This script must be run from the top-level directory of ASPECT."
   exit 1
@@ -47,6 +56,7 @@ fi
 
 astyle="$(find_astyle)"
 astyle="${astyle:-`which astyle`}" # Fallback to `which astyle`
+export astyle
 
 if test -z "${astyle}"; then
   echo "*** No astyle program found."
@@ -61,8 +71,7 @@ fi
 echo "--- Found astyle 2.04 at ${astyle}"
 
 
-# Collect all header and source files and process them in batches of 50 files
-# with up to 10 in parallel.
+# Indent a file.
 #
 # We use astyle 2.04 for indentation, which is a tool that predates C++11
 # and that consequently has trouble with things such as
@@ -94,19 +103,33 @@ echo "--- Found astyle 2.04 at ${astyle}"
 # look-behind expression is not part of the match itself (which is only ">"
 # in the expression above) and is only used to restrict which occurrences
 # of ">" are actually matches (and consequently substituted).
+indent_file() {
+  file="${1}"
+  tmpfile="$(mktemp "${TMPDIR}/$(basename "$1").tmp.XXXXXXXX")"
+
+  cat ${file} \
+      | perl -p -e 's/(?<=>)>/ >/g;' \
+      | "${astyle}" --options=contrib/utilities/astyle.rc \
+      | perl -p -e 's/(?<=>) >/>/g;' > ${tmpfile}
+
+  if ! diff -q "${file}" "${tmpfile}" >/dev/null; then
+    mv "${tmpfile}" "${file}"
+  else
+    rm ${tmpfile}
+  fi
+}
+export -f indent_file
+
+
+
+# Collect all header and source files and process them 
+# with up to 10 processes in parallel.
+#
 echo "--- Indenting all ASPECT header and source files"
 
 find tests include source benchmarks cookbooks unit_tests \
      \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
-  | xargs -n 50 -P 10 perl -pi -e 's/(?<=>)>/ >/g;'
-
-find tests include source benchmarks cookbooks unit_tests \
-     \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
-  | xargs -n 50 -P 10 "${astyle}" --options=contrib/utilities/astyle.rc
-
-find tests include source benchmarks cookbooks unit_tests \
-     \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
-  | xargs -n 50 -P 10 perl -pi -e 's/(?<=>) >/>/g;'
+  | xargs -P 10 -I {} bash -c "indent_file {}"
 
 
 # remove execute permission on source files:

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -61,11 +61,53 @@ fi
 echo "--- Found astyle 2.04 at ${astyle}"
 
 
-# collect all header and source files and process them in batches of 50 files
-# with up to 10 in parallel
+# Collect all header and source files and process them in batches of 50 files
+# with up to 10 in parallel.
+#
+# We use astyle 2.04 for indentation, which is a tool that predates C++11
+# and that consequently has trouble with things such as
+#   std::vector<Point<dim>>
+# where it interprets the closing `>>` as a right shift operator. It then
+# gets its template closing angle bracket counter all out of whack and
+# produces awkward indentations. To avoid this, we first convert all closing
+# `>>` into `> >`, run astyle, and then change it back. This leads to reasonable
+# results.
+#
+# One might think that a regex substitution such as
+#   s/>>/> >/g;
+# would work (and putting the space on the left hand side for the way back).
+# But this is not true because Perl does not go back to look at the substitution
+# again, even with the /g modifier. As a consequence, the regex above
+# replaces *triple* closing angle brackets as
+#   ">>>"  ->  "> >>"
+# and it does not look at the ">>" on the right hand side because the 'point'
+# within the string where the regex matcher starts looking again with /g
+# is now the last ">", having replaced the initial ">>" by "> >". Clearly,
+# strings such as ">>>>" with four or more closing brackets encounter
+# similar issues.
+#
+# The way to work around this is to replace "a '>' preceded by another
+# '>' by ' >'". This is expressed with positive look-behind, and leads to
+# the regex substitution
+#   s/(?<=>)>/ >/g
+# where "(?<=" starts the positive look-behind expression. Note that the
+# look-behind expression is not part of the match itself (which is only ">"
+# in the expression above) and is only used to restrict which occurrences
+# of ">" are actually matches (and consequently substituted).
 echo "--- Indenting all ASPECT header and source files"
 
-find tests include source benchmarks cookbooks unit_tests \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print | xargs -n 50 -P 10 "${astyle}" --options=contrib/utilities/astyle.rc
+find tests include source benchmarks cookbooks unit_tests \
+     \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
+  | xargs -n 50 -P 10 perl -pi -e 's/(?<=>)>/ >/g;'
+
+find tests include source benchmarks cookbooks unit_tests \
+     \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
+  | xargs -n 50 -P 10 "${astyle}" --options=contrib/utilities/astyle.rc
+
+find tests include source benchmarks cookbooks unit_tests \
+     \( -name '*.cc' -o -name '*.h' -o -name '*.h.in' \) -print \
+  | xargs -n 50 -P 10 perl -pi -e 's/(?<=>) >/>/g;'
+
 
 # remove execute permission on source files:
 find tests include source benchmarks cookbooks unit_tests \( -name '*.cc' -o -name '*.h' -o -name '*.prm' \) -print | xargs -n 50 -P 10 chmod -x

--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -241,11 +241,11 @@ namespace aspect
   namespace ASPECT_REGISTER_ADIABATIC_CONDITIONS_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::AdiabaticConditions::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::AdiabaticConditions::register_adiabatic_conditions<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::AdiabaticConditions::register_adiabatic_conditions<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::AdiabaticConditions::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::AdiabaticConditions::register_adiabatic_conditions<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::AdiabaticConditions::register_adiabatic_conditions<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -404,11 +404,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_COMPOSITION_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryComposition::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryComposition::Manager<2>::register_boundary_composition, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryComposition::Manager<2>::register_boundary_composition, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryComposition::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryComposition::Manager<3>::register_boundary_composition, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryComposition::Manager<3>::register_boundary_composition, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -187,11 +187,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_FLUID_PRESSURE_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryFluidPressure::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryFluidPressure::register_boundary_fluid_pressure<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryFluidPressure::register_boundary_fluid_pressure<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryFluidPressure::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryFluidPressure::register_boundary_fluid_pressure<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryFluidPressure::register_boundary_fluid_pressure<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_heat_flux/function.h
+++ b/include/aspect/boundary_heat_flux/function.h
@@ -48,10 +48,10 @@ namespace aspect
          * Return the boundary heat flux as a function of position.
          */
         std::vector<Tensor<1,dim>>
-                                heat_flux (const types::boundary_id boundary_indicator,
-                                           const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-                                           const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                                           const std::vector<Tensor<1,dim>> &normal_vectors) const override;
+        heat_flux (const types::boundary_id boundary_indicator,
+                   const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                   const std::vector<Tensor<1,dim>> &normal_vectors) const override;
 
         /**
          * A function that is called at the beginning of each time step to

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -91,10 +91,10 @@ namespace aspect
          */
         virtual
         std::vector<Tensor<1,dim>>
-                                heat_flux (const types::boundary_id boundary_indicator,
-                                           const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-                                           const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                                           const std::vector<Tensor<1,dim>> &normal_vectors) const = 0;
+        heat_flux (const types::boundary_id boundary_indicator,
+                   const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                   const std::vector<Tensor<1,dim>> &normal_vectors) const = 0;
 
         /**
          * Declare the parameters this class takes through input files. The
@@ -193,11 +193,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_HEAT_FLUX_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryHeatFlux::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryHeatFlux::register_boundary_heat_flux<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryHeatFlux::register_boundary_heat_flux<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryHeatFlux::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryHeatFlux::register_boundary_heat_flux<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryHeatFlux::register_boundary_heat_flux<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -428,11 +428,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryTemperature::Manager<2>::register_boundary_temperature, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryTemperature::Manager<2>::register_boundary_temperature, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTemperature::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryTemperature::Manager<3>::register_boundary_temperature, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryTemperature::Manager<3>::register_boundary_temperature, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -217,11 +217,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_TRACTION_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTraction::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryTraction::register_boundary_traction<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryTraction::register_boundary_traction<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryTraction::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryTraction::register_boundary_traction<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryTraction::register_boundary_traction<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -396,11 +396,11 @@ namespace aspect
   namespace ASPECT_REGISTER_BOUNDARY_VELOCITY_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryVelocity::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::BoundaryVelocity::Manager<2>::register_boundary_velocity, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::BoundaryVelocity::Manager<2>::register_boundary_velocity, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::BoundaryVelocity::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::BoundaryVelocity::Manager<3>::register_boundary_velocity, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::BoundaryVelocity::Manager<3>::register_boundary_velocity, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -153,7 +153,7 @@ namespace aspect
          * file.
          */
         std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-            get_periodic_boundary_pairs () const override;
+        get_periodic_boundary_pairs () const override;
 
         /**
          * @copydoc Interface::adjust_positions_for_periodicity

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -142,7 +142,7 @@ namespace aspect
            * Return a copy of this manifold.
            */
           std::unique_ptr<Manifold<dim,dim>>
-                                          clone() const override;
+          clone() const override;
 
           /**
            * Set the minimal radius of the domain.

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -121,7 +121,7 @@ namespace aspect
              * Return a copy of this manifold.
              */
             std::unique_ptr<Manifold<dim,3>>
-                                          clone() const override;
+            clone() const override;
 
           private:
             /**
@@ -297,7 +297,7 @@ namespace aspect
          * North-West, South-West and South-East.
          */
         const std::vector<Point<2>> &
-                                 get_corners() const;
+        get_corners() const;
 
 
         /**

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -177,11 +177,11 @@ namespace aspect
   namespace ASPECT_REGISTER_INITIAL_TOPOGRAPHY_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialTopographyModel::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::InitialTopographyModel::register_initial_topography_model<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::InitialTopographyModel::register_initial_topography_model<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialTopographyModel::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::InitialTopographyModel::register_initial_topography_model<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::InitialTopographyModel::register_initial_topography_model<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -306,7 +306,7 @@ namespace aspect
          */
         virtual
         std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-            get_periodic_boundary_pairs () const;
+        get_periodic_boundary_pairs () const;
 
         /**
          * Adjust positions to be inside the domain considering periodic boundary conditions.
@@ -454,11 +454,11 @@ namespace aspect
   namespace ASPECT_REGISTER_GEOMETRY_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::GeometryModel::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::GeometryModel::register_geometry_model<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::GeometryModel::register_geometry_model<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::GeometryModel::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::GeometryModel::register_geometry_model<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::GeometryModel::register_geometry_model<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -134,7 +134,7 @@ namespace aspect
          * file.
          */
         std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-            get_periodic_boundary_pairs () const override;
+        get_periodic_boundary_pairs () const override;
 
         /**
          * @copydoc Interface::adjust_positions_for_periodicity

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -133,7 +133,7 @@ namespace aspect
          * file.
          */
         std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-            get_periodic_boundary_pairs () const override;
+        get_periodic_boundary_pairs () const override;
 
         /**
          * @copydoc Interface::adjust_positions_for_periodicity

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -174,11 +174,11 @@ namespace aspect
   namespace ASPECT_REGISTER_GRAVITY_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::GravityModel::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::GravityModel::register_gravity_model<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::GravityModel::register_gravity_model<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::GravityModel::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::GravityModel::register_gravity_model<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::GravityModel::register_gravity_model<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -490,11 +490,11 @@ namespace aspect
   namespace ASPECT_REGISTER_HEATING_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::HeatingModel::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::HeatingModel::Manager<2>::register_heating_model, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::HeatingModel::Manager<2>::register_heating_model, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::HeatingModel::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::HeatingModel::Manager<3>::register_heating_model, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::HeatingModel::Manager<3>::register_heating_model, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -346,11 +346,11 @@ namespace aspect
   namespace ASPECT_REGISTER_INITIAL_COMPOSITION_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialComposition::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::InitialComposition::Manager<2>::register_initial_composition, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::InitialComposition::Manager<2>::register_initial_composition, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialComposition::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::InitialComposition::Manager<3>::register_initial_composition, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::InitialComposition::Manager<3>::register_initial_composition, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -334,11 +334,11 @@ namespace aspect
   namespace ASPECT_REGISTER_INITIAL_TEMPERATURE_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialTemperature::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::InitialTemperature::Manager<2>::register_initial_temperature, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::InitialTemperature::Manager<2>::register_initial_temperature, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::InitialTemperature::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::InitialTemperature::Manager<3>::register_initial_temperature, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::InitialTemperature::Manager<3>::register_initial_temperature, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -42,7 +42,7 @@ namespace aspect
    */
   template <int dim>
   std::vector<VariableDeclaration<dim>>
-                                     construct_default_variables (const Parameters<dim> &parameters);
+  construct_default_variables (const Parameters<dim> &parameters);
 
 
 

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -116,8 +116,8 @@ namespace aspect
        */
       DEAL_II_DEPRECATED
       std::vector<std::vector<double>>
-                                    get_averages(const unsigned int n_slices,
-                                                 const std::vector<std::string> &property_names) const;
+      get_averages(const unsigned int n_slices,
+                   const std::vector<std::string> &property_names) const;
 
       /**
        * Return a depth profile of lateral averages of the selected
@@ -136,8 +136,8 @@ namespace aspect
        * as many vectors returned as names in @p property_names.
        */
       std::vector<std::vector<double>>
-                                    compute_lateral_averages(const unsigned int n_slices,
-                                                             const std::vector<std::string> &property_names) const;
+      compute_lateral_averages(const unsigned int n_slices,
+                               const std::vector<std::string> &property_names) const;
 
       /**
        * Return a depth profile of lateral averages of the selected
@@ -162,8 +162,8 @@ namespace aspect
        * and there are as many vectors returned as names in @p property_names.
        */
       std::vector<std::vector<double>>
-                                    compute_lateral_averages(const std::vector<double> &depth_bounds,
-                                                             const std::vector<std::string> &property_names) const;
+      compute_lateral_averages(const std::vector<double> &depth_bounds,
+                               const std::vector<std::string> &property_names) const;
 
       /**
        * Return a depth profile of lateral averages. This function is the
@@ -196,8 +196,8 @@ namespace aspect
        * the number of @p depth_bounds).
        */
       std::vector<std::vector<double>>
-                                    compute_lateral_averages(const std::vector<double> &depth_bounds,
-                                                             std::vector<std::unique_ptr<internal::FunctorBase<dim>>> &functors) const;
+      compute_lateral_averages(const std::vector<double> &depth_bounds,
+                               std::vector<std::unique_ptr<internal::FunctorBase<dim>>> &functors) const;
 
       /**
        * Fill the argument with a set of lateral averages of the current

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1535,11 +1535,11 @@ namespace aspect
   namespace ASPECT_REGISTER_MATERIAL_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::MaterialModel::register_material_model<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::MaterialModel::register_material_model<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::MaterialModel::register_material_model<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::MaterialModel::register_material_model<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -223,7 +223,7 @@ namespace aspect
          * used in the computation, as specified in the input file.
          */
         const std::map<types::boundary_id, std::vector<std::string>> &
-                                                                  get_active_mesh_deformation_names () const;
+        get_active_mesh_deformation_names () const;
 
         /**
          * Return a map of boundary indicators to vectors of pointers to all mesh deformation models
@@ -599,11 +599,11 @@ namespace aspect
   namespace ASPECT_REGISTER_MESH_DEFORMATION_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::MeshDeformation::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::MeshDeformation::MeshDeformationHandler<2>::register_mesh_deformation, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::MeshDeformation::MeshDeformationHandler<2>::register_mesh_deformation, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::MeshDeformation::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::MeshDeformation::MeshDeformationHandler<3>::register_mesh_deformation, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::MeshDeformation::MeshDeformationHandler<3>::register_mesh_deformation, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -377,11 +377,11 @@ namespace aspect
   namespace ASPECT_REGISTER_MESH_REFINEMENT_CRITERION_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::MeshRefinement::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::MeshRefinement::Manager<2>::register_mesh_refinement_criterion, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::MeshRefinement::Manager<2>::register_mesh_refinement_criterion, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::MeshRefinement::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::MeshRefinement::Manager<3>::register_mesh_refinement_criterion, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::MeshRefinement::Manager<3>::register_mesh_refinement_criterion, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -129,8 +129,8 @@ namespace aspect
            * to generate the initial particle distribution.
            */
           std::pair<Particles::internal::LevelInd,Particle<dim>>
-                                                              generate_particle (const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
-                                                                                 const types::particle_index id);
+          generate_particle (const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
+                             const types::particle_index id);
 
 
           /**
@@ -167,8 +167,8 @@ namespace aspect
            */
           DEAL_II_DEPRECATED
           std::pair<Particles::internal::LevelInd,Particle<dim>>
-                                                              generate_particle(const Point<dim> &position,
-                                                                                const types::particle_index id) const;
+          generate_particle(const Point<dim> &position,
+                            const types::particle_index id) const;
 
           /**
            * Generate a particle at the specified position and with the
@@ -275,11 +275,11 @@ namespace aspect
   namespace ASPECT_REGISTER_PARTICLE_GENERATOR_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Generator::Interface<2>,classname<2 >> \
-        dummy_ ## classname ## _2d (&aspect::Particle::Generator::register_particle_generator<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Particle::Generator::register_particle_generator<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Generator::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Particle::Generator::register_particle_generator<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Particle::Generator::register_particle_generator<3>, \
+                                name, description); \
   }
     }
   }

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -252,11 +252,11 @@ namespace aspect
   namespace ASPECT_REGISTER_PARTICLE_INTEGRATOR_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Integrator::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::Particle::Integrator::register_particle_integrator<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Particle::Integrator::register_particle_integrator<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Integrator::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Particle::Integrator::register_particle_integrator<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Particle::Integrator::register_particle_integrator<3>, \
+                                name, description); \
   }
     }
   }

--- a/include/aspect/particle/interpolator/bilinear_least_squares.h
+++ b/include/aspect/particle/interpolator/bilinear_least_squares.h
@@ -47,10 +47,10 @@ namespace aspect
            * Return the cell-wise evaluated properties of the bilinear least squares function at the positions.
            */
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;

--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -44,10 +44,10 @@ namespace aspect
            * given positions.
            */
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;

--- a/include/aspect/particle/interpolator/harmonic_average.h
+++ b/include/aspect/particle/interpolator/harmonic_average.h
@@ -44,10 +44,10 @@ namespace aspect
            * given positions.
            */
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -77,9 +77,9 @@ namespace aspect
           DEAL_II_DEPRECATED
           virtual
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
 
           /**
            * Perform an interpolation of the properties of the particles in
@@ -107,10 +107,10 @@ namespace aspect
            */
           virtual
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const = 0;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const = 0;
 
           /**
            * Declare the parameters this class takes through input files. The
@@ -215,11 +215,11 @@ namespace aspect
   namespace ASPECT_REGISTER_PARTICLE_INTERPOLATOR_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Interpolator::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::Particle::Interpolator::register_particle_interpolator<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Particle::Interpolator::register_particle_interpolator<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Interpolator::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Particle::Interpolator::register_particle_interpolator<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Particle::Interpolator::register_particle_interpolator<3>, \
+                                name, description); \
   }
     }
   }

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -45,10 +45,10 @@ namespace aspect
            * or adjacent cells if none is present in same cell.
            */
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;

--- a/include/aspect/particle/interpolator/quadratic_least_squares.h
+++ b/include/aspect/particle/interpolator/quadratic_least_squares.h
@@ -53,10 +53,10 @@ namespace aspect
            * Return the cell-wise evaluated properties of the quadratic least squares function at the positions.
            */
           std::vector<std::vector<double>>
-                                        properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                             const std::vector<Point<dim>> &positions,
-                                                             const ComponentMask &selected_properties,
-                                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
 
           // avoid -Woverloaded-virtual:
           using Interface<dim>::properties_at_points;

--- a/include/aspect/particle/property/composition.h
+++ b/include/aspect/particle/property/composition.h
@@ -89,7 +89,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/elastic_stress.h
+++ b/include/aspect/particle/property/elastic_stress.h
@@ -82,7 +82,7 @@ namespace aspect
            * @copydoc aspect::Particle::Property::Interface::get_property_information()
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
 
         private:
           /**

--- a/include/aspect/particle/property/function.h
+++ b/include/aspect/particle/property/function.h
@@ -66,7 +66,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
 
 
           /**

--- a/include/aspect/particle/property/initial_composition.h
+++ b/include/aspect/particle/property/initial_composition.h
@@ -74,7 +74,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/initial_position.h
+++ b/include/aspect/particle/property/initial_position.h
@@ -62,7 +62,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -90,7 +90,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/integrated_strain_invariant.h
+++ b/include/aspect/particle/property/integrated_strain_invariant.h
@@ -89,7 +89,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -469,7 +469,7 @@ namespace aspect
            */
           virtual
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const = 0;
+          get_property_information() const = 0;
 
 
           /**
@@ -530,7 +530,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
 
           /**
            * Read the parameters this class needs to determine which integrator is used,
@@ -779,11 +779,11 @@ namespace aspect
   namespace ASPECT_REGISTER_PARTICLE_PROPERTY_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Property::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::Particle::Property::Manager<2>::register_particle_property, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Particle::Property::Manager<2>::register_particle_property, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Particle::Property::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Particle::Property::Manager<3>::register_particle_property, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Particle::Property::Manager<3>::register_particle_property, \
+                                name, description); \
   }
 
     }

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -90,7 +90,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
 
           /**
            * Declare the parameters this class takes through input files.

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -90,7 +90,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -78,7 +78,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/reference_position.h
+++ b/include/aspect/particle/property/reference_position.h
@@ -78,7 +78,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -87,7 +87,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
       };
     }
   }

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -86,7 +86,7 @@ namespace aspect
            * @copydoc aspect::Particle::Property::Interface::get_property_information()
            */
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const override;
+          get_property_information() const override;
 
         private:
           unsigned int n_components;

--- a/include/aspect/postprocess/geoid.h
+++ b/include/aspect/postprocess/geoid.h
@@ -149,7 +149,7 @@ namespace aspect
          * The outer vector stores the inner vector associated with each quadrature point on a spherical surface.
          */
         std::pair<std::vector<double>,std::vector<double>>
-                                                        to_spherical_harmonic_coefficients(const std::vector<std::vector<double>> &spherical_function) const;
+        to_spherical_harmonic_coefficients(const std::vector<std::vector<double>> &spherical_function) const;
 
         /**
          * Function to compute the density contribution in spherical harmonic expansion throughout the mantle
@@ -157,7 +157,7 @@ namespace aspect
          * This function returns a pair containing real spherical harmonics of density integral (cos and sin part) from min degree to max degree.
          */
         std::pair<std::vector<double>,std::vector<double>>
-                                                        density_contribution (const double &outer_radius) const;
+        density_contribution (const double &outer_radius) const;
 
         /**
          * Function to compute the surface and CMB topography contribution in spherical harmonic expansion

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -226,7 +226,7 @@ namespace aspect
          * individual postprocessors.
          */
         std::list<std::pair<std::string,std::string>>
-                                                   execute (TableHandler &statistics);
+        execute (TableHandler &statistics);
 
         /**
          * Go through the list of all postprocessors that have been selected
@@ -453,11 +453,11 @@ namespace aspect
   namespace ASPECT_REGISTER_POSTPROCESSOR_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::Postprocess::Manager<2>::register_postprocessor, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Postprocess::Manager<2>::register_postprocessor, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Postprocess::Manager<3>::register_postprocessor, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Postprocess::Manager<3>::register_postprocessor, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -66,7 +66,7 @@ namespace aspect
            * Implementation of the corresponding function of the base class.
            */
           const std::vector<DataOutBase::Patch<0,dim>> &
-                                                    get_patches () const override;
+          get_patches () const override;
 
           /**
            * Implementation of the corresponding function of the base class.

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -704,11 +704,11 @@ namespace aspect
   namespace ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::VisualizationPostprocessors::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::Postprocess::Visualization<2>::register_visualization_postprocessor, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::Postprocess::Visualization<2>::register_visualization_postprocessor, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::Postprocess::VisualizationPostprocessors::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::Postprocess::Visualization<3>::register_visualization_postprocessor, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::Postprocess::Visualization<3>::register_visualization_postprocessor, \
+                                name, description); \
   }
 }
 

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -196,11 +196,11 @@ namespace aspect
   namespace ASPECT_REGISTER_PRESCRIBED_STOKES_SOLUTION_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::PrescribedStokesSolution::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::PrescribedStokesSolution::register_prescribed_stokes_solution_model<2>, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::PrescribedStokesSolution::register_prescribed_stokes_solution_model<2>, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::PrescribedStokesSolution::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::PrescribedStokesSolution::register_prescribed_stokes_solution_model<3>, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::PrescribedStokesSolution::register_prescribed_stokes_solution_model<3>, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -278,11 +278,11 @@ namespace aspect
   namespace ASPECT_REGISTER_TERMINATION_CRITERION_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::TerminationCriteria::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::TerminationCriteria::Manager<2>::register_termination_criterion, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::TerminationCriteria::Manager<2>::register_termination_criterion, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::TerminationCriteria::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::TerminationCriteria::Manager<3>::register_termination_criterion, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::TerminationCriteria::Manager<3>::register_termination_criterion, \
+                                name, description); \
   }
   }
 }

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -320,11 +320,11 @@ namespace aspect
   namespace ASPECT_REGISTER_TIME_STEPPING_MODEL_ ## classname \
   { \
     aspect::internal::Plugins::RegisterHelper<aspect::TimeStepping::Interface<2>,classname<2>> \
-        dummy_ ## classname ## _2d (&aspect::TimeStepping::Manager<2>::register_time_stepping_model, \
-                                    name, description); \
+    dummy_ ## classname ## _2d (&aspect::TimeStepping::Manager<2>::register_time_stepping_model, \
+                                name, description); \
     aspect::internal::Plugins::RegisterHelper<aspect::TimeStepping::Interface<3>,classname<3>> \
-        dummy_ ## classname ## _3d (&aspect::TimeStepping::Manager<3>::register_time_stepping_model, \
-                                    name, description); \
+    dummy_ ## classname ## _3d (&aspect::TimeStepping::Manager<3>::register_time_stepping_model, \
+                                name, description); \
   }
 
   }

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -213,10 +213,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<AdiabaticConditions::Interface<2>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<AdiabaticConditions::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<AdiabaticConditions::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<AdiabaticConditions::Interface<3>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<AdiabaticConditions::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<AdiabaticConditions::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -394,10 +394,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryComposition::Interface<2>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<BoundaryComposition::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryComposition::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryComposition::Interface<3>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<BoundaryComposition::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryComposition::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -135,10 +135,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryFluidPressure::Interface<2>>::PluginInfo> *
-                                                                                internal::Plugins::PluginList<BoundaryFluidPressure::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryFluidPressure::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryFluidPressure::Interface<3>>::PluginInfo> *
-                                                                                internal::Plugins::PluginList<BoundaryFluidPressure::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryFluidPressure::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_heat_flux/function.cc
+++ b/source/boundary_heat_flux/function.cc
@@ -30,11 +30,11 @@ namespace aspect
   {
     template <int dim>
     std::vector<Tensor<1,dim>>
-                            Function<dim>::
-                            heat_flux (const types::boundary_id /*boundary_indicator*/,
-                                       const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-                                       const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
-                                       const std::vector<Tensor<1,dim>> &normal_vectors) const
+    Function<dim>::
+    heat_flux (const types::boundary_id /*boundary_indicator*/,
+               const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+               const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
+               const std::vector<Tensor<1,dim>> &normal_vectors) const
     {
       const unsigned int n_evaluation_points = material_model_inputs.position.size();
       std::vector<Tensor<1,dim>> heat_flux(normal_vectors);

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -140,10 +140,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryHeatFlux::Interface<2>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryHeatFlux::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryHeatFlux::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryHeatFlux::Interface<3>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryHeatFlux::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryHeatFlux::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -408,10 +408,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryTemperature::Interface<2>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<BoundaryTemperature::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryTemperature::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryTemperature::Interface<3>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<BoundaryTemperature::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryTemperature::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -169,10 +169,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryTraction::Interface<2>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryTraction::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryTraction::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryTraction::Interface<3>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryTraction::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryTraction::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -188,8 +188,8 @@ namespace aspect
           {
             velocities[i]
               = std::make_unique<Functions::InterpolatedUniformGridData<2>> (grid_extent,
-                                                                             table_intervals,
-                                                                             velocity_values[i]);
+                                                                              table_intervals,
+                                                                              velocity_values[i]);
           }
 
         AssertThrow(i == n_points,

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -389,8 +389,8 @@ namespace aspect
             {
               boundary_velocity_objects[boundary_id.first].push_back(
                 std::unique_ptr<Interface<dim>> (std::get<dim>(registered_plugins)
-                                                 .create_plugin (name,
-                                                                 "Boundary velocity::Model names")));
+                                                  .create_plugin (name,
+                                                                  "Boundary velocity::Model names")));
 
               if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_velocity_objects[boundary_id.first].back().get()))
                 sim->initialize_simulator (this->get_simulator());
@@ -422,10 +422,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<BoundaryVelocity::Interface<2>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryVelocity::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryVelocity::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<BoundaryVelocity::Interface<3>>::PluginInfo> *
-                                                                           internal::Plugins::PluginList<BoundaryVelocity::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<BoundaryVelocity::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/fe_variable_collection.cc
+++ b/source/fe_variable_collection.cc
@@ -197,7 +197,7 @@ namespace aspect
 
   template <int dim>
   const std::vector<FEVariable<dim>> &
-                                  FEVariableCollection<dim>::get_variables() const
+  FEVariableCollection<dim>::get_variables() const
   {
     return variables;
   }

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -75,7 +75,7 @@ namespace aspect
 
       // Tell p4est about the periodicity of the mesh.
       std::vector<GridTools::PeriodicFacePair<typename parallel::distributed::Triangulation<dim>::cell_iterator>>
-          periodicity_vector;
+      periodicity_vector;
       for (int i=0; i<dim; ++i)
         if (periodic[i])
           GridTools::collect_periodic_faces
@@ -184,8 +184,8 @@ namespace aspect
 
     template <int dim>
     std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-        Box<dim>::
-        get_periodic_boundary_pairs () const
+    Box<dim>::
+    get_periodic_boundary_pairs () const
     {
       std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>> periodic_boundaries;
       for ( unsigned int i=0; i<dim; ++i)

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -364,8 +364,8 @@ namespace aspect
 
       template <int dim>
       std::unique_ptr<Manifold<dim,dim>>
-                                      ChunkGeometry<dim>::
-                                      clone() const
+      ChunkGeometry<dim>::
+      clone() const
       {
         return std::make_unique<ChunkGeometry>(*this);
       }

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -227,7 +227,7 @@ namespace aspect
 
     template <int dim>
     std::unique_ptr<Manifold<dim,3>>
-                                  EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::clone() const
+    EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::clone() const
     {
       return std::make_unique<EllipsoidalChunkGeometry>(*this);
     }
@@ -681,7 +681,7 @@ namespace aspect
 
     template <int dim>
     const std::vector<Point<2>> &
-                             EllipsoidalChunk<dim>::get_corners() const
+    EllipsoidalChunk<dim>::get_corners() const
     {
       return corners;
     }

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -155,11 +155,11 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<InitialTopographyModel::Interface<2>>::PluginInfo> *
-                                                                                 internal::Plugins::PluginList<InitialTopographyModel::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialTopographyModel::Interface<2>>::plugins = nullptr;
 
       template <>
       std::list<internal::Plugins::PluginList<InitialTopographyModel::Interface<3>>::PluginInfo> *
-                                                                                 internal::Plugins::PluginList<InitialTopographyModel::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialTopographyModel::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -49,7 +49,7 @@ namespace aspect
 
     template <int dim>
     std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-        Interface<dim>::get_periodic_boundary_pairs() const
+    Interface<dim>::get_periodic_boundary_pairs() const
     {
       // return an empty set in the base class
       return std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>();
@@ -367,11 +367,11 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<GeometryModel::Interface<2>>::PluginInfo> *
-                                                                        internal::Plugins::PluginList<GeometryModel::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<GeometryModel::Interface<2>>::plugins = nullptr;
 
       template <>
       std::list<internal::Plugins::PluginList<GeometryModel::Interface<3>>::PluginInfo> *
-                                                                        internal::Plugins::PluginList<GeometryModel::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<GeometryModel::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -223,7 +223,7 @@ namespace aspect
             {
               // Tell p4est about the periodicity of the mesh.
               std::vector<GridTools::PeriodicFacePair<typename parallel::distributed::Triangulation<dim>::cell_iterator>>
-                  matched_pairs;
+              matched_pairs;
               FullMatrix<double> rotation_matrix(dim);
               rotation_matrix[0][1] = 1.;
               rotation_matrix[1][0] = -1.;
@@ -359,8 +359,8 @@ namespace aspect
 
     template <int dim>
     std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-        SphericalShell<dim>::
-        get_periodic_boundary_pairs () const
+    SphericalShell<dim>::
+    get_periodic_boundary_pairs () const
     {
       std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>> periodic_boundaries;
       if (periodic)
@@ -577,7 +577,7 @@ namespace aspect
       if (periodic)
         {
           std::vector<GridTools::PeriodicFacePair<typename DoFHandler<dim>::cell_iterator>>
-                                                                                         matched_pairs;
+          matched_pairs;
           FullMatrix<double> rotation_matrix(dim);
           rotation_matrix[0][1] = 1.;
           rotation_matrix[1][0] = -1.;

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -109,7 +109,7 @@ namespace aspect
 
       // tell p4est about the periodicity of the mesh.
       std::vector<GridTools::PeriodicFacePair<typename parallel::distributed::Triangulation<dim>::cell_iterator>>
-          periodicity_vector;
+      periodicity_vector;
       for (int i=0; i<dim+dim-1; ++i)
         {
           if (periodic[i])
@@ -194,8 +194,8 @@ namespace aspect
 
     template <int dim>
     std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>>
-        TwoMergedBoxes<dim>::
-        get_periodic_boundary_pairs () const
+    TwoMergedBoxes<dim>::
+    get_periodic_boundary_pairs () const
     {
       std::set<std::pair<std::pair<types::boundary_id, types::boundary_id>, unsigned int>> periodic_boundaries;
       for ( unsigned int i=0; i<dim+dim-1; ++i)

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -152,10 +152,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<GravityModel::Interface<2>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<GravityModel::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<GravityModel::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<GravityModel::Interface<3>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<GravityModel::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<GravityModel::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -375,10 +375,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<HeatingModel::Interface<2>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<HeatingModel::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<HeatingModel::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<HeatingModel::Interface<3>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<HeatingModel::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<HeatingModel::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -260,10 +260,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<InitialComposition::Interface<2>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<InitialComposition::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialComposition::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<InitialComposition::Interface<3>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<InitialComposition::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialComposition::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -72,7 +72,7 @@ namespace aspect
           std::vector<double> melt_fraction(1);
 
           Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>>
-                                                                                (this->get_material_model()).melt_fractions(in,melt_fraction);
+          (this->get_material_model()).melt_fractions(in,melt_fraction);
           return melt_fraction[0];
         }
       return 0.0;

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -249,10 +249,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<InitialTemperature::Interface<2>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<InitialTemperature::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialTemperature::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<InitialTemperature::Interface<3>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<InitialTemperature::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<InitialTemperature::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -236,7 +236,7 @@ namespace aspect
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points,
-                                                                       this->n_compositional_fields()));
+                                                                        this->n_compositional_fields()));
         }
     }
   }

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -232,7 +232,7 @@ namespace aspect
         // the index j corresponds to the jth compositional field
         // the index k corresponds to the kth phase in the lookup
         std::vector<std::vector<double>> phase_volume_fractions(unique_phase_names.size(),
-                                                                std::vector<double>(in.n_evaluation_points(), 0.));
+                                                                 std::vector<double>(in.n_evaluation_points(), 0.));
         for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
           for (unsigned j = 0; j < material_lookup.size(); ++j)
             for (unsigned int k = 0; k < unique_phase_indices[j].size(); ++k)
@@ -261,7 +261,7 @@ namespace aspect
         // the index i corresponds to the ith evaluation point
         // the index j corresponds to the jth compositional field
         std::vector<std::vector<double>> dominant_phase_indices(1, std::vector<double>(in.n_evaluation_points(),
-                                                                                       std::numeric_limits<double>::quiet_NaN()));
+                                                                                        std::numeric_limits<double>::quiet_NaN()));
         for (unsigned int i = 0; i < in.n_evaluation_points(); ++i)
           {
             const unsigned int dominant_material_index = std::distance(volume_fractions[i].begin(), std::max_element(volume_fractions[i].begin(), volume_fractions[i].end()));

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -1107,11 +1107,11 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<MaterialModel::Interface<2>>::PluginInfo> *
-                                                                        internal::Plugins::PluginList<MaterialModel::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<MaterialModel::Interface<2>>::plugins = nullptr;
 
       template <>
       std::list<internal::Plugins::PluginList<MaterialModel::Interface<3>>::PluginInfo> *
-                                                                        internal::Plugins::PluginList<MaterialModel::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<MaterialModel::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -339,8 +339,8 @@ namespace aspect
             {
               mesh_deformation_objects[boundary_and_object_names.first].push_back(
                 std::unique_ptr<Interface<dim>> (std::get<dim>(registered_plugins)
-                                                 .create_plugin (object_name,
-                                                                 "Mesh deformation::Model names")));
+                                                  .create_plugin (object_name,
+                                                                  "Mesh deformation::Model names")));
 
               if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(mesh_deformation_objects[boundary_and_object_names.first].back().get()))
                 sim->initialize_simulator (this->get_simulator());
@@ -773,7 +773,7 @@ namespace aspect
       const UpdateFlags update_flags(update_values | update_JxW_values | update_gradients);
       additional_data.mapping_update_flags = update_flags;
       std::shared_ptr<MatrixFree<dim, double>> system_mf_storage(
-                                              new MatrixFree<dim, double>());
+        new MatrixFree<dim, double>());
       system_mf_storage->reinit(*sim.mapping,
                                 mesh_deformation_dof_handler,
                                 mesh_velocity_constraints,
@@ -894,7 +894,7 @@ namespace aspect
           additional_data.mapping_update_flags = update_flags;
           additional_data.mg_level = level;
           std::shared_ptr<MatrixFree<dim, double>> mg_mf_storage_level(
-                                                  new MatrixFree<dim, double>());
+            new MatrixFree<dim, double>());
 
           mg_mf_storage_level->reinit(mapping,
                                       mesh_deformation_dof_handler,
@@ -1021,7 +1021,7 @@ namespace aspect
       else
         {
           const std::vector<Point<dim>> support_points
-                                     = mesh_deformation_fe.base_element(0).get_unit_support_points();
+            = mesh_deformation_fe.base_element(0).get_unit_support_points();
 
           const Quadrature<dim> quad(support_points);
           const UpdateFlags update_flags = UpdateFlags(update_quadrature_points);
@@ -1080,7 +1080,7 @@ namespace aspect
       distributed_mesh_velocity.reinit(sim.introspection.index_sets.system_partitioning, sim.mpi_communicator);
 
       const std::vector<Point<dim>> support_points
-                                 = sim.finite_element.base_element(sim.introspection.component_indices.velocities[0]).get_unit_support_points();
+        = sim.finite_element.base_element(sim.introspection.component_indices.velocities[0]).get_unit_support_points();
 
       const Quadrature<dim> quad(support_points);
       const UpdateFlags update_flags = UpdateFlags(update_values | update_JxW_values);
@@ -1257,7 +1257,7 @@ namespace aspect
 
     template <int dim>
     const std::map<types::boundary_id, std::vector<std::string>> &
-                                                              MeshDeformationHandler<dim>::get_active_mesh_deformation_names () const
+    MeshDeformationHandler<dim>::get_active_mesh_deformation_names () const
     {
       return mesh_deformation_object_names;
     }
@@ -1338,10 +1338,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<MeshDeformation::Interface<2>>::PluginInfo> *
-                                                                          internal::Plugins::PluginList<MeshDeformation::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<MeshDeformation::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<MeshDeformation::Interface<3>>::PluginInfo> *
-                                                                          internal::Plugins::PluginList<MeshDeformation::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<MeshDeformation::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -151,7 +151,7 @@ namespace aspect
       // here in turns. then normalize the output vector and
       // verify that its values are non-negative numbers
       std::vector<Vector<float>> all_error_indicators (mesh_refinement_objects.size(),
-                                                       Vector<float>(error_indicators.size()));
+                                                        Vector<float>(error_indicators.size()));
       unsigned int index = 0;
       for (typename std::list<std::unique_ptr<Interface<dim>>>::const_iterator
            p = mesh_refinement_objects.begin();
@@ -524,10 +524,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<MeshRefinement::Interface<2>>::PluginInfo> *
-                                                                         internal::Plugins::PluginList<MeshRefinement::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<MeshRefinement::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<MeshRefinement::Interface<3>>::PluginInfo> *
-                                                                         internal::Plugins::PluginList<MeshRefinement::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<MeshRefinement::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -58,7 +58,7 @@ namespace aspect
       // the values of the compositional fields are stored as block vectors for each field
       // we have to extract them in this structure
       std::vector<std::vector<double>> prelim_composition_values (this->n_compositional_fields(),
-                                                                  std::vector<double> (quadrature.size()));
+                                                                   std::vector<double> (quadrature.size()));
 
       MaterialModel::MaterialModelInputs<dim> in(quadrature.size(), this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(quadrature.size(), this->n_compositional_fields());

--- a/source/mesh_refinement/viscosity.cc
+++ b/source/mesh_refinement/viscosity.cc
@@ -62,7 +62,7 @@ namespace aspect
       // the values of the compositional fields are stored as block vectors for each field
       // we have to extract them in this structure
       std::vector<std::vector<double>> prelim_composition_values (this->n_compositional_fields(),
-                                                                  std::vector<double> (quadrature.size()));
+                                                                   std::vector<double> (quadrature.size()));
 
       MaterialModel::MaterialModelInputs<dim> in(quadrature.size(),
                                                  this->n_compositional_fields());

--- a/source/mesh_refinement/volume_of_fluid_interface.cc
+++ b/source/mesh_refinement/volume_of_fluid_interface.cc
@@ -48,7 +48,7 @@ namespace aspect
 
       // Create a map from vertices to adjacent cells
       const std::vector<std::set<typename Triangulation<dim>::active_cell_iterator>>
-                                                                                  vertex_to_cells(GridTools::vertex_to_cell_map(this->get_triangulation()));
+      vertex_to_cells(GridTools::vertex_to_cell_map(this->get_triangulation()));
 
       std::set<typename Triangulation<dim>::active_cell_iterator> marked_cells;
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -86,8 +86,8 @@ namespace aspect
 
       template <int dim>
       std::pair<Particles::internal::LevelInd,Particle<dim>>
-                                                          Interface<dim>::generate_particle(const Point<dim> &position,
-                                                              const types::particle_index id) const
+      Interface<dim>::generate_particle(const Point<dim> &position,
+                                        const types::particle_index id) const
       {
         // Try to find the cell of the given position. If the position is not
         // in the domain on the local process, throw a ExcParticlePointNotInDomain
@@ -131,8 +131,8 @@ namespace aspect
 
       template <int dim>
       std::pair<Particles::internal::LevelInd,Particle<dim>>
-                                                          Interface<dim>::generate_particle (const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
-                                                              const types::particle_index id)
+      Interface<dim>::generate_particle (const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
+                                         const types::particle_index id)
       {
         // Uniform distribution on the interval [0,1]. This
         // will be used to generate random particle locations.
@@ -305,10 +305,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Particle::Generator::Interface<2>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<Particle::Generator::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Generator::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Particle::Generator::Interface<3>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<Particle::Generator::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Generator::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/particle/generator/reference_cell.cc
+++ b/source/particle/generator/reference_cell.cc
@@ -43,7 +43,7 @@ namespace aspect
 
       template <int dim>
       std::vector<Point<dim>>
-                           ReferenceCell<dim>::generate_particle_positions_in_unit_cell()
+      ReferenceCell<dim>::generate_particle_positions_in_unit_cell()
       {
         std::vector<Point<dim>> particle_positions;
         std::array<double, dim> spacing;

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -244,10 +244,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Particle::Integrator::Interface<2>>::PluginInfo> *
-                                                                               internal::Plugins::PluginList<Particle::Integrator::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Integrator::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Particle::Integrator::Interface<3>>::PluginInfo> *
-                                                                               internal::Plugins::PluginList<Particle::Integrator::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Integrator::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -42,10 +42,10 @@ namespace aspect
 
       template <int dim>
       std::vector<std::vector<double>>
-                                    BilinearLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                                    const std::vector<Point<dim>> &positions,
-                                                                                    const ComponentMask &selected_properties,
-                                                                                    const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      BilinearLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                      const std::vector<Point<dim>> &positions,
+                                                      const ComponentMask &selected_properties,
+                                                      const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
 
@@ -83,8 +83,8 @@ namespace aspect
 
 
         std::vector<std::vector<double>> cell_properties(positions.size(),
-                                                         std::vector<double>(n_particle_properties,
-                                                                             numbers::signaling_nan<double>()));
+                                                          std::vector<double>(n_particle_properties,
+                                                                              numbers::signaling_nan<double>()));
 
         const unsigned int n_particles = std::distance(particle_range.begin(), particle_range.end());
         const unsigned int n_matrix_columns = (dim == 2) ? 3 : 4;

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -33,10 +33,10 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double>>
-                                    CellAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                           const std::vector<Point<dim>> &positions,
-                                                                           const ComponentMask &selected_properties,
-                                                                           const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      CellAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                             const std::vector<Point<dim>> &positions,
+                                             const ComponentMask &selected_properties,
+                                             const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -34,10 +34,10 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double>>
-                                    HarmonicAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                               const std::vector<Point<dim>> &positions,
-                                                                               const ComponentMask &selected_properties,
-                                                                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      HarmonicAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                 const std::vector<Point<dim>> &positions,
+                                                 const ComponentMask &selected_properties,
+                                                 const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -29,9 +29,9 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double>>
-                                    Interface<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                         const std::vector<Point<dim>> &positions,
-                                                                         const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      Interface<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                           const std::vector<Point<dim>> &positions,
+                                           const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         return properties_at_points(particle_handler,positions,ComponentMask(), cell);
       }
@@ -149,10 +149,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Particle::Interpolator::Interface<2>>::PluginInfo> *
-                                                                                 internal::Plugins::PluginList<Particle::Interpolator::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Interpolator::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Particle::Interpolator::Interface<3>>::PluginInfo> *
-                                                                                 internal::Plugins::PluginList<Particle::Interpolator::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Interpolator::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -32,10 +32,10 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double>>
-                                    NearestNeighbor<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                               const std::vector<Point<dim>> &positions,
-                                                                               const ComponentMask &selected_properties,
-                                                                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      NearestNeighbor<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                 const std::vector<Point<dim>> &positions,
+                                                 const ComponentMask &selected_properties,
+                                                 const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
 

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -36,10 +36,10 @@ namespace aspect
     {
       template <int dim>
       std::vector<std::vector<double>>
-                                    QuadraticLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                                                                     const std::vector<Point<dim>> &positions,
-                                                                                     const ComponentMask &selected_properties,
-                                                                                     const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      QuadraticLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                       const std::vector<Point<dim>> &positions,
+                                                       const ComponentMask &selected_properties,
+                                                       const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
 
@@ -77,8 +77,8 @@ namespace aspect
 
 
         std::vector<std::vector<double>> cell_properties(positions.size(),
-                                                         std::vector<double>(n_particle_properties,
-                                                                             numbers::signaling_nan<double>()));
+                                                          std::vector<double>(n_particle_properties,
+                                                                              numbers::signaling_nan<double>()));
 
         const unsigned int n_particles = std::distance(particle_range.begin(), particle_range.end());
 

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -67,7 +67,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     Composition<dim>::get_property_information() const
+      Composition<dim>::get_property_information() const
       {
 
         AssertThrow(this->n_compositional_fields() > 0,

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -146,7 +146,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     ElasticStress<dim>::get_property_information() const
+      ElasticStress<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information;
 

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -43,7 +43,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     Function<dim>::get_property_information() const
+      Function<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("function",n_components));
         return property_information;

--- a/source/particle/property/initial_composition.cc
+++ b/source/particle/property/initial_composition.cc
@@ -49,7 +49,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     InitialComposition<dim>::get_property_information() const
+      InitialComposition<dim>::get_property_information() const
       {
         AssertThrow(this->n_compositional_fields() > 0,
                     ExcMessage("You have requested the particle property <initial "

--- a/source/particle/property/initial_position.cc
+++ b/source/particle/property/initial_position.cc
@@ -38,7 +38,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     InitialPosition<dim>::get_property_information() const
+      InitialPosition<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("initial position",static_cast<unsigned int> (dim)));
         return property_information;

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -95,7 +95,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     IntegratedStrain<dim>::get_property_information() const
+      IntegratedStrain<dim>::get_property_information() const
       {
         const unsigned int n_components = Tensor<2,dim>::n_independent_components;
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("integrated strain",n_components));

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -88,7 +88,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     IntegratedStrainInvariant<dim>::get_property_information() const
+      IntegratedStrainInvariant<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("integrated strain invariant",1));
         return property_information;

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -297,7 +297,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     IntegratorProperties<dim>::get_property_information() const
+      IntegratorProperties<dim>::get_property_information() const
       {
         return {{"internal: integrator properties", n_integrator_properties}};
       }
@@ -516,9 +516,9 @@ namespace aspect
                   if (cell_at_fixed_boundary == false)
                     {
                       const std::vector<std::vector<double>> interpolated_properties = interpolator.properties_at_points(particle_handler,
-                                                                                       std::vector<Point<dim>> (1,particle_location),
-                                                                                       ComponentMask(property_information.n_components(),true),
-                                                                                       found_cell);
+                                                                                        std::vector<Point<dim>> (1,particle_location),
+                                                                                        ComponentMask(property_information.n_components(),true),
+                                                                                        found_cell);
                       for (unsigned int property_component = 0; property_component < property_information.get_components_by_plugin_index(property_index); ++property_component)
                         particle_properties.push_back(interpolated_properties[0][property_information.get_position_by_plugin_index(property_index)+property_component]);
                     }
@@ -821,10 +821,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Particle::Property::Interface<2>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<Particle::Property::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Property::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Particle::Property::Interface<3>>::PluginInfo> *
-                                                                             internal::Plugins::PluginList<Particle::Property::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Particle::Property::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -71,7 +71,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     MeltParticle<dim>::get_property_information() const
+      MeltParticle<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("melt_presence",1));
         return property_information;

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -64,7 +64,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     PTPath<dim>::get_property_information() const
+      PTPath<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("p",1));
         property_information.emplace_back("T",1);

--- a/source/particle/property/position.cc
+++ b/source/particle/property/position.cc
@@ -55,7 +55,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     Position<dim>::get_property_information() const
+      Position<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("position",dim));
         return property_information;

--- a/source/particle/property/reference_position.cc
+++ b/source/particle/property/reference_position.cc
@@ -55,7 +55,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     ReferencePosition<dim>::get_property_information() const
+      ReferencePosition<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("reference position",dim));
         return property_information;

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -62,7 +62,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     Velocity<dim>::get_property_information() const
+      Velocity<dim>::get_property_information() const
       {
         const std::vector<std::pair<std::string,unsigned int>> property_information (1,std::make_pair("velocity",dim));
         return property_information;

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -199,7 +199,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     ViscoPlasticStrainInvariant<dim>::get_property_information() const
+      ViscoPlasticStrainInvariant<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information;
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -68,8 +68,8 @@ namespace aspect
       // If we restarted from a checkpoint we will fill this particle handler
       // later with its serialized variables and stored particles
       particle_handler = std::make_unique<ParticleHandler<dim>>(this->get_triangulation(),
-                                                                this->get_mapping(),
-                                                                property_manager->get_n_property_components());
+                                                                 this->get_mapping(),
+                                                                 property_manager->get_n_property_components());
 
       particle_handler_backup.initialize(this->get_triangulation(),
                                          this->get_mapping(),
@@ -968,17 +968,17 @@ namespace aspect
             melt_component_indices[2] = simulator_access.introspection().variable("compaction pressure").first_component_index;
 
             fluid_velocity = std::make_unique<FEPointEvaluation<dim, dim>>(simulator_access.get_mapping(),
-                                                                           simulator_access.get_fe(),
-                                                                           update_flags,
-                                                                           melt_component_indices[0]);
+                                                                            simulator_access.get_fe(),
+                                                                            update_flags,
+                                                                            melt_component_indices[0]);
             fluid_pressure = std::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
-                                                                         simulator_access.get_fe(),
-                                                                         update_flags,
-                                                                         melt_component_indices[1]);
+                                                                          simulator_access.get_fe(),
+                                                                          update_flags,
+                                                                          melt_component_indices[1]);
             compaction_pressure = std::make_unique<FEPointEvaluation<1, dim>>(simulator_access.get_mapping(),
-                                                                              simulator_access.get_fe(),
-                                                                              update_flags,
-                                                                              melt_component_indices[2]);
+                                                                               simulator_access.get_fe(),
+                                                                               update_flags,
+                                                                               melt_component_indices[2]);
 
           }
       }
@@ -1154,8 +1154,8 @@ namespace aspect
       // A function to create a pointer to a SolutionEvaluators object.
       template <int dim>
       std::unique_ptr<internal::SolutionEvaluators<dim>>
-                                                      construct_solution_evaluators (const SimulatorAccess<dim> &simulator_access,
-                                                                                     const UpdateFlags update_flags)
+      construct_solution_evaluators (const SimulatorAccess<dim> &simulator_access,
+                                     const UpdateFlags update_flags)
       {
         switch (simulator_access.n_compositional_fields())
           {
@@ -1279,8 +1279,8 @@ namespace aspect
         TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Advect");
 
         std::unique_ptr<internal::SolutionEvaluators<dim>> evaluators =
-                                                          std::make_unique<internal::SolutionEvaluatorsImplementation<dim, 0>>(*this,
-                                                              update_values);
+          std::make_unique<internal::SolutionEvaluatorsImplementation<dim, 0>>(*this,
+                                                                                update_values);
 
         // Loop over all cells and advect the particles cell-wise
         for (const auto &cell : this->get_dof_handler().active_cell_iterators())

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -39,7 +39,7 @@ namespace aspect
   {
     template <int dim>
     std::pair<std::vector<double>,std::vector<double>>
-                                                    Geoid<dim>::to_spherical_harmonic_coefficients(const std::vector<std::vector<double>> &spherical_function) const
+    Geoid<dim>::to_spherical_harmonic_coefficients(const std::vector<std::vector<double>> &spherical_function) const
     {
       std::vector<double> cosi(spherical_function.size(),0);
       std::vector<double> sini(spherical_function.size(),0);
@@ -82,7 +82,7 @@ namespace aspect
 
     template <int dim>
     std::pair<std::vector<double>,std::vector<double>>
-                                                    Geoid<dim>::density_contribution (const double &/*outer_radius*/) const
+    Geoid<dim>::density_contribution (const double &/*outer_radius*/) const
     {
       Assert(false, ExcNotImplemented());
       return std::make_pair(std::vector<double>(), std::vector<double>());
@@ -91,7 +91,7 @@ namespace aspect
 
     template <>
     std::pair<std::vector<double>,std::vector<double>>
-                                                    Geoid<3>::density_contribution (const double &outer_radius) const
+    Geoid<3>::density_contribution (const double &outer_radius) const
     {
       const unsigned int quadrature_degree = this->introspection().polynomial_degree.temperature;
 

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -336,22 +336,22 @@ namespace aspect
       };
 
       const std::vector<Tensor<1,dim>>
-                                    g = Utilities::MPI::all_reduce<decltype(local_g)>
-                                        (local_g,
-                                         this->get_mpi_communicator(),
-                                         tensor_sum);
+      g = Utilities::MPI::all_reduce<decltype(local_g)>
+          (local_g,
+           this->get_mpi_communicator(),
+           tensor_sum);
 
       const std::vector<Tensor<1,dim>>
-                                    g_anomaly = Utilities::MPI::all_reduce<decltype(local_g_anomaly)>
-                                                (local_g_anomaly,
-                                                 this->get_mpi_communicator(),
-                                                 tensor_sum);
+      g_anomaly = Utilities::MPI::all_reduce<decltype(local_g_anomaly)>
+                  (local_g_anomaly,
+                   this->get_mpi_communicator(),
+                   tensor_sum);
 
       const std::vector<SymmetricTensor<2,dim>>
-                                             g_gradient = Utilities::MPI::all_reduce<decltype(local_g_gradient)>
-                                                          (local_g_gradient,
-                                                           this->get_mpi_communicator(),
-                                                           tensor_sum);
+      g_gradient = Utilities::MPI::all_reduce<decltype(local_g_gradient)>
+                   (local_g_gradient,
+                    this->get_mpi_communicator(),
+                    tensor_sum);
 
       double sum_g = 0;
       double min_g = std::numeric_limits<double>::max();

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -88,7 +88,7 @@ namespace aspect
 
     template <int dim>
     std::list<std::pair<std::string,std::string>>
-                                               Manager<dim>::execute (TableHandler &statistics)
+    Manager<dim>::execute (TableHandler &statistics)
     {
       // call the execute() functions of all postprocessor objects we have
       // here in turns
@@ -423,10 +423,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Postprocess::Interface<2>>::PluginInfo> *
-                                                                      internal::Plugins::PluginList<Postprocess::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Postprocess::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Postprocess::Interface<3>>::PluginInfo> *
-                                                                      internal::Plugins::PluginList<Postprocess::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Postprocess::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/postprocess/melt_statistics.cc
+++ b/source/postprocess/melt_statistics.cc
@@ -39,7 +39,7 @@ namespace aspect
       const Quadrature<dim> &quadrature_formula = this->introspection().quadratures.temperature;
       const unsigned int n_q_points = quadrature_formula.size();
       std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),
-                                                           std::vector<double> (n_q_points));
+                                                            std::vector<double> (n_q_points));
 
       FEValues<dim> fe_values (this->get_mapping(),
                                this->get_fe(),
@@ -72,7 +72,7 @@ namespace aspect
             std::vector<double> melt_fractions(n_q_points, 0.0);
             if (Plugins::plugin_type_matches<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()))
               Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>>(this->get_material_model()).melt_fractions(in,
-                                                                                    melt_fractions);
+                  melt_fractions);
 
             for (unsigned int q=0; q<n_q_points; ++q)
               {

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -145,7 +145,7 @@ namespace aspect
 
       template <int dim>
       const std::vector<DataOutBase::Patch<0,dim>> &
-                                                ParticleOutput<dim>::get_patches () const
+      ParticleOutput<dim>::get_patches () const
       {
         return patches;
       }

--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -61,8 +61,8 @@ namespace aspect
 
       // evaluate the solution at all of our evaluation points
       std::vector<Vector<double>>
-                               current_point_values (evaluation_points_cartesian.size(),
-                                                     Vector<double> (this->introspection().n_components));
+      current_point_values (evaluation_points_cartesian.size(),
+                            Vector<double> (this->introspection().n_components));
 
       for (unsigned int p=0; p<evaluation_points_cartesian.size(); ++p)
         {

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -1426,10 +1426,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<2>>::PluginInfo> *
-          internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<3>>::PluginInfo> *
-          internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<Postprocess::VisualizationPostprocessors::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -63,7 +63,7 @@ namespace aspect
                         this->get_solution(), true);
               // Also get velocity gradients
               std::vector<Tensor<2, dim>> velocity_gradient(n_q_points,
-                                                            Tensor<2, dim>());
+                                                             Tensor<2, dim>());
               fe_values[this->introspection().extractors.velocities].get_function_gradients(
                 this->get_solution(), velocity_gradient);
 

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -147,7 +147,7 @@ namespace aspect
                                    "model you use does not actually compute a melt fraction."));
 
             Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()).
-                                                                                  melt_fractions(in, melt_fractions);
+            melt_fractions(in, melt_fractions);
           }
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -143,10 +143,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<PrescribedStokesSolution::Interface<2>>::PluginInfo> *
-                                                                                   internal::Plugins::PluginList<PrescribedStokesSolution::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<PrescribedStokesSolution::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<PrescribedStokesSolution::Interface<3>>::PluginInfo> *
-                                                                                   internal::Plugins::PluginList<PrescribedStokesSolution::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<PrescribedStokesSolution::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -199,22 +199,22 @@ namespace aspect
           face_finite_element_values (face_quadrature.size() > 0
                                       ?
                                       std::make_unique<FEFaceValues<dim>> (mapping,
-                                                                           finite_element, face_quadrature,
-                                                                           face_update_flags)
+                                                                            finite_element, face_quadrature,
+                                                                            face_update_flags)
                                       :
                                       nullptr),
           neighbor_face_finite_element_values (face_quadrature.size() > 0
                                                ?
                                                std::make_unique<FEFaceValues<dim>> (mapping,
-                                                                                    finite_element, face_quadrature,
-                                                                                    face_update_flags)
+                                                                                     finite_element, face_quadrature,
+                                                                                     face_update_flags)
                                                :
                                                nullptr),
           subface_finite_element_values (face_quadrature.size() > 0
                                          ?
                                          std::make_unique<FESubfaceValues<dim>> (mapping,
-                                                                                 finite_element, face_quadrature,
-                                                                                 face_update_flags)
+                                                                                  finite_element, face_quadrature,
+                                                                                  face_update_flags)
                                          :
                                          nullptr),
           local_dof_indices (finite_element.dofs_per_cell),
@@ -287,25 +287,25 @@ namespace aspect
           face_finite_element_values (scratch.face_finite_element_values.get()
                                       ?
                                       std::make_unique<FEFaceValues<dim>> (scratch.face_finite_element_values->get_mapping(),
-                                                                           scratch.face_finite_element_values->get_fe(),
-                                                                           scratch.face_finite_element_values->get_quadrature(),
-                                                                           scratch.face_finite_element_values->get_update_flags())
+                                                                            scratch.face_finite_element_values->get_fe(),
+                                                                            scratch.face_finite_element_values->get_quadrature(),
+                                                                            scratch.face_finite_element_values->get_update_flags())
                                       :
                                       nullptr),
           neighbor_face_finite_element_values (scratch.neighbor_face_finite_element_values.get()
                                                ?
                                                std::make_unique<FEFaceValues<dim>> (scratch.neighbor_face_finite_element_values->get_mapping(),
-                                                                                    scratch.neighbor_face_finite_element_values->get_fe(),
-                                                                                    scratch.neighbor_face_finite_element_values->get_quadrature(),
-                                                                                    scratch.neighbor_face_finite_element_values->get_update_flags())
+                                                                                     scratch.neighbor_face_finite_element_values->get_fe(),
+                                                                                     scratch.neighbor_face_finite_element_values->get_quadrature(),
+                                                                                     scratch.neighbor_face_finite_element_values->get_update_flags())
                                                :
                                                nullptr),
           subface_finite_element_values (scratch.subface_finite_element_values.get()
                                          ?
                                          std::make_unique<FESubfaceValues<dim>> (scratch.subface_finite_element_values->get_mapping(),
-                                                                                 scratch.subface_finite_element_values->get_fe(),
-                                                                                 scratch.subface_finite_element_values->get_quadrature(),
-                                                                                 scratch.subface_finite_element_values->get_update_flags())
+                                                                                  scratch.subface_finite_element_values->get_fe(),
+                                                                                  scratch.subface_finite_element_values->get_quadrature(),
+                                                                                  scratch.subface_finite_element_values->get_update_flags())
                                          :
                                          nullptr),
           local_dof_indices (scratch.finite_element_values.get_fe().dofs_per_cell),

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -84,7 +84,7 @@ namespace aspect
     // the values of the compositional fields are stored as block vectors for each field
     // we have to extract them in this structure
     std::vector<std::vector<double>> composition_values (introspection.n_compositional_fields,
-                                                         std::vector<double> (n_q_points));
+                                                          std::vector<double> (n_q_points));
 
     for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
       input_finite_element_values[introspection.extractors.compositional_fields[c]].get_function_values(input_solution,

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -80,11 +80,11 @@ namespace aspect
      */
     template <int dim>
     std::vector<VariableDeclaration<dim>> construct_variables(const Parameters<dim> &parameters,
-                                                              SimulatorSignals<dim> &signals,
-                                                              std::unique_ptr<MeltHandler<dim>> &melt_handler)
+                                                               SimulatorSignals<dim> &signals,
+                                                               std::unique_ptr<MeltHandler<dim>> &melt_handler)
     {
       std::vector<VariableDeclaration<dim>> variables
-                                         = construct_default_variables (parameters);
+        = construct_default_variables (parameters);
       if (melt_handler)
         melt_handler->edit_finite_element_variables (parameters, variables);
 
@@ -103,8 +103,8 @@ namespace aspect
      */
     template <int dim>
     std::unique_ptr<Mapping<dim>>
-                               construct_mapping(const GeometryModel::Interface<dim> &geometry_model,
-                                                 const InitialTopographyModel::Interface<dim> &initial_topography_model)
+    construct_mapping(const GeometryModel::Interface<dim> &geometry_model,
+                      const InitialTopographyModel::Interface<dim> &initial_topography_model)
     {
       if (geometry_model.has_curved_elements())
         return std::make_unique<MappingQCache<dim>>(4);
@@ -1551,7 +1551,7 @@ namespace aspect
     // run all the postprocessing routines and then write
     // the current state of the statistics table to a file
     std::list<std::pair<std::string,std::string>>
-                                               output_list = postprocess_manager.execute (statistics);
+    output_list = postprocess_manager.execute (statistics);
 
     // if we are on processor zero, print to screen
     // whatever the postprocessors have generated
@@ -1589,7 +1589,7 @@ namespace aspect
     system_trans(dof_handler);
 
     std::unique_ptr<parallel::distributed::SolutionTransfer<dim,LinearAlgebra::Vector>>
-        mesh_deformation_trans;
+    mesh_deformation_trans;
 
     {
       TimerOutput::Scope timer (computing_timer, "Refine mesh structure, part 1");
@@ -1694,7 +1694,7 @@ namespace aspect
         };
 
         GridTools::exchange_cell_data_to_ghosts<unsigned int, DoFHandler<dim>>
-                                                                            (dof_handler, pack, unpack);
+        (dof_handler, pack, unpack);
 
       }
       triangulation.prepare_coarsening_and_refinement();

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -79,7 +79,7 @@ namespace aspect
 
         // get the temperature/composition support points
         const std::vector<Point<dim>> support_points
-                                   = finite_element.base_element(base_element).get_unit_support_points();
+          = finite_element.base_element(base_element).get_unit_support_points();
         Assert (support_points.size() != 0,
                 ExcInternalError());
 
@@ -250,7 +250,7 @@ namespace aspect
 
     // get the temperature/composition support points
     const std::vector<Point<dim>> support_points
-                               = finite_element.base_element(base_element).get_unit_support_points();
+      = finite_element.base_element(base_element).get_unit_support_points();
     Assert (support_points.size() != 0,
             ExcInternalError());
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -156,8 +156,8 @@ namespace aspect
 
     template <int dim>
     std::shared_ptr<FiniteElement<dim>>
-                                     new_FE_Q_or_DGP(const bool discontinuous,
-                                                     const unsigned int degree)
+    new_FE_Q_or_DGP(const bool discontinuous,
+                    const unsigned int degree)
     {
       if (discontinuous)
         return std::make_shared<FE_DGP<dim>>(degree);
@@ -169,8 +169,8 @@ namespace aspect
 
     template <int dim>
     std::shared_ptr<FiniteElement<dim>>
-                                     new_FE_Q_or_DGQ(const bool discontinuous,
-                                                     const unsigned int degree)
+    new_FE_Q_or_DGQ(const bool discontinuous,
+                    const unsigned int degree)
     {
       if (discontinuous)
         return std::make_shared<FE_DGQ<dim>>(degree);
@@ -184,7 +184,7 @@ namespace aspect
 
   template <int dim>
   std::vector<VariableDeclaration<dim>>
-                                     construct_default_variables (const Parameters<dim> &parameters)
+  construct_default_variables (const Parameters<dim> &parameters)
   {
     std::vector<VariableDeclaration<dim>> variables;
 

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -473,8 +473,8 @@ namespace aspect
 
   template <int dim>
   std::vector<std::vector<double>>
-                                LateralAveraging<dim>::compute_lateral_averages(const std::vector<double> &depth_bounds,
-                                                                                std::vector<std::unique_ptr<internal::FunctorBase<dim>>> &functors) const
+  LateralAveraging<dim>::compute_lateral_averages(const std::vector<double> &depth_bounds,
+                                                  std::vector<std::unique_ptr<internal::FunctorBase<dim>>> &functors) const
   {
     Assert (functors.size() > 0,
             ExcMessage ("To call this function, you need to request a positive "
@@ -490,7 +490,7 @@ namespace aspect
     const unsigned int n_slices = depth_bounds.size()-1;
 
     std::vector<std::vector<double>> values(n_properties,
-                                            std::vector<double>(n_slices,0.0));
+                                             std::vector<double>(n_slices,0.0));
     std::vector<double> volume(n_slices,0.0);
 
     // We would like to use a quadrature formula that is appropriately accurate laterally,
@@ -527,7 +527,7 @@ namespace aspect
     std::unique_ptr<Quadrature<dim>> quadrature_formula;
     if (geometry_unique_depth_direction != numbers::invalid_unsigned_int)
       quadrature_formula = std::make_unique<Quadrature<dim>>(internal::get_quadrature_formula<dim>(lateral_quadrature_degree,
-                                                             geometry_unique_depth_direction));
+                                                              geometry_unique_depth_direction));
     else
       quadrature_formula = std::make_unique<Quadrature<dim>>(QIterated<dim>(QMidpoint<1>(),10));
 
@@ -539,9 +539,9 @@ namespace aspect
                              update_values | update_gradients | update_quadrature_points | update_JxW_values);
 
     std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),
-                                                         std::vector<double> (n_q_points));
+                                                          std::vector<double> (n_q_points));
     std::vector<std::vector<double>> output_values(n_properties,
-                                                   std::vector<double>(n_q_points));
+                                                    std::vector<double>(n_q_points));
 
     MaterialModel::MaterialModelInputs<dim> in(n_q_points,
                                                this->n_compositional_fields());
@@ -734,8 +734,8 @@ namespace aspect
 
   template <int dim>
   std::vector<std::vector<double>>
-                                LateralAveraging<dim>::get_averages(const unsigned int n_slices,
-                                                                    const std::vector<std::string> &property_names) const
+  LateralAveraging<dim>::get_averages(const unsigned int n_slices,
+                                      const std::vector<std::string> &property_names) const
   {
     return compute_lateral_averages(n_slices, property_names);
   }
@@ -744,8 +744,8 @@ namespace aspect
 
   template <int dim>
   std::vector<std::vector<double>>
-                                LateralAveraging<dim>::compute_lateral_averages(const unsigned int n_slices,
-                                                                                const std::vector<std::string> &property_names) const
+  LateralAveraging<dim>::compute_lateral_averages(const unsigned int n_slices,
+                                                  const std::vector<std::string> &property_names) const
   {
     const double maximal_depth = this->get_geometry_model().maximal_depth();
     std::vector<double> depth_bounds(n_slices+1, 0.0);
@@ -761,8 +761,8 @@ namespace aspect
 
   template <int dim>
   std::vector<std::vector<double>>
-                                LateralAveraging<dim>::compute_lateral_averages(const std::vector<double> &depth_thresholds,
-                                                                                const std::vector<std::string> &property_names) const
+  LateralAveraging<dim>::compute_lateral_averages(const std::vector<double> &depth_thresholds,
+                                                  const std::vector<std::string> &property_names) const
   {
     std::vector<std::unique_ptr<internal::FunctorBase<dim>>> functors;
     for (unsigned int property_index=0; property_index<property_names.size(); ++property_index)

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -265,7 +265,7 @@ namespace aspect
 
     // Vectors for evaluating the finite element solution
     std::vector<std::vector<double>> composition_values (introspection.n_compositional_fields,
-                                                         std::vector<double> (n_q_points));
+                                                          std::vector<double> (n_q_points));
     std::vector<Tensor<1,dim>> velocities( n_q_points );
 
     typename DoFHandler<dim>::active_cell_iterator cell;

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -753,7 +753,7 @@ namespace aspect
               viscosity_x_2 = 2.0*cell_data->viscosity(cell, q);
 
             SymmetricTensor<2,dim,VectorizedArray<number>> sym_grad_u =
-                                                          velocity.get_symmetric_gradient (q);
+              velocity.get_symmetric_gradient (q);
             const VectorizedArray<number> pres = pressure.get_value(q);
             const VectorizedArray<number> div = trace(sym_grad_u);
 
@@ -784,8 +784,8 @@ namespace aspect
                 const SymmetricTensor<2,dim,VectorizedArray<number>> grads_phi_u_i = velocity.get_symmetric_gradient (q);
 
                 SymmetricTensor<2,dim,VectorizedArray<number>> newton_velocity_term =
-                                                              (grads_phi_u_i * cell_data->strain_rate_table(cell,q))
-                                                              * cell_data->newton_factor_wrt_strain_rate_table(cell,q);
+                  (grads_phi_u_i * cell_data->strain_rate_table(cell,q))
+                  * cell_data->newton_factor_wrt_strain_rate_table(cell,q);
 
                 if (cell_data->symmetrize_newton_system)
                   newton_velocity_term +=
@@ -863,19 +863,19 @@ namespace aspect
   {
     if (cell_data->apply_stabilization_free_surface_faces)
       MatrixFreeOperators::Base<dim, dealii::LinearAlgebra::distributed::BlockVector<number>>::
-          data->loop(&StokesOperator::local_apply,
-                     &StokesOperator::local_apply_face,
-                     &StokesOperator::local_apply_boundary_face,
-                     this,
-                     dst,
-                     src,
-                     false, /*zero_dst_vector*/
-                     MatrixFree<dim, number>::DataAccessOnFaces::values,
-                     MatrixFree<dim, number>::DataAccessOnFaces::values);
+      data->loop(&StokesOperator::local_apply,
+                 &StokesOperator::local_apply_face,
+                 &StokesOperator::local_apply_boundary_face,
+                 this,
+                 dst,
+                 src,
+                 false, /*zero_dst_vector*/
+                 MatrixFree<dim, number>::DataAccessOnFaces::values,
+                 MatrixFree<dim, number>::DataAccessOnFaces::values);
 
     else
       MatrixFreeOperators::Base<dim, dealii::LinearAlgebra::distributed::BlockVector<number>>::
-          data->cell_loop(&StokesOperator::local_apply, this, dst, src);
+      data->cell_loop(&StokesOperator::local_apply, this, dst, src);
   }
 
   /**
@@ -967,7 +967,7 @@ namespace aspect
                const dealii::LinearAlgebra::distributed::Vector<number> &src) const
   {
     MatrixFreeOperators::Base<dim,dealii::LinearAlgebra::distributed::Vector<number>>::
-                                                                                   data->cell_loop(&MassMatrixOperator::local_apply, this, dst, src);
+    data->cell_loop(&MassMatrixOperator::local_apply, this, dst, src);
   }
 
 
@@ -1137,7 +1137,7 @@ namespace aspect
               viscosity_x_2 = 2.0*cell_data->viscosity(cell, q);
 
             SymmetricTensor<2,dim,VectorizedArray<number>> sym_grad_u =
-                                                          velocity.get_symmetric_gradient (q);
+              velocity.get_symmetric_gradient (q);
             sym_grad_u *= viscosity_x_2;
 
             if (cell_data->is_compressible)
@@ -1163,7 +1163,7 @@ namespace aspect
                const dealii::LinearAlgebra::distributed::Vector<number> &src) const
   {
     MatrixFreeOperators::Base<dim,dealii::LinearAlgebra::distributed::Vector<number>>::
-                                                                                   data->cell_loop(&ABlockOperator::local_apply, this, dst, src);
+    data->cell_loop(&ABlockOperator::local_apply, this, dst, src);
   }
 
 
@@ -1234,7 +1234,7 @@ namespace aspect
                   viscosity_x_2 = 2.0*cell_data->viscosity(cell, q);
 
                 SymmetricTensor<2,dim,VectorizedArray<number>> sym_grad_u =
-                                                              velocity.get_symmetric_gradient (q);
+                  velocity.get_symmetric_gradient (q);
 
                 sym_grad_u *= viscosity_x_2;
 
@@ -1946,7 +1946,7 @@ namespace aspect
               viscosity_x_2 = 2.0*active_cell_data.viscosity(cell, q);
 
             SymmetricTensor<2,dim,VectorizedArray<double>> sym_grad_u =
-                                                          velocity.get_symmetric_gradient (q);
+              velocity.get_symmetric_gradient (q);
             const VectorizedArray<double> pres = pressure.get_value(q);
             const VectorizedArray<double> div = trace(sym_grad_u);
             pressure.submit_value(sim.pressure_scaling*div, q);
@@ -2473,10 +2473,10 @@ namespace aspect
         if (sim.parameters.stokes_krylov_type == Parameters<dim>::StokesKrylovType::gmres)
           {
             SolverGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>
-                                                                              solver(solver_control_cheap, mem,
-                                                                                     SolverGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>::
-                                                                                     AdditionalData(sim.parameters.stokes_gmres_restart_length+2,
-                                                                                         true));
+            solver(solver_control_cheap, mem,
+                   SolverGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>::
+                   AdditionalData(sim.parameters.stokes_gmres_restart_length+2,
+                                  true));
 
             solver.solve (stokes_matrix,
                           solution_copy,
@@ -2486,9 +2486,9 @@ namespace aspect
         else if (sim.parameters.stokes_krylov_type == Parameters<dim>::StokesKrylovType::idr_s)
           {
             SolverIDR<dealii::LinearAlgebra::distributed::BlockVector<double>>
-                                                                            solver(solver_control_cheap, mem,
-                                                                                   SolverIDR<dealii::LinearAlgebra::distributed::BlockVector<double>>::
-                                                                                   AdditionalData(sim.parameters.idr_s_parameter));
+            solver(solver_control_cheap, mem,
+                   SolverIDR<dealii::LinearAlgebra::distributed::BlockVector<double>>::
+                   AdditionalData(sim.parameters.idr_s_parameter));
 
             solver.solve (stokes_matrix,
                           solution_copy,
@@ -2527,9 +2527,9 @@ namespace aspect
                                                           std::max(sim.parameters.stokes_gmres_restart_length, 100U));
 
         SolverFGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>
-                                                                           solver(solver_control_expensive, mem,
-                                                                                  SolverFGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>::
-                                                                                  AdditionalData(number_of_temporary_vectors));
+        solver(solver_control_expensive, mem,
+               SolverFGMRES<dealii::LinearAlgebra::distributed::BlockVector<double>>::
+               AdditionalData(number_of_temporary_vectors));
 
         try
           {
@@ -2780,7 +2780,7 @@ namespace aspect
       stokes_constraints.push_back(&constraints_p);
 
       std::shared_ptr<MatrixFree<dim,double>>
-                                           stokes_mf_storage(new MatrixFree<dim,double>());
+      stokes_mf_storage(new MatrixFree<dim,double>());
       stokes_mf_storage->reinit(*sim.mapping,stokes_dofs, stokes_constraints,
                                 QGauss<1>(sim.parameters.stokes_velocity_degree+1), additional_data);
       stokes_matrix.clear();
@@ -2796,7 +2796,7 @@ namespace aspect
       additional_data.mapping_update_flags = (update_values | update_gradients |
                                               update_JxW_values | update_quadrature_points);
       std::shared_ptr<MatrixFree<dim,double>>
-                                           ablock_mf_storage(new MatrixFree<dim,double>());
+      ablock_mf_storage(new MatrixFree<dim,double>());
       ablock_mf_storage->reinit(*sim.mapping,dof_handler_v, constraints_v,
                                 QGauss<1>(sim.parameters.stokes_velocity_degree+1), additional_data);
 
@@ -2813,7 +2813,7 @@ namespace aspect
       additional_data.mapping_update_flags = (update_values | update_JxW_values |
                                               update_quadrature_points);
       std::shared_ptr<MatrixFree<dim,double>>
-                                           Schur_mf_storage(new MatrixFree<dim,double>());
+      Schur_mf_storage(new MatrixFree<dim,double>());
       Schur_mf_storage->reinit(*sim.mapping,dof_handler_p, constraints_p,
                                QGauss<1>(sim.parameters.stokes_velocity_degree+1), additional_data);
 
@@ -2872,7 +2872,7 @@ namespace aspect
                                                     update_quadrature_points);
             additional_data.mg_level = level;
             std::shared_ptr<MatrixFree<dim,GMGNumberType>>
-                                                        mg_mf_storage_level(new MatrixFree<dim,GMGNumberType>());
+            mg_mf_storage_level(new MatrixFree<dim,GMGNumberType>());
 
             mg_mf_storage_level->reinit(mapping, dof_handler_v, level_constraints,
                                         QGauss<1>(sim.parameters.stokes_velocity_degree+1),
@@ -2905,7 +2905,7 @@ namespace aspect
                                                     update_quadrature_points);
             additional_data.mg_level = level;
             std::shared_ptr<MatrixFree<dim,GMGNumberType>>
-                                                        mg_mf_storage_level(new MatrixFree<dim,GMGNumberType>());
+            mg_mf_storage_level(new MatrixFree<dim,GMGNumberType>());
 
             const Mapping<dim> &mapping =
               (sim.mesh_deformation) ? sim.mesh_deformation->get_level_mapping(level) : *sim.mapping;

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -227,8 +227,8 @@ namespace aspect
 
               data[c]
                 = std::make_unique<Functions::InterpolatedUniformGridData<dim>> (grid_extent,
-                                                                                 table_intervals,
-                                                                                 std::move(data_table[c]));
+                                                                                  table_intervals,
+                                                                                  std::move(data_table[c]));
             }
           else
             // Create the object and move the big objects. Due to an old design flaw,
@@ -1095,7 +1095,7 @@ namespace aspect
                                   "> not found!"));
 
           lookups.push_back(std::make_unique<Utilities::StructuredDataLookup<dim-1>> (components,
-                                                                                      this->scale_factor));
+                                                                                       this->scale_factor));
           lookups[i]->load_file(filename,this->get_mpi_communicator());
         }
     }
@@ -1252,7 +1252,7 @@ namespace aspect
                                "a spherical shell, chunk, or box geometry."));
 
       lookup = std::make_unique<Utilities::StructuredDataLookup<spacedim>> (components,
-                                                                            this->scale_factor);
+                                                                             this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
 

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -279,10 +279,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<TerminationCriteria::Interface<2>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<TerminationCriteria::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<TerminationCriteria::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<TerminationCriteria::Interface<3>>::PluginInfo> *
-                                                                              internal::Plugins::PluginList<TerminationCriteria::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<TerminationCriteria::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -392,10 +392,10 @@ namespace aspect
     {
       template <>
       std::list<internal::Plugins::PluginList<TimeStepping::Interface<2>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<TimeStepping::Interface<2>>::plugins = nullptr;
+      internal::Plugins::PluginList<TimeStepping::Interface<2>>::plugins = nullptr;
       template <>
       std::list<internal::Plugins::PluginList<TimeStepping::Interface<3>>::PluginInfo> *
-                                                                       internal::Plugins::PluginList<TimeStepping::Interface<3>>::plugins = nullptr;
+      internal::Plugins::PluginList<TimeStepping::Interface<3>>::plugins = nullptr;
     }
   }
 

--- a/tests/boundary_heatflux_update.cc
+++ b/tests/boundary_heatflux_update.cc
@@ -27,10 +27,10 @@ namespace aspect
          */
         virtual
         std::vector<Tensor<1,dim>>
-                                heat_flux (const types::boundary_id /*boundary_indicator*/,
-                                           const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-                                           const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
-                                           const std::vector<Tensor<1,dim>> &normal_vectors) const
+        heat_flux (const types::boundary_id /*boundary_indicator*/,
+                   const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                   const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
+                   const std::vector<Tensor<1,dim>> &normal_vectors) const
         {
           std::vector<Tensor<1,dim>> heat_flux(normal_vectors);
           const unsigned int n_evaluation_points = material_model_inputs.position.size();

--- a/tests/particle_property_post_initialize_function.cc
+++ b/tests/particle_property_post_initialize_function.cc
@@ -38,7 +38,7 @@ namespace aspect
 
           virtual
           std::vector<std::pair<std::string, unsigned int>>
-                                                         get_property_information() const
+          get_property_information() const
           {
             return std::vector<std::pair<std::string, unsigned int>>();
           }

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -113,8 +113,8 @@ namespace aspect
           lateral_averaging_properties.push_back(std::make_unique<internal::FunctorDepthAverageUnscaledViscosity<dim>>());
 
           std::vector<std::vector<double>> averages =
-                                          this->get_lateral_averaging().compute_lateral_averages(reference_viscosity_coordinates,
-                                              lateral_averaging_properties);
+            this->get_lateral_averaging().compute_lateral_averages(reference_viscosity_coordinates,
+                                                                   lateral_averaging_properties);
 
           laterally_averaged_viscosity_profile.swap(averages[0]);
 


### PR DESCRIPTION
This is the promised follow-up to #4562. It improves indentation via the hack described in the `indent` script where I temporarily pretend that everything that contains `>>` is `> >`, then run astyle, then change it back. The result looks much nicer.

@MFraters -- FYI

/rebuild