### PR TITLE
Fastscape updates: erosional baselevel, periodicity, masks, stratigraphy ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,6 @@ ENDIF()
 FIND_LIBRARY(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
 IF(FASTSCAPE)
   MESSAGE(STATUS "FastScape found at ${FASTSCAPE}")
-  TARGET_LINK_LIBRARIES(aspect "${FASTSCAPE}")
 ELSE()
   FIND_FILE(FASTSCAPE_SRC fastscape.cc HINTS "${CMAKE_SOURCE_DIR}/source/mesh_deformation")
   LIST(REMOVE_ITEM TARGET_SRC ${FASTSCAPE_SRC})
@@ -492,6 +491,13 @@ ENDIF()
 
 ADD_EXECUTABLE(${TARGET} ${TARGET_SRC})
 DEAL_II_SETUP_TARGET(${TARGET})
+
+# Library needs to be linked after executable is added, but if fastscape isn't found
+# then the .cc files need to be removed before.
+# TODO: find a way to do this where they don't have to be separated.
+IF(FASTSCAPE)
+  TARGET_LINK_LIBRARIES(${TARGET} ${FASTSCAPE})
+ENDIF()
 
 # deal.II does not define NDEBUG, but the world builder relies on it to disable
 # its asserts in release mode. Set it manually for anything but debug mode.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,19 @@ IF(NOT ASPECT_ADDITIONAL_CXX_FLAGS STREQUAL "")
   MESSAGE(STATUS "  DEAL_II_CXX_FLAGS_RELEASE: ${DEAL_II_CXX_FLAGS_RELEASE}")
 ENDIF()
 
+# Check if a fastscape library is available, if so link it with aspect.
+# If the library is not found, then remove both fastscape files from list
+# so aspect can still compile.
+FIND_LIBRARY(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+IF(FASTSCAPE)
+  MESSAGE(STATUS "FastScape found at ${FASTSCAPE}")
+  TARGET_LINK_LIBRARIES(aspect "${FASTSCAPE}")
+ELSE()
+  FIND_FILE(FASTSCAPE_SOURCE fastscape.cc HINTS "${CMAKE_SOURCE_DIR}/source/mesh_deformation")
+  LIST(REMOVE_ITEM TARGET_SRC ${FASTSCAPE_SOURCE})
+  MESSAGE(STATUS "FastScape library not found")
+ENDIF()
+
 ADD_EXECUTABLE(${TARGET} ${TARGET_SRC})
 DEAL_II_SETUP_TARGET(${TARGET})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,15 +478,15 @@ IF(NOT ASPECT_ADDITIONAL_CXX_FLAGS STREQUAL "")
 ENDIF()
 
 # Check if a fastscape library is available, if so link it with aspect.
-# If the library is not found, then remove both fastscape files from list
+# If the library is not found, then remove fastscape .cc and .h from list
 # so aspect can still compile.
 FIND_LIBRARY(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
 IF(FASTSCAPE)
   MESSAGE(STATUS "FastScape found at ${FASTSCAPE}")
   TARGET_LINK_LIBRARIES(aspect "${FASTSCAPE}")
 ELSE()
-  FIND_FILE(FASTSCAPE_SOURCE fastscape.cc HINTS "${CMAKE_SOURCE_DIR}/source/mesh_deformation")
-  LIST(REMOVE_ITEM TARGET_SRC ${FASTSCAPE_SOURCE})
+  FIND_FILE(FASTSCAPE_SRC fastscape.cc HINTS "${CMAKE_SOURCE_DIR}/source/mesh_deformation")
+  LIST(REMOVE_ITEM TARGET_SRC ${FASTSCAPE_SRC})
   MESSAGE(STATUS "FastScape library not found")
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,7 @@ ENDIF()
 # Check if a fastscape library is available, if so link it with aspect.
 # If the library is not found, then remove fastscape .cc and .h from list
 # so aspect can still compile.
+# TODO: likely need to switch ENV and normal positions so it checks ENV second.
 FIND_LIBRARY(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
 IF(FASTSCAPE)
   MESSAGE(STATUS "FastScape found at ${FASTSCAPE}")

--- a/Named_VTK.f90
+++ b/Named_VTK.f90
@@ -80,14 +80,20 @@ call system ('mkdir -p '//trim(foldername)//'/VTK')
     npart2=len_trim(part2)
 
     open(unit=77,file=(foldername//'/VTK/Topography'//cstep//'.vtk'),status='unknown', &
-    form='unformatted',access='direct', recl=nheader+3*4*nn+nfooter+(npart1+1+npart2+4*nn) &
-    +(npart1+5+npart2+4*nn),convert='big_endian')
+    form='unformatted',access='direct', recl=nheader+3*4*nn+nfooter+(npart1+10+npart2+4*nn) &
+    +(npart1+5+npart2+4*nn)+(npart1+8+npart2+4*nn)+(npart1+12+npart2+4*nn)+(npart1+13+npart2+4*nn) &
+    +(npart1+13+npart2+4*nn)+(npart1+9+npart2+4*nn),convert='big_endian')
     write (77,rec=1) &
     header(1:nheader), &
     ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(h(i+(j-1)*nx)*abs(vex)),i=1,nx),j=1,ny), &
     footer(1:nfooter), &
-    part1(1:npart1)//'H'//part2(1:npart2),sngl(h(1:nn)), &
-    part1(1:npart1)//'HHHHH'//part2(1:npart2),sngl(f(1:nn))
+    part1(1:npart1)//'topography'//part2(1:npart2),sngl(h(1:nn)), &
+    part1(1:npart1)//'HHHHH'//part2(1:npart2),sngl(f(1:nn)), &
+    part1(1:npart1)//'basement'//part2(1:npart2),sngl(b(1:nn)), &
+    part1(1:npart1)//'erosion_rate'//part2(1:npart2),sngl(erate(1:nn)), &
+    part1(1:npart1)//'total_erosion'//part2(1:npart2),sngl(etot(1:nn)), &
+    part1(1:npart1)//'drainage_area'//part2(1:npart2),sngl(a(1:nn)) , &
+    part1(1:npart1)//'catchment'//part2(1:npart2),sngl(catch(1:nn))
     close(77)
 
     if (vex.lt.0.d0) then

--- a/Named_VTK.f90
+++ b/Named_VTK.f90
@@ -1,0 +1,116 @@
+subroutine Fastscape_Named_VTK (f, vex, istep, foldername, k)
+
+    ! subroutine to create a simple VTK file for plotting inside of aspect folder.
+    ! To use, add this file into the fastscape src directory, and then add
+    ! the line ${FASTSCAPELIB_SRC_DIR}/Named_VTK.f90 to the appropriate place
+    ! in cmakelists.txt
+
+    use FastScapeContext
+    implicit none
+
+    integer, intent(in) :: k, istep !,atime
+    double precision, intent(in) :: vex
+    double precision, intent(in), dimension(*) :: f
+    character(len=k), intent(in) :: foldername
+    character*7 cstep
+
+    integer nheader,nfooter,npart1,npart2, ftime
+    character header*1024,footer*1024,part1*1024,part2*1024,nxc*6,nyc*6,nnc*12
+    integer i,j
+    character*10 fwtime
+    double precision dx,dy
+
+
+    dx = xl/(nx - 1)
+    dy = yl/(ny - 1)
+
+    ! Finding the fastscape time incremented by dt. dt may be a double
+    ! that is converted to an integer, but we don't care about then
+    ! exact time that much.
+    ! ftime = (atime + step*dt)
+
+    !Writing the fastscape time to a string, up to 1 billion years. (add another zero if needed eventually)
+   ! write (fwtime,'(i10)') ftime
+   ! if (ftime.lt.10) fwtime(1:9)='000000000'
+   ! if (ftime.lt.100) fwtime(1:8)='00000000'
+   ! if (ftime.lt.1000) fwtime(1:7)='0000000'
+   ! if (ftime.lt.10000) fwtime(1:6)='000000'
+   ! if (ftime.lt.100000) fwtime(1:5)='00000'
+   ! if (ftime.lt.1000000) fwtime(1:4)='0000'
+   ! if (ftime.lt.10000000) fwtime(1:3)='000'
+   ! if (ftime.lt.100000000) fwtime(1:2)='00'
+   ! if (ftime.lt.1000000000) fwtime(1:1)='0'
+
+    write (cstep,'(i7)') istep
+    if (istep.lt.10) cstep(1:6)='000000'
+    if (istep.lt.100) cstep(1:5)='00000'
+    if (istep.lt.1000) cstep(1:4)='0000'
+    if (istep.lt.10000) cstep(1:3)='000'
+    if (istep.lt.100000) cstep(1:2)='00'
+    if (istep.lt.1000000) cstep(1:1)='0'
+
+
+
+!Use the output folder of aspect and create a vtk folder inside of it.
+!#ifdef ON_WINDOWS
+!    call system ('if not exist "'//trim(foldername)//'/VTK" mkdir '//trim(foldername)//'/VTK')
+!#else
+call system ('mkdir -p '//trim(foldername)//'/VTK')
+!call system ('pwd')
+!#endif
+
+    write (nxc,'(i6)') nx
+    write (nyc,'(i6)') ny
+    write (nnc,'(i12)') nn
+
+    header(1:1024)=''
+    header='# vtk DataFile Version 3.0'//char(10)//'FastScape'//char(10) &
+    //'BINARY'//char(10)//'DATASET STRUCTURED_GRID'//char(10) &
+    //'DIMENSIONS '//nxc//' '//nyc//' 1'//char(10)//'POINTS' &
+    //nnc//' float'//char(10)
+    nheader=len_trim(header)
+    footer(1:1024)=''
+    footer='POINT_DATA'//nnc//char(10)
+    nfooter=len_trim(footer)
+    part1(1:1024)=''
+    part1='SCALARS '
+    npart1=len_trim(part1)+1
+    part2(1:1024)=''
+    part2=' float 1'//char(10)//'LOOKUP_TABLE default'//char(10)
+    npart2=len_trim(part2)
+
+    open(unit=77,file=(foldername//'/VTK/Topography'//cstep//'.vtk'),status='unknown', &
+    form='unformatted',access='direct', recl=nheader+3*4*nn+nfooter+(npart1+1+npart2+4*nn) &
+    +(npart1+5+npart2+4*nn),convert='big_endian')
+    write (77,rec=1) &
+    header(1:nheader), &
+    ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(h(i+(j-1)*nx)*abs(vex)),i=1,nx),j=1,ny), &
+    footer(1:nfooter), &
+    part1(1:npart1)//'H'//part2(1:npart2),sngl(h(1:nn)), &
+    part1(1:npart1)//'HHHHH'//part2(1:npart2),sngl(f(1:nn))
+    close(77)
+
+    if (vex.lt.0.d0) then
+      open(unit=77,file=(foldername//'/VTK/Basement'//cstep//'.vtk'),status='unknown',form='unformatted',access='direct', &
+      recl=nheader+3*4*nn+nfooter+(npart1+1+npart2+4*nn) &
+      +(npart1+5+npart2+4*nn),convert='big_endian')
+      write (77,rec=1) &
+      header(1:nheader), &
+      ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(b(i+(j-1)*nx)*abs(vex)),i=1,nx),j=1,ny), &
+      footer(1:nfooter), &
+      part1(1:npart1)//'B'//part2(1:npart2),sngl(b(1:nn)), &
+      part1(1:npart1)//'HHHHH'//part2(1:npart2),sngl(f(1:nn))
+      close(77)
+      open(unit=77,file=(foldername//'/VTK/SeaLevel'//cstep//'.vtk'),status='unknown',form='unformatted',access='direct', &
+      recl=nheader+3*4*nn+nfooter+(npart1+2+npart2+4*nn),convert='big_endian')
+      write (77,rec=1) &
+      header(1:nheader), &
+      ((sngl(dx*(i-1)),sngl(dy*(j-1)),sngl(sealevel*abs(vex)),i=1,nx),j=1,ny), &
+      footer(1:nfooter), &
+      part1(1:npart1)//'SL'//part2(1:npart2),(sngl(sealevel),i=1,nn)
+      close(77)
+    endif
+
+
+    return
+  end subroutine Fastscape_Named_VTK

--- a/cookbooks/fastscape_eroding_box.prm
+++ b/cookbooks/fastscape_eroding_box.prm
@@ -76,7 +76,7 @@ subsection Mesh deformation
       # Seed number for initial topography noise
       set Fastscape seed = 1000
 
-      #Because no boundaries are periodic, no flux, and no advection we don't need ghost nodes.
+      # Because no boundaries are periodic, no flux, and no advection we don't need ghost nodes.
       set Use ghost nodes = false
       set Vertical exaggeration = 1
 

--- a/cookbooks/fastscape_eroding_box.prm
+++ b/cookbooks/fastscape_eroding_box.prm
@@ -3,9 +3,9 @@
 set Dimension                              = 3
 
 set Use years in output instead of seconds = true
-set End time                               = 2e5
-set Maximum time step                      = 20000 #5e6
-set Output directory                       = eroding_plateau
+set End time                               = 2.5e5
+set Maximum time step                      = 50000 #5e6
+set Output directory                       = eroding_box
 
 set Pressure normalization                 = no #surface
 set Surface pressure                       = 0
@@ -15,18 +15,17 @@ subsection Geometry model
   set Model name = box
 
   subsection Box
-    set X extent = 50e3
+    set X extent = 100e3
     set Y extent = 100e3
     set Z extent = 25e3
-    set X repetitions = 2
+    set X repetitions = 4
     set Y repetitions = 4
-    set X periodic = true
   end
   
   subsection Initial topography model
     set Model name = function
     subsection Function
-      set Function expression = if(y>50e3, 1000, 0)          
+      set Function expression = if(y>20e3 && y<80e3 && x>20e3 && x<80e3, 2500, 0)          
     end
   end
 end
@@ -40,37 +39,53 @@ subsection Initial temperature model
   end
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = initial temperature
 end
 
-
 # X boundaries are periodic, and the rest are tangential.
 subsection Boundary velocity model
-  set Tangential velocity boundary indicators = bottom, front, back
+  set Tangential velocity boundary indicators = bottom, front, back, left, right
 end
 
 # Here we setup the top boundary with fastscape.
 subsection Mesh deformation
   set Mesh deformation boundary indicators = top : fastscape
   
-    # We set fastscape as 2 levels more resolved than ASPECT's initial global resolution.
     subsection Fastscape
-      set Additional fastscape refinement = 2
-      set Vertical exaggeration = 1
-      set Maximum timestep = 2000
-      set Number of steps = 10
+      # As the highest resolution at the surface is 4 in the mesh refiniment function, we set this the same.
+      set Surface resolution = 4
+
+      # Because we only have 1 level of refinement at the surface we set this to 0.
+      # If we had multiple resolutions, e.g. 3 different cell sizes at the surface,
+      # this would be set to 2 (number of cell sizes at surface - 1).
+      set Resolution difference = 0
+
+      # We set fastscape as 1 levels more resolved than ASPECT's initial global surface resolution.
+      set Additional fastscape refinement = 1
+
+      # Number of FastScape timesteps we want per ASPECT timestep.
+      set Number of steps = 5
+
+      # Set the maximum allowable FastScape timestep. If the (ASPECT timestep)/(Number of steps)
+      # is greater than this value, then the number of steps is automatically doubled.
+      # This is continued until the FastScape timestep is less than this value.
+      set Maximum timestep = 10000
+
+      # Seed number for initial topography noise
       set Fastscape seed = 1000
 
-      # The bottom boundary is fixed, but all other boundaries are left open,
-      # making the left and right boundaries periodic.
+      #Because no boundaries are periodic, no flux, and no advection we don't need ghost nodes.
+      set Use ghost nodes = false
+      set Vertical exaggeration = 1
+
+      # Fix all boundaries in FastScape.
       subsection Boundary conditions
         set Bottom = 1
-        set Right  = 0
-        set Top    = 0
-        set Left   = 0
+        set Right  = 1
+        set Top    = 1
+        set Left   = 1
       end
    
       # We use both SPL and diffusion. The bedrock deposition
@@ -80,13 +95,17 @@ subsection Mesh deformation
       subsection Erosional parameters
         set Drainage area exponent = 0.4
         set Bedrock diffusivity = 1e-2
-        set Multi-direction slope exponent = 1
         set Bedrock river incision rate = 1e-4
         set Slope exponent = 1
         set Bedrock deposition coefficient = 1
+
+        # A negative value indicates varied flow. 10 is steepest descent, and 1 is uniform distribution.
+        set Multi-direction slope exponent = -1
        end
-    
    end
+
+   set Additional tangential mesh velocity boundary indicators = left, right, front, back
+
 end
 
 subsection Gravity model
@@ -131,13 +150,13 @@ subsection Mesh refinement
     subsection Maximum refinement function
       set Coordinate system   = cartesian
       set Variable names      = x,y,z
-      set Function expression = if(z>=20e3, 4, 3)
+      set Function expression = if(z>=23000, 4, 2)
   end
   
       subsection Minimum refinement function
       set Coordinate system   = cartesian
       set Variable names      = x,y,z
-      set Function expression = if(z>=20e3, 4, 3)
+      set Function expression = if(z>=23000, 4, 2)
   end
 end
 
@@ -148,5 +167,6 @@ subsection Postprocess
     set Time between graphical output = 0
     set List of output variables      = strain rate
     set Interpolate output = true
+    set Write higher order output = true
   end
 end

--- a/cookbooks/fastscape_eroding_plateau.prm
+++ b/cookbooks/fastscape_eroding_plateau.prm
@@ -1,0 +1,152 @@
+# At the top, we define the number of space dimensions we would like to
+# work in:
+set Dimension                              = 3
+
+set Use years in output instead of seconds = true
+set End time                               = 2e5
+set Maximum time step                      = 20000 #5e6
+set Output directory                       = eroding_plateau
+
+set Pressure normalization                 = no #surface
+set Surface pressure                       = 0
+
+# A box which has one half raised by 1 km.
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 50e3
+    set Y extent = 100e3
+    set Z extent = 25e3
+    set X repetitions = 2
+    set Y repetitions = 4
+    set X periodic = true
+  end
+  
+  subsection Initial topography model
+    set Model name = function
+    subsection Function
+      set Function expression = if(y>50e3, 1000, 0)          
+    end
+  end
+end
+
+# We do not consider temperature in this setup
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = initial temperature
+end
+
+
+# X boundaries are periodic, and the rest are tangential.
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, front, back
+end
+
+# Here we setup the top boundary with fastscape.
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top : fastscape
+  
+    # We set fastscape as 2 levels more resolved than ASPECT's initial global resolution.
+    subsection Fastscape
+      set Additional fastscape refinement = 2
+      set Vertical exaggeration = 1
+      set Maximum timestep = 2000
+      set Number of steps = 10
+      set Fastscape seed = 1000
+
+      # The bottom boundary is fixed, but all other boundaries are left open,
+      # making the left and right boundaries periodic.
+      subsection Boundary conditions
+        set Bottom = 1
+        set Right  = 0
+        set Top    = 0
+        set Left   = 0
+      end
+   
+      # We use both SPL and diffusion. The bedrock deposition
+      # variable allows deposition of sediment, however, because
+      # the sediment variables are not set, they are equal to
+      # bedrock values.
+      subsection Erosional parameters
+        set Drainage area exponent = 0.4
+        set Bedrock diffusivity = 1e-2
+        set Multi-direction slope exponent = 1
+        set Bedrock river incision rate = 1e-4
+        set Slope exponent = 1
+        set Bedrock deposition coefficient = 1
+       end
+    
+   end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0   # = Ra 
+  end
+end
+
+# Dimensionless
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1
+    set Thermal expansion coefficient = 1
+    set Viscosity                     = 1
+  end
+end
+
+
+# We also have to specify that we want to use the Boussinesq
+# approximation (assuming the density in the temperature
+# equation to be constant, and incompressibility).
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+
+# We set our global refinement at the resolution level we want at the surface. As of now,
+# FastScape initial resolution is determined based off this.
+subsection Mesh refinement
+  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 1
+  set Time steps between mesh refinement       = 0
+  set Strategy                                 = maximum refinement function, minimum refinement function
+  
+    subsection Maximum refinement function
+      set Coordinate system   = cartesian
+      set Variable names      = x,y,z
+      set Function expression = if(z>=20e3, 4, 3)
+  end
+  
+      subsection Minimum refinement function
+      set Coordinate system   = cartesian
+      set Variable names      = x,y,z
+      set Function expression = if(z>=20e3, 4, 3)
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization
+
+  subsection Visualization
+    set Time between graphical output = 0
+    set List of output variables      = strain rate
+    set Interpolate output = true
+  end
+end

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -75,8 +75,8 @@ namespace aspect
          * Return a point that denotes the repetitions of the box in each dimension
          * of the domain.
          */
-        std::pair<int, int >
-        get_repetitions() const;
+        unsigned int
+        get_repetitions(unsigned int dimension) const;
 
         /**
          * Return a point that denotes the lower left corner of the box

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -58,7 +58,7 @@ void fastscape_set_u_(double *up);
 //Functions to run FastScape
 void fastscape_get_step_(int *sstep);
 void fastscape_execute_step_();
-void fastscape_vtk_(double *fp, const double *vexp);
+void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
 void fastscape_copy_h_(double *hp);
 
 //end run

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -240,6 +240,20 @@ namespace aspect
       bool use_v;
       // Precision value for node movement.
       double precision;
+
+
+        /**
+         * Interval between the generation of graphical output. This parameter
+         * is read from the input file and consequently is not part of the
+         * state that needs to be saved and restored.
+         */
+        double output_interval;
+
+        /**
+         * A time (in seconds) at which the last graphical output was supposed
+         * to be produced. Used to check for the next necessary output time.
+         */
+        mutable double last_output_time;
   };
 }
 }

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -120,6 +120,7 @@ namespace aspect
         mutable bool restart;
         mutable int restart_step;
         int resolution_difference;
+        mutable double keep_time;
 
         double m;
         double n;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -54,6 +54,7 @@ void fastscape_view_();
 void fastscape_set_bc_(const int *jbc);
 void fastscape_set_v_(double *ux, double *uy);
 void fastscape_set_u_(double *up);
+void fastscape_set_h_(double *hp);
 
 //Functions to run FastScape
 void fastscape_get_step_(int *sstep);

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -122,6 +122,9 @@ namespace aspect
         mutable int restart_step;
         int resolution_difference;
         mutable double keep_time;
+        double dx;
+        double dy;
+        double end_time;
 
         //Boundary conditions
         unsigned int bottom;
@@ -133,6 +136,7 @@ namespace aspect
         double bottom_flux;
         double top_flux;
 
+        //Erosional parameters
         double m;
         double n;
         double p;
@@ -142,9 +146,6 @@ namespace aspect
         double kfsed;
         double kdd;
         double kdsed;
-        double dx;
-        double dy;
-        double end_time;
 
         //Marine parameters
         double sl;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -27,58 +27,71 @@
  * fastscape as a reference.
  */
 
-#ifdef __cplusplus
-extern"C" {
-#endif
-//Functions to initialize FastScape
-void fastscape_init_();
-void fastscape_set_nx_ny_(const int *nnx, const int *nny);
-void fastscape_setup_();
-
-//TODO: These were originally double and not const double, make sure this isn't an issue.
-void fastscape_set_xl_yl_(const double *xxl,const double *yyl);
-void fastscape_set_dt_(double *dtt);
-void fastscape_init_h_(double *hp);
-void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
-                                         double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
-void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
-                                      const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
-
-void fastscape_view_();
-void fastscape_set_bc_(const int *jbc);
-void fastscape_set_v_(double *ux, double *uy);
-void fastscape_set_u_(double *up);
-void fastscape_set_h_(double *hp);
-
-//Functions to run FastScape
-void fastscape_get_step_(int *sstep);
-void fastscape_execute_step_();
-void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
-void fastscape_copy_h_(double *hp);
-void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
-//void folder_output_(int *length, int *astep, const char *c);
-void fastscape_copy_slope_(double *slopep);
-
-//end run
-void fastscape_debug_();
-void fastscape_destroy_();
-#ifdef  __cplusplus
-}
-#endif
-
 namespace aspect
 {
   using namespace dealii;
 
   namespace MeshDeformation
   {
+	#ifdef __cplusplus
+    extern"C" {
+	#endif
+	//Functions to initialize FastScape
+	void fastscape_init_();
+	//Set the nx and ny
+	void fastscape_set_nx_ny_(const int *nnx, const int *nny);
+	void fastscape_setup_();
+	//Set the boundary conditions.
+	void fastscape_set_bc_(const int *jbc);
+
+	//Set the x and y extent
+	void fastscape_set_xl_yl_(const double *xxl,const double *yyl);
+	//Set the timestep
+	void fastscape_set_dt_(double *dtt);
+	//Initialize heights
+	void fastscape_init_h_(double *hp);
+	//Parameters for hillslope diffusion, SPL, and enriched SPL (deposition).
+	void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
+                                         double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
+	//Parameters for the marine component.
+	void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
+                                      const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
+
+	//Set the velocities ux and uy, heights, or uplift.
+	void fastscape_set_v_(double *ux, double *uy);
+	void fastscape_set_u_(double *up);
+	void fastscape_set_h_(double *hp);
+
+	//Functions to run FastScape
+	void fastscape_get_step_(int *sstep);
+	void fastscape_execute_step_();
+	//Create a visualization file into the ASPECT/VTK folder
+	void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
+	//Copy the height array from FastScape back into ASPECT.
+	void fastscape_copy_h_(double *hp);
+	//Initialize stratigrapy, called once and handles visualization from there on.
+	void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
+	//void folder_output_(int *length, int *astep, const char *c);
+	//Copy slopes, used in determined ghost node height for mass flux flow in from a boundary.
+	void fastscape_copy_slope_(double *slopep);
+
+	//View additional information from FastScape, not included in the .cc.
+	void fastscape_view_();
+	void fastscape_debug_();
+
+	//end run
+	void fastscape_destroy_();
+	#ifdef  __cplusplus
+	}
+    #endif
+
     template<int dim>
     class FastScape : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
-
-        //FastScape();
-
+        /**
+         * Function to initialize variables for FastScape.
+         */
         virtual void initialize ();
 
         virtual
@@ -86,7 +99,6 @@ namespace aspect
         compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                  ConstraintMatrix &mesh_velocity_constraints,
                                                  const std::set<types::boundary_id> &boundary_id) const;
-
 
         /**
          * Declare parameters for the free surface handling.
@@ -100,73 +112,123 @@ namespace aspect
         void parse_parameters (ParameterHandler &prm);
 
       private:
-        /**
-         * A function object representing the mesh deformation.
-         */
+        //Number of FastScape steps per ASPECT timestep.
         int nstep;
-        int bc;
-        int array_size;
+        //Maximum timestep for FastScape, if time_step/nsteps exceeds this, nsteps is doubled.
         double max_timestep;
-        double vexp;
-        int nx;
-        int ny;
-        int nz;
-        unsigned int additional_refinement;
-        unsigned int initial_global_refinement;
-        double x_extent;
-        double y_extent;
-        bool slice;
-        int fs_seed;
-        int surface_resolution;
+        //Whether or not the model is being restarted.
         mutable bool restart;
+        //FastScape resets to step 0 on restart, this keeps the step number from the previous run.
         mutable int restart_step;
-        int resolution_difference;
+        //Variable to track FastScape runtime.
         mutable double keep_time;
+        //Model endtime to check if we should destroy FastScape.
+        double end_time;
+
+        //Cell size in FastScape, dx should always equal dy.
         double dx;
         double dy;
-        double end_time;
+        //Length of X in FastScape (model X + 2*dx for ghost nodes).
+        double x_extent;
+        //Length of Y in FastScape (model Y + 2*dy for ghost nodes).
+        double y_extent;
+        //Size of y if FastScape is coupled with a 2D ASPECT model.
         double y_extent_2d;
+        //Number of x points in FastScape array.
+        int nx;
+        //Number of y points in FastScape array.
+        int ny;
+        //Size of the FastScape array (nx*ny).
+        int array_size;
 
-        //Boundary conditions
+        //Vertical exaggeration in FastScape visualization.
+        double vexp;
+        //How many levels FastScape should be refined above the maximum ASPECT surface resolution
+        unsigned int additional_refinement;
+        //Maximum expected refinement level at ASPECT's surface.
+        int surface_resolution;
+        //Expected difference in refinement level of the highest and lowest surface resolution.
+        int resolution_difference;
+        //Whether or not to send back the center slice or averaged surface in 2D.
+        bool slice;
+        //Seed number for initializing random topography noise in FastScape.
+        int fs_seed;
+        //Variable to hold ASPECT model dimensions.
+        std::array<std::pair<double,double>,dim> grid_extent;
+        //Table for interpolation of FastScape surface velocities back to ASPECT.
+        std::array< unsigned int, dim > table_intervals;
+        //Used to check whether fastscape is called at the surface.
+        std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
+
+        /**
+         * Boundary conditions
+         */
+        //Boundary conditions for all sides, either 1 (fixed) or 0 (open).
         unsigned int bottom;
-        unsigned int right;
         unsigned int top;
+        unsigned int right;
         unsigned int left;
-        double left_flux;
-        double right_flux;
+        //Integer that holds the full boundary conditions (e.g. 1111).
+        int bc;
+
+        //Prescribed flux per unit length into the model through a boundary, in m^2/yr.
         double bottom_flux;
         double top_flux;
+        double right_flux;
+        double left_flux;
 
-        //Erosional parameters
+        /**
+         * Erosional parameters
+         */
+        //Drainage area exponent (m in SPL)
         double m;
+        //Slope exponent (n in SPL)
         double n;
+        //Slope exponent for multi-direction flow. where 0 is uniform, and 10 is steepest descent. (-1 is varied)
         double p;
+        //Bedrock deposition coefficient. Higher values mean more material is deposited.
         double g;
+        //Sediment deposition coefficient.
         double gsed;
+        //Bedrock river incision rate for SPL.
         double kff;
+        //Sediment river incision rate.
         double kfsed;
+        //Bedrock transport coefficient (diffusivity).
         double kdd;
+        //Sediment transport coefficient.
         double kdsed;
 
-        //Marine parameters
+        /**
+         * Marine parameters
+         */
+        //Sea level. Initial topography of FastScape is set at model height and not changed to zero.
         double sl;
+        //Surface porosity for sand.
         double p1;
+        //Surface porosity for shale.
         double p2;
+        //Sands e-folding depth for exponential porosity law.
         double z1;
+        //Shales e-folding depth for exponential porosity law.
         double z2;
+        //Sand-shale ratio
         double r;
+        //Averaging depth/thickness for sand-shale equation (m).
         double l;
+        //Sand marine transport coefficient (diffusivity).
         double kds1;
+        //Shale marine transport coefficient (diffusivity).
         double kds2;
+        //Whether or not to use the marine component of FastScape.
         bool use_marine;
 
-        //Stratigraphy parameters
+        /**
+         * Stratigraphy parameters.
+         */
         bool use_strat;
         int nstepp;
         int nreflectorp;
-
-        std::array<std::pair<double,double>,dim> grid_extent;
-        std::array< unsigned int, dim > table_intervals;
     };
   }
 }

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -118,6 +118,7 @@ namespace aspect
         double y_extent;
         bool slice;
         int fs_seed;
