### PR TITLE
Create indentation artifact by Github tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,9 +50,17 @@ jobs:
         cd
         rm -rf astyle*
         astyle --version
-    - name: indent
+    - name: make indent
       run: |
         ./contrib/utilities/indent
+        git diff > changes-astyle.diff
+    - name: archive indent results
+      uses: actions/upload-artifact@v2
+      with:
+        name: changes-astyle.diff
+        path: changes-astyle.diff
+    - name: check indentation
+      run: |
         git diff --exit-code
     - name: compile
       run: |


### PR DESCRIPTION
Currently the Github actions workflow only checks the indentation, but does not provide a diff file that fixes it. This PR adds that by uploading the diff as an artifact. The artifact will be uploaded for every build, but if the indentation is fine the artifact will be empty.