### PR TITLE
Add missing instantiation.

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -1403,7 +1403,8 @@ namespace aspect
     namespace VisualizationPostprocessors
     {
 #define INSTANTIATE(dim) \
-  template class Interface<dim>;
+  template class Interface<dim>; \
+  template class CellDataVectorCreator<dim>;
 
       ASPECT_INSTANTIATE(INSTANTIATE)
 


### PR DESCRIPTION
We didn't notice this because the class so far does not have any interesting member functions, but it become clear to me that we were missing the instantiation when doing something related to #4244. Might as well make this a separate patch.

/rebuild