+        int surface_res;
         mutable bool restart;
         mutable int restart_step;
 

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -233,6 +233,11 @@ namespace aspect
       bool use_strat;
       int nstepp;
       int nreflectorp;
+
+      // Whether to use fastscape's advection and uplift. Turn off for free surface.
+      bool use_v;
+      // Precision value for node movement.
+      double precision;
   };
 }
 }

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -55,8 +55,9 @@ void fastscape_get_step_(int *sstep);
 void fastscape_execute_step_();
 void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
 void fastscape_copy_h_(double *hp);
-void fastscape_strati_(int *nstepp, int *nreflectorp, int *nfreqp, const double *vexp);
+void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
 void folder_output_(int *length, int *astep, const char *c);
+void fastscape_copy_slope_(double *slopep);
 
 //end run
 void fastscape_debug_();
@@ -112,10 +113,6 @@ namespace aspect
         int nz;
         unsigned int additional_refinement;
         unsigned int initial_global_refinement;
-        unsigned int bottom;
-        unsigned int right;
-        unsigned int top;
-        unsigned int left;
         double x_extent;
         double y_extent;
         bool slice;
@@ -125,6 +122,16 @@ namespace aspect
         mutable int restart_step;
         int resolution_difference;
         mutable double keep_time;
+
+        //Boundary conditions
+        unsigned int bottom;
+        unsigned int right;
+        unsigned int top;
+        unsigned int left;
+        double left_flux;
+        double right_flux;
+        double bottom_flux;
+        double top_flux;
 
         double m;
         double n;
@@ -153,6 +160,8 @@ namespace aspect
 
         //Stratigraphy parameters
         bool use_strat;
+        int nstepp;
+        int nreflectorp;
 
         std::array<std::pair<double,double>,dim> grid_extent;
         std::array< unsigned int, dim > table_intervals;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -112,6 +112,13 @@ namespace aspect
        */
       void parse_parameters (ParameterHandler &prm);
 
+        /**
+         * A function that fills the viscosity derivatives in the
+         * MaterialModelOutputs object that is handed over, if they exist.
+         * Does nothing otherwise.
+         */
+        void set_ghost_nodes(double *h, double *vx, double *vy, double *vz, int nx, int ny) const;
+
     private:
       // Number of FastScape steps per ASPECT timestep.
       int nstep;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -41,6 +41,8 @@ void fastscape_set_dt_(double *dtt);
 void fastscape_init_h_(double *hp);
 void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
                                          double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
+void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
+                                      const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
 
 void fastscape_view_();
 void fastscape_set_bc_(const int *jbc);
@@ -134,6 +136,18 @@ namespace aspect
         double dx;
         double dy;
         double end_time;
+
+        //Marine parameters
+        double sl;
+        double p1;
+        double p2;
+        double z1;
+        double z2;
+        double r;
+        double l;
+        double kds1;
+        double kds2;
+        bool use_marine;
 
         std::array<std::pair<double,double>,dim> grid_extent;
         std::array< unsigned int, dim > table_intervals;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -19,14 +19,6 @@
 #define _aspect_mesh_deformation_fast_scape_h
 
 #include <aspect/mesh_deformation/interface.h>
-#include <aspect/simulator_access.h>
-#include <vector>
-#include <array>
-#include <deal.II/base/function_lib.h>
-#include <deal.II/base/timer.h>
-
-
-
 
 /*
  * Define FastScape functions as C functions. Must use exact same function/variable name

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -136,6 +136,7 @@ namespace aspect
         double kdsed;
         double dx;
         double dy;
+        double end_time;
 
         std::array<std::pair<double,double>,dim> grid_extent;
         std::array< unsigned int, dim > table_intervals;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -126,6 +126,8 @@ namespace aspect
         double y_extent;
         bool slice;
         int fs_seed;
+        mutable bool restart;
+        mutable int restart_step;
 
         double m;
         double n;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -125,6 +125,7 @@ namespace aspect
         double dx;
         double dy;
         double end_time;
+        double y_extent_2d;
 
         //Boundary conditions
         unsigned int bottom;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -25,12 +25,12 @@ namespace aspect
 
   namespace MeshDeformation
   {
-/**
- * Define FastScape functions as C functions. Must use exact same function/variable name
- * and type as used in FastScape. All function names must be made lowercase, and an
- * underscore added at the end. Types must be defined as pointers, and sent to
- * fastscape as a reference.
- */    
+    /**
+     * Define FastScape functions as C functions. Must use exact same function/variable name
+     * and type as used in FastScape. All function names must be made lowercase, and an
+     * underscore added at the end. Types must be defined as pointers, and sent to
+     * fastscape as a reference.
+     */
 #ifdef __cplusplus
     extern"C" {
 #endif

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -59,6 +59,7 @@ namespace aspect
     void fastscape_set_v_(double *ux, double *uy);
     void fastscape_set_u_(double *up);
     void fastscape_set_h_(double *hp);
+    void fastscape_set_basement_(double *b);
 
     // Functions to run FastScape
     void fastscape_get_step_(int *sstep);
@@ -67,6 +68,8 @@ namespace aspect
     void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
     // Copy the height array from FastScape back into ASPECT.
     void fastscape_copy_h_(double *hp);
+    // Copy the basement array from FastScape back into ASPECT.
+    void fastscape_copy_basement_(double *b);
     // Initialize stratigrapy, called once and handles visualization from there on.
     void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
     //void folder_output_(int *length, int *astep, const char *c);
@@ -157,6 +160,8 @@ namespace aspect
       std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
       // Whether or not to use the ghost nodes.
       bool use_ghost;
+      // Sediment rain in m/yr, added to surface every ASPECT timestep.
+      double sediment_rain;
 
 
       /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -56,7 +56,7 @@ void fastscape_execute_step_();
 void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
 void fastscape_copy_h_(double *hp);
 void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
-void folder_output_(int *length, int *astep, const char *c);
+//void folder_output_(int *length, int *astep, const char *c);
 void fastscape_copy_slope_(double *slopep);
 
 //end run

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -161,7 +161,9 @@ namespace aspect
       // Whether or not to use the ghost nodes.
       bool use_ghost;
       // Sediment rain in m/yr, added to surface every ASPECT timestep.
-      double sediment_rain;
+      std::vector<double> sr_values;
+      std::vector<double> sr_times;
+
 
 
       /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -55,6 +55,8 @@ void fastscape_get_step_(int *sstep);
 void fastscape_execute_step_();
 void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
 void fastscape_copy_h_(double *hp);
+void fastscape_strati_(int *nstepp, int *nreflectorp, int *nfreqp, const double *vexp);
+void folder_output_(int *length, int *astep, const char *c);
 
 //end run
 void fastscape_debug_();
@@ -148,6 +150,9 @@ namespace aspect
         double kds1;
         double kds2;
         bool use_marine;
+
+        //Stratigraphy parameters
+        bool use_strat;
 
         std::array<std::pair<double,double>,dim> grid_extent;
         std::array< unsigned int, dim > table_intervals;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -98,7 +98,7 @@ namespace aspect
       virtual
       void
       compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
-                                               ConstraintMatrix &mesh_velocity_constraints,
+                                               AffineConstraints<double> &mesh_velocity_constraints,
                                                const std::set<types::boundary_id> &boundary_id) const;
 
       /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -33,207 +33,205 @@ namespace aspect
 
   namespace MeshDeformation
   {
-	#ifdef __cplusplus
+#ifdef __cplusplus
     extern"C" {
-	#endif
-	//Functions to initialize FastScape
-	void fastscape_init_();
-	//Set the nx and ny
-	void fastscape_set_nx_ny_(const int *nnx, const int *nny);
-	void fastscape_setup_();
-	//Set the boundary conditions.
-	void fastscape_set_bc_(const int *jbc);
+#endif
+    //Functions to initialize FastScape
+    void fastscape_init_();
+    //Set the nx and ny
+    void fastscape_set_nx_ny_(const int *nnx, const int *nny);
+    void fastscape_setup_();
+    //Set the boundary conditions.
+    void fastscape_set_bc_(const int *jbc);
 
-	//Set the x and y extent
-	void fastscape_set_xl_yl_(const double *xxl,const double *yyl);
-	//Set the timestep
-	void fastscape_set_dt_(double *dtt);
-	//Initialize heights
-	void fastscape_init_h_(double *hp);
-	//Parameters for hillslope diffusion, SPL, and enriched SPL (deposition).
-	void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
-                                         double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
-	//Parameters for the marine component.
-	void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
-                                      const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
+    //Set the x and y extent
+    void fastscape_set_xl_yl_(const double *xxl,const double *yyl);
+    //Set the timestep
+    void fastscape_set_dt_(double *dtt);
+    //Initialize heights
+    void fastscape_init_h_(double *hp);
+    //Parameters for hillslope diffusion, SPL, and enriched SPL (deposition).
+    void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
+                                             double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
+    //Parameters for the marine component.
+    void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
+                                          const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
 
-	//Set the velocities ux and uy, heights, or uplift.
-	void fastscape_set_v_(double *ux, double *uy);
-	void fastscape_set_u_(double *up);
-	void fastscape_set_h_(double *hp);
+    //Set the velocities ux and uy, heights, or uplift.
+    void fastscape_set_v_(double *ux, double *uy);
+    void fastscape_set_u_(double *up);
+    void fastscape_set_h_(double *hp);
 
-	//Functions to run FastScape
-	void fastscape_get_step_(int *sstep);
-	void fastscape_execute_step_();
-	//Create a visualization file into the ASPECT/VTK folder
-	void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
-	//Copy the height array from FastScape back into ASPECT.
-	void fastscape_copy_h_(double *hp);
-	//Initialize stratigrapy, called once and handles visualization from there on.
-	void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
-	//void folder_output_(int *length, int *astep, const char *c);
-	//Copy slopes, used in determined ghost node height for mass flux flow in from a boundary.
-	void fastscape_copy_slope_(double *slopep);
+    //Functions to run FastScape
+    void fastscape_get_step_(int *sstep);
+    void fastscape_execute_step_();
+    //Create a visualization file into the ASPECT/VTK folder
+    void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
+    //Copy the height array from FastScape back into ASPECT.
+    void fastscape_copy_h_(double *hp);
+    //Initialize stratigrapy, called once and handles visualization from there on.
+    void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
+    //void folder_output_(int *length, int *astep, const char *c);
+    //Copy slopes, used in determined ghost node height for mass flux flow in from a boundary.
+    void fastscape_copy_slope_(double *slopep);
 
-	//View additional information from FastScape, not included in the .cc.
-	void fastscape_view_();
-	void fastscape_debug_();
+    //View additional information from FastScape, not included in the .cc.
+    void fastscape_view_();
+    void fastscape_debug_();
 
-	//end run
-	void fastscape_destroy_();
-	#ifdef  __cplusplus
-	}
-    #endif
-
-    template<int dim>
-    class FastScape : public Interface<dim>, public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Function to initialize variables for FastScape.
-         */
-        virtual void initialize ();
-
-        virtual
-        void
-        compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
-                                                 ConstraintMatrix &mesh_velocity_constraints,
-                                                 const std::set<types::boundary_id> &boundary_id) const;
-
-        /**
-         * Declare parameters for the free surface handling.
-         */
-        static
-        void declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Parse parameters for the free surface handling.
-         */
-        void parse_parameters (ParameterHandler &prm);
-
-      private:
-        //Number of FastScape steps per ASPECT timestep.
-        int nstep;
-        //Maximum timestep for FastScape, if time_step/nsteps exceeds this, nsteps is doubled.
-        double max_timestep;
-        //Whether or not the model is being restarted.
-        mutable bool restart;
-        //FastScape resets to step 0 on restart, this keeps the step number from the previous run.
-        mutable int restart_step;
-        //Variable to track FastScape runtime.
-        mutable double keep_time;
-        //Model endtime to check if we should destroy FastScape.
-        double end_time;
-
-        //Cell size in FastScape, dx should always equal dy.
-        double dx;
-        double dy;
-        //Length of X in FastScape (model X + 2*dx for ghost nodes).
-        double x_extent;
-        //Length of Y in FastScape (model Y + 2*dy for ghost nodes).
-        double y_extent;
-        //Size of y if FastScape is coupled with a 2D ASPECT model.
-        double y_extent_2d;
-        //Number of x points in FastScape array.
-        int nx;
-        //Number of y points in FastScape array.
-        int ny;
-        //Size of the FastScape array (nx*ny).
-        int array_size;
-
-        //Vertical exaggeration in FastScape visualization.
-        double vexp;
-        //How many levels FastScape should be refined above the maximum ASPECT surface resolution
-        unsigned int additional_refinement;
-        //Maximum expected refinement level at ASPECT's surface.
-        int surface_resolution;
-        //Expected difference in refinement level of the highest and lowest surface resolution.
-        int resolution_difference;
-        //Whether or not to send back the center slice or averaged surface in 2D.
-        bool slice;
-        //Seed number for initializing random topography noise in FastScape.
-        int fs_seed;
-        //Variable to hold ASPECT model dimensions.
-        std::array<std::pair<double,double>,dim> grid_extent;
-        //Table for interpolation of FastScape surface velocities back to ASPECT.
-        std::array< unsigned int, dim > table_intervals;
-        //Used to check whether fastscape is called at the surface.
-        std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
-        //Whether or not to use the ghost nodes.
-        bool use_ghost;
-
-
-        /**
-         * Boundary conditions
-         */
-        //Boundary conditions for all sides, either 1 (fixed) or 0 (open).
-        unsigned int bottom;
-        unsigned int top;
-        unsigned int right;
-        unsigned int left;
-        //Integer that holds the full boundary conditions (e.g. 1111).
-        int bc;
-
-        //Prescribed flux per unit length into the model through a boundary, in m^2/yr.
-        double bottom_flux;
-        double top_flux;
-        double right_flux;
-        double left_flux;
-
-        /**
-         * Erosional parameters
-         */
-        //Drainage area exponent (m in SPL)
-        double m;
-        //Slope exponent (n in SPL)
-        double n;
-        //Slope exponent for multi-direction flow. where 0 is uniform, and 10 is steepest descent. (-1 is varied)
-        double p;
-        //Bedrock deposition coefficient. Higher values mean more material is deposited.
-        double g;
-        //Sediment deposition coefficient.
-        double gsed;
-        //Bedrock river incision rate for SPL.
-        double kff;
-        //Sediment river incision rate.
-        double kfsed;
-        //Bedrock transport coefficient (diffusivity).
-        double kdd;
-        //Sediment transport coefficient.
-        double kdsed;
-
-        /**
-         * Marine parameters
-         */
-        //Sea level. Initial topography of FastScape is set at model height and not changed to zero.
-        double sl;
-        //Surface porosity for sand.
-        double p1;
-        //Surface porosity for shale.
-        double p2;
-        //Sands e-folding depth for exponential porosity law.
-        double z1;
-        //Shales e-folding depth for exponential porosity law.
-        double z2;
-        //Sand-shale ratio
-        double r;
-        //Averaging depth/thickness for sand-shale equation (m).
-        double l;
-        //Sand marine transport coefficient (diffusivity).
-        double kds1;
-        //Shale marine transport coefficient (diffusivity).
-        double kds2;
-        //Whether or not to use the marine component of FastScape.
-        bool use_marine;
-
-        /**
-         * Stratigraphy parameters.
-         */
-        bool use_strat;
-        int nstepp;
-        int nreflectorp;
-    };
+    //end run
+    void fastscape_destroy_();
+#ifdef  __cplusplus
   }
+#endif
+
+  template<int dim>
+  class FastScape : public Interface<dim>, public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Function to initialize variables for FastScape.
+       */
+      virtual void initialize ();
+
+      virtual
+      void
+      compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
+                                               ConstraintMatrix &mesh_velocity_constraints,
+                                               const std::set<types::boundary_id> &boundary_id) const;
+
+      /**
+       * Declare parameters for the free surface handling.
+       */
+      static
+      void declare_parameters (ParameterHandler &prm);
+
+      /**
+       * Parse parameters for the free surface handling.
+       */
+      void parse_parameters (ParameterHandler &prm);
+
+    private:
+      //Number of FastScape steps per ASPECT timestep.
+      int nstep;
+      //Maximum timestep for FastScape, if time_step/nsteps exceeds this, nsteps is doubled.
+      double max_timestep;
+      //Whether or not the model is being restarted.
+      mutable bool restart;
+      //FastScape resets to step 0 on restart, this keeps the step number from the previous run.
+      mutable int restart_step;
+      //Model endtime to check if we should destroy FastScape.
+      double end_time;
+
+      //Cell size in FastScape, dx should always equal dy.
+      double dx;
+      double dy;
+      //Length of X in FastScape (model X + 2*dx for ghost nodes).
+      double x_extent;
+      //Length of Y in FastScape (model Y + 2*dy for ghost nodes).
+      double y_extent;
+      //Size of y if FastScape is coupled with a 2D ASPECT model.
+      double y_extent_2d;
+      //Number of x points in FastScape array.
+      int nx;
+      //Number of y points in FastScape array.
+      int ny;
+      //Size of the FastScape array (nx*ny).
+      int array_size;
+
+      //Vertical exaggeration in FastScape visualization.
+      double vexp;
+      //How many levels FastScape should be refined above the maximum ASPECT surface resolution
+      unsigned int additional_refinement;
+      //Maximum expected refinement level at ASPECT's surface.
+      int surface_resolution;
+      //Expected difference in refinement level of the highest and lowest surface resolution.
+      int resolution_difference;
+      //Whether or not to send back the center slice or averaged surface in 2D.
+      bool slice;
+      //Seed number for initializing random topography noise in FastScape.
+      int fs_seed;
+      //Variable to hold ASPECT model dimensions.
+      std::array<std::pair<double,double>,dim> grid_extent;
+      //Table for interpolation of FastScape surface velocities back to ASPECT.
+      std::array< unsigned int, dim > table_intervals;
+      //Used to check whether fastscape is called at the surface.
+      std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
+      //Whether or not to use the ghost nodes.
+      bool use_ghost;
+
+
+      /**
+       * Boundary conditions
+       */
+      //Boundary conditions for all sides, either 1 (fixed) or 0 (open).
+      unsigned int bottom;
+      unsigned int top;
+      unsigned int right;
+      unsigned int left;
+      //Integer that holds the full boundary conditions (e.g. 1111).
+      int bc;
+
+      //Prescribed flux per unit length into the model through a boundary, in m^2/yr.
+      double bottom_flux;
+      double top_flux;
+      double right_flux;
+      double left_flux;
+
+      /**
+       * Erosional parameters
+       */
+      //Drainage area exponent (m in SPL)
+      double m;
+      //Slope exponent (n in SPL)
+      double n;
+      //Slope exponent for multi-direction flow. where 0 is uniform, and 10 is steepest descent. (-1 is varied)
+      double p;
+      //Bedrock deposition coefficient. Higher values mean more material is deposited.
+      double g;
+      //Sediment deposition coefficient.
+      double gsed;
+      //Bedrock river incision rate for SPL.
+      double kff;
+      //Sediment river incision rate.
+      double kfsed;
+      //Bedrock transport coefficient (diffusivity).
+      double kdd;
+      //Sediment transport coefficient.
+      double kdsed;
+
+      /**
+       * Marine parameters
+       */
+      //Sea level. Initial topography of FastScape is set at model height and not changed to zero.
+      double sl;
+      //Surface porosity for sand.
+      double p1;
+      //Surface porosity for shale.
+      double p2;
+      //Sands e-folding depth for exponential porosity law.
+      double z1;
+      //Shales e-folding depth for exponential porosity law.
+      double z2;
+      //Sand-shale ratio
+      double r;
+      //Averaging depth/thickness for sand-shale equation (m).
+      double l;
+      //Sand marine transport coefficient (diffusivity).
+      double kds1;
+      //Shale marine transport coefficient (diffusivity).
+      double kds2;
+      //Whether or not to use the marine component of FastScape.
+      bool use_marine;
+
+      /**
+       * Stratigraphy parameters.
+       */
+      bool use_strat;
+      int nstepp;
+      int nreflectorp;
+  };
+}
 }
 
 

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -23,6 +23,8 @@
 #include <vector>
 #include <array>
 #include <deal.II/base/function_lib.h>
