### PR TITLE
set velocity in computation of initial lithostatsic pressure

### DIFF
--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -142,8 +142,8 @@ namespace aspect
       // We do not need the viscosity.
       in0.strain_rate.resize(0);
 
-      // The velocity is zero for the lithostatic case.
-      in0.velocity[0]= Tensor<1,dim> ();
+      // We set all entries of the velocity vector to zero since this is the lithostatic case.
+      in0.velocity[0] = Tensor<1,dim> ();
 
       // Evaluate the material model to get the density.
       this->get_material_model().evaluate(in0, out0);
@@ -199,8 +199,8 @@ namespace aspect
           // We do not need the viscosity.
           in.strain_rate.resize(0);
 
-          // The velocity is zero for the lithostatic case.
-          in.velocity[0]= Tensor<1,dim> ();
+          // We set all entries of the velocity vector to zero since this is the lithostatic case.
+          in.velocity[0] = Tensor<1,dim> ();
 
           // Evaluate the material model to get the density at the current point.
           this->get_material_model().evaluate(in, out);

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -142,6 +142,9 @@ namespace aspect
       // We do not need the viscosity.
       in0.strain_rate.resize(0);
 
+      // The velocity is zero for the lithostatic case.
+      in0.velocity[0]= Tensor<1,dim> ();
+
       // Evaluate the material model to get the density.
       this->get_material_model().evaluate(in0, out0);
       const double density0 = out0.densities[0];
@@ -195,6 +198,9 @@ namespace aspect
 
           // We do not need the viscosity.
           in.strain_rate.resize(0);
+
+          // The velocity is zero for the lithostatic case.
+          in.velocity[0]= Tensor<1,dim> ();
 
           // Evaluate the material model to get the density at the current point.
           this->get_material_model().evaluate(in, out);


### PR DESCRIPTION
In the computation of the initial lithostatic pressure, the velocity, which is a material model input, was not set to any value, which means it was NaN. Material models that use the velocity in their evaluate function would then cause a floating point exception. That is fixed by this PR. 

This is needed so that #3768 works. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.

