### PR TITLE
Use unformatted output -- we here really just want a bit-by-bit copy into a file.

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -883,7 +883,7 @@ namespace aspect
 
       // now write and then move the tmp file to its final destination
       // if necessary
-      out << file_contents;
+      out.write (file_contents.data(), file_contents.size());
       out.close ();
 
       if (tmp_filename != filename)


### PR DESCRIPTION
Using `operator<<` involves some formatting overhead (for example trying to fit a specific field width set with `out << std::width(...)` etc.). We really don't want that here -- just dump it all into that file alright!

/rebuild