+#include <deal.II/base/timer.h>
+
 
 
 
@@ -114,6 +116,7 @@ namespace aspect
         unsigned int additional_refinement;
         unsigned int initial_global_refinement;
         int numx;
+        int numy;
         unsigned int bottom;
         unsigned int right;
         unsigned int top;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -116,9 +116,10 @@ namespace aspect
         double y_extent;
         bool slice;
         int fs_seed;
-        int surface_res;
+        int surface_resolution;
         mutable bool restart;
         mutable int restart_step;
+        int resolution_difference;
 
         double m;
         double n;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -14,18 +14,10 @@
   <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef _aspect_mesh_deformation_fast_scape_h
 #define _aspect_mesh_deformation_fast_scape_h
 
 #include <aspect/mesh_deformation/interface.h>
-
-/*
- * Define FastScape functions as C functions. Must use exact same function/variable name
- * and type as used in FastScape. All function names must be made lowercase, and an
- * underscore added at the end. Types must be defined as pointers, and sent to
- * fastscape as a reference.
- */
 
 namespace aspect
 {
@@ -33,53 +25,59 @@ namespace aspect
 
   namespace MeshDeformation
   {
+/**
+ * Define FastScape functions as C functions. Must use exact same function/variable name
+ * and type as used in FastScape. All function names must be made lowercase, and an
+ * underscore added at the end. Types must be defined as pointers, and sent to
+ * fastscape as a reference.
+ */    
 #ifdef __cplusplus
     extern"C" {
 #endif
-    //Functions to initialize FastScape
+    // Functions to initialize FastScape
     void fastscape_init_();
-    //Set the nx and ny
+    // Set the nx and ny
     void fastscape_set_nx_ny_(const int *nnx, const int *nny);
     void fastscape_setup_();
-    //Set the boundary conditions.
+    // Set the boundary conditions.
     void fastscape_set_bc_(const int *jbc);
 
-    //Set the x and y extent
+    // Set the x and y extent
     void fastscape_set_xl_yl_(const double *xxl,const double *yyl);
-    //Set the timestep
+    // Set the timestep
     void fastscape_set_dt_(double *dtt);
-    //Initialize heights
+    // Initialize heights
     void fastscape_init_h_(double *hp);
-    //Parameters for hillslope diffusion, SPL, and enriched SPL (deposition).
+    // Parameters for hillslope diffusion, SPL, and enriched SPL (deposition).
     void fastscape_set_erosional_parameters_(double *kkf,const double *kkfsed,const double *mm,const double *nnn,
                                              double *kkd,const double *kkdsed,const double *gg1,const double *gg2,const double *pp);
-    //Parameters for the marine component.
+    // Parameters for the marine component.
     void fastscape_set_marine_parameters_(const double *sl, const double *p1, const double *p2, const double *z1,
                                           const double *z2, const double *r, const double *l, const double *kds1, const double *kds2);
 
-    //Set the velocities ux and uy, heights, or uplift.
+    // Set the velocities ux and uy, heights, or uplift.
     void fastscape_set_v_(double *ux, double *uy);
     void fastscape_set_u_(double *up);
     void fastscape_set_h_(double *hp);
 
-    //Functions to run FastScape
+    // Functions to run FastScape
     void fastscape_get_step_(int *sstep);
     void fastscape_execute_step_();
-    //Create a visualization file into the ASPECT/VTK folder
+    // Create a visualization file into the ASPECT/VTK folder
     void fastscape_named_vtk_(double *fp, const double *vexp, int *astep, const char *c, int *length);
-    //Copy the height array from FastScape back into ASPECT.
+    // Copy the height array from FastScape back into ASPECT.
     void fastscape_copy_h_(double *hp);
-    //Initialize stratigrapy, called once and handles visualization from there on.
+    // Initialize stratigrapy, called once and handles visualization from there on.
     void fastscape_strati_(const int *nstepp, const int *nreflectorp, int *nfreqp, const double *vexp);
     //void folder_output_(int *length, int *astep, const char *c);
-    //Copy slopes, used in determined ghost node height for mass flux flow in from a boundary.
+    // Copy slopes, used in determined ghost node height for mass flux flow in from a boundary.
     void fastscape_copy_slope_(double *slopep);
 
-    //View additional information from FastScape, not included in the .cc.
+    // View additional information from FastScape, not included in the .cc.
     void fastscape_view_();
     void fastscape_debug_();
 
-    //end run
+    // end run
     void fastscape_destroy_();
 #ifdef  __cplusplus
   }
@@ -112,67 +110,67 @@ namespace aspect
       void parse_parameters (ParameterHandler &prm);
 
     private:
-      //Number of FastScape steps per ASPECT timestep.
+      // Number of FastScape steps per ASPECT timestep.
       int nstep;
-      //Maximum timestep for FastScape, if time_step/nsteps exceeds this, nsteps is doubled.
+      // Maximum timestep for FastScape, if time_step/nsteps exceeds this, nsteps is doubled.
       double max_timestep;
-      //Whether or not the model is being restarted.
+      // Whether or not the model is being restarted.
       mutable bool restart;
-      //FastScape resets to step 0 on restart, this keeps the step number from the previous run.
+      // FastScape resets to step 0 on restart, this keeps the step number from the previous run.
       mutable int restart_step;
-      //Model endtime to check if we should destroy FastScape.
+      // Model endtime to check if we should destroy FastScape.
       double end_time;
 
-      //Cell size in FastScape, dx should always equal dy.
+      // Cell size in FastScape, dx should always equal dy.
       double dx;
       double dy;
-      //Length of X in FastScape (model X + 2*dx for ghost nodes).
+      // Length of X in FastScape (model X + 2*dx for ghost nodes).
       double x_extent;
-      //Length of Y in FastScape (model Y + 2*dy for ghost nodes).
+      // Length of Y in FastScape (model Y + 2*dy for ghost nodes).
       double y_extent;
-      //Size of y if FastScape is coupled with a 2D ASPECT model.
+      // Size of y if FastScape is coupled with a 2D ASPECT model.
       double y_extent_2d;
-      //Number of x points in FastScape array.
+      // Number of x points in FastScape array.
       int nx;
-      //Number of y points in FastScape array.
+      // Number of y points in FastScape array.
       int ny;
-      //Size of the FastScape array (nx*ny).
+      // Size of the FastScape array (nx*ny).
       int array_size;
 
-      //Vertical exaggeration in FastScape visualization.
+      // Vertical exaggeration in FastScape visualization.
       double vexp;
-      //How many levels FastScape should be refined above the maximum ASPECT surface resolution
+      // How many levels FastScape should be refined above the maximum ASPECT surface resolution
       unsigned int additional_refinement;
-      //Maximum expected refinement level at ASPECT's surface.
+      // Maximum expected refinement level at ASPECT's surface.
       int surface_resolution;
-      //Expected difference in refinement level of the highest and lowest surface resolution.
+      // Expected difference in refinement level of the highest and lowest surface resolution.
       int resolution_difference;
-      //Whether or not to send back the center slice or averaged surface in 2D.
+      // Whether or not to send back the center slice or averaged surface in 2D.
       bool slice;
-      //Seed number for initializing random topography noise in FastScape.
+      // Seed number for initializing random topography noise in FastScape.
       int fs_seed;
-      //Variable to hold ASPECT model dimensions.
+      // Variable to hold ASPECT model dimensions.
       std::array<std::pair<double,double>,dim> grid_extent;
-      //Table for interpolation of FastScape surface velocities back to ASPECT.
+      // Table for interpolation of FastScape surface velocities back to ASPECT.
       std::array< unsigned int, dim > table_intervals;
-      //Used to check whether fastscape is called at the surface.
+      // Used to check whether fastscape is called at the surface.
       std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
-      //Whether or not to use the ghost nodes.
+      // Whether or not to use the ghost nodes.
       bool use_ghost;
 
 
       /**
        * Boundary conditions
        */
-      //Boundary conditions for all sides, either 1 (fixed) or 0 (open).
+      // Boundary conditions for all sides, either 1 (fixed) or 0 (open).
       unsigned int bottom;
       unsigned int top;
       unsigned int right;
       unsigned int left;
-      //Integer that holds the full boundary conditions (e.g. 1111).
+      // Integer that holds the full boundary conditions (e.g. 1111).
       int bc;
 
-      //Prescribed flux per unit length into the model through a boundary, in m^2/yr.
+      // Prescribed flux per unit length into the model through a boundary, in m^2/yr.
       double bottom_flux;
       double top_flux;
       double right_flux;
@@ -181,47 +179,47 @@ namespace aspect
       /**
        * Erosional parameters
        */
-      //Drainage area exponent (m in SPL)
+      // Drainage area exponent (m in SPL)
       double m;
-      //Slope exponent (n in SPL)
+      // Slope exponent (n in SPL)
       double n;
-      //Slope exponent for multi-direction flow. where 0 is uniform, and 10 is steepest descent. (-1 is varied)
+      // Slope exponent for multi-direction flow. where 0 is uniform, and 10 is steepest descent. (-1 is varied)
       double p;
-      //Bedrock deposition coefficient. Higher values mean more material is deposited.
+      // Bedrock deposition coefficient. Higher values mean more material is deposited.
       double g;
-      //Sediment deposition coefficient.
+      // Sediment deposition coefficient.
       double gsed;
-      //Bedrock river incision rate for SPL.
+      // Bedrock river incision rate for SPL.
       double kff;
-      //Sediment river incision rate.
+      // Sediment river incision rate.
       double kfsed;
-      //Bedrock transport coefficient (diffusivity).
+      // Bedrock transport coefficient (diffusivity).
       double kdd;
-      //Sediment transport coefficient.
+      // Sediment transport coefficient.
       double kdsed;
 
       /**
        * Marine parameters
        */
-      //Sea level. Initial topography of FastScape is set at model height and not changed to zero.
+      // Sea level. Initial topography of FastScape is set at model height and not changed to zero.
       double sl;
-      //Surface porosity for sand.
+      // Surface porosity for sand.
       double p1;
-      //Surface porosity for shale.
+      // Surface porosity for shale.
       double p2;
-      //Sands e-folding depth for exponential porosity law.
+      // Sands e-folding depth for exponential porosity law.
       double z1;
-      //Shales e-folding depth for exponential porosity law.
+      // Shales e-folding depth for exponential porosity law.
       double z2;
-      //Sand-shale ratio
+      // Sand-shale ratio
       double r;
-      //Averaging depth/thickness for sand-shale equation (m).
+      // Averaging depth/thickness for sand-shale equation (m).
       double l;
-      //Sand marine transport coefficient (diffusivity).
+      // Sand marine transport coefficient (diffusivity).
       double kds1;
-      //Shale marine transport coefficient (diffusivity).
+      // Shale marine transport coefficient (diffusivity).
       double kds2;
-      //Whether or not to use the marine component of FastScape.
+      // Whether or not to use the marine component of FastScape.
       bool use_marine;
 
       /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -159,6 +159,9 @@ namespace aspect
         std::array< unsigned int, dim > table_intervals;
         //Used to check whether fastscape is called at the surface.
         std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
+        //Whether or not to use the ghost nodes.
+        bool use_ghost;
+
 
         /**
          * Boundary conditions

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -108,8 +108,6 @@ namespace aspect
         int nz;
         unsigned int additional_refinement;
         unsigned int initial_global_refinement;
-        int numx;
-        int numy;
         unsigned int bottom;
         unsigned int right;
         unsigned int top;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -124,6 +124,7 @@ namespace aspect
         double x_extent;
         double y_extent;
         bool slice;
+        int fs_seed;
 
         double m;
         double n;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -211,6 +211,14 @@ namespace aspect
       double kdd;
       // Sediment transport coefficient.
       double kdsed;
+      
+      // Orographic parameters
+      int mmax;
+      int wb;
+      int wd;
+      double reduc_mmax;
+      double reduc_wb;
+      bool stackoro;
 
       /**
        * Marine parameters

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -167,6 +167,8 @@ namespace aspect
       std::map<types::boundary_id, std::vector<std::string> > mesh_deformation_boundary_indicators_map;
       // Whether or not to use the ghost nodes.
       bool use_ghost;
+      // Magintude in meters of the initial noise appleid to FastScape.
+      int noise_h;
       // Sediment rain in m/yr, added to surface every ASPECT timestep.
       std::vector<double> sr_values;
       std::vector<double> sr_times;

--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -83,13 +83,6 @@ namespace aspect
                                              LinearAlgebra::Vector &output) const;
 
         /**
-         * Stabilization parameter for the free surface. Should be between
-         * zero and one. A value of zero means no stabilization.  See Kaus
-         * et. al. 2010 for more details.
-         */
-        double free_surface_theta;
-
-        /**
          * A struct for holding information about how to advect the free surface.
          */
         struct SurfaceAdvection

--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -32,35 +32,6 @@ namespace aspect
 {
   using namespace dealii;
 
-  namespace Assemblers
-  {
-    /**
-     * Apply stabilization to a cell of the system matrix. The
-     * stabilization is only added to cells on a free surface. The
-     * scheme is based on that of Kaus et. al., 2010. Called during
-     * assembly of the system matrix.
-     */
-    template <int dim>
-    class ApplyStabilization: public Assemblers::Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        ApplyStabilization(const double stabilization_theta);
-
-        void
-        execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                 internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;
-
-      private:
-        /**
-         * Stabilization parameter for the free surface. Should be between
-         * zero and one. A value of zero means no stabilization. See Kaus
-         * et. al. 2010 for more details.
-         */
-        const double free_surface_theta;
-    };
-  }
-
   namespace MeshDeformation
   {
     /**
@@ -78,13 +49,6 @@ namespace aspect
          * to the appropriate Simulator signal.
          */
         void initialize() override;
-
-        /**
-         * Called by Simulator::set_assemblers() to allow the FreeSurface plugin
-         * to register its assembler.
-         */
-        void set_assemblers(const SimulatorAccess<dim> &simulator_access,
-                            aspect::Assemblers::Manager<dim> &assemblers) const;
 
         /**
          * A function that creates constraints for the velocity of certain mesh

--- a/include/aspect/mesh_refinement/artificial_viscosity.h
+++ b/include/aspect/mesh_refinement/artificial_viscosity.h
@@ -27,52 +27,52 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * artificial viscosity of the temperature or compositional fields.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class ArtificialViscosity : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * @copydoc Interface<dim>::execute()
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * artificial viscosity of the temperature or compositional fields.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class ArtificialViscosity : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * @copydoc Interface<dim>::execute()
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
+    private:
 
-      private:
+      /**
+       * Scaling factor for the temperature indicator.
+       */
+      double temperature_scaling_factor;
 
-        /**
-         * Scaling factor for the temperature indicator.
-         */
-        double temperature_scaling_factor;
-
-        /**
-         * The scaling factors for each compositional field.
-         */
-        std::vector<double> composition_scaling_factors;
-    };
-  }
+      /**
+       * The scaling factors for each compositional field.
+       */
+      std::vector<double> composition_scaling_factors;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/boundary.h
+++ b/include/aspect/mesh_refinement/boundary.h
@@ -27,55 +27,55 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion that refines the
+   * mesh on selected boundaries. This is useful for cases where one wants
+   * to accurately model processes at a boundary.  Frequently, there are
+   * also strong temperature or compositional gradients at boundaries, so
+   * this refinement criterion can be redundant.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Boundary : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
 
-    /**
-     * A class that implements a mesh refinement criterion that refines the
-     * mesh on selected boundaries. This is useful for cases where one wants
-     * to accurately model processes at a boundary.  Frequently, there are
-     * also strong temperature or compositional gradients at boundaries, so
-     * this refinement criterion can be redundant.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Boundary : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
 
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * A set of boundary indicators marked for refinement
-         */
-        std::set<types::boundary_id> boundary_refinement_indicators;
-    };
-  }
+    private:
+      /**
+       * A set of boundary indicators marked for refinement
+       */
+      std::set<types::boundary_id> boundary_refinement_indicators;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/compaction_length.h
+++ b/include/aspect/mesh_refinement/compaction_length.h
@@ -27,53 +27,53 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * compaction length, a typical length scale in models with melt
+   * migration. The user can specify a desired ratio between the
+   * compaction length and the size of the mesh cells, and every cell
+   * where this ratio is smaller than specified is marked for refinement.
+   * This means that there will always be a given (minimum) number of
+   * mesh cells per compaction length.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class CompactionLength : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * After cells have been marked for coarsening/refinement, apply
+       * additional criteria independent of the error estimate.
+       */
+      void
+      tag_additional_cells () const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * compaction length, a typical length scale in models with melt
-     * migration. The user can specify a desired ratio between the
-     * compaction length and the size of the mesh cells, and every cell
-     * where this ratio is smaller than specified is marked for refinement.
-     * This means that there will always be a given (minimum) number of
-     * mesh cells per compaction length.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class CompactionLength : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * After cells have been marked for coarsening/refinement, apply
-         * additional criteria independent of the error estimate.
-         */
-        void
-        tag_additional_cells () const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * The desired ratio between compaction length and size of the mesh cells,
-         * in other words, how many cells the mesh should have per compaction length.
-         */
-        double cells_per_compaction_length;
-    };
-  }
+    private:
+      /**
+       * The desired ratio between compaction length and size of the mesh cells,
+       * in other words, how many cells the mesh should have per compaction length.
+       */
+      double cells_per_compaction_length;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/composition.h
+++ b/include/aspect/mesh_refinement/composition.h
@@ -27,52 +27,52 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * compositional fields (if available).
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Composition : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * compositional fields (if available).
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Composition : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * The scaling factors that should be applied to the individual
-         * refinement indicators before merging.
-         */
-        std::vector<double> composition_scaling_factors;
-    };
-  }
+    private:
+      /**
+       * The scaling factors that should be applied to the individual
+       * refinement indicators before merging.
+       */
+      std::vector<double> composition_scaling_factors;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/composition_approximate_gradient.h
+++ b/include/aspect/mesh_refinement/composition_approximate_gradient.h
@@ -27,52 +27,52 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on
+   * the approximated gradient of the compositional fields (if available).
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class CompositionApproximateGradient : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on
-     * the approximated gradient of the compositional fields (if available).
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class CompositionApproximateGradient : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * The scaling factors that should be applied to the individual
-         * refinement indicators before merging.
-         */
-        std::vector<double> composition_scaling_factors;
-    };
-  }
+    private:
+      /**
+       * The scaling factors that should be applied to the individual
+       * refinement indicators before merging.
+       */
+      std::vector<double> composition_scaling_factors;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/composition_gradient.h
+++ b/include/aspect/mesh_refinement/composition_gradient.h
@@ -27,52 +27,52 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * gradient of the compositional fields (if available).
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class CompositionGradient : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * gradient of the compositional fields (if available).
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class CompositionGradient : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * The scaling factors that should be applied to the individual
-         * refinement indicators before merging.
-         */
-        std::vector<double> composition_scaling_factors;
-    };
-  }
+    private:
+      /**
+       * The scaling factors that should be applied to the individual
+       * refinement indicators before merging.
+       */
+      std::vector<double> composition_scaling_factors;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/composition_threshold.h
+++ b/include/aspect/mesh_refinement/composition_threshold.h
@@ -27,50 +27,50 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * absolute value of the compositional fields. Every cell that contains a
+   * value exceeding a threshold given in the input file is marked for
+   * refinement.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class CompositionThreshold : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * After cells have been marked for coarsening/refinement, apply
+       * additional criteria independent of the error estimate.
+       */
+      void
+      tag_additional_cells () const override;
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * absolute value of the compositional fields. Every cell that contains a
-     * value exceeding a threshold given in the input file is marked for
-     * refinement.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class CompositionThreshold : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * After cells have been marked for coarsening/refinement, apply
-         * additional criteria independent of the error estimate.
-         */
-        void
-        tag_additional_cells () const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
-
-      private:
-        /**
-         * The thresholds that should be used for the individual
-         * compositional fields.
-         */
-        std::vector<double> composition_thresholds;
-    };
-  }
+    private:
+      /**
+       * The thresholds that should be used for the individual
+       * compositional fields.
+       */
+      std::vector<double> composition_thresholds;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/density.h
+++ b/include/aspect/mesh_refinement/density.h
@@ -27,34 +27,34 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion based on a field
-     * representing the density $\rho$ as a spatially variable function and
-     * that we compute from the solution vector (assuming the density actually
-     * depends on the solution).
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Density : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion based on a field
+   * representing the density $\rho$ as a spatially variable function and
+   * that we compute from the solution vector (assuming the density actually
+   * depends on the solution).
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Density : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -1,18 +1,14 @@
 /*
   Copyright (C) 2011 - 2019 by the authors of the ASPECT code.
-
   This file is part of ASPECT.
-
   ASPECT is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2, or (at your option)
   any later version.
-
   ASPECT is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-
   You should have received a copy of the GNU General Public License
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
@@ -34,336 +30,21 @@
 
 namespace aspect
 {
-using namespace dealii;
+  using namespace dealii;
 
-template <int dim> class Simulator;
-template <int dim> class SimulatorAccess;
-
-
-/**
- * A namespace for everything to do with the decision on how to refine the
- * mesh every few time steps.
- *
- * @ingroup MeshRefinement
- */
-namespace MeshRefinement
-{
-
-  /**
-   * This class declares the public interface of mesh refinement plugins.
-   * Plugins have two different ways to influence adaptive refinement (and
-   * can make use of either or both):
-   *
-   * First, execute() allows the plugin to specify weights for individual
-   * cells that are then used to coarsen and refine (where larger numbers
-   * indicate a larger error).
-   *
-   * Second, after cells get flagged for coarsening and refinement (using
-   * the first approach), tag_additional_cells() is executed for each
-   * plugin. Here the plugin is free to set or clear coarsen and refine
-   * flags on any cell.
-   *
-   * Access to the data of the simulator is granted by the @p protected
-   * member functions of the SimulatorAccess class, i.e., classes
-   * implementing this interface will in general want to derive from both
-   * this Interface class as well as from the SimulatorAccess class.
-   *
-   * @ingroup MeshRefinement
-   */
-  template <int dim>
-  class Interface
-  {
-    public:
-      /**
-       * Destructor. Does nothing but is virtual so that derived classes
-       * destructors are also virtual.
-       */
-      virtual
-      ~Interface ();
-
-      /**
-       * Initialization function. This function is called once at the
-       * beginning of the program after parse_parameters is run and after
-       * the SimulatorAccess (if applicable) is initialized.
-       */
-      virtual void initialize ();
-
-      /**
-       * A function that is called once at the beginning of each timestep.
-       * The default implementation of the function does nothing, but
-       * derived classes that need more elaborate setups for a given time
-       * step may overload the function.
-       *
-       * The point of this function is to allow refinement plugins to do an
-       * initialization once during each time step.
-       */
-      virtual
-      void
-      update ();
-
-      /**
-       * Execute this mesh refinement criterion. The default implementation
-       * sets all the error indicators to zero.
-       *
-       * @param[out] error_indicators A vector that for every active cell of
-       * the current mesh (which may be a partition of a distributed mesh)
-       * provides an error indicator. This vector will already have the
-       * correct size when the function is called.
-       */
-      virtual
-      void
-      execute (Vector<float> &error_indicators) const;
-
-      /**
-       * After cells have been marked for coarsening/refinement, apply
-       * additional criteria independent of the error estimate. The default
-       * implementation does nothing.
-       *
-       * This function is also called during the initial global refinement
-       * cycle. At this point you do not have access to solutions,
-       * DoFHandlers, or finite element spaces. You can check if this is the
-       * case by querying this->get_dof_handler().n_dofs() == 0.
-       */
-      virtual
-      void
-      tag_additional_cells () const;
-
-      /**
-       * Declare the parameters this class takes through input files.
-       * Derived classes should overload this function if they actually do
-       * take parameters; this class declares a fall-back function that does
-       * nothing, so that postprocessor classes that do not take any
-       * parameters do not have to do anything at all.
-       *
-       * This function is static (and needs to be static in derived classes)
-       * so that it can be called without creating actual objects (because
-       * declaring parameters happens before we read the input file and thus
-       * at a time when we don't even know yet which postprocessor objects
-       * we need).
-       */
-      static
-      void
-      declare_parameters (ParameterHandler &prm);
-
-      /**
-       * Read the parameters this class declares from the parameter file.
-       * The default implementation in this class does nothing, so that
-       * derived classes that do not need any parameters do not need to
-       * implement it.
-       */
-      virtual
-      void
-      parse_parameters (ParameterHandler &prm);
-  };
-
-
-
-
+  template <int dim> class Simulator;
+  template <int dim> class SimulatorAccess;
 
 
   /**
-   * A class that manages all objects that provide functionality to refine
-   * meshes.
+   * A namespace for everything to do with the decision on how to refine the
+   * mesh every few time steps.
    *
    * @ingroup MeshRefinement
    */
-  template <int dim>
-  class Manager : public ::aspect::SimulatorAccess<dim>
+  namespace MeshRefinement
   {
-    public:
-      /**
-       * Destructor. Made virtual since this class has virtual member
-       * functions.
-       */
-      ~Manager () override;
 
-      /**
-       * Update all of the mesh refinement objects that have been requested
-       * in the input file. Individual mesh refinement objects may choose to
-       * implement an update function to modify object variables once per
-       * time step.
-       */
-      virtual
-      void
-      update ();
-
-      /**
-       * Execute all of the mesh refinement objects that have been requested
-       * in the input file. The error indicators are then each individually
-       * normalized and merged according to the operation specified in the
-       * input file (e.g., via a plus, a maximum operation, etc).
-       */
-      virtual
-      void
-      execute (Vector<float> &error_indicators) const;
-
-      /**
-       * Apply additional refinement criteria independent of the error
-       * estimate for all of the mesh refinement objects that have been
-       * requested in the input file.
-       */
-      virtual
-      void
-      tag_additional_cells () const;
-
-      /**
-       * Declare the parameters of all known mesh refinement plugins, as
-       * well as of ones this class has itself.
-       */
-      static
-      void
-      declare_parameters (ParameterHandler &prm);
-
-      /**
-       * Read the parameters this class declares from the parameter file.
-       * This determines which mesh refinement objects will be created; then
-       * let these objects read their parameters as well.
-       */
-      void
-      parse_parameters (ParameterHandler &prm);
-
-      /**
-       * Go through the list of all mesh refinement strategies that have been selected
-       * in the input file (and are consequently currently active) and return
-       * true if one of them has the desired type specified by the template
-       * argument.
-       */
-      template <typename MeshRefinementType>
-      bool
-      has_matching_mesh_refinement_strategy () const;
-
-      /**
-       * Go through the list of all mesh refinement strategies that have been selected
-       * in the input file (and are consequently currently active) and see
-       * if one of them has the type specified by the template
-       * argument or can be casted to that type. If so, return a reference
-       * to it. If no mesh refinement strategy is active that matches the
-       * given type, throw an exception.
-       */
-      template <typename MeshRefinementType>
-      const MeshRefinementType &
-      get_matching_mesh_refinement_strategy () const;
-
-      /**
-       * A function that is used to register mesh refinement objects in such
-       * a way that the Manager can deal with all of them without having to
-       * know them by name. This allows the files in which individual
-       * plugins are implemented to register these plugins, rather than also
-       * having to modify the Manager class by adding the new mesh
-       * refinement class.
-       *
-       * @param name The name under which this plugin is to be called in
-       * parameter files.
-       * @param description A text description of what this model does and
-       * that will be listed in the documentation of the parameter file.
-       * @param declare_parameters_function A pointer to a function that
-       * declares the parameters for this plugin.
-       * @param factory_function A pointer to a function that creates such a
-       * mesh refinement object and returns a pointer to it.
-       */
-      static
-      void
-      register_mesh_refinement_criterion (const std::string &name,
-                                          const std::string &description,
-                                          void (*declare_parameters_function) (ParameterHandler &),
-                                          Interface<dim> *(*factory_function) ());
-
-      /**
-       * For the current plugin subsystem, write a connection graph of all of the
-       * plugins we know about, in the format that the
-       * programs dot and neato understand. This allows for a visualization of
-       * how all of the plugins that ASPECT knows about are interconnected, and
-       * connect to other parts of the ASPECT code.
-       *
-       * @param output_stream The stream to write the output to.
-       */
-      static
-      void
-      write_plugin_graph (std::ostream &output_stream);
-
-      /**
-       * Exception.
-       */
-      DeclException1 (ExcMeshRefinementNameNotFound,
-                      std::string,
-                      << "Could not find entry <"
-                      << arg1
-                      << "> among the names of registered mesh refinement objects.");
-    private:
-      /**
-       * An enum that describes the different ways in which we can merge the
-       * results of multiple mesh refinement criteria.
-       */
-      enum MergeOperation
-      { plus, max };
-
-      /**
-       * How to merge the results of multiple mesh refinement criteria.
-       */
-      MergeOperation merge_operation;
-
-      /**
-       * Whether to normalize the individual refinement indicators to the
-       * range $[0,1]$ before merging.
-       */
-      bool normalize_criteria;
-
-      /**
-       * The scaling factors that should be applied to the individual
-       * refinement indicators before merging.
-       */
-      std::vector<double> scaling_factors;
-
-      /**
-       * A list of mesh refinement objects that have been requested in the
-       * parameter file.
-       */
-      std::list<std::unique_ptr<Interface<dim> > > mesh_refinement_objects;
-  };
-
-
-
-  template <int dim>
-  template <typename MeshRefinementType>
-  inline
-  bool
-  Manager<dim>::has_matching_mesh_refinement_strategy () const
-  {
-    for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
-         p = mesh_refinement_objects.begin();
-         p != mesh_refinement_objects.end(); ++p)
-      if (Plugins::plugin_type_matches<MeshRefinementType>(*(*p)))
-        return true;
-
-    return false;
-  }
-
-
-
-  template <int dim>
-  template <typename MeshRefinementType>
-  inline
-  const MeshRefinementType &
-  Manager<dim>::get_matching_mesh_refinement_strategy () const
-  {
-    AssertThrow(has_matching_mesh_refinement_strategy<MeshRefinementType> (),
-                ExcMessage("You asked MeshRefinement::Manager::get_matching_mesh_refinement_strategy() for a "
-                           "mesh refinement strategy of type <" + boost::core::demangle(typeid(MeshRefinementType).name()) + "> "
-                           "that could not be found in the current model. Activate this "
-                           "mesh refinement strategy in the input file."));
-
-    for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
-         p = mesh_refinement_objects.begin();
-         p != mesh_refinement_objects.end(); ++p)
-      if (Plugins::plugin_type_matches<MeshRefinementType>(*(*p)))
-        return Plugins::get_plugin_as_type<MeshRefinementType>(*(*p));
-
-    // We will never get here, because we had the Assert above. Just to avoid warnings.
-    typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator mesh_refinement_strategy;
-    return Plugins::get_plugin_as_type<MeshRefinementType>(*(*mesh_refinement_strategy));
-  }
-
-<<<<<<< HEAD
     /**
      * This class declares the public interface of mesh refinement plugins.
      * Plugins have two different ways to influence adaptive refinement (and
@@ -686,7 +367,6 @@ namespace MeshRefinement
      *
      * @ingroup MeshRefinement
      */
