### PR TITLE
Avoid ending a preprocessor macro with an empty line.

### DIFF
--- a/source/fe_variable_collection.cc
+++ b/source/fe_variable_collection.cc
@@ -253,7 +253,7 @@ namespace aspect
 #define INSTANTIATE(dim) \
   template struct VariableDeclaration<dim>; \
   template struct FEVariable<dim>; \
-  template class FEVariableCollection<dim>; \
+  template class FEVariableCollection<dim>;
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -703,7 +703,7 @@ namespace aspect
                                                           const bool skip_interior_cells) const; \
   template void Simulator<dim>::get_artificial_viscosity (Vector<float> &viscosity_per_cell,  \
                                                           const AdvectionField &advection_field, \
-                                                          const bool skip_interior_cells) const; \
+                                                          const bool skip_interior_cells) const;
 
 
   ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1941,7 +1941,7 @@ namespace aspect
     template class MeltAdvectionSystem<dim>; \
     template class MeltPressureRHSCompatibilityModification<dim>; \
     template class MeltBoundaryTraction<dim>; \
-  } \
+  }
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 


### PR DESCRIPTION
There are a number of files that for reasons I had never understood always needed to be recompiled after calling the indent script. I've finally figured out why that is so: We end a `#define` macro definition with a trailing backslash followed by an empty line. One part of our indentation script changes the whitespace for that, and another part changes it back. That results in no actual changes, but touched the file, requiring the recompile.

This patch fixes this for all affected files.

/rebuild