### PR TITLE
Make --close-templates the default for astyle.

### DIFF
--- a/contrib/utilities/astyle.rc
+++ b/contrib/utilities/astyle.rc
@@ -32,3 +32,6 @@
 --max-instatement-indent=80
 --suffix=none
 --quiet
+
+# use "classname<dim>", not "classname< dim >" or other variations
+--close-templates


### PR DESCRIPTION
As requested in #4614.

/rebuild