-
 #define ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(classname,name,description) \
   template class classname<2>; \
   template class classname<3>; \
@@ -699,7 +379,7 @@ namespace MeshRefinement
         dummy_ ## classname ## _3d (&aspect::MeshRefinement::Manager<3>::register_mesh_refinement_criterion, \
                                     name, description); \
   }
-}
+  }
 }
 
 

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -34,21 +34,336 @@
 
 namespace aspect
 {
-  using namespace dealii;
+using namespace dealii;
 
-  template <int dim> class Simulator;
-  template <int dim> class SimulatorAccess;
+template <int dim> class Simulator;
+template <int dim> class SimulatorAccess;
 
+
+/**
+ * A namespace for everything to do with the decision on how to refine the
+ * mesh every few time steps.
+ *
+ * @ingroup MeshRefinement
+ */
+namespace MeshRefinement
+{
 
   /**
-   * A namespace for everything to do with the decision on how to refine the
-   * mesh every few time steps.
+   * This class declares the public interface of mesh refinement plugins.
+   * Plugins have two different ways to influence adaptive refinement (and
+   * can make use of either or both):
+   *
+   * First, execute() allows the plugin to specify weights for individual
+   * cells that are then used to coarsen and refine (where larger numbers
+   * indicate a larger error).
+   *
+   * Second, after cells get flagged for coarsening and refinement (using
+   * the first approach), tag_additional_cells() is executed for each
+   * plugin. Here the plugin is free to set or clear coarsen and refine
+   * flags on any cell.
+   *
+   * Access to the data of the simulator is granted by the @p protected
+   * member functions of the SimulatorAccess class, i.e., classes
+   * implementing this interface will in general want to derive from both
+   * this Interface class as well as from the SimulatorAccess class.
    *
    * @ingroup MeshRefinement
    */
-  namespace MeshRefinement
+  template <int dim>
+  class Interface
   {
+    public:
+      /**
+       * Destructor. Does nothing but is virtual so that derived classes
+       * destructors are also virtual.
+       */
+      virtual
+      ~Interface ();
 
+      /**
+       * Initialization function. This function is called once at the
+       * beginning of the program after parse_parameters is run and after
+       * the SimulatorAccess (if applicable) is initialized.
+       */
+      virtual void initialize ();
+
+      /**
+       * A function that is called once at the beginning of each timestep.
+       * The default implementation of the function does nothing, but
+       * derived classes that need more elaborate setups for a given time
+       * step may overload the function.
+       *
+       * The point of this function is to allow refinement plugins to do an
+       * initialization once during each time step.
+       */
+      virtual
+      void
+      update ();
+
+      /**
+       * Execute this mesh refinement criterion. The default implementation
+       * sets all the error indicators to zero.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      virtual
+      void
+      execute (Vector<float> &error_indicators) const;
+
+      /**
+       * After cells have been marked for coarsening/refinement, apply
+       * additional criteria independent of the error estimate. The default
+       * implementation does nothing.
+       *
+       * This function is also called during the initial global refinement
+       * cycle. At this point you do not have access to solutions,
+       * DoFHandlers, or finite element spaces. You can check if this is the
+       * case by querying this->get_dof_handler().n_dofs() == 0.
+       */
+      virtual
+      void
+      tag_additional_cells () const;
+
+      /**
+       * Declare the parameters this class takes through input files.
+       * Derived classes should overload this function if they actually do
+       * take parameters; this class declares a fall-back function that does
+       * nothing, so that postprocessor classes that do not take any
+       * parameters do not have to do anything at all.
+       *
+       * This function is static (and needs to be static in derived classes)
+       * so that it can be called without creating actual objects (because
+       * declaring parameters happens before we read the input file and thus
+       * at a time when we don't even know yet which postprocessor objects
+       * we need).
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
+
+      /**
+       * Read the parameters this class declares from the parameter file.
+       * The default implementation in this class does nothing, so that
+       * derived classes that do not need any parameters do not need to
+       * implement it.
+       */
+      virtual
+      void
+      parse_parameters (ParameterHandler &prm);
+  };
+
+
+
+
+
+
+  /**
+   * A class that manages all objects that provide functionality to refine
+   * meshes.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Manager : public ::aspect::SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Destructor. Made virtual since this class has virtual member
+       * functions.
+       */
+      ~Manager () override;
+
+      /**
+       * Update all of the mesh refinement objects that have been requested
+       * in the input file. Individual mesh refinement objects may choose to
+       * implement an update function to modify object variables once per
+       * time step.
+       */
+      virtual
+      void
+      update ();
+
+      /**
+       * Execute all of the mesh refinement objects that have been requested
+       * in the input file. The error indicators are then each individually
+       * normalized and merged according to the operation specified in the
+       * input file (e.g., via a plus, a maximum operation, etc).
+       */
+      virtual
+      void
+      execute (Vector<float> &error_indicators) const;
+
+      /**
+       * Apply additional refinement criteria independent of the error
+       * estimate for all of the mesh refinement objects that have been
+       * requested in the input file.
+       */
+      virtual
+      void
+      tag_additional_cells () const;
+
+      /**
+       * Declare the parameters of all known mesh refinement plugins, as
+       * well as of ones this class has itself.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
+
+      /**
+       * Read the parameters this class declares from the parameter file.
+       * This determines which mesh refinement objects will be created; then
+       * let these objects read their parameters as well.
+       */
+      void
+      parse_parameters (ParameterHandler &prm);
+
+      /**
+       * Go through the list of all mesh refinement strategies that have been selected
+       * in the input file (and are consequently currently active) and return
+       * true if one of them has the desired type specified by the template
+       * argument.
+       */
+      template <typename MeshRefinementType>
+      bool
+      has_matching_mesh_refinement_strategy () const;
+
+      /**
+       * Go through the list of all mesh refinement strategies that have been selected
+       * in the input file (and are consequently currently active) and see
+       * if one of them has the type specified by the template
+       * argument or can be casted to that type. If so, return a reference
+       * to it. If no mesh refinement strategy is active that matches the
+       * given type, throw an exception.
+       */
+      template <typename MeshRefinementType>
+      const MeshRefinementType &
+      get_matching_mesh_refinement_strategy () const;
+
+      /**
+       * A function that is used to register mesh refinement objects in such
+       * a way that the Manager can deal with all of them without having to
+       * know them by name. This allows the files in which individual
+       * plugins are implemented to register these plugins, rather than also
+       * having to modify the Manager class by adding the new mesh
+       * refinement class.
+       *
+       * @param name The name under which this plugin is to be called in
+       * parameter files.
+       * @param description A text description of what this model does and
+       * that will be listed in the documentation of the parameter file.
+       * @param declare_parameters_function A pointer to a function that
+       * declares the parameters for this plugin.
+       * @param factory_function A pointer to a function that creates such a
+       * mesh refinement object and returns a pointer to it.
+       */
+      static
+      void
+      register_mesh_refinement_criterion (const std::string &name,
+                                          const std::string &description,
+                                          void (*declare_parameters_function) (ParameterHandler &),
+                                          Interface<dim> *(*factory_function) ());
+
+      /**
+       * For the current plugin subsystem, write a connection graph of all of the
+       * plugins we know about, in the format that the
+       * programs dot and neato understand. This allows for a visualization of
+       * how all of the plugins that ASPECT knows about are interconnected, and
+       * connect to other parts of the ASPECT code.
+       *
+       * @param output_stream The stream to write the output to.
+       */
+      static
+      void
+      write_plugin_graph (std::ostream &output_stream);
+
+      /**
+       * Exception.
+       */
+      DeclException1 (ExcMeshRefinementNameNotFound,
+                      std::string,
+                      << "Could not find entry <"
+                      << arg1
+                      << "> among the names of registered mesh refinement objects.");
+    private:
+      /**
+       * An enum that describes the different ways in which we can merge the
+       * results of multiple mesh refinement criteria.
+       */
+      enum MergeOperation
+      { plus, max };
+
+      /**
+       * How to merge the results of multiple mesh refinement criteria.
+       */
+      MergeOperation merge_operation;
+
+      /**
+       * Whether to normalize the individual refinement indicators to the
+       * range $[0,1]$ before merging.
+       */
+      bool normalize_criteria;
+
+      /**
+       * The scaling factors that should be applied to the individual
+       * refinement indicators before merging.
+       */
+      std::vector<double> scaling_factors;
+
+      /**
+       * A list of mesh refinement objects that have been requested in the
+       * parameter file.
+       */
+      std::list<std::unique_ptr<Interface<dim> > > mesh_refinement_objects;
+  };
+
+
+
+  template <int dim>
+  template <typename MeshRefinementType>
+  inline
+  bool
+  Manager<dim>::has_matching_mesh_refinement_strategy () const
+  {
+    for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
+         p = mesh_refinement_objects.begin();
+         p != mesh_refinement_objects.end(); ++p)
+      if (Plugins::plugin_type_matches<MeshRefinementType>(*(*p)))
+        return true;
+
+    return false;
+  }
+
+
+
+  template <int dim>
+  template <typename MeshRefinementType>
+  inline
+  const MeshRefinementType &
+  Manager<dim>::get_matching_mesh_refinement_strategy () const
+  {
+    AssertThrow(has_matching_mesh_refinement_strategy<MeshRefinementType> (),
+                ExcMessage("You asked MeshRefinement::Manager::get_matching_mesh_refinement_strategy() for a "
+                           "mesh refinement strategy of type <" + boost::core::demangle(typeid(MeshRefinementType).name()) + "> "
+                           "that could not be found in the current model. Activate this "
+                           "mesh refinement strategy in the input file."));
+
+    for (typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator
+         p = mesh_refinement_objects.begin();
+         p != mesh_refinement_objects.end(); ++p)
+      if (Plugins::plugin_type_matches<MeshRefinementType>(*(*p)))
+        return Plugins::get_plugin_as_type<MeshRefinementType>(*(*p));
+
+    // We will never get here, because we had the Assert above. Just to avoid warnings.
+    typename std::list<std::unique_ptr<Interface<dim> > >::const_iterator mesh_refinement_strategy;
+    return Plugins::get_plugin_as_type<MeshRefinementType>(*(*mesh_refinement_strategy));
+  }
+
+<<<<<<< HEAD
     /**
      * This class declares the public interface of mesh refinement plugins.
      * Plugins have two different ways to influence adaptive refinement (and
@@ -371,6 +686,7 @@ namespace aspect
      *
      * @ingroup MeshRefinement
      */
+
 #define ASPECT_REGISTER_MESH_REFINEMENT_CRITERION(classname,name,description) \
   template class classname<2>; \
   template class classname<3>; \
@@ -383,7 +699,7 @@ namespace aspect
         dummy_ ## classname ## _3d (&aspect::MeshRefinement::Manager<3>::register_mesh_refinement_criterion, \
                                     name, description); \
   }
-  }
+}
 }
 
 

--- a/include/aspect/mesh_refinement/maximum_refinement_function.h
+++ b/include/aspect/mesh_refinement/maximum_refinement_function.h
@@ -30,65 +30,65 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a maximum refinement level based on a
+   * functional description provided in the input file.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class MaximumRefinementFunction : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * At the beginning of each time step, update the time for the
+       * ParsedFunction.
+       */
+      void
+      update () override;
 
-    /**
-     * A class that implements a maximum refinement level based on a
-     * functional description provided in the input file.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class MaximumRefinementFunction : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * At the beginning of each time step, update the time for the
-         * ParsedFunction.
-         */
-        void
-        update () override;
+      /**
+       * After cells have been marked for coarsening/refinement, apply
+       * additional criteria independent of the error estimate.
+       *
+       */
+      void
+      tag_additional_cells () const override;
 
-        /**
-         * After cells have been marked for coarsening/refinement, apply
-         * additional criteria independent of the error estimate.
-         *
-         */
-        void
-        tag_additional_cells () const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
+    private:
+      /**
+       * The coordinate representation to evaluate the function. Possible
+       * choices are depth, cartesian and spherical.
+       */
+      Utilities::Coordinates::CoordinateSystem coordinate_system;
 
-      private:
-        /**
-         * The coordinate representation to evaluate the function. Possible
-         * choices are depth, cartesian and spherical.
-         */
-        Utilities::Coordinates::CoordinateSystem coordinate_system;
+      /**
+       * A function object representing the maximum refinement level. The
+       * function always depends on 3 variables, although in the case of the
+       * 'depth' coordinate system only the first is used to evaluate the
+       * function.
+       */
+      Functions::ParsedFunction<dim> max_refinement_level;
 
-        /**
-         * A function object representing the maximum refinement level. The
-         * function always depends on 3 variables, although in the case of the
-         * 'depth' coordinate system only the first is used to evaluate the
-         * function.
-         */
-        Functions::ParsedFunction<dim> max_refinement_level;
-
-    };
-  }
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/minimum_refinement_function.h
+++ b/include/aspect/mesh_refinement/minimum_refinement_function.h
@@ -31,65 +31,65 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a minimum refinement level based on a
+   * functional description provided in the input file.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class MinimumRefinementFunction : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
+      /**
+       * At the beginning of each time step, update the time for the
+       * ParsedFunction.
+       */
+      void
+      update () override;
 
-    /**
-     * A class that implements a minimum refinement level based on a
-     * functional description provided in the input file.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class MinimumRefinementFunction : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * At the beginning of each time step, update the time for the
-         * ParsedFunction.
-         */
-        void
-        update () override;
+      /**
+       * After cells have been marked for coarsening/refinement, apply
+       * additional criteria independent of the error estimate.
+       *
+       */
+      void
+      tag_additional_cells () const override;
 
-        /**
-         * After cells have been marked for coarsening/refinement, apply
-         * additional criteria independent of the error estimate.
-         *
-         */
-        void
-        tag_additional_cells () const override;
+      /**
+       * Declare the parameters this class takes through input files.
+       */
+      static
+      void
+      declare_parameters (ParameterHandler &prm);
 
-        /**
-         * Declare the parameters this class takes through input files.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
+      /**
+       * Read the parameters this class declares from the parameter file.
+       */
+      void
+      parse_parameters (ParameterHandler &prm) override;
 
-        /**
-         * Read the parameters this class declares from the parameter file.
-         */
-        void
-        parse_parameters (ParameterHandler &prm) override;
+    private:
+      /**
+       * The coordinate representation to evaluate the function. Possible
+       * choices are depth, cartesian and spherical.
+       */
+      Utilities::Coordinates::CoordinateSystem coordinate_system;
 
-      private:
-        /**
-         * The coordinate representation to evaluate the function. Possible
-         * choices are depth, cartesian and spherical.
-         */
-        Utilities::Coordinates::CoordinateSystem coordinate_system;
+      /**
+       * A function object representing the minimum refinement level. The
+       * function always depends on 3 variables, although in the case of the
+       * 'depth' coordinate system only the first is used to evaluate the
+       * function.
+       */
+      Functions::ParsedFunction<dim> min_refinement_level;
 
-        /**
-         * A function object representing the minimum refinement level. The
-         * function always depends on 3 variables, although in the case of the
-         * 'depth' coordinate system only the first is used to evaluate the
-         * function.
-         */
-        Functions::ParsedFunction<dim> min_refinement_level;
-
-    };
-  }
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/nonadiabatic_temperature.h
+++ b/include/aspect/mesh_refinement/nonadiabatic_temperature.h
@@ -27,32 +27,32 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion based on the excess
-     * temperature (difference between temperature and adiabatic temperature).
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class NonadiabaticTemperature : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion based on the excess
+   * temperature (difference between temperature and adiabatic temperature).
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class NonadiabaticTemperature : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/particle_density.h
+++ b/include/aspect/mesh_refinement/particle_density.h
@@ -27,43 +27,43 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A mesh refinement criterion that computes
-     * refinement indicators based on the density
-     * of particles. In practice this plugin
-     * equilibrates the number of particles per cell,
-     * leading to fine cells in high particle density regions
-     * and coarse cells in low particle density regions.
-     * This plugin is mostly useful for models with inhomogeneous
-     * particle density, e.g. when tracking an initial interface
-     * with a high particle density, or when the spatial particle
-     * density denotes the region of interest. Additionally, this
-     * plugin tends to balance the computational load between
-     * processes in parallel computations, because the particle
-     * and mesh density is more aligned.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class ParticleDensity : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A mesh refinement criterion that computes
+   * refinement indicators based on the density
+   * of particles. In practice this plugin
+   * equilibrates the number of particles per cell,
+   * leading to fine cells in high particle density regions
+   * and coarse cells in low particle density regions.
+   * This plugin is mostly useful for models with inhomogeneous
+   * particle density, e.g. when tracking an initial interface
+   * with a high particle density, or when the spatial particle
+   * density denotes the region of interest. Additionally, this
+   * plugin tends to balance the computational load between
+   * processes in parallel computations, because the particle
+   * and mesh density is more aligned.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class ParticleDensity : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/slope.h
+++ b/include/aspect/mesh_refinement/slope.h
@@ -27,36 +27,36 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
+namespace MeshRefinement
+{
+
+  /**
+   * A class that implements a mesh refinement criterion that refines the
+   * mesh with a deforming surface.  Specifically, it calculates the slope of the
+   * surface by comparing the local normal and gravity vectors.
+   * Cells with steeper slopes get refined. This is useful for cases where
+   * there is steep topography which needs to be tracked better.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Slope : public Interface<dim>,
+    public SimulatorAccess<dim>
   {
+    public:
 
-    /**
-     * A class that implements a mesh refinement criterion that refines the
-     * mesh with a deforming surface.  Specifically, it calculates the slope of the
-     * surface by comparing the local normal and gravity vectors.
-     * Cells with steeper slopes get refined. This is useful for cases where
-     * there is steep topography which needs to be tracked better.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Slope : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/strain_rate.h
+++ b/include/aspect/mesh_refinement/strain_rate.h
@@ -27,32 +27,32 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion based on
-     * the strain rate field.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class StrainRate : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion based on
+   * the strain rate field.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class StrainRate : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/temperature.h
+++ b/include/aspect/mesh_refinement/temperature.h
@@ -27,32 +27,32 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion based on the
-     * temperature field.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Temperature : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion based on the
+   * temperature field.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Temperature : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/thermal_energy_density.h
+++ b/include/aspect/mesh_refinement/thermal_energy_density.h
@@ -27,33 +27,33 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion based on a field
-     * representing the energy density $\rho c_P T$ as a spatially variable
-     * function and that we compute from the solution vector.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class ThermalEnergyDensity : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion based on a field
+   * representing the energy density $\rho c_P T$ as a spatially variable
+   * function and that we compute from the solution vector.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class ThermalEnergyDensity : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/include/aspect/mesh_refinement/topography.h
+++ b/include/aspect/mesh_refinement/topography.h
@@ -27,33 +27,33 @@
 
 namespace aspect
 {
-  namespace MeshRefinement
-  {
+namespace MeshRefinement
+{
 
-    /**
-     * A class that implements a mesh refinement criterion that refines the
-     * mesh in the uppermost nodes. This is useful for cases where one wants
-     * to accurately model processes at of close to the surface of the model.
-     *
-     * @ingroup MeshRefinement
-     */
-    template <int dim>
-    class Topography : public Interface<dim>,
-      public SimulatorAccess<dim>
-    {
-      public:
-        /**
-         * Execute this mesh refinement criterion.
-         *
-         * @param[out] error_indicators A vector that for every active cell of
-         * the current mesh (which may be a partition of a distributed mesh)
-         * provides an error indicator. This vector will already have the
-         * correct size when the function is called.
-         */
-        void
-        execute (Vector<float> &error_indicators) const override;
-    };
-  }
+  /**
+   * A class that implements a mesh refinement criterion that refines the
+   * mesh in the uppermost nodes. This is useful for cases where one wants
+   * to accurately model processes at of close to the surface of the model.
+   *
+   * @ingroup MeshRefinement
+   */
+  template <int dim>
+  class Topography : public Interface<dim>,
+    public SimulatorAccess<dim>
+  {
+    public:
+      /**
+       * Execute this mesh refinement criterion.
+       *
+       * @param[out] error_indicators A vector that for every active cell of
+       * the current mesh (which may be a partition of a distributed mesh)
+       * provides an error indicator. This vector will already have the
+       * correct size when the function is called.
+       */
+      void
+      execute (Vector<float> &error_indicators) const override;
+  };
+}
 }
 
 #endif

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -202,10 +202,10 @@ namespace aspect
     }
 
     template <int dim>
