### PR TITLE
Rename a function.

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -538,14 +538,20 @@ namespace aspect
 
     namespace
     {
-      // Add new output_data_names to a set output_data_names_set, and check for uniqueness of names.
-      // Multiple copies in output_data_names are collapsed into one copy before checking
-      // for uniqueness with output_data_names_set, because vector data fields are represented as multiple
-      // copies of the same name.
-      void add_data_names_to_set(const std::vector<std::string> &output_data_names,
-                                 std::set<std::string> &output_data_names_set)
+      /**
+       * Add new output_data_names to a set output_data_names_set, and check
+       * for uniqueness of names. Multiple copies in output_data_names are
+       * collapsed into one copy before checking for uniqueness with
+       * output_data_names_set, because vector data fields are represented
+       * as multiple copies of the same name.
+       */
+      void track_output_field_names(const std::vector<std::string> &output_data_names,
+                                    std::set<std::string> &output_data_names_set)
       {
-        const std::set<std::string> set_of_names(output_data_names.begin(),output_data_names.end());
+        // Copy the vector elements into a std::set. This discards
+        // duplicates as mentioned in the comment above.
+        const std::set<std::string> set_of_names(output_data_names.begin(),
+                                                 output_data_names.end());
 
         for (const auto &name: set_of_names)
           {
@@ -603,7 +609,7 @@ namespace aspect
       std::set<std::string> visualization_field_names;
 
       // Insert base variable names into set of all output field names
-      add_data_names_to_set(base_variables.get_names(), visualization_field_names);
+      track_output_field_names(base_variables.get_names(), visualization_field_names);
 
       std::unique_ptr<internal::MeshDeformationPostprocessor<dim>> mesh_deformation_variables;
 
@@ -635,7 +641,7 @@ namespace aspect
           mesh_deformation_variables->initialize_simulator(this->get_simulator());
 
           // Insert mesh deformation variable names into set of all output field names
-          add_data_names_to_set(mesh_deformation_variables->get_names(), visualization_field_names);
+          track_output_field_names(mesh_deformation_variables->get_names(), visualization_field_names);
 
           data_out.add_data_vector (this->get_mesh_velocity(),
                                     *mesh_deformation_variables);
@@ -662,7 +668,7 @@ namespace aspect
               if (const DataPostprocessor<dim> *viz_postprocessor
                   = dynamic_cast<const DataPostprocessor<dim>*>(& *p))
                 {
-                  add_data_names_to_set(viz_postprocessor->get_names(), visualization_field_names);
+                  track_output_field_names(viz_postprocessor->get_names(), visualization_field_names);
 
                   if (dynamic_cast<const VisualizationPostprocessors::SurfaceOnlyVisualization<dim>*>
                       (& *p) == nullptr)
@@ -686,7 +692,7 @@ namespace aspect
                                       "vectors that have as many entries as there are active cells "
                                       "on the current processor."));
 
-                  add_data_names_to_set(std::vector<std::string>(1,cell_data.first), visualization_field_names);
+                  track_output_field_names(std::vector<std::string>(1,cell_data.first), visualization_field_names);
 
                   // store the pointer, then attach the vector to the DataOut object
                   cell_data_vectors.push_back (std::unique_ptr<Vector<float>>


### PR DESCRIPTION
While there, document it better.

The function had confused me because, from the name, I had assumed that the point is that it adds something to a list. The problem was that the list was never actually used for anything -- the point wasn't to add something to the list, but to keep track of unique names of output variables, so the point of the function was to assert if necessary.

/rebase