### PR TITLE
Fix which variables are captured by the lambda function for background output.

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -496,9 +496,12 @@ namespace aspect
                     output_history.background_thread.join();
                   // ...then continue with writing our own data.
                   output_history.background_thread
-                    = std::thread([ &, my_file_contents = std::move(file_contents)]()
+                    = std::thread([this,
+                                   my_filename = std::move(filename),
+                                   my_temporary_output_location = temporary_output_location,
+                                   my_file_contents = std::move(file_contents)]()
                   {
-                    writer (filename, temporary_output_location, *my_file_contents);
+                    writer (my_filename, my_temporary_output_location, *my_file_contents);
                   });
                 }
               else


### PR DESCRIPTION
Follow-up to #4639. This patch actually fixes the issue that the variables we use in the lambda function (on another thread) are captured by reference and so may go stale.

/rebuild