-    std::pair<int,int>
-    Box<dim>::get_repetitions() const
+    unsigned int
+    Box<dim>::get_repetitions(unsigned int dimension) const
     {
-      return std::make_pair (repetitions[0], repetitions[1]);
+      return repetitions[dimension];
     }
 
     template <int dim>

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -575,7 +575,6 @@ namespace aspect
                       int index = i+numx*((ny-1)/2);
                       V2[i-1] = V[index];
                     }
-                  //TODO: This isn't working anymore, need to figure out why.
                   else
                     {
                       for (int ys=edge; ys<(ny-edge); ys++)
@@ -687,7 +686,7 @@ namespace aspect
       {
         prm.enter_subsection ("Fastscape");
         {
-          prm.declare_entry("Number of steps", "5",
+          prm.declare_entry("Number of steps", "10",
                             Patterns::Integer(),
                             "Number of steps per ASPECT timestep");
           prm.declare_entry("Maximum timestep", "10e3",
@@ -705,7 +704,7 @@ namespace aspect
                              "If this is set to true, then a 2D model will only consider the "
                              "center slice fastscape gives. If set to false, then aspect will"
                              "average the inner third of what fastscape calculates.");
-          prm.declare_entry("Fastscape seed", "1",
+          prm.declare_entry("Fastscape seed", "1000",
                             Patterns::Integer(),
                             "Seed used for adding an initial 0-1 m noise to fastscape topography.");
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -123,9 +123,9 @@ namespace aspect
 
       double a_dt = this->get_timestep();
       if (this->convert_output_to_years())
-      {
-         a_dt = this->get_timestep()/year_in_seconds;
-      }
+        {
+          a_dt = this->get_timestep()/year_in_seconds;
+        }
 
       //We only want to run fastscape if there was a change in time, and if we're at the top boundary.
       if (a_dt > 0 && top_boundary)
@@ -176,11 +176,11 @@ namespace aspect
                             for (int ys=0; ys<ny; ys++)
                               {
                                 double index = indx+numx*ys;
-                            	if(current_timestep == 1)
-                            	{
-                                	//double h_seed = (std::rand()%2000)/100;
+                                if (current_timestep == 1)
+                                  {
+                                    //double h_seed = (std::rand()%2000)/100;
                                     temporary_variables[0][index-1] = this->get_geometry_model().height_above_reference_surface(vertex); //vertex(dim-1);   //z component
-                            	}
+                                  }
 
 
                                 for (unsigned int i=0; i<dim; ++i)
@@ -193,10 +193,10 @@ namespace aspect
                             double indy = 2+vertex(1)/dy;
                             double index = (indy-1)*numx+indx;
 
-                        	if(current_timestep == 1)
-                        	{
-                              temporary_variables[0][index-1] = vertex(dim-1); //this->get_geometry_model().height_above_reference_surface(vertex); //vertex(dim-1);   //z component
-                        	}
+                            if (current_timestep == 1)
+                              {
+                                temporary_variables[0][index-1] = vertex(dim-1); //this->get_geometry_model().height_above_reference_surface(vertex); //vertex(dim-1);   //z component
+                              }
 
                             for (unsigned int i=0; i<dim; ++i)
                               temporary_variables[i+1][index-1] = vel[corner][i]*year_in_seconds;
@@ -204,34 +204,34 @@ namespace aspect
                       }
                   }
 
-        	//Set ghost nodes for left and right boundaries
+          //Set ghost nodes for left and right boundaries
 
-        	  for(int j=0; j<numy; j++)
-        	  {
-        		 double index_left = numx*j+1;
-        		 double index_right = numx*(j+1);
+          for (int j=0; j<numy; j++)
+            {
+              double index_left = numx*j+1;
+              double index_right = numx*(j+1);
 
-                 for (unsigned int i=0; i<dim+1; ++i)
-                 {
-                   temporary_variables[i][index_left-1] = temporary_variables[i][index_left];
-                   temporary_variables[i][index_right-1] = temporary_variables[i][index_right-2];
-                 }
-        	  }
+              for (unsigned int i=0; i<dim+1; ++i)
+                {
+                  temporary_variables[i][index_left-1] = temporary_variables[i][index_left];
+                  temporary_variables[i][index_right-1] = temporary_variables[i][index_right-2];
+                }
+            }
 
           //Set ghost node for top and bottom boundaries
-          if(dim == 3)
-           {
-        	  for(int j=0; j<numx; j++)
-        	  {
-        		 double index_bot = j+1;
-        		 double index_top = numx*(numy-1)+j+1;
+          if (dim == 3)
+            {
+              for (int j=0; j<numx; j++)
+                {
+                  double index_bot = j+1;
+                  double index_top = numx*(numy-1)+j+1;
 
-                 for (unsigned int i=0; i<dim+1; ++i)
-                 {
-                   temporary_variables[i][index_bot-1] = temporary_variables[i][index_bot+numx-1];
-                   temporary_variables[i][index_top-1] = temporary_variables[i][index_top-numx-1];
-                 }
-        	  }
+                  for (unsigned int i=0; i<dim+1; ++i)
+                    {
+                      temporary_variables[i][index_bot-1] = temporary_variables[i][index_bot+numx-1];
+                      temporary_variables[i][index_top-1] = temporary_variables[i][index_top-numx-1];
+                    }
+                }
             }
 
           //Run fastscape on single processor.
@@ -256,7 +256,7 @@ namespace aspect
               //Create variables for output directory and restart file
               std::string filename;
               filename = this->get_output_directory();
-              const char* c=filename.c_str();
+              const char *c=filename.c_str();
               int length = filename.length();
               const std::string restart_filename = filename + "fastscape_h_restart.txt";
               const std::string restart_step_filename = filename + "fastscape_steps_restart.txt";
@@ -305,76 +305,73 @@ namespace aspect
                 }
 
               //If it's the first time this is called, or we are restarting from a checkpoint, initialize fastscape.
-              if(current_timestep == 1 || restart)
-              {
-
-              	this->get_pcout() <<"   Initializing Fastscape... "<< (1+initial_global_refinement+additional_refinement)  <<
-              			" levels, cell size: "<<dx<<" m."<<std::endl;
-
-              	//If we are restarting from a checkpoint, load h values for fastscape so we don't lose resolution.
-                if (restart)
+              if (current_timestep == 1 || restart)
                 {
-                 this->get_pcout() <<"      Loading Fastscape restart file... "<<std::endl;
-  				 restart = false;
 
-  				 //Load in h values.
-                 std::ifstream in;
-  				 in.open(restart_filename.c_str());
-              	 if(in)
-              	 {
-              	   int line = 0;
+                  this->get_pcout() <<"   Initializing Fastscape... "<< (1+initial_global_refinement+additional_refinement)  <<
+                                    " levels, cell size: "<<dx<<" m."<<std::endl;
 
-              	   while (line <= array_size)
-              	   {
-              		  in >> h[line];
-              	      line++;
-              	   }
+                  //If we are restarting from a checkpoint, load h values for fastscape so we don't lose resolution.
+                  if (restart)
+                    {
+                      this->get_pcout() <<"      Loading Fastscape restart file... "<<std::endl;
+                      restart = false;
 
-              	   in.close();
-              	 }
-              	 else if(!in)
-              	      AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
+                      //Load in h values.
+                      std::ifstream in;
+                      in.open(restart_filename.c_str());
+                      if (in)
+                        {
+                          int line = 0;
 
-              	 /*
-              	  * Now load the fastscape istep at time of restart.
-              	  * Reinitializing fastscape always resets this to 0, so here
-              	  * we keep it in a separate variable to keep track for visualization files.
-              	  */
-                 std::ifstream in_step;
-  				 in_step.open(restart_step_filename.c_str());
-              	 if(in)
-              	 {
+                          while (line <= array_size)
+                            {
+                              in >> h[line];
+                              line++;
+                            }
 
-              	   in_step >> restart_step;
-              	   in_step.close();
-              	 }
-              	 else if(!in_step)
-              	      AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
+                          in.close();
+                        }
+                      else if (!in)
+                        AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
+
+                      /*
+                       * Now load the fastscape istep at time of restart.
+                       * Reinitializing fastscape always resets this to 0, so here
+                       * we keep it in a separate variable to keep track for visualization files.
+                       */
+                      std::ifstream in_step;
+                      in_step.open(restart_step_filename.c_str());
+                      if (in)
+                        {
+
+                          in_step >> restart_step;
+                          in_step.close();
+                        }
+                      else if (!in_step)
+                        AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
+                    }
+
+                  //Initialize fastscape with grid and extent.
+                  fastscape_init_();
+                  fastscape_set_nx_ny_(&nx,&ny);
+                  fastscape_setup_();
+                  fastscape_set_xl_yl_(&x_extent,&y_extent);
+
+                  //set boundary conditions
+                  fastscape_set_bc_(&bc);
+
+                  //Initialize topography
+                  fastscape_init_h_(h.get());
+
+                  //Set erosional parameters. May have to move this if sed values are updated over time.
+                  fastscape_set_erosional_parameters_(kf.get(), &kfsed, &m, &n, kd.get(), &kdsed, &g, &g, &p);
                 }
-
-            	//Initialize fastscape with grid and extent.
-                fastscape_init_();
-                fastscape_set_nx_ny_(&nx,&ny);
-                fastscape_setup_();
-                fastscape_set_xl_yl_(&x_extent,&y_extent);
-
-                //set boundary conditions
-                fastscape_set_bc_(&bc);
-
-                //Initialize topography
-                fastscape_init_h_(h.get());
-
-                //Set erosional parameters. May have to move this if sed values are updated over time.
-                fastscape_set_erosional_parameters_(kf.get(), &kfsed, &m, &n, kd.get(), &kdsed, &g, &g, &p);
-              }
               else
-              {
-            	  //If it isn't the first timestep we just want to know current h values in fastscape.
+                {
+                  //If it isn't the first timestep we just want to know current h values in fastscape.
                   fastscape_copy_h_(h.get());
-              }
-
-              //Get current fastscape timestep.
-              fastscape_get_step_(&istep);
+                }
 
               /*
                * Keep initial h values so we can calculate velocity later.
@@ -383,131 +380,98 @@ namespace aspect
                */
               for (int i=0; i<=array_size; i++)
                 {
-            	  //Initialize random topography noise first time fastscape is called.
-            	  if(current_timestep == 1)
-            	  {
-                	  double h_seed = (std::rand()%2000)/100;
-                	  h[i] = h[i] + h_seed;
-            	  }
+                  //Initialize random topography noise first time fastscape is called.
+                  if (current_timestep == 1)
+                    {
+                      double h_seed = (std::rand()%2000)/100;
+                      h[i] = h[i] + h_seed;
+                    }
                   temporary_variables[0][i] = h[i];
                 }
+
+              //Get current fastscape timestep.
+              fastscape_get_step_(&istep);
 
               //Write a file to store h & step in case of restart.
               if ((this->get_parameters().checkpoint_time_secs == 0) &&
                   (this->get_parameters().checkpoint_steps > 0) &&
                   (current_timestep % this->get_parameters().checkpoint_steps == 0))
-              {
-                std::ofstream out_h (restart_filename.c_str());
-                std::ofstream out_step (restart_step_filename.c_str());
+                {
+                  std::ofstream out_h (restart_filename.c_str());
+                  std::ofstream out_step (restart_step_filename.c_str());
 
-                out_step<<(istep+restart_step)<<std::endl;
+                  out_step<<(istep+restart_step)<<std::endl;
 
-                for (int i=0; i<=array_size; i++)
-                      out_h<<h[i]<<std::endl;
-              }
+                  for (int i=0; i<=array_size; i++)
+                    out_h<<h[i]<<std::endl;
+                }
 
 
-          	  //If opposite boundaries are both open, set as periodic and replace ghost nodes with
+              //If opposite boundaries are both open, set as periodic and replace ghost nodes with
               //the value on opposite side.
-              if(left == 0 && right == 0)
-              {
-          	  for(int j=0; j<numy; j++)
-          	  {
-          		 double index_left = numx*j+1;
-          		 double index_right = numx*(j+1);
-          		 double side = index_left;
-          	 	 int jj = 0;
-          	 	// int below = 0;
-          	 	// int above = 0;
-          	 	// int avg = 1;
-          	 	 //std::vector<std::vector<double>> temporary_variables(dim+1, std::vector<double>(4,std::numeric_limits<double>::epsilon()));
-          	 	//std::vector<double> p_above(4,0);
-          	 	//std::vector<double> p_below(4,0);
+              if (left == 0 && right == 0)
+                {
+                  for (int j=0; j<numy; j++)
+                    {
+                      double index_left = numx*j+1;
+                      double index_right = numx*(j+1);
+                      double side = index_left;
+                      int jj = 0;
 
-          	 	 /*
-          	 	  * This is a simple way to switch the sides so I don't have to rewrite the end result twice.
-          	 	  * Also, it makes it so if both sides are going against each other, we just ignore periodic boundaries.
-          	 	  */
-          	 	 if(vx[index_right-2] > 0 && vx[index_left] >= 0)
-          	 	 {
-          	 		 side = index_right;
-          	 	     jj = 2;
-          	 	 }
-          	 	 else if((vx[index_right-2] < 0 && vx[index_left] > 0) || (vx[index_right-2] > 0 && vx[index_left] < 0))
-          	 		 continue;
+                      //If they aren't going the same direction, don't set the ghost nodes.
+                      if (vx[index_right-2] > 0 && vx[index_left] >= 0)
+                        {
+                          side = index_right;
+                          jj = 2;
+                        }
+                      else if ((vx[index_right-2] < 0 && vx[index_left] > 0) || (vx[index_right-2] > 0 && vx[index_left] < 0))
+                        continue;
 
-          	 	 /*
-          	 	  * This checks whether we have surrounding nodes to average the value.
-          	 	  * If we are at a corner, then we only average 2 values instead of 3.
-          	 	  */
-          	 	/* if(side-jj+numx <= array_size && side-1+numx <= array_size)
-          	 	 {
-          	 		 avg = avg+1;
-                     above = 1;
-          	 	     p_above[0] = h[side-jj+numx];
-          	 	     p_above[1] = vz[side-jj+numx];
-          	       	p_above[2] = vx[side-jj+numx];
-          	        p_above[3] = vy[side-jj+numx];
-          	 	 }
+                      vz[index_right-1] =   vz[side-jj];
+                      vz[index_left-1] =    vz[side-jj];
 
-          	 	 if(side-jj-numx >= 0 && side-1-numx >= 0)
-          	 	 {
-          	 		 avg = avg+1;
-          	 		 below = 1;
-          	 	     p_below[0] = h[side-jj-numx];
-          	 	     p_below[1] = vz[side-jj-numx];
-          	 	     p_below[2] = vx[side-jj-numx];
-          	 	     p_below[3] = vy[side-jj-numx];
-          	 	 }*/
+                      vy[index_right-1] = vy[side-jj];
+                      vy[index_left-1] =  vy[side-jj];
 
-                   vz[index_right-1] =   vz[side-jj]; //(h[side-jj] - h[side-1])/a_dt; (vz[side-jj] + p_below[1] + p_above[1])/avg;
-                   vz[index_left-1] =    vz[side-jj];//(h[side-jj] - h[side-1])/a_dt;
+                      vx[index_right-1] = vx[side-jj];
+                      vx[index_left-1] =  vx[side-jj];
 
-                   vy[index_right-1] = vy[side-jj];
-                   vy[index_left-1] =  vy[side-jj];
-
-                   vx[index_right-1] = vx[side-jj];
-                   vx[index_left-1] =  vx[side-jj];
-
-                   h[index_right-1] = h[side-jj];     //index_bot+numx index_top-numx
-                   h[index_left-1] = h[side-jj];
-
-                   //std::cout<<index_right<<"  "<<avg<<"  "<<vx[side-jj]<<"  "<<p_above[2]<<"  "<<p_below[2]<<"  "<<vx[index_right-1]<<std::endl;
-
-          		 }
-          	  }
+                      h[index_right-1] = h[side-jj];
+                      h[index_left-1] = h[side-jj];
+                    }
+                }
 
 
-              if(top == 0 && bottom == 0)
-              {
-        	  for(int j=0; j<numx; j++)
-        	  {
-        		 double index_bot = j+1;
-        		 double index_top = numx*(numy-1)+j+1;
-          		 double side = index_bot;
-          		 int jj = numx;
+              if (top == 0 && bottom == 0)
+                {
+                  for (int j=0; j<numx; j++)
+                    {
+                      double index_bot = j+1;
+                      double index_top = numx*(numy-1)+j+1;
+                      double side = index_bot;
+                      int jj = numx;
 
-          	 	 if(vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] >= 0)
-          	 	 {
-          	 		 side = index_top;
-          	 		 jj = -numx;
-          	 	 }
-          	 	 else if((vy[index_bot+numx-1] < 0 && vy[index_top-numx-1] > 0) || (vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] < 0))
-          	 		 continue;
+                      if (vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] >= 0)
+                        {
+                          side = index_top;
+                          jj = -numx;
+                        }
+                      else if ((vy[index_bot+numx-1] < 0 && vy[index_top-numx-1] > 0) || (vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] < 0))
+                        continue;
 
-                   vz[index_bot-1] = vz[side+jj-1];   //(h[side+jj-1] - h[side-1])/a_dt;     //index_bot+numx index_top-numx
-                   vz[index_top-1] = vz[side+jj-1];   // (h[side+jj-1] - h[side-1])/a_dt;
+                      vz[index_bot-1] = vz[side+jj-1];
+                      vz[index_top-1] = vz[side+jj-1];
 
-                   vy[index_bot-1] = vy[side+jj-1];
-                   vy[index_top-1] =  vy[side+jj-1];
+                      vy[index_bot-1] = vy[side+jj-1];
+                      vy[index_top-1] =  vy[side+jj-1];
 
-                   vx[index_bot-1] = vx[side+jj-1];
-                   vx[index_top-1] =  vx[side+jj-1];
+                      vx[index_bot-1] = vx[side+jj-1];
+                      vx[index_top-1] =  vx[side+jj-1];
 
-                   h[index_bot-1] = h[side+jj-1];     //index_bot+numx index_top-numx
-                   h[index_top-1] = h[side+jj-1];
-        	  }
-              }
+                      h[index_bot-1] = h[side+jj-1];
+                      h[index_top-1] = h[side+jj-1];
+                    }
+                }
 
               //Find a fastscape timestep that is below our maximum timestep.
               double f_dt = a_dt/steps;
@@ -526,17 +490,17 @@ namespace aspect
               fastscape_set_h_(h.get());
 
               //Initialize first time step, and update steps.
-              //int astep = round(this->get_time()/year_in_seconds);
               int visualization_step = istep+restart_step;
               steps = istep+steps;
+              fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
               //I really need to figure out a better way to make visualization files output correctly.
-        	  this->get_pcout() <<"   Calling Fastscape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
+              this->get_pcout() <<"   Calling Fastscape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
               do
                 {
-            	  //Write fastscape visualization
-            	  visualization_step = istep+restart_step;
-                  fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
+                  //Write fastscape visualization
+                  //visualization_step = istep+restart_step;
+                  //fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
                   //execute step, this increases timestep counter
                   fastscape_execute_step_();
@@ -551,10 +515,10 @@ namespace aspect
 
               //If we've reached the end time, destroy fastscape.
               if (this->get_time()+a_dt >= end_time)
-            	 {
-            	  this->get_pcout()<<"   Destroying Fastscape..."<<std::endl;
+                {
+                  this->get_pcout()<<"   Destroying Fastscape..."<<std::endl;
                   fastscape_destroy_();
-            	 }
+                }
 
               //Find out our velocities from the change in height.
               for (int i=0; i<=array_size; i++)
@@ -582,9 +546,6 @@ namespace aspect
           data_table.TableBase<dim,double>::reinit(size_idx);
           TableIndices<dim> idx;
 
-          //Average the 2D slices together to get a 1D velocity array.
-          // double V3;
-
           //this variable gives us how many slices near the boundaries to ignore,
           //this helps with lower values due to fixed top and bottom boundaries.
           int edge = (nx+1)/2;
@@ -594,21 +555,21 @@ namespace aspect
 
               for (int i=1; i<(numx-1); i++)
                 {
-            	  //Multiply edge by bottom and top, so it only takes them off if they're fixed.
-            	  if(slice)
-            	  {
+                  //Multiply edge by bottom and top, so it only takes them off if they're fixed.
+                  if (slice)
+                    {
                       int index = i+numx*((ny-1)/2);
                       V2[i-1] = V[index];
-            	  }
-            	  else
-            	  {
-                  for (int ys=(edge); ys<(ny-edge); ys++)
-                    {
-                      int index = i+numx*ys;
-                      V2[i-1] += V[index];
                     }
-                    V2[i-1] = V2[i-1]/(ny-edge*2);
-            	  }
+                  else
+                    {
+                      for (int ys=(edge); ys<(ny-edge); ys++)
+                        {
+                          int index = i+numx*ys;
+                          V2[i-1] += V[index];
+                        }
+                      V2[i-1] = V2[i-1]/(ny-edge*2);
+                    }
                 }
 
               for (unsigned int i=0; i<data_table.size()[1]; ++i)
@@ -621,13 +582,13 @@ namespace aspect
 
                       //Convert from m/yr to m/s if needed
                       if (i == 1)
-                      {
+                        {
                           if (this->convert_output_to_years())
-                             data_table(idx) = V2[j]/year_in_seconds;
+                            data_table(idx) = V2[j]/year_in_seconds;
                           else
-                        	 data_table(idx) = V2[j];
+                            data_table(idx) = V2[j];
 
-                      }
+                        }
                       else
                         data_table(idx)= 0;
 
@@ -652,12 +613,12 @@ namespace aspect
                           idx[0] = j;
 
                           if (k==1)
-                          {
+                            {
                               if (this->convert_output_to_years())
-                                 data_table(idx) = V[(nx+1)+nx*i+j]/year_in_seconds;  //(nx+1)+nx*i+j  nx*i+j
+                                data_table(idx) = V[(nx+1)+nx*i+j]/year_in_seconds;  //(nx+1)+nx*i+j  nx*i+j
                               else
-                            	  data_table(idx) = V[(nx+1)+nx*i+j];
-                          }
+                                data_table(idx) = V[(nx+1)+nx*i+j];
+                            }
                           else
                             data_table(idx)= 0;
 
@@ -695,17 +656,17 @@ namespace aspect
     void FastScape<dim>::declare_parameters(ParameterHandler &prm)
     {
 
-        prm.declare_entry ("End time",
-                           /* boost::lexical_cast<std::string>(std::numeric_limits<double>::max() /
-                                                year_in_seconds) = */ "5.69e+300",
-                           Patterns::Double (),
-                           "The end time of the simulation. The default value is a number "
-                           "so that when converted from years to seconds it is approximately "
-                           "equal to the largest number representable in floating point "
-                           "arithmetic. For all practical purposes, this equals infinity. "
-                           "Units: Years if the "
-                           "'Use years in output instead of seconds' parameter is set; "
-                           "seconds otherwise.");
+      prm.declare_entry ("End time",
+                         /* boost::lexical_cast<std::string>(std::numeric_limits<double>::max() /
+                                              year_in_seconds) = */ "5.69e+300",
+                         Patterns::Double (),
+                         "The end time of the simulation. The default value is a number "
+                         "so that when converted from years to seconds it is approximately "
+                         "equal to the largest number representable in floating point "
+                         "arithmetic. For all practical purposes, this equals infinity. "
+                         "Units: Years if the "
+                         "'Use years in output instead of seconds' parameter is set; "
+                         "seconds otherwise.");
 
       prm.enter_subsection ("Mesh deformation");
       {
@@ -735,18 +696,18 @@ namespace aspect
 
           prm.enter_subsection ("Boundary conditions");
           {
-              prm.declare_entry ("Bottom", "1",
-            		             Patterns::Integer (0, 1),
-                                 "Bottom boundary condition, where 1 is fixed and 0 is reflective.");
-              prm.declare_entry ("Right", "1",
- 		                         Patterns::Integer (0, 1),
-                                 "Right boundary condition, where 1 is fixed and 0 is reflective.");
-              prm.declare_entry ("Top", "1",
- 		                         Patterns::Integer (0, 1),
-                                 "Top boundary condition, where 1 is fixed and 0 is reflective.");
-              prm.declare_entry ("Left", "1",
- 		                         Patterns::Integer (0, 1),
-                                 "Left boundary condition, where 1 is fixed and 0 is reflective.");
+            prm.declare_entry ("Bottom", "1",
+                               Patterns::Integer (0, 1),
+                               "Bottom boundary condition, where 1 is fixed and 0 is reflective.");
+            prm.declare_entry ("Right", "1",
+                               Patterns::Integer (0, 1),
+                               "Right boundary condition, where 1 is fixed and 0 is reflective.");
+            prm.declare_entry ("Top", "1",
+                               Patterns::Integer (0, 1),
+                               "Top boundary condition, where 1 is fixed and 0 is reflective.");
+            prm.declare_entry ("Left", "1",
+                               Patterns::Integer (0, 1),
+                               "Left boundary condition, where 1 is fixed and 0 is reflective.");
           }
           prm.leave_subsection();
 
@@ -809,9 +770,9 @@ namespace aspect
     template <int dim>
     void FastScape<dim>::parse_parameters(ParameterHandler &prm)
     {
-        end_time = prm.get_double ("End time");
-        if (prm.get_bool ("Use years in output instead of seconds") == true)
-          end_time *= year_in_seconds;
+      end_time = prm.get_double ("End time");
+      if (prm.get_bool ("Use years in output instead of seconds") == true)
+        end_time *= year_in_seconds;
       prm.enter_subsection ("Mesh deformation");
       {
         prm.enter_subsection("Fastscape");
@@ -825,12 +786,12 @@ namespace aspect
 
           prm.enter_subsection("Boundary conditions");
           {
-           bottom = prm.get_integer("Bottom");
-           right = prm.get_integer("Right");
-           top = prm.get_integer("Top");
-           left = prm.get_integer("Left");
+            bottom = prm.get_integer("Bottom");
+            right = prm.get_integer("Right");
+            top = prm.get_integer("Top");
+            left = prm.get_integer("Left");
 
-           bc = bottom*1000+right*100+top*10+left;
+            bc = bottom*1000+right*100+top*10+left;
           }
           prm.leave_subsection();
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -243,7 +243,9 @@ namespace aspect
               std::unique_ptr<double[]> kf (new double[array_size]());
               std::unique_ptr<double[]> kd (new double[array_size]());
               std::unique_ptr<double[]> slopep (new double[array_size]());
+              std::unique_ptr<double[]> b (new double[array_size]());
               std::vector<double> h_old(array_size);
+              
 
               // Create variables for output directory and restart file
               std::string dirname = this->get_output_directory();
@@ -251,6 +253,7 @@ namespace aspect
               int length = dirname.length();
               const std::string restart_filename = dirname + "fastscape_h_restart.txt";
               const std::string restart_step_filename = dirname + "fastscape_steps_restart.txt";
+              const std::string restart_filename_basement = dirname + "fastscape_b_restart.txt";
 
               // Initialize kf and kd.
               for (int i=0; i<array_size; i++)
@@ -331,6 +334,24 @@ namespace aspect
                         }
                       else if (!in)
                         AssertThrow(false,ExcMessage("Cannot open file to restart FastScape."));
+                      
+                     // Load in b values.
+                      std::ifstream in_b;
+                      in_b.open(restart_filename_basement.c_str());
+                      if (in_b)
+                        {
+                          int line = 0;
+
+                          while (line < array_size)
+                            {
+                              in_b >> b[line];
+                              line++;
+                            }
+
+                          in_b.close();
+                        }
+                      else if (!in_b)
+                        AssertThrow(false,ExcMessage("Cannot open basement file to restart FastScape."));
 
                       /*
                        * Now load the fastscape istep at time of restart.
@@ -339,7 +360,7 @@ namespace aspect
                        */
                       std::ifstream in_step;
                       in_step.open(restart_step_filename.c_str());
-                      if (in)
+                      if (in_step)
                         {
                           in_step >> restart_step;
                           in_step.close();
@@ -363,19 +384,24 @@ namespace aspect
                   fastscape_init_h_(h.get());
 
                   // Set erosional parameters. May have to move this if sed values are updated over time.
-                  fastscape_set_erosional_parameters_(kf.get(), &kfsed, &m, &n, kd.get(), &kdsed, &g, &g, &p);
+                  fastscape_set_erosional_parameters_(kf.get(), &kfsed, &m, &n, kd.get(), &kdsed, &g, &gsed, &p);
 
                   if (use_marine)
                     fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
 
-                  //if (use_strat)
-                  //  folder_output_(&length, &restart_step, c);
+                  // Only set the basement if it's a restart
+                  if(current_timestep != 1)
+                    fastscape_set_basement_(b.get());
                 }
               else
                 {
-                  // If it isn't the first timestep we just want to know current h values in fastscape.
+                  // If it isn't the first timestep we ignore initialization and instead copy all height values from FastScape.
                   fastscape_copy_h_(h.get());
                 }
+                
+              /*
+               * Generally, any additional modifications should occur below this point.
+               */
 
               /*
                * The ghost nodes are added as a single layer of nodes surrounding the entire model,
@@ -600,6 +626,7 @@ namespace aspect
                     }
                 }
 
+                
               /*
                * Keep initial h values so we can calculate velocity later.
                * In the first timestep, h will be given from other processors.
@@ -617,6 +644,21 @@ namespace aspect
                       const double h_seed = (std::rand()%100)/10 - 5;
                       h[i] = h[i] + h_seed;
                     }
+                    
+                   // Here we add the sediment rain (m/yr) as a flat increase in height.
+                   // This is done because adding it as an uplift rate would affect the basement.
+                   if(sediment_rain > 0)
+                   {
+                     // Only apply sediment rain to areas below sea level.
+                     if(h[i] < sl)
+                     {
+                     // If the rain would put us above sea level, set height to sea level.
+                     if(h[i] + sediment_rain*a_dt > sl)
+                       h[i] = sl; 
+                     else
+                       h[i] = h[i] + sediment_rain*a_dt; 	
+                     }
+                   }   
                 }
 
               // Get current fastscape timestep.
@@ -629,13 +671,25 @@ namespace aspect
                   (this->get_parameters().checkpoint_steps > 0) &&
                   (current_timestep % this->get_parameters().checkpoint_steps == 0))
                 {
+            
                   std::ofstream out_h (restart_filename.c_str());
                   std::ofstream out_step (restart_step_filename.c_str());
+                  std::ofstream out_b (restart_filename_basement.c_str());
+                  std::stringstream bufferb;
+                  std::stringstream bufferh;
+                  
+                  fastscape_copy_basement_(b.get());
 
-                  out_step << (istep+restart_step) << std::endl;
+                  out_step << (istep+restart_step) << "\n";
 
                   for (int i=0; i<array_size; i++)
-                    out_h << h[i] << std::endl;
+                  {
+                   bufferh << h[i] << "\n";
+                   bufferb << b[i] << "\n";
+                  }
+                  
+                  out_h << bufferh.str();
+                  out_b << bufferb.str();
                 }
 
               // Find a fastscape timestep that is below our maximum timestep.
@@ -852,9 +906,9 @@ namespace aspect
           prm.declare_entry("Maximum timestep", "10e3",
                             Patterns::Double(0),
                             "Maximum timestep for FastScape.");
-          prm.declare_entry("Vertical exaggeration", "3",
+          prm.declare_entry("Vertical exaggeration", "-1",
                             Patterns::Double(),
-                            "Vertical exaggeration for FastScape's VTK file.");
+                            "Vertical exaggeration for FastScape's VTK file. -1 outputs topography, basement, and sealevel.");
           prm.declare_entry("Additional fastscape refinement", "0",
                             Patterns::Integer(),
                             "How many levels above ASPECT FastScape should be refined.");
@@ -891,6 +945,9 @@ namespace aspect
           prm.declare_entry ("Use ghost nodes", "true",
                              Patterns::Bool (),
                              "Flag to use ghost nodes");
+          prm.declare_entry("Sediment rain", "0",
+                            Patterns::Double(),
+                            "Sediment rain in m/yr. This will be added to as flat height increase to FastScape at every node.");
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -1016,6 +1073,7 @@ namespace aspect
           nreflectorp = prm.get_integer("Number of horizons");
           y_extent_2d = prm.get_double("Y extent in 2d");
           use_ghost = prm.get_bool("Use ghost nodes");
+          sediment_rain = prm.get_double("Sediment rain");
 
           prm.enter_subsection("Boundary conditions");
           {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -193,7 +193,7 @@ namespace aspect
                                  */
                                 const double index = indx+nx*ys;
 
-                                temporary_variables[0].push_back(vertex(dim-1));
+                                temporary_variables[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);
                                 temporary_variables[1].push_back(index-1);
 
                                 for (unsigned int i=0; i<dim; ++i)
@@ -214,7 +214,7 @@ namespace aspect
 
                             const double index = (indy-1)*nx+indx;
 
-                            temporary_variables[0].push_back(vertex(dim-1));   //z component
+                            temporary_variables[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);   //z component
                             temporary_variables[1].push_back(index-1);
 
                             for (unsigned int i=0; i<dim; ++i)

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -66,7 +66,7 @@ namespace aspect
       if (dim == 2)
         {
           dy = dx;
-          y_extent = grid_extent[0].second*3+2*dy;
+          y_extent = round(y_extent_2d/dy)*dy+2*dy;             //x_extent; //grid_extent[0].second*3+2*dy;
           ny = 1+y_extent/dy;
         }
 
@@ -621,8 +621,9 @@ namespace aspect
                 while (istep<steps);
 
                 auto t_end = std::chrono::high_resolution_clock::now();
-                keep_time += std::chrono::duration<double>(t_end-t_start).count();
-                this->get_pcout()<<"      Total FastScape runtime... "<<round(keep_time*1000)/1000<<"s"<<std::endl;
+                double r_time = std::chrono::duration<double>(t_end-t_start).count();
+                keep_time += r_time;
+                this->get_pcout()<<"      FastScape runtime... "<<round(r_time*1000)/1000<<"s"<<std::endl;
               }
 
               //If we've reached the end time, destroy fastscape.
@@ -678,17 +679,17 @@ namespace aspect
                 {
                   if (slice)
                     {
-                      int index = i+nx*((ny-1)/2);
+                      int index = i+nx*(round((ny-1)/2));
                       V2[i-1] = V[index];
                     }
                   else
                     {
-                      for (int ys=edge; ys<(ny-edge); ys++)
+                      for (int ys=1; ys<(ny-1); ys++)
                         {
                           int index = i+nx*ys;
                           V2[i-1] += V[index];
                         }
-                      V2[i-1] = V2[i-1]/(ny-edge*2);
+                      V2[i-1] = V2[i-1]/(ny-2);
                     }
                 }
 
@@ -832,6 +833,10 @@ namespace aspect
           prm.declare_entry("Number of horizons", "1",
                             Patterns::Integer(),
                             "Number of horizons to track and visualize in FastScape..");
+          prm.declare_entry("Y extent in 2d", "100000",
+                            Patterns::Double(),
+                            "Y extent when used with 2D");
+
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -965,6 +970,7 @@ namespace aspect
           use_strat = prm.get_bool("Use stratigraphy");
           nstepp = prm.get_integer("Total steps");
           nreflectorp = prm.get_integer("Number of horizons");
+          y_extent_2d = prm.get_double("Y extent in 2d");
 
           prm.enter_subsection("Boundary conditions");
           {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -367,7 +367,7 @@ namespace aspect
                   //Initialize random topography noise first time fastscape is called.
                   if (current_timestep == 1)
                     {
-                      double h_seed = 0; //(std::rand()%2000)/100;
+                      double h_seed = (std::rand()%2000)/100;
                       h[i] = h[i] + h_seed;
                     }
                   h_old[i] = h[i];

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -156,19 +156,19 @@ namespace aspect
                           {
                             for (int ys=0; ys<ny; ys++)
                               {
-                            	/*
-                            	 * Fastscape indexes from 1 to n, starting at X and Y = 0, and increases
-                            	 * across the X row. At the end of the row, it jumps back to X = 0
-                            	 * and up to the next X row in increasing Y direction. We track
-                            	 * this to correctly place the variables later on.
-                            	 */
+                                /*
+                                 * Fastscape indexes from 1 to n, starting at X and Y = 0, and increases
+                                 * across the X row. At the end of the row, it jumps back to X = 0
+                                 * and up to the next X row in increasing Y direction. We track
+                                 * this to correctly place the variables later on.
+                                 */
                                 double index = indx+nx*ys;
 
                                 temporary_variables[0].push_back(vertex(dim-1));
                                 temporary_variables[1].push_back(index-1);
 
                                 for (unsigned int i=0; i<dim; ++i)
-                                	temporary_variables[i+2].push_back(vel[corner][i]*year_in_seconds);
+                                  temporary_variables[i+2].push_back(vel[corner][i]*year_in_seconds);
                               }
                           }
 
@@ -247,7 +247,7 @@ namespace aspect
               for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
                 {
 
-            	  //First, find out the size of the array a processor wants to send.
+                  //First, find out the size of the array a processor wants to send.
                   MPI_Status status;
                   MPI_Probe(p, 42, this->get_mpi_communicator(), &status);
                   int incoming_size = 0;
@@ -414,44 +414,44 @@ namespace aspect
                   vx[index_right-1] = vx[index_right-2];
                   vx[index_left-1] = vx[index_left];
 
-                  if(current_timestep == 1 || left_flux == 0)
-                  {
-                	//If its the first timestep add in initial slope. If we have no flux,
-                	//set the ghost node to the node next to it.
-                	slope = left_flux/kdd;
-                    h[index_left-1] = h[index_left] + slope*2*dx;
-                  }
+                  if (current_timestep == 1 || left_flux == 0)
+                    {
+                      //If its the first timestep add in initial slope. If we have no flux,
+                      //set the ghost node to the node next to it.
+                      slope = left_flux/kdd;
+                      h[index_left-1] = h[index_left] + slope*2*dx;
+                    }
                   else
-                  {
-                    //If we have flux through boundary, we need to update the height to keep the correct slope.
-                	//Because the corner nodes always show a slope of zero, this will update them according to
-                	//the nodes next to them.
-                	  if(j == 0)
-                		  slope = left_flux/kdd - std::tan(slopep[index_left+nx]*boost::math::double_constants::pi/180);
-                	  else if(j==(ny-1))
-                		  slope = left_flux/kdd - std::tan(slopep[index_left-nx]*boost::math::double_constants::pi/180);
-                	  else
-                		  slope = left_flux/kdd - std::tan(slopep[index_left]*boost::math::double_constants::pi/180);
+                    {
+                      //If we have flux through boundary, we need to update the height to keep the correct slope.
+                      //Because the corner nodes always show a slope of zero, this will update them according to
+                      //the nodes next to them.
+                      if (j == 0)
+                        slope = left_flux/kdd - std::tan(slopep[index_left+nx]*boost::math::double_constants::pi/180);
+                      else if (j==(ny-1))
+                        slope = left_flux/kdd - std::tan(slopep[index_left-nx]*boost::math::double_constants::pi/180);
+                      else
+                        slope = left_flux/kdd - std::tan(slopep[index_left]*boost::math::double_constants::pi/180);
 
-                  	  h[index_left-1] = h[index_left-1] + slope*2*dx;
-                  }
+                      h[index_left-1] = h[index_left-1] + slope*2*dx;
+                    }
 
-                  if(current_timestep == 1 || right_flux == 0)
-                  {
-                  	slope = right_flux/kdd;
-                    h[index_right-1] = h[index_right-2] + slope*2*dx;
-                  }
+                  if (current_timestep == 1 || right_flux == 0)
+                    {
+                      slope = right_flux/kdd;
+                      h[index_right-1] = h[index_right-2] + slope*2*dx;
+                    }
                   else
-                  {
-                	  if(j == 0)
-                		  slope = right_flux/kdd - std::tan(slopep[index_right+nx-2]*boost::math::double_constants::pi/180);
-                	  else if(j==(ny-1))
-                		  slope = right_flux/kdd - std::tan(slopep[index_right-nx-2]*boost::math::double_constants::pi/180);
-                	  else
-                		  slope = right_flux/kdd - std::tan(slopep[index_right-2]*boost::math::double_constants::pi/180);
+                    {
+                      if (j == 0)
+                        slope = right_flux/kdd - std::tan(slopep[index_right+nx-2]*boost::math::double_constants::pi/180);
+                      else if (j==(ny-1))
+                        slope = right_flux/kdd - std::tan(slopep[index_right-nx-2]*boost::math::double_constants::pi/180);
+                      else
+                        slope = right_flux/kdd - std::tan(slopep[index_right-2]*boost::math::double_constants::pi/180);
 
-                  	h[index_right-1] = h[index_right-1] + slope*2*dx;
-                  }
+                      h[index_right-1] = h[index_right-1] + slope*2*dx;
+                    }
 
                   //If we set the boundaries as periodic, then reset any values to the
                   //nodes on the opposite side.
@@ -493,7 +493,7 @@ namespace aspect
                 {
                   double index_bot = j+1;
                   double index_top = nx*(ny-1)+j+1;
-            	  double slope = 0;
+                  double slope = 0;
 
                   vz[index_bot-1] = vz[index_bot+nx-1];
                   vz[index_top-1] = vz[index_top-nx-1];
@@ -504,39 +504,39 @@ namespace aspect
                   vx[index_bot-1] = vx[index_bot+nx-1];
                   vx[index_top-1] =  vx[index_top-nx-1];
 
-                  if(current_timestep == 1 || top_flux == 0)
-                  {
-                    slope = top_flux/kdd;
-                    h[index_top-1] = h[index_top-nx-1] + slope*2*dx;
-                  }
+                  if (current_timestep == 1 || top_flux == 0)
+                    {
+                      slope = top_flux/kdd;
+                      h[index_top-1] = h[index_top-nx-1] + slope*2*dx;
+                    }
                   else
-                  {
-                	  if(j == 0)
-                		  slope = top_flux/kdd - std::tan(slopep[index_top-nx]*boost::math::double_constants::pi/180);
-                	  else if(j==(nx-1))
-                		  slope = top_flux/kdd - std::tan(slopep[index_top-nx-2]*boost::math::double_constants::pi/180);
-                	  else
-                		  slope = top_flux/kdd - std::tan(slopep[index_top-nx-1]*boost::math::double_constants::pi/180);
+                    {
+                      if (j == 0)
+                        slope = top_flux/kdd - std::tan(slopep[index_top-nx]*boost::math::double_constants::pi/180);
+                      else if (j==(nx-1))
+                        slope = top_flux/kdd - std::tan(slopep[index_top-nx-2]*boost::math::double_constants::pi/180);
+                      else
+                        slope = top_flux/kdd - std::tan(slopep[index_top-nx-1]*boost::math::double_constants::pi/180);
 
-                	  h[index_top-1] = h[index_top-1] + slope*2*dx;
-                   }
+                      h[index_top-1] = h[index_top-1] + slope*2*dx;
+                    }
 
-                  if(current_timestep == 1 || bottom_flux == 0)
-                  {
-                    slope = bottom_flux/kdd;
-                    h[index_bot-1] = h[index_bot+nx-1] + slope*2*dx;
-                  }
+                  if (current_timestep == 1 || bottom_flux == 0)
+                    {
+                      slope = bottom_flux/kdd;
+                      h[index_bot-1] = h[index_bot+nx-1] + slope*2*dx;
+                    }
                   else
-                  {
-                	  if(j == 0)
-                		  slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx]*boost::math::double_constants::pi/180);
-                	  else if(j==(nx-1))
-                		  slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx-2]*boost::math::double_constants::pi/180);
-                	  else
-                		  slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx-1]*boost::math::double_constants::pi/180);
+                    {
+                      if (j == 0)
+                        slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx]*boost::math::double_constants::pi/180);
+                      else if (j==(nx-1))
+                        slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx-2]*boost::math::double_constants::pi/180);
+                      else
+                        slope = bottom_flux/kdd - std::tan(slopep[index_bot+nx-1]*boost::math::double_constants::pi/180);
 
-                  	h[index_bot-1] = h[index_bot-1] + slope*2*dx;
-                  }
+                      h[index_bot-1] = h[index_bot-1] + slope*2*dx;
+                    }
 
                   if (bottom == 0 && top == 0)
                     {
@@ -600,10 +600,10 @@ namespace aspect
                  * TODO: The frequency in this needs to be the same as the total timesteps fastscape will
                  * run for, need to figure out how to work this in better.
                  */
-                if(use_strat && current_timestep == 1)
-                	fastscape_strati_(&nstepp, &nreflectorp, &steps, &vexp);
-				else if(!use_strat)
-                    fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
+                if (use_strat && current_timestep == 1)
+                  fastscape_strati_(&nstepp, &nreflectorp, &steps, &vexp);
+                else if (!use_strat)
+                  fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
                 do
                   {
@@ -630,8 +630,8 @@ namespace aspect
 
                   visualization_step = visualization_step+1;
 
-                  if(!use_strat)
-                     fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
+                  if (!use_strat)
+                    fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
                   fastscape_destroy_();
                 }
@@ -826,7 +826,7 @@ namespace aspect
                              "Flag to use stratigraphy");
           prm.declare_entry("Total steps", "100000",
                             Patterns::Integer(),
-							"Total number of steps you expect in the FastScape model, only used if stratigraphy is turned on.");
+                            "Total number of steps you expect in the FastScape model, only used if stratigraphy is turned on.");
           prm.declare_entry("Number of horizons", "1",
                             Patterns::Integer(),
                             "Number of horizons to track and visualize in FastScape..");
@@ -977,9 +977,9 @@ namespace aspect
 
             bc = bottom*1000+right*100+top*10+left;
 
-            if((left_flux != 0 && top_flux != 0) || (left_flux != 0 && bottom_flux != 0) ||
-            		(right_flux != 0 && bottom_flux != 0) || (right_flux != 0 && top_flux != 0))
-		           AssertThrow(false,ExcMessage("Currently the plugin does not support mass flux through adjacent boundaries."));
+            if ((left_flux != 0 && top_flux != 0) || (left_flux != 0 && bottom_flux != 0) ||
+                (right_flux != 0 && bottom_flux != 0) || (right_flux != 0 && top_flux != 0))
+              AssertThrow(false,ExcMessage("Currently the plugin does not support mass flux through adjacent boundaries."));
           }
           prm.leave_subsection();
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -147,7 +147,7 @@ namespace aspect
                         // If our x or y index isn't close to a whole number, then it's likely an artifact
                         // from using an over-resolved quadrature rule, in that case ignore it.
                         if (indx - floor(indx) >= precision)
-                        	continue;
+                          continue;
 
                         if (dim == 2)
                           {
@@ -169,7 +169,7 @@ namespace aspect
                           {
                             double indy = 2+vertex(1)/dy;
                             if (indy - floor(indy) >= precision)
-                            	continue;
+                              continue;
 
                             double index = (indy-1)*nx+indx;
 
@@ -486,28 +486,28 @@ namespace aspect
               //I really need to figure out a better way to make visualization files output correctly.
               this->get_pcout() <<"   Calling FastScape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
               {
-           	  auto t_start = std::chrono::high_resolution_clock::now();
+                auto t_start = std::chrono::high_resolution_clock::now();
 
-              do
-                {
-                  //Write fastscape visualization
-                  //visualization_step = istep+restart_step;
-                  //fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
+                do
+                  {
+                    //Write fastscape visualization
+                    //visualization_step = istep+restart_step;
+                    //fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
-                  //execute step, this increases timestep counter
-                  fastscape_execute_step_();
+                    //execute step, this increases timestep counter
+                    fastscape_execute_step_();
 
-                  //get value of time step counter
-                  fastscape_get_step_(&istep);
+                    //get value of time step counter
+                    fastscape_get_step_(&istep);
 
-                  //outputs new h values
-                  fastscape_copy_h_(h.get());
-                }
-              while (istep<steps);
+                    //outputs new h values
+                    fastscape_copy_h_(h.get());
+                  }
+                while (istep<steps);
 
-              auto t_end = std::chrono::high_resolution_clock::now();
-              keep_time += std::chrono::duration<double>(t_end-t_start).count();
-              this->get_pcout()<<"      Total FastScape runtime... "<<round(keep_time*1000)/1000<<"s"<<std::endl;
+                auto t_end = std::chrono::high_resolution_clock::now();
+                keep_time += std::chrono::duration<double>(t_end-t_start).count();
+                this->get_pcout()<<"      Total FastScape runtime... "<<round(keep_time*1000)/1000<<"s"<<std::endl;
               }
 
               //If we've reached the end time, destroy fastscape.
@@ -527,7 +527,7 @@ namespace aspect
             }
           else
             {
-        	  TimerOutput::Scope timer_section(this->get_computing_timer(), "Fastscape 1 proc");
+              TimerOutput::Scope timer_section(this->get_computing_timer(), "Fastscape 1 proc");
               for (int i=0; i<dim+1; i++)
                 MPI_Send(&temporary_variables[i][0], array_size+1, MPI_DOUBLE, 0, 42, this->get_mpi_communicator());
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -14,7 +14,6 @@
   <http://www.gnu.org/licenses/>.
  */
 
-
 #include <aspect/mesh_deformation/fastscape.h>
 #include <aspect/geometry_model/box.h>
 #include <deal.II/numerics/vector_tools.h>

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -358,14 +358,6 @@ namespace aspect
                   // Set boundary conditions
                   fastscape_set_bc_(&bc);
 
-                  // Initialize random noise, as this is applied here ghost node noise will match whatever is on the edges.
-                  std::srand(fs_seed);
-                  for (int i=0; i<array_size; i++)
-                    {
-                      const double h_seed = (std::rand()%2000)/100;
-                      h[i] = h[i] + h_seed;
-                    }
-
                   // Initialize topography
                   fastscape_init_h_(h.get());
 
@@ -612,9 +604,18 @@ namespace aspect
                * In the first timestep, h will be given from other processors.
                * In later timesteps, we copy h directly from fastscape.
                */
+              std::srand(fs_seed);
               for (int i=0; i<array_size; i++)
                 {
                   h_old[i] = h[i];
+
+                  // Initialize random noise after h_old is set, so aspect sees this initial topography change.
+                  if (current_timestep == 1)
+                    {
+                      // + or - 5 meters of topography.
+                      const double h_seed = (std::rand()%100)/10 - 5;
+                      h[i] = h[i] + h_seed;
+                    }
                 }
 
               // Get current fastscape timestep.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -55,8 +55,8 @@ namespace aspect
           const std::vector<std::string> names = mesh_deformation_boundary_indicators_map[*p];
           for (unsigned int i = 0; i < names.size(); ++i )
             {
-                if(names[i] == "fastscape")
-                  AssertThrow((*p == relevant_boundary),
+              if (names[i] == "fastscape")
+                AssertThrow((*p == relevant_boundary),
                             ExcMessage("Fastscape can only be called on the surface boundary."));
             }
         }
@@ -136,7 +136,7 @@ namespace aspect
           std::vector<std::vector<double>> temporary_variables(dim+2, std::vector<double>());
           //Vector to hold the velocities that represent the change to the surface.
           std::vector<double> V(array_size);
-          const double precision = 0.001;
+          //precision = 0.001;
 
           // Get a quadrature rule that exists only on the corners, and increase the refinement if specified.
           const QIterated<dim-1> face_corners (QTrapez<1>(),
@@ -191,7 +191,7 @@ namespace aspect
                                  * Nx*ys effectively tells us what row we are in
                                  * and then indx tells us what position in that row.
                                  */
-                                const double index = indx+nx*ys;
+                                const double index = round(indx)+nx*ys;
 
                                 temporary_variables[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);
                                 temporary_variables[1].push_back(index-1);
@@ -212,7 +212,7 @@ namespace aspect
                             if (abs(indy - round(indy)) >= precision)
                               continue;
 
-                            const double index = (indy-1)*nx+indx;
+                            const double index = round((indy-1))*nx+round(indx);
 
                             temporary_variables[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);   //z component
                             temporary_variables[1].push_back(index-1);
@@ -245,7 +245,7 @@ namespace aspect
               std::unique_ptr<double[]> slopep (new double[array_size]());
               std::unique_ptr<double[]> b (new double[array_size]());
               std::vector<double> h_old(array_size);
-              
+
 
               // Create variables for output directory and restart file
               std::string dirname = this->get_output_directory();
@@ -334,8 +334,8 @@ namespace aspect
                         }
                       else if (!in)
                         AssertThrow(false,ExcMessage("Cannot open file to restart FastScape."));
-                      
-                     // Load in b values.
+
+                      // Load in b values.
                       std::ifstream in_b;
                       in_b.open(restart_filename_basement.c_str());
                       if (in_b)
@@ -390,15 +390,16 @@ namespace aspect
                     fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
 
                   // Only set the basement if it's a restart
-                  if(current_timestep != 1)
+                  if (current_timestep != 1)
                     fastscape_set_basement_(b.get());
                 }
               else
                 {
                   // If it isn't the first timestep we ignore initialization and instead copy all height values from FastScape.
-                  fastscape_copy_h_(h.get());
+                 if(use_v)
+                   fastscape_copy_h_(h.get());
                 }
-                
+
               /*
                * Generally, any additional modifications should occur below this point.
                */
@@ -626,7 +627,7 @@ namespace aspect
                     }
                 }
 
-                
+
               /*
                * Keep initial h values so we can calculate velocity later.
                * In the first timestep, h will be given from other processors.
@@ -644,21 +645,21 @@ namespace aspect
                       const double h_seed = (std::rand()%100)/10 - 5;
                       h[i] = h[i] + h_seed;
                     }
-                    
-                   // Here we add the sediment rain (m/yr) as a flat increase in height.
-                   // This is done because adding it as an uplift rate would affect the basement.
-                   if(sediment_rain > 0)
-                   {
-                     // Only apply sediment rain to areas below sea level.
-                     if(h[i] < sl)
-                     {
-                     // If the rain would put us above sea level, set height to sea level.
-                     if(h[i] + sediment_rain*a_dt > sl)
-                       h[i] = sl; 
-                     else
-                       h[i] = h[i] + sediment_rain*a_dt; 	
-                     }
-                   }   
+
+                  // Here we add the sediment rain (m/yr) as a flat increase in height.
+                  // This is done because adding it as an uplift rate would affect the basement.
+                  if (sediment_rain > 0)
+                    {
+                      // Only apply sediment rain to areas below sea level.
+                      if (h[i] < sl)
+                        {
+                          // If the rain would put us above sea level, set height to sea level.
+                          if (h[i] + sediment_rain*a_dt > sl)
+                            h[i] = sl;
+                          else
+                            h[i] = h[i] + sediment_rain*a_dt;
+                        }
+                    }
                 }
 
               // Get current fastscape timestep.
@@ -671,23 +672,23 @@ namespace aspect
                   (this->get_parameters().checkpoint_steps > 0) &&
                   (current_timestep % this->get_parameters().checkpoint_steps == 0))
                 {
-            
+
                   std::ofstream out_h (restart_filename.c_str());
                   std::ofstream out_step (restart_step_filename.c_str());
                   std::ofstream out_b (restart_filename_basement.c_str());
                   std::stringstream bufferb;
                   std::stringstream bufferh;
-                  
+
                   fastscape_copy_basement_(b.get());
 
                   out_step << (istep+restart_step) << "\n";
 
                   for (int i=0; i<array_size; i++)
-                  {
-                   bufferh << h[i] << "\n";
-                   bufferb << b[i] << "\n";
-                  }
-                  
+                    {
+                      bufferh << h[i] << "\n";
+                      bufferb << b[i] << "\n";
+                    }
+
                   out_h << bufferh.str();
                   out_b << bufferb.str();
                 }
@@ -705,8 +706,12 @@ namespace aspect
               fastscape_set_dt_(&f_dt);
 
               // Set velocity components and h.
-              fastscape_set_u_(vz.get());
-              fastscape_set_v_(vx.get(), vy.get());
+              if(use_v)
+              {
+                fastscape_set_u_(vz.get());
+                fastscape_set_v_(vx.get(), vy.get());
+              }
+
               fastscape_set_h_(h.get());
 
               // The visualization number depends on the FastScape step, and since this goes back
@@ -948,6 +953,13 @@ namespace aspect
           prm.declare_entry("Sediment rain", "0",
                             Patterns::Double(),
                             "Sediment rain in m/yr. This will be added to as flat height increase to FastScape at every node.");
+          prm.declare_entry ("Use velocities", "true",
+                             Patterns::Bool (),
+                             "Flag to use FastScape advection and uplift.");
+          prm.declare_entry("Precision", "0.001",
+                            Patterns::Double(),
+                            "How close an ASPECT node needs to be to a FastScape node.");
+
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -1074,6 +1086,9 @@ namespace aspect
           y_extent_2d = prm.get_double("Y extent in 2d");
           use_ghost = prm.get_bool("Use ghost nodes");
           sediment_rain = prm.get_double("Sediment rain");
+          use_v = prm.get_bool("Use velocities");
+          precision = prm.get_double("Precision");
+
 
           prm.enter_subsection("Boundary conditions");
           {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -345,7 +345,8 @@ namespace aspect
                   if (use_marine)
                     fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
 
-                  folder_output_(&length, &restart_step, c);
+                  if (use_strat)
+                    folder_output_(&length, &restart_step, c);
 
                 }
               else
@@ -862,7 +863,7 @@ namespace aspect
 
           prm.enter_subsection ("Erosional parameters");
           {
-            prm.declare_entry("Drainage area exponent (m)", "0.4",
+            prm.declare_entry("Drainage area exponent", "0.4",
                               Patterns::Double(),
                               "Exponent for drainage area.");
             prm.declare_entry("Slope exponent", "1",

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -335,6 +335,9 @@ namespace aspect
 
                   if (use_marine)
                     fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
+
+                  folder_output_(&length, &restart_step, c);
+
                 }
               else
                 {
@@ -502,11 +505,19 @@ namespace aspect
               int visualization_step = istep+restart_step;
               steps = istep+steps;
 
+              int nstepp = 200000;
+              int nreflectorp = 4;
+              int nfreqp = 1;
+
               //I really need to figure out a better way to make visualization files output correctly.
               this->get_pcout() <<"   Calling FastScape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
               {
                 auto t_start = std::chrono::high_resolution_clock::now();
-                fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
+
+                if(use_strat && current_timestep == 1)
+                	fastscape_strati_(&nstepp, &nreflectorp, &steps, &vexp);
+				else if(!use_strat)
+                    fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
                 do
                   {
@@ -722,6 +733,9 @@ namespace aspect
           prm.declare_entry ("Use marine parameters", "false",
                              Patterns::Bool (),
                              "Flag to use marine parameters");
+          prm.declare_entry ("Use stratigraphy", "false",
+                             Patterns::Bool (),
+                             "Flag to use marine parameters");
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -787,35 +801,35 @@ namespace aspect
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Sand porosity", "0.1",
+            prm.declare_entry("Sand porosity", "0.0",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Shale porosity", "0.05",
+            prm.declare_entry("Shale porosity", "0.0",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Sand e-folding depth", "1e4",
+            prm.declare_entry("Sand e-folding depth", "1e3",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Shale e-folding depth", "1e4",
+            prm.declare_entry("Shale e-folding depth", "1e3",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Sand-shale ratio", "0.75",
+            prm.declare_entry("Sand-shale ratio", "0.5",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Depth averaging thickness", "250",
+            prm.declare_entry("Depth averaging thickness", "1e2",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Sand transport coefficient", "1e-3",
+            prm.declare_entry("Sand transport coefficient", "5e2",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
-            prm.declare_entry("Shale transport coefficient", "1e-3",
+            prm.declare_entry("Shale transport coefficient", "2.5e2",
                               Patterns::Double(),
                               "Theta parameter described in \\cite{KMM2010}. "
                               "An unstabilized free surface can overshoot its ");
@@ -857,6 +871,7 @@ namespace aspect
           surface_resolution = prm.get_integer("Surface resolution");
           resolution_difference = prm.get_integer("Resolution difference");
           use_marine = prm.get_bool("Use marine parameters");
+          use_strat = prm.get_bool("Use stratigraphy");
 
           prm.enter_subsection("Boundary conditions");
           {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -52,7 +52,7 @@ namespace aspect
       int y_repetitions = repetitions.second;
 
       //Set nx and dx, as these will be the same regardless of dimension.
-      nx = 3+std::pow(2,initial_global_refinement+additional_refinement)*x_repetitions;
+      nx = 3+std::pow(2,surface_res+additional_refinement)*x_repetitions;
       dx = grid_extent[0].second/(nx-3);
       x_extent = geometry->get_extents()[0]+2*dx;
 
@@ -76,7 +76,7 @@ namespace aspect
 
       if (dim == 3)
         {
-          ny = 3+std::pow(2,initial_global_refinement+additional_refinement)*y_repetitions;
+          ny = 3+std::pow(2,surface_res+additional_refinement)*y_repetitions;
           dy = grid_extent[1].second/(ny-3);
           table_intervals[1] = ny-3;
           y_extent = geometry->get_extents()[1]+2*dy;
@@ -286,13 +286,13 @@ namespace aspect
               if (current_timestep == 1 || restart)
                 {
 
-                  this->get_pcout() <<"   Initializing Fastscape... "<< (1+initial_global_refinement+additional_refinement)  <<
+                  this->get_pcout() <<"   Initializing FastScape... "<< (1+surface_res+additional_refinement)  <<
                                     " levels, cell size: "<<dx<<" m."<<std::endl;
 
                   //If we are restarting from a checkpoint, load h values for fastscape so we don't lose resolution.
                   if (restart)
                     {
-                      this->get_pcout() <<"      Loading Fastscape restart file... "<<std::endl;
+                      this->get_pcout() <<"      Loading FastScape restart file... "<<std::endl;
                       restart = false;
 
                       //Load in h values.
@@ -311,7 +311,7 @@ namespace aspect
                           in.close();
                         }
                       else if (!in)
-                        AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
+                        AssertThrow(false,ExcMessage("Cannot open file to restart FastScape."));
 
                       /*
                        * Now load the fastscape istep at time of restart.
@@ -483,7 +483,7 @@ namespace aspect
               fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
               //I really need to figure out a better way to make visualization files output correctly.
-              this->get_pcout() <<"   Calling Fastscape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
+              this->get_pcout() <<"   Calling FastScape... "<<(steps-istep)<<" timesteps of "<<f_dt<<" years."<<std::endl;
               do
                 {
                   //Write fastscape visualization
@@ -504,7 +504,7 @@ namespace aspect
               //If we've reached the end time, destroy fastscape.
               if (this->get_time()+a_dt >= end_time)
                 {
-                  this->get_pcout()<<"   Destroying Fastscape..."<<std::endl;
+                  this->get_pcout()<<"   Destroying FastScape..."<<std::endl;
                   fastscape_destroy_();
                 }
 
@@ -682,6 +682,9 @@ namespace aspect
           prm.declare_entry("Fastscape seed", "1000",
                             Patterns::Integer(),
                             "Seed used for adding an initial 0-1 m noise to fastscape topography.");
+          prm.declare_entry("Surface resolution", "1",
+                            Patterns::Integer(),
+                            "This should be set to the expect ASPECT resolution level you expect at the surface.");
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -773,6 +776,7 @@ namespace aspect
           additional_refinement = prm.get_integer("Additional fastscape refinement");
           slice = prm.get_bool("Use center slice for 2d");
           fs_seed = prm.get_integer("Fastscape seed");
+          surface_res = prm.get_integer("Surface resolution");
 
           prm.enter_subsection("Boundary conditions");
           {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -334,31 +334,50 @@ namespace aspect
           	  {
           		 double index_left = numx*j+1;
           		 double index_right = numx*(j+1);
+          		 double side = index_left;
+          	 	 int jj = 0;
+          	 	 int avg = 3;
+          	 	 double avg_above = true;
+          	 	 double avg_below = true;
 
-          		 if(vx[index_right-2] > 0 && vx[index_left] > 0)
-          		 {
-                   vz[index_right-1] = (h[index_right-2] - h[index_right-1])/a_dt;
-                   vz[index_left-1] = (h[index_right-2] - h[index_right-1])/a_dt;
+          	 	 /*
+          	 	  * This is a simple way to switch the sides so I don't have to rewrite the end result twice.
+          	 	  * Also, it makes it so if both sides are going against each other, we just ignore periodic boundaries.
+          	 	  */
+          	 	 if(vx[index_right-2] > 0 && vx[index_left] >= 0)
+          	 	 {
+          	 		 side = index_right;
+          	 	     jj = 2;
+          	 	 }
+          	 	 else if((vx[index_right-2] < 0 && vx[index_left] > 0) || (vx[index_right-2] > 0 && vx[index_left] < 0))
+          	 		 continue;
 
-                   vy[index_right-1] = vy[index_right-2];
-                   vy[index_left-1] =  vy[index_right-2];
+          	 	 /*
+          	 	  * This checks whether we have surrounding nodes to average the value.
+          	 	  * If we are at a corner, then we only average 2 values instead of 3.
+          	 	  */
+          	 	 if(side-jj+numx > array_size || side-1+numx > array_size)
+          	 	 {
+          	 		 avg = avg-1;
+          	 	     avg_above = false;
+          	 	 }
+          	 	 else if(side-jj+numx < 0)
+          	 	 {
+          	 		 avg = avg-1;
+          	 		 avg_below = false;
+          	 	 }
 
-                   vx[index_right-1] = vx[index_right-2];
-                   vx[index_left-1] =  vx[index_right-2];
-          		 }
-          		 else if(vx[index_right-2] < 0 && vx[index_left] < 0)
-          		 {
-                   vz[index_right-1] = (h[index_left] - h[index_left-1])/a_dt;
-                   vz[index_left-1] = (h[index_left] - h[index_left-1])/a_dt;
+                   vz[index_right-1] = (h[side-jj] - h[side-1])/a_dt;
+                   vz[index_left-1] = (h[side-jj] - h[side-1])/a_dt;
 
-                   vy[index_right-1] = vy[index_left];
-                   vy[index_left-1] =  vy[index_left];
+                   vy[index_right-1] = vy[side-jj];
+                   vy[index_left-1] =  vy[side-jj];
 
-                   vx[index_right-1] = vx[index_left];
-                   vx[index_left-1] =  vx[index_left];
+                   vx[index_right-1] = vx[side-jj];
+                   vx[index_left-1] =  vx[side-jj];
           		 }
           	  }
-              }
+
 
               if(top == 1 && bottom == 1)
               {
@@ -366,19 +385,30 @@ namespace aspect
         	  {
         		 double index_bot = j+1;
         		 double index_top = numx*(numy-1)+j+1;
+          		 double side = index_bot;
+          		 int jj = numx;
 
-          		 if(vy[index_bot+numx-1] < 0 && vy[index_top-numx-1] < 0)
-          		 {
-                   vz[index_bot-1] = (h[index_bot+numx-1] - h[index_bot-1])/a_dt;
-                   vz[index_top-1] = (h[index_bot+numx-1] - h[index_bot-1])/a_dt;
+          	 	 if(vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] >= 0)
+          	 	 {
+          	 		 side = index_top;
+          	 		 jj = -numx;
+          	 	 }
+          	 	 else if((vy[index_bot+numx-1] < 0 && vy[index_top-numx-1] > 0) || (vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] < 0))
+          	 		 continue;
 
-                   vy[index_bot-1] = vy[index_bot+numx-1];
-                   vy[index_top-1] =  vy[index_bot+numx-1];
+          		// if(vy[index_bot+numx-1] < 0 && vy[index_top-numx-1] < 0)
+          		// {
+          	 	 //std::cout<<jj<<std::endl;
+                   vz[index_bot-1] = (h[side+jj-1] - h[side-1])/a_dt;     //index_bot+numx index_top-numx
+                   vz[index_top-1] = (h[side+jj-1] - h[side-1])/a_dt;
 
-                   vx[index_bot-1] = vx[index_bot+numx-1];
-                   vx[index_top-1] =  vx[index_bot+numx-1];
-          		 }
-          		 else if(vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] > 0)
+                   vy[index_bot-1] = vy[side+jj-1];
+                   vy[index_top-1] =  vy[side+jj-1];
+
+                   vx[index_bot-1] = vx[side+jj-1];
+                   vx[index_top-1] =  vx[side+jj-1];
+          	//	 }
+          		/* else if(vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] > 0)
           		 {
                    vz[index_bot-1] = (h[index_top-numx-1] - h[index_top-1])/a_dt;
                    vz[index_top-1] = (h[index_top-numx-1] - h[index_top-1])/a_dt;
@@ -388,7 +418,7 @@ namespace aspect
 
                    vx[index_bot-1] = vx[index_top-numx-1];
                    vx[index_top-1] =  vx[index_top-numx-1];
-          		 }
+          		 }*/
         	  }
               }
 
@@ -421,12 +451,12 @@ namespace aspect
               fastscape_get_step_(&istep);
               steps = istep+steps;
 
-              fastscape_named_vtk_(h.get(), &vexp, &istep, c, &length);
+              //fastscape_named_vtk_(h.get(), &vexp, &istep, c, &length);
 
               do
                 {
             	  //Write fastscape visualization
-                  //fastscape_named_vtk_(h.get(), &vexp, &istep, c, &length);
+                  fastscape_named_vtk_(h.get(), &vexp, &istep, c, &length);
 
                   //execute step, this increases timestep counter
                   fastscape_execute_step_();

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -347,8 +347,8 @@ namespace aspect
                   if (use_marine)
                     fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
 
-                  if (use_strat)
-                    folder_output_(&length, &restart_step, c);
+                  //if (use_strat)
+                  //  folder_output_(&length, &restart_step, c);
 
                 }
               else

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -550,7 +550,7 @@ namespace aspect
               TimerOutput::Scope timer_section(this->get_computing_timer(), "Fastscape 1 proc");
 
               for (unsigned int i=0; i<temporary_variables.size(); i++)
-                MPI_Send(&temporary_variables[i][0], temporary_variables[1].size(), MPI_DOUBLE, 0, 42, this->get_mpi_communicator());
+                MPI_Ssend(&temporary_variables[i][0], temporary_variables[1].size(), MPI_DOUBLE, 0, 42, this->get_mpi_communicator());
 
 
               MPI_Bcast(&V[0], array_size+1, MPI_DOUBLE, 0, this->get_mpi_communicator());

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -56,9 +56,6 @@ namespace aspect
       dx = grid_extent[0].second/(nx-3);
       x_extent = geometry->get_extents()[0]+2*dx;
 
-      //Find the number of grid points in x direction for indexing.
-      //TODO: numx and nx are always the same, why did I make two variables?
-      numx = 1+x_extent/dx;
 
       //sub intervals are 1 less than points.
       table_intervals[0] = nx-3;
@@ -67,11 +64,9 @@ namespace aspect
 
       if (dim == 2)
         {
-          //ny = nx*3-1; //*2-1dy_slices;
           dy = dx;
           y_extent = grid_extent[0].second*3+2*dy; //(ny-1)*dy;
-          numy = 1+y_extent/dy;
-          ny = numy;
+          ny = 1+y_extent/dy;
         }
 
       if (dim == 3)
@@ -80,7 +75,6 @@ namespace aspect
           dy = grid_extent[1].second/(ny-3);
           table_intervals[1] = ny-3;
           y_extent = geometry->get_extents()[1]+2*dy;
-          numy = 1+y_extent/dy;
         }
 
       //Determine array size to send to fastscape
@@ -153,7 +147,7 @@ namespace aspect
                           {
                             for (int ys=0; ys<ny; ys++)
                               {
-                                double index = indx+numx*ys;
+                                double index = indx+nx*ys;
                                 if (current_timestep == 1)
                                   {
                                     //double h_seed = (std::rand()%2000)/100;
@@ -169,7 +163,7 @@ namespace aspect
                         if (dim == 3)
                           {
                             double indy = 2+vertex(1)/dy;
-                            double index = (indy-1)*numx+indx;
+                            double index = (indy-1)*nx+indx;
 
                             if (current_timestep == 1)
                               {
@@ -184,10 +178,10 @@ namespace aspect
 
           //Set ghost nodes for left and right boundaries
 
-          for (int j=0; j<numy; j++)
+          for (int j=0; j<ny; j++)
             {
-              double index_left = numx*j+1;
-              double index_right = numx*(j+1);
+              double index_left = nx*j+1;
+              double index_right = nx*(j+1);
 
               for (unsigned int i=0; i<dim+1; ++i)
                 {
@@ -199,15 +193,15 @@ namespace aspect
           //Set ghost node for top and bottom boundaries
           if (dim == 3)
             {
-              for (int j=0; j<numx; j++)
+              for (int j=0; j<nx; j++)
                 {
                   double index_bot = j+1;
-                  double index_top = numx*(numy-1)+j+1;
+                  double index_top = nx*(ny-1)+j+1;
 
                   for (unsigned int i=0; i<dim+1; ++i)
                     {
-                      temporary_variables[i][index_bot-1] = temporary_variables[i][index_bot+numx-1];
-                      temporary_variables[i][index_top-1] = temporary_variables[i][index_top-numx-1];
+                      temporary_variables[i][index_bot-1] = temporary_variables[i][index_bot+nx-1];
+                      temporary_variables[i][index_top-1] = temporary_variables[i][index_top-nx-1];
                     }
                 }
             }
@@ -389,10 +383,10 @@ namespace aspect
               //the value on opposite side.
               if (left == 0 && right == 0)
                 {
-                  for (int j=0; j<numy; j++)
+                  for (int j=0; j<ny; j++)
                     {
-                      double index_left = numx*j+1;
-                      double index_right = numx*(j+1);
+                      double index_left = nx*j+1;
+                      double index_right = nx*(j+1);
                       double side = index_left;
                       int jj = 0;
 
@@ -427,22 +421,22 @@ namespace aspect
 
               if (top == 0 && bottom == 0)
                 {
-                  for (int j=0; j<numx; j++)
+                  for (int j=0; j<nx; j++)
                     {
                       double index_bot = j+1;
-                      double index_top = numx*(numy-1)+j+1;
+                      double index_top = nx*(ny-1)+j+1;
                       double side = index_bot;
-                      int jj = numx;
+                      int jj = nx;
 
-                      if (vy[index_bot+numx-1] > 0 && vy[index_top-numx-1] >= 0)
+                      if (vy[index_bot+nx-1] > 0 && vy[index_top-nx-1] >= 0)
                         {
                           side = index_top;
-                          jj = -numx;
+                          jj = -nx;
                         }
-                      else if (vy[index_bot+numx-1] <= 0 && vy[index_top-numx-1] < 0)
+                      else if (vy[index_bot+nx-1] <= 0 && vy[index_top-nx-1] < 0)
                         {
                           side = index_bot;
-                          jj = numx;
+                          jj = nx;
                         }
                       else
                         continue;
@@ -541,21 +535,21 @@ namespace aspect
           int edge = (nx+1)/2;
           if (dim == 2)
             {
-              std::vector<double> V2(numx);
+              std::vector<double> V2(nx);
 
-              for (int i=1; i<(numx-1); i++)
+              for (int i=1; i<(nx-1); i++)
                 {
                   //Multiply edge by bottom and top, so it only takes them off if they're fixed.
                   if (slice)
                     {
-                      int index = i+numx*((ny-1)/2);
+                      int index = i+nx*((ny-1)/2);
                       V2[i-1] = V[index];
                     }
                   else
                     {
                       for (int ys=edge; ys<(ny-edge); ys++)
                         {
-                          int index = i+numx*ys;
+                          int index = i+nx*ys;
                           V2[i-1] += V[index];
                         }
                       V2[i-1] = V2[i-1]/(ny-edge*2);

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -204,6 +204,7 @@ namespace aspect
               std::unique_ptr<double[]> vz (new double[array_size]);
               std::unique_ptr<double[]> kf (new double[array_size]);
               std::unique_ptr<double[]> kd (new double[array_size]);
+              std::unique_ptr<double[]> slopep (new double[array_size]);
               int istep = 0;
               int steps = nstep;
               std::srand(fs_seed);
@@ -224,6 +225,7 @@ namespace aspect
                   vx[i] = 0;
                   vz[i] = 0;
                   vy[i] = 0;
+                  slopep[i] = 0;
 
                   kf[i] = kff;
                   kd[i] = kdd;
@@ -394,7 +396,6 @@ namespace aspect
                * Copy the slopes at each point, this will be used to set an H
                * at the ghost nodes if a boundary mass flux is given.
                */
-              std::unique_ptr<double[]> slopep (new double[array_size]);
               fastscape_copy_slope_(slopep.get());
 
               //Now we set the ghost nodes at the left and right boundaries.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -55,8 +55,9 @@ namespace aspect
           const std::vector<std::string> names = mesh_deformation_boundary_indicators_map[*p];
           for (unsigned int i = 0; i < names.size(); ++i )
             {
-              AssertThrow((names[i] == "fastscape") && (*p == relevant_boundary),
-                          ExcMessage("Fastscape can only be called on the surface boundary."));
+                if(names[i] == "fastscape")
+                  AssertThrow((*p == relevant_boundary),
+                            ExcMessage("Fastscape can only be called on the surface boundary."));
             }
         }
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -109,7 +109,6 @@ namespace aspect
       Utilities::create_directory (this->get_output_directory() + "VTK/",
                                    this->get_mpi_communicator(),
                                    false);
-
       last_output_time = 0;
     }
 
@@ -260,7 +259,9 @@ namespace aspect
               bool make_vtk = 0;
               if (this->get_time() >= last_output_time + output_interval)
               {
-		make_vtk = 1;
+                // Don't create a visualization file on a restart.
+                if(!restart)
+		  make_vtk = 1;
 
                 if (output_interval > 0)
                {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -782,7 +782,7 @@ namespace aspect
               }
 
               visualization_step = current_timestep;
-              if (make_vtk && current_timestep > 1)
+              if (make_vtk)
                  fastscape_named_vtk_(h.get(), &vexp, &visualization_step, c, &length);
 
               // If we've reached the end time, destroy fastscape.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -17,31 +17,7 @@
 
 #include <aspect/mesh_deformation/fastscape.h>
 #include <aspect/geometry_model/box.h>
-#include <deal.II/grid/grid_generator.h>
-#include <aspect/utilities.h>
-#include <deal.II/base/table.h>
-#include <deal.II/base/table_indices.h>
-
 #include <deal.II/numerics/vector_tools.h>
-
-
-#include <aspect/simulator.h>
-#include <aspect/adiabatic_conditions/interface.h>
-#include <aspect/initial_temperature/interface.h>
-#include <aspect/initial_composition/interface.h>
-#include <aspect/postprocess/particles.h>
-
-#include <deal.II/base/quadrature_lib.h>
-#include <deal.II/base/function.h>
-
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/grid/tria_iterator.h>
-#include <deal.II/dofs/dof_accessor.h>
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/numerics/vector_tools.h>
-
-#include <fstream>
-#include <iostream>
 
 namespace aspect
 {
@@ -464,10 +440,10 @@ namespace aspect
                           jj = -numx;
                         }
                       else if (vy[index_bot+numx-1] <= 0 && vy[index_top-numx-1] < 0)
-                      {
+                        {
                           side = index_bot;
                           jj = numx;
-                      }
+                        }
                       else
                         continue;
 
@@ -641,8 +617,6 @@ namespace aspect
                 }
             }
 
-
-
           Functions::InterpolatedUniformGridData<dim> *velocities;
           velocities = new Functions::InterpolatedUniformGridData<dim> (grid_extent,
                                                                         table_intervals,
@@ -665,6 +639,7 @@ namespace aspect
 
         }
     }
+
 
     template <int dim>
     void FastScape<dim>::declare_parameters(ParameterHandler &prm)
@@ -781,6 +756,7 @@ namespace aspect
       prm.leave_subsection ();
     }
 
+
     template <int dim>
     void FastScape<dim>::parse_parameters(ParameterHandler &prm)
     {
@@ -847,14 +823,12 @@ namespace aspect
   {
     ASPECT_REGISTER_MESH_DEFORMATION_MODEL(FastScape,
                                            "fastscape",
-                                           "A plugin, which prescribes the surface mesh to "
-                                           "deform according to an analytically prescribed "
-                                           "function. Note that the function prescribes a "
-                                           "deformation velocity, i.e. the return value of "
-                                           "this plugin is later multiplied by the time step length "
-                                           "to compute the displacement increment in this time step. "
-                                           "The format of the "
-                                           "functions follows the syntax understood by the "
-                                           "muparser library, see Section~\\ref{sec:muparser-format}.")
+                                           "A plugin which uses the program FastScape to add surface processes "
+                                           "such as diffusion, sedimentation, and the Stream Power Law to ASPECT. "
+                                           "FastScape is initialized with ASPECT height and velocities, and then "
+                                           "continues to run in the background, updating with new ASPECT velocities "
+                                           "when called. Once FastScape has run for the given amount of timesteps, it "
+                                           "compares the initial and final heights to send a velocity back to the mesh "
+                                           "deformation plugin.")
   }
 }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -332,6 +332,9 @@ namespace aspect
 
                   //Set erosional parameters. May have to move this if sed values are updated over time.
                   fastscape_set_erosional_parameters_(kf.get(), &kfsed, &m, &n, kd.get(), &kdsed, &g, &g, &p);
+
+                  if (use_marine)
+                    fastscape_set_marine_parameters_(&sl, &p1, &p2, &z1, &z2, &r, &l, &kds1, &kds2);
                 }
               else
                 {
@@ -716,6 +719,9 @@ namespace aspect
           prm.declare_entry("Resolution difference", "0",
                             Patterns::Integer(),
                             "This should be set to the expect ASPECT resolution level you expect at the surface.");
+          prm.declare_entry ("Use marine parameters", "false",
+                             Patterns::Bool (),
+                             "Flag to use marine parameters");
 
           prm.enter_subsection ("Boundary conditions");
           {
@@ -774,6 +780,47 @@ namespace aspect
                               "An unstabilized free surface can overshoot its ");
           }
           prm.leave_subsection();
+
+          prm.enter_subsection ("Marine parameters");
+          {
+            prm.declare_entry("Sea level", "0",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Sand porosity", "0.1",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Shale porosity", "0.05",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Sand e-folding depth", "1e4",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Shale e-folding depth", "1e4",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Sand-shale ratio", "0.75",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Depth averaging thickness", "250",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Sand transport coefficient", "1e-3",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+            prm.declare_entry("Shale transport coefficient", "1e-3",
+                              Patterns::Double(),
+                              "Theta parameter described in \\cite{KMM2010}. "
+                              "An unstabilized free surface can overshoot its ");
+          }
+          prm.leave_subsection();
         }
         prm.leave_subsection();
       }
@@ -809,6 +856,7 @@ namespace aspect
           fs_seed = prm.get_integer("Fastscape seed");
           surface_resolution = prm.get_integer("Surface resolution");
           resolution_difference = prm.get_integer("Resolution difference");
+          use_marine = prm.get_bool("Use marine parameters");
 
           prm.enter_subsection("Boundary conditions");
           {
@@ -832,6 +880,20 @@ namespace aspect
             g = prm.get_double("Bedrock deposition coefficient");
             gsed = prm.get_double("Sediment deposition coefficient");
             p = prm.get_double("Multi-direction slope exponent");
+          }
+          prm.leave_subsection();
+
+          prm.enter_subsection("Marine parameters");
+          {
+            sl = prm.get_double("Sea level");
+            p1 = prm.get_double("Sand porosity");
+            p2 = prm.get_double("Shale porosity");
+            z1 = prm.get_double("Sand e-folding depth");
+            z2 = prm.get_double("Shale e-folding depth");
+            r = prm.get_double("Sand-shale ratio");
+            l = prm.get_double("Depth averaging thickness");
+            kds1 = prm.get_double("Sand transport coefficient");
+            kds2 = prm.get_double("Shale transport coefficient");
           }
           prm.leave_subsection();
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -444,7 +444,7 @@ namespace aspect
                   if (current_timestep == 1)
                     {
                       // + or - 5 meters of topography.
-                      const double h_seed = (std::rand()%100)/10 - 5;
+                      const double h_seed = (std::rand()%( 2*noise_h+1 )) - noise_h;
                       h[i] = h[i] + h_seed;
                     }
               
@@ -1117,6 +1117,9 @@ namespace aspect
           prm.declare_entry ("Sediment rain intervals", "0",
                              Patterns::List (Patterns::Double(0)),
                              "A list of sediment rain times.");
+          prm.declare_entry("Initial noise magnitude", "5",
+                            Patterns::Integer(),
+                            "Maximum topography change in meters from the initial noise.");
 
 
           prm.enter_subsection ("Boundary conditions");
@@ -1263,6 +1266,7 @@ namespace aspect
           use_ghost = prm.get_bool("Use ghost nodes");
           use_v = prm.get_bool("Use velocities");
           precision = prm.get_double("Precision");
+          noise_h = prm.get_integer("Initial noise magnitude");
           sr_values = Utilities::string_to_double
                              (Utilities::split_string_list(prm.get ("Sediment rain")));
           sr_times = Utilities::string_to_double

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -65,6 +65,31 @@ namespace aspect
       // Initialize parameters for restarting fastscape
       restart = this->get_parameters().resume_computation;
       restart_step = 0;
+      
+      // Since we don't open these until we're on one processor, we need to check if the 
+      // restart files exist before hand.
+      // TODO: This was quickly done and can likely be shortened/improved.
+      if(restart)
+      {
+        // Create variables for output directory and restart file
+        std::string dirname = this->get_output_directory();
+        
+        std::ifstream in;
+        in.open(dirname + "fastscape_h_restart.txt");
+        if (in.fail())
+            AssertThrow(false,ExcMessage("Cannot open topography file to restart FastScape."));
+        in.close();
+        
+        in.open(dirname + "fastscape_b_restart.txt");
+        if (in.fail())
+            AssertThrow(false,ExcMessage("Cannot open basement file to restart FastScape."));
+        in.close();
+        
+        in.open(dirname + "fastscape_steps_restart.txt");
+        if (in.fail())
+            AssertThrow(false,ExcMessage("Cannot open steps file to restart FastScape."));
+        in.close();
+      }
 
       // second is for maximum coordinates, first for minimum.
       for (unsigned int i=0; i<dim; ++i)
@@ -353,8 +378,6 @@ namespace aspect
 
                           in.close();
                         }
-                      else if (!in)
-                        AssertThrow(false,ExcMessage("Cannot open file to restart FastScape."));
 
                       // Load in b values.
                       std::ifstream in_b;
@@ -371,8 +394,6 @@ namespace aspect
 
                           in_b.close();
                         }
-                      else if (!in_b)
-                        AssertThrow(false,ExcMessage("Cannot open basement file to restart FastScape."));
 
                       /*
                        * Now load the fastscape istep at time of restart.
@@ -386,8 +407,6 @@ namespace aspect
                           in_step >> restart_step;
                           in_step.close();
                         }
-                      else if (!in_step)
-                        AssertThrow(false,ExcMessage("Cannot open file to restart fastscape."));
 
                       restart = false;
                     }

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -122,6 +122,8 @@ namespace aspect
                                                        free_surface_theta *
                                                        g_norm;
 
+                  std::cout<<"Pressure perturb: "<<pressure_perturbation<<std::endl;
+
                   // see Kaus et al 2010 for details of the stabilization term
                   for (unsigned int i=0; i< stokes_dofs_per_cell; ++i)
                     for (unsigned int j=0; j< stokes_dofs_per_cell; ++j)

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -260,17 +260,6 @@ namespace aspect
       {
         prm.enter_subsection ("Free surface");
         {
-          prm.declare_entry("Free surface stabilization theta", "0.5",
-                            Patterns::Double(0., 1.),
-                            "Theta parameter described in \\cite{KMM2010}. "
-                            "An unstabilized free surface can overshoot its "
-                            "equilibrium position quite easily and generate "
-                            "unphysical results.  One solution is to use a "
-                            "quasi-implicit correction term to the forces near the "
-                            "free surface.  This parameter describes how much "
-                            "the free surface is stabilized with this term, "
-                            "where zero is no stabilization, and one is fully "
-                            "implicit.");
           prm.declare_entry("Surface velocity projection", "normal",
                             Patterns::Selection("normal|vertical"),
                             "After each time step the free surface must be "
@@ -299,7 +288,6 @@ namespace aspect
       {
         prm.enter_subsection ("Free surface");
         {
-          free_surface_theta = prm.get_double("Free surface stabilization theta");
           std::string advection_dir = prm.get("Surface velocity projection");
 
           if ( advection_dir == "normal")

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -357,7 +357,7 @@ namespace Assemblers
                            "\n\n"
                            "The format is id1: object1 \\& object2, id2: object3 \\& object2, where "
                            "objects are one of " + std::get<dim>(registered_plugins).get_description_string());
-          prm.declare_entry("surface stabilization theta", "0.5",
+          prm.declare_entry("Surface stabilization theta", "0.5",
                             Patterns::Double(0., 1.),
                             "Theta parameter described in \\cite{KMM2010}. "
                             "An unstabilized free surface can overshoot its "
@@ -380,7 +380,7 @@ namespace Assemblers
     {
       prm.enter_subsection ("Mesh deformation");
       {
-        surface_theta = prm.get_double("surface stabilization theta");
+        surface_theta = prm.get_double("Surface stabilization theta");
 
         // Create the map of prescribed mesh movement boundary indicators
         // Each boundary indicator can carry a number of mesh deformation plugin names.

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -38,10 +38,128 @@
 
 #include <deal.II/numerics/vector_tools.h>
 
+#include <aspect/simulator_signals.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/geometry_model/interface.h>
+#include <aspect/simulator/assemblers/interface.h>
+#include <aspect/melt.h>
+
+#ifdef ASPECT_USE_PETSC
+#  include <deal.II/lac/sparsity_tools.h>
+#endif
+
 
 
 namespace aspect
 {
+
+namespace Assemblers
+  {
+    template <int dim>
+    ApplyStabilization<dim>::ApplyStabilization(const double stabilization_theta)
+      :
+      surface_theta(stabilization_theta)
+    {}
+
+    template <int dim>
+    void
+    ApplyStabilization<dim>::
+    execute (internal::Assembly::Scratch::ScratchBase<dim>       &scratch_base,
+             internal::Assembly::CopyData::CopyDataBase<dim>      &data_base) const
+    {
+      internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>& > (scratch_base);
+      internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>& > (data_base);
+
+      AssertThrow(!this->get_mesh_deformation_handler().get_active_mesh_deformation_boundary_indicators().empty(),
+                  ExcMessage("Applying free surface stabilization, even though no mesh deformation is active. "));
+
+      if (this->get_parameters().include_melt_transport)
+        {
+          this->get_melt_handler().apply_free_surface_stabilization_with_melt (surface_theta,
+                                                                               scratch.cell,
+                                                                               scratch,
+                                                                               data);
+          return;
+        }
+
+      const Introspection<dim> &introspection = this->introspection();
+      const FiniteElement<dim> &fe = this->get_fe();
+
+      const typename DoFHandler<dim>::active_cell_iterator cell (&this->get_triangulation(),
+                                                                 scratch.finite_element_values.get_cell()->level(),
+                                                                 scratch.finite_element_values.get_cell()->index(),
+                                                                 &this->get_dof_handler());
+
+      const unsigned int n_face_q_points = scratch.face_finite_element_values.n_quadrature_points;
+      const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
+
+      // Get the boundary indicators of those boundaries with a free surface
+      const std::set<types::boundary_id> tmp_free_surface_boundary_indicators = this->get_mesh_deformation_handler().get_active_mesh_deformation_boundary_indicators();
+
+
+      // only apply on free surface faces
+      if (cell->at_boundary() && cell->is_locally_owned())
+        for (unsigned int face_no=0; face_no<GeometryInfo<dim>::faces_per_cell; ++face_no)
+          if (cell->face(face_no)->at_boundary())
+            {
+              const types::boundary_id boundary_indicator
+                = cell->face(face_no)->boundary_id();
+
+              if (tmp_free_surface_boundary_indicators.find(boundary_indicator)
+                  == tmp_free_surface_boundary_indicators.end())
+                continue;
+
+              scratch.face_finite_element_values.reinit(cell, face_no);
+
+              this->compute_material_model_input_values (this->get_solution(),
+                                                         scratch.face_finite_element_values,
+                                                         cell,
+                                                         false,
+                                                         scratch.face_material_model_inputs);
+
+              this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
+
+              for (unsigned int q_point = 0; q_point < n_face_q_points; ++q_point)
+                {
+                  for (unsigned int i = 0, i_stokes = 0; i_stokes < stokes_dofs_per_cell; /*increment at end of loop*/)
+                    {
+                      if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                        {
+                          scratch.phi_u[i_stokes] = scratch.face_finite_element_values[introspection.extractors.velocities].value(i, q_point);
+                          ++i_stokes;
+                        }
+                      ++i;
+                    }
+
+                  const Tensor<1,dim>
+                  gravity = this->get_gravity_model().gravity_vector(scratch.face_finite_element_values.quadrature_point(q_point));
+                  const double g_norm = gravity.norm();
+
+                  // construct the relevant vectors
+                  const Tensor<1,dim> n_hat = scratch.face_finite_element_values.normal_vector(q_point);
+                  const Tensor<1,dim> g_hat = (g_norm == 0.0 ? Tensor<1,dim>() : gravity/g_norm);
+
+                  const double pressure_perturbation = scratch.face_material_model_outputs.densities[q_point] *
+                                                       this->get_timestep() *
+                                                       surface_theta *
+                                                       g_norm;
+
+                  // see Kaus et al 2010 for details of the stabilization term
+                  for (unsigned int i=0; i< stokes_dofs_per_cell; ++i)
+                    for (unsigned int j=0; j< stokes_dofs_per_cell; ++j)
+                      {
+                        // The fictive stabilization stress is (phi_u[i].g)*(phi_u[j].n)
+                        const double stress_value = -pressure_perturbation*
+                                                    (scratch.phi_u[i]*g_hat) * (scratch.phi_u[j]*n_hat)
+                                                    *scratch.face_finite_element_values.JxW(q_point);
+
+                        data.local_matrix(i,j) += stress_value;
+                      }
+                }
+            }
+    }
+  }
+
   namespace MeshDeformation
   {
     template <int dim>
@@ -136,6 +254,35 @@ namespace aspect
       // so we need to fetch it separately.
       if (!Plugins::plugin_type_matches<InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
         include_initial_topography = true;
+
+
+      this->get_signals().set_assemblers.connect(std::bind(&MeshDeformationHandler<dim>::set_assemblers,
+                                                           std::cref(*this),
+                                                           std::placeholders::_1,
+                                                           std::placeholders::_2));
+
+    }
+
+    template <int dim>
+    void MeshDeformationHandler<dim>::set_assemblers(const SimulatorAccess<dim> &,
+                                          aspect::Assemblers::Manager<dim> &assemblers) const
+    {
+      aspect::Assemblers::ApplyStabilization<dim> *surface_stabilization
+        = new aspect::Assemblers::ApplyStabilization<dim>(surface_theta);
+
+      assemblers.stokes_system.push_back(
+        std::unique_ptr<aspect::Assemblers::ApplyStabilization<dim> > (surface_stabilization));
+
+      // Note that we do not want face_material_model_data, because we do not
+      // connect to a face assembler. We instead connect to a normal assembler,
+      // and compute our own material_model_inputs in apply_stabilization
+      // (because we want to use the solution instead of the current_linearization_point
+      // to compute the material properties).
+      assemblers.stokes_system_assembler_on_boundary_face_properties.needed_update_flags |= (update_values  |
+          update_gradients |
+          update_quadrature_points |
+          update_normal_vectors |
+          update_JxW_values);
     }
 
 
@@ -210,6 +357,18 @@ namespace aspect
                            "\n\n"
                            "The format is id1: object1 \\& object2, id2: object3 \\& object2, where "
                            "objects are one of " + std::get<dim>(registered_plugins).get_description_string());
+          prm.declare_entry("surface stabilization theta", "0.5",
+                            Patterns::Double(0., 1.),
+                            "Theta parameter described in \\cite{KMM2010}. "
+                            "An unstabilized free surface can overshoot its "
+                            "equilibrium position quite easily and generate "
+                            "unphysical results.  One solution is to use a "
+                            "quasi-implicit correction term to the forces near the "
+                            "free surface.  This parameter describes how much "
+                            "the free surface is stabilized with this term, "
+                            "where zero is no stabilization, and one is fully "
+                            "implicit.");
+
       }
       prm.leave_subsection ();
 
@@ -221,6 +380,8 @@ namespace aspect
     {
       prm.enter_subsection ("Mesh deformation");
       {
+        surface_theta = prm.get_double("surface stabilization theta");
+
         // Create the map of prescribed mesh movement boundary indicators
         // Each boundary indicator can carry a number of mesh deformation plugin names.
         const std::vector<std::string> x_mesh_deformation_boundary_indicators

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -71,12 +71,12 @@ namespace aspect
 
       double domain_width = 100e3, kappa = 0.5;
       if (analytical_solution_example == 1)
-         kappa = 100;
+        kappa = 100;
       else if (analytical_solution_example == 2)
-      {
-         kappa = 100;
-         domain_width = 100e3;
-      }
+        {
+          kappa = 100;
+          domain_width = 100e3;
+        }
 
       // loop over all of the surface cells and save the elevation to stored_value
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
@@ -94,29 +94,29 @@ namespace aspect
                     const Point<dim> vertex = face_vals.quadrature_point(corner);
                     const double elevation = this->get_geometry_model().height_above_reference_surface(vertex);
                     if (write_to_file)
-                    {
-                      if (analytical_solution_example == 0)
-                      output_file << vertex << ' '<< elevation << std::endl;
-                      else if (analytical_solution_example == 1)
                       {
-                      // compute analytical solution and write out diff
-                      double sum = 0.;
-                      for (unsigned int n=1; n<=n_max; ++n)
-                         sum += std::cos(2.*n*numbers::PI*vertex[0]/domain_width)
-                               * std::exp(-kappa*2.*n*n*numbers::PI*numbers::PI*(time/year_in_seconds)/(domain_width*domain_width))
-                               /(4.*n*n-1.);
+                        if (analytical_solution_example == 0)
+                          output_file << vertex << ' '<< elevation << std::endl;
+                        else if (analytical_solution_example == 1)
+                          {
+                            // compute analytical solution and write out diff
+                            double sum = 0.;
+                            for (unsigned int n=1; n<=n_max; ++n)
+                              sum += std::cos(2.*n*numbers::PI*vertex[0]/domain_width)
+                                     * std::exp(-kappa*2.*n*n*numbers::PI*numbers::PI*(time/year_in_seconds)/(domain_width*domain_width))
+                                     /(4.*n*n-1.);
 
-                      const double topo = 100e3/numbers::PI - 200e3/numbers::PI*sum;
-                   
-                      output_file << vertex << ' '<< elevation << ' ' << topo << std::endl;
-                      }
-                      else if (analytical_solution_example == 2)
-                      {
-                       const double topo = 50e3 * std::sin(vertex[0]*numbers::PI/domain_width)
+                            const double topo = 100e3/numbers::PI - 200e3/numbers::PI*sum;
+
+                            output_file << vertex << ' '<< elevation << ' ' << topo << std::endl;
+                          }
+                        else if (analytical_solution_example == 2)
+                          {
+                            const double topo = 50e3 * std::sin(vertex[0]*numbers::PI/domain_width)
                                                 * std::exp(-kappa*numbers::PI*numbers::PI*(time/year_in_seconds)/(domain_width*domain_width));
-                       output_file << vertex << ' '<< elevation << ' ' << topo << std::endl;
+                            output_file << vertex << ' '<< elevation << ' ' << topo << std::endl;
+                          }
                       }
-                    }
                     if ( elevation > local_max_height)
                       local_max_height = elevation;
                     if ( elevation < local_min_height)

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -112,7 +112,7 @@ namespace aspect
                       }
                       else if (analytical_solution_example == 2)
                       {
-                       const double topo = 5e3 * std::sin(vertex[0]*numbers::PI/domain_width)
+                       const double topo = 50e3 * std::sin(vertex[0]*numbers::PI/domain_width)
                                                 * std::exp(-kappa*numbers::PI*numbers::PI*(time/year_in_seconds)/(domain_width*domain_width));
                        output_file << vertex << ' '<< elevation << ' ' << topo << std::endl;
                       }


### PR DESCRIPTION
Hi Derek, 
this is the aspect-fastscape branch I currently use. It includes the things I added like the extra erosional baselevel, the parameter to fix the topography for periodic models that you suggested, the masks for the sediment_age and depo_depth and changes Anne made to get stratigraphy working correctly


### Before your first pull request:

* [ ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
