### PR TITLE
Fix .md markup problems with <span.

### DIFF
--- a/doc/sphinx/user/extending/compatibility.md
+++ b/doc/sphinx/user/extending/compatibility.md
@@ -2,14 +2,14 @@
 
 We strive to maintain compatibility for user written plugins with new versions
 of ASPECT for as long as possible. However,
-occasionally we have to restructure interface classes to improve <span
+occasionally we have to restructure interface classes to improve 
 ASPECT further. This is in particular true for new
-major versions. In order to allow running old plugins with newer <span
+major versions. In order to allow running old plugins with newer 
 ASPECT versions we provide scripts that can
 automatically update existing plugins to the new syntax. Executing
 `doc/update_source_files.sh` with one or more plugin files as arguments will
 create a backup of the old file (named `old_filename.bak`), and replace the
-existing file with a version that should work with the current <span
+existing file with a version that should work with the current 
 ASPECT version. Using this script would look like
 this:
 

--- a/doc/sphinx/user/extending/contributing.md
+++ b/doc/sphinx/user/extending/contributing.md
@@ -13,7 +13,7 @@ Do something about it! No matter whether you are a C++ expert or first-time
 user, there are no such things as too-unimportant contributions, and if you
 struggled with something, it is most likely somebody else will as well. The
 process of contributing to a new project can be daunting, but we appreciate
-every contribution and are happy to work with you on improving <span
+every contribution and are happy to work with you on improving 
 ASPECT. To get you started we have collected a set of
 guidelines and advice on how to get involved in the community. To avoid
 duplication we store these guidelines in a separate file [CONTRIBUTING.md][]

--- a/doc/sphinx/user/extending/extending-solver.md
+++ b/doc/sphinx/user/extending/extending-solver.md
@@ -57,7 +57,7 @@ DEAL.II tutorial:
     of the consequences of making things run with realistic geometries,
     material models, etc.
 
-Neither of these two programs is nearly as modular as <span
+Neither of these two programs is nearly as modular as 
 ASPECT, but that was also not the goal in creating
 them. They will, however, serve as good introductions to the general approach
 for solving thermal convection problems.

--- a/doc/sphinx/user/extending/idea-of-plugins.md
+++ b/doc/sphinx/user/extending/idea-of-plugins.md
@@ -1,7 +1,7 @@
 
 # The idea of plugins and the `SimulatorAccess` and `Introspection` classes
 
-The most common modification you will probably want to do to <span
+The most common modification you will probably want to do to 
 ASPECT are to switch to a different material model
 (i.e., have different values of functional dependencies for the coefficients
 $\eta,\rho,C_p, \ldots$ discussed in {ref}`sec:coefficients`8]);
@@ -144,7 +144,7 @@ is defined on. Furthermore, you may need to know what the current simulation
 time is. A variety of other pieces of information enters computations in these
 kinds of plugins.
 
-All of this information is of course part of the core of <span
+All of this information is of course part of the core of 
 ASPECT, as part of the [aspect::Simulator class][].
 However, this is a rather heavy class: it&rsquo;s got dozens of member
 variables and functions, and it is the one that does all of the numerical

--- a/doc/sphinx/user/extending/index.md
+++ b/doc/sphinx/user/extending/index.md
@@ -1,7 +1,7 @@
 (cha:extending)=
 # Extending and contributing to ASPECT
 
-After you have familiarized yourself with <span
+After you have familiarized yourself with 
 ASPECT using the examples of
 {ref}`sec:cookbooks`1] you will invariably want to set up your
 own models. During this process you might experience that not all of your

--- a/doc/sphinx/user/extending/plugin-types/heating-models.md
+++ b/doc/sphinx/user/extending/plugin-types/heating-models.md
@@ -102,7 +102,7 @@ documentation page just mentioned.
 Just like for material models, the functions `initialize()` and `update()` can
 be implemented if desired (the default implementation does nothing) and are
 useful if the heating model has an internal state. The function `initialize()`
-is called once during the initialization of <span
+is called once during the initialization of 
 ASPECT and can be used to allocate memory for the
 heating model, initialize state, or read information from an external file.
 The function `update()` is called at the beginning of every time step.

--- a/doc/sphinx/user/extending/plugin-types/initial-conditions.md
+++ b/doc/sphinx/user/extending/plugin-types/initial-conditions.md
@@ -6,7 +6,7 @@ a function that for each point can return the initial temperature. Note that
 the model {math:numref}`eq:stokes-1`2]&ndash;{math:numref}`eq:temperature`3] does not require
 initial values for the pressure or velocity. However, if coefficients are
 nonlinear, one can significantly reduce the number of initial nonlinear
-iterations if a good guess for them is available; consequently, <span
+iterations if a good guess for them is available; consequently, 
 ASPECT initializes the pressure with the
 adiabatically computed hydrostatic pressure, and a zero velocity. Neither of
 these two has to be provided by the objects considered in this section.

--- a/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
+++ b/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
@@ -1,7 +1,7 @@
 # Mesh refinement criteria
 
 Despite research since the mid-1980s, it isn&rsquo;t completely clear how to
-refine meshes for complex situations like the ones modeled by <span
+refine meshes for complex situations like the ones modeled by 
 ASPECT. The basic problem is that mesh refinement
 criteria either can refine based on some variable such as the temperature, the
 pressure, the velocity, or a compositional field, but that oftentimes this by

--- a/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
+++ b/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
@@ -131,5 +131,5 @@ Visualization plugins can come in two flavors:
     `CellDataVectorCreator` class for more information.
 
 If all of this sounds confusing, we recommend consulting the implementation of
-the various visualization plugins that already exist in the <span
+the various visualization plugins that already exist in the 
 ASPECT sources, and using them as a template.

--- a/doc/sphinx/user/extending/signals.md
+++ b/doc/sphinx/user/extending/signals.md
@@ -3,11 +3,11 @@
 Not all things you may want to do fit neatly into the list of plugins of the
 previous sections. Rather, there are cases where you may want to change things
 that are more of the one-off kind and that require code that is at a lower
-level and requires more knowledge about <span
+level and requires more knowledge about 
 ASPECT&rsquo;s internal workings. For such changes,
 we still want to stick with the general principle outlined at the beginning of
 {ref}`sec:1][22]: You should be able to make all of your changes and
-extensions in your own files, without having to modify <span
+extensions in your own files, without having to modify 
 ASPECT&rsquo;s own sources.
 
 To support this, ASPECT uses a
@@ -163,7 +163,7 @@ As a final note, it is generally true that writing functions that can connect
 to signals require significantly more internal knowledge of the workings of
 ASPECT than writing plugins through the
 mechanisms outlined above. It also allows to affect the course of a simulation
-by working on the internal data structures of <span
+by working on the internal data structures of 
 ASPECT in ways that are not available to the largely
 passive and reactive plugins discussed in previous sections. With this
 obviously also comes the potential for trouble. On the other hand, it also

--- a/doc/sphinx/user/extending/testing/running-tests.md
+++ b/doc/sphinx/user/extending/testing/running-tests.md
@@ -9,7 +9,7 @@ numerical output is significant. The test suite is run using the `ctest`
 program that comes with `cmake`, and should therefore be available on all
 systems that have compiled ASPECT.
 
-After running `cmake` and then compiling <span
+After running `cmake` and then compiling 
 ASPECT, you can run the test suite by using the
 command `ctest` in your build directory. By default, this will only run a
 small subset of all tests given that both setting up all tests (several
@@ -83,7 +83,7 @@ Given that some tests are expected to fail on any given system raises the
 question why it makes sense to have tests at all? The answer is that there is
 *one* system on which all tests are supposed to succeed: This system is a
 machine that churns through all tests every time someone proposes a change to
-the ASPECT code base via the <span
+the ASPECT code base via the 
 ASPECT GitHub page.[9] Upon completion of the test
 suite, both the general summary (pass/fail) and a full verbose log will
 available from the GitHub page. Because the official test setup is set up in a
@@ -101,7 +101,7 @@ docker run -v ASPECT_SOURCE_DIR:/home/dealii/aspect \
 ```
 
 This command executes the shell script `cmake/compile_and_update_tests.sh`
-*inside* the docker container that contains the official <span
-ASPECT test system. Note that by mounting your <span
+*inside* the docker container that contains the official 
+ASPECT test system. Note that by mounting your 
 ASPECT folder into the container you are actually
 updating the reference test results on the host system (i.e. your computer).

--- a/doc/sphinx/user/extending/testing/writing-tests.md
+++ b/doc/sphinx/user/extending/testing/writing-tests.md
@@ -16,7 +16,7 @@ the vtu format, the output files are compressed, and can not be compared using
 Numdiff). An easy way to create all of the files you need is to copy the
 folder of an existing test and rename it to the name of your parameter file.
 
-To actually run the test, you have to go to your <span
+To actually run the test, you have to go to your 
 ASPECT build directory and run
 
 ``` ksh

--- a/doc/sphinx/user/install/docker-container/developing-in-container.md
+++ b/doc/sphinx/user/install/docker-container/developing-in-container.md
@@ -2,9 +2,9 @@
 # Developing ASPECT within a container
 
 
-The above given workflow does not include advice on how to modify <span
+The above given workflow does not include advice on how to modify 
 ASPECT inside the container. We recommend a slightly
-different workflow for advanced users that want to modify parts of <span
+different workflow for advanced users that want to modify parts of 
 ASPECT. The ASPECT
 docker container itself is build on top of a <span
 class="smallcaps">deal.II</span> container that contains all dependencies for
@@ -21,7 +21,7 @@ docker run -it -v "$(pwd):/home/dealii/aspect:ro" \
   tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5 bash
 ```
 
-Inside of the container you now find a read-only <span
+Inside of the container you now find a read-only 
 ASPECT directory that contains your modified source
 code. You can compile and run a model inside the container, e.g. in the
 following way:

--- a/doc/sphinx/user/install/docker-container/installing-docker.md
+++ b/doc/sphinx/user/install/docker-container/installing-docker.md
@@ -18,6 +18,6 @@ image from Docker Hub is as simple as typing in a terminal:
 docker pull geodynamics/aspect
 ```
 
-Note that the transfer size of the compressed image containing <span
+Note that the transfer size of the compressed image containing 
 ASPECT and all its dependencies is about 900&nbsp;MB.
 When extracted the image requires about 3.2&nbsp;GB of disk space.

--- a/doc/sphinx/user/install/docker-container/running-models.md
+++ b/doc/sphinx/user/install/docker-container/running-models.md
@@ -3,7 +3,7 @@
 
 #### Running ASPECT models
 
-Although it is possible to use the downloaded <span
+Although it is possible to use the downloaded 
 ASPECT docker image in a number of different ways, we
 recommend the following workflow:
 

--- a/doc/sphinx/user/install/index.md
+++ b/doc/sphinx/user/install/index.md
@@ -22,7 +22,7 @@ guide users to an informed decision about the best option for their purpose.
 |        Modifying ASPECT         |     Possible      |          Possible          |     Possible     |
 |    Configuring dependencies     |     Possible      |             No             |        No        |
 
-*Features of the different installation options of <span
+*Features of the different installation options of 
 ASPECT.*
 
 </div>

--- a/doc/sphinx/user/install/local-installation/compiling.md
+++ b/doc/sphinx/user/install/local-installation/compiling.md
@@ -9,11 +9,11 @@ libraries it builds on, you can compile it by typing
       make
 
 on the command line (or `make -jN` if you have multiple processors in your
-machine, where `N` is the number of processors). This builds the <span
+machine, where `N` is the number of processors). This builds the 
 ASPECT executable which will reside in the `build`
-directory and will be named `aspect`. To run <span
+directory and will be named `aspect`. To run 
 ASPECT from the main source directory you would need
-to reference it as `./build/aspect`. If you intend to modify <span
+to reference it as `./build/aspect`. If you intend to modify 
 ASPECT for your own experiments, you may want to also
 generate documentation about the source code. This can be done using the
 command

--- a/doc/sphinx/user/install/local-installation/system-prereqs.md
+++ b/doc/sphinx/user/install/local-installation/system-prereqs.md
@@ -11,11 +11,11 @@ zlib, which is used for compressing the output data. To use more than one
 process for your computations you will need to install a MPI library, its
 headers and the necessary executables to run MPI programs. There are some
 optional packages for additional features, like the HDF5 libraries for
-additional output formats and Numdiff for checking <span
+additional output formats and Numdiff for checking 
 ASPECT's test results with reasonable accuracy,
 but these are not strictly required, and in some operating systems they are
 not available as packages but need to be compiled from scratch. Finally, for
-obtaining a recent development version of <span
+obtaining a recent development version of 
 ASPECT you will need the git version control system.
 
 An exemplary command to obtain all required packages on Ubuntu 14.04 would be:

--- a/doc/sphinx/user/install/local-installation/using-candi.md
+++ b/doc/sphinx/user/install/local-installation/using-candi.md
@@ -4,7 +4,7 @@
 #### Using candi to compile dependencies
 
 In its default configuration `candi` downloads and compiles a <span
-class="smallcaps">deal.II</span> configuration that is able to run <span
+class="smallcaps">deal.II</span> configuration that is able to run 
 ASPECT, but it also contains a number of packages
 that are not required (and that can be safely disabled if problems occur
 during the installation). We require at least the packages <span
@@ -56,5 +56,5 @@ class="smallcaps">p4est</span> and TRILINOS.
     `$DEAL_II_DIR/examples/step-32`. Prepare and compile by running
     `cmake . && make` and run with `mpirun -n 2 ./step-32`.
 
-Congratulations, you are now set up for compiling <span
+Congratulations, you are now set up for compiling 
 ASPECT itself.

--- a/doc/sphinx/user/run-aspect/2d-vs-3d.md
+++ b/doc/sphinx/user/run-aspect/2d-vs-3d.md
@@ -12,7 +12,7 @@ line like the following into the parameter file (see
 ```
 
 Internally, dealing with the dimension builds on a feature in <span
-class="smallcaps">deal.II</span>, upon which <span
+class="smallcaps">deal.II</span>, upon which 
 ASPECT is based, that is called
 *dimension-independent programming*. In essence, what this does is that you
 write your code only once in a way so that the space dimension is a variable
@@ -24,7 +24,7 @@ expensive for finding bugs; it is also a useful feature when scoping out
 whether certain parameter settings will have the desired effect by testing
 them in 2d first, before running them in 3d. This feature is discussed in
 detail in the [DEAL.II tutorial program
-step-4][]. Like there, all the functions and classes in <span
+step-4][]. Like there, all the functions and classes in 
 ASPECT are compiled for both 2d and 3d. Which
 dimension is actually called internally depends on what you have set in the
 input file, but in either case, the machine code generated for 2d and 3d

--- a/doc/sphinx/user/run-aspect/debug-mode.md
+++ b/doc/sphinx/user/run-aspect/debug-mode.md
@@ -8,7 +8,7 @@ ASPECT uses debug mode, i.e., it calls a
 version of the DEAL.II library that contain
 lots of checks for the correctness of function arguments, the consistency of
 the internal state of data structure, etc. If you program with <span
-class="smallcaps">deal.II</span>, for example to extend <span
+class="smallcaps">deal.II</span>, for example to extend 
 ASPECT, it has been our experience over the years
 that, by number, most programming errors are of the kind where one forgets to
 initialize a vector, one accesses data that has not been updated, one tries to

--- a/doc/sphinx/user/run-aspect/gui/using.md
+++ b/doc/sphinx/user/run-aspect/gui/using.md
@@ -22,7 +22,7 @@ file can then be used to start an ASPECT model
 as usual. Note that it is possible to prepare and execute the parameter file
 with different versions of ASPECT, e.g. if you
 prepare parameter files on a local machine, and execute the model on a remote
-compute cluster. Note however that if the two <span
+compute cluster. Note however that if the two 
 ASPECT versions contain different default values or
 parameter names have changed, this can lead to unexpected model behavior or
 even unusable parameter files.

--- a/doc/sphinx/user/run-aspect/overview.md
+++ b/doc/sphinx/user/run-aspect/overview.md
@@ -14,7 +14,7 @@ or, if you want to run the program in parallel, using something like
       mpirun -np 4 ./aspect parameter-file.prm
 
 to run with 4 processors. In either case, the argument denotes the (path and)
-name of a file that contains input parameters.[7] When you download <span
+name of a file that contains input parameters.[7] When you download 
 ASPECT, there are a number of sample input files in
 the `cookbooks` directory, corresponding to the examples discussed in
 {ref}`5][], and input files for some of the benchmarks discussed in
@@ -87,12 +87,12 @@ Number of degrees of freedom: 33,859 (20,786+2,680+10,393)
 ...
 ```
 
-The output starts with a header that lists the used <span
+The output starts with a header that lists the used 
 ASPECT, DEAL.II, <span
 class="smallcaps">Trilinos</span> and <span class="smallcaps">p4est</span>
-versions as well as the mode you compiled <span
+versions as well as the mode you compiled 
 ASPECT in (see [4.4][]), and the number of parallel
-processes used[9]. With this information we strive to make <span
+processes used[9]. With this information we strive to make 
 ASPECT models as reproducible as possible.
 
 The following output depends on the model, and in this case was produced by a
@@ -118,7 +118,7 @@ Within each time step, the output indicates the number of iterations performed
 by the linear solvers, and we generate a number of lines of output by the
 postprocessors that were selected (see
 {ref}`parameters:Postprocess`50]). Here, we have selected to run
-all postprocessors that are currently implemented in <span
+all postprocessors that are currently implemented in 
 ASPECT which includes the ones that evaluate
 properties of the velocity, temperature, and heat flux as well as a
 postprocessor that generates graphical output for visualization.

--- a/doc/sphinx/user/run-aspect/parameters-overview/muparser-format.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/muparser-format.md
@@ -3,7 +3,7 @@
 
 #### A note on the syntax of formulas in input files
 
-Input files have different ways of describing certain things to <span
+Input files have different ways of describing certain things to 
 ASPECT. For example, you could select a plugin for
 the temperature initial values that prescribes a constant temperature, or a
 plugin that implements a particular formula for these initial conditions in
@@ -62,7 +62,7 @@ way, however, using something like python to debug these expressions before
 defining them in the parameter file is recommended. For more examples of
 functions used in parameter files, go to the `cookbooks` directory and use
 grep to search for "Function expression" in the parameters files.
-You can also search "Function expression" on the <span
+You can also search "Function expression" on the 
 ASPECT github page. For more examples of the syntax
 understood, reference the documentation of the muparser library linked to
 above.

--- a/doc/sphinx/user/run-aspect/parameters-overview/structure.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/structure.md
@@ -15,7 +15,7 @@ sub-directories. And just as with files, parameters have both a name (the
 thing to the left of the equals sign) and a content (what's to the
 right).
 
-All parameters you can list in this input file have been *declared* in <span
+All parameters you can list in this input file have been *declared* in 
 ASPECT. What this means is that you can't just
 list anything in the input file, and expect that entries that are unknown are
 simply ignored. Rather, if your input file contains a line setting a parameter

--- a/doc/sphinx/user/run-aspect/run-faster/debug-vs-optimized.md
+++ b/doc/sphinx/user/run-aspect/run-faster/debug-vs-optimized.md
@@ -2,7 +2,7 @@
 
 #### Debug vs.&nbsp;optimized mode
 
-Both DEAL.II and <span
+Both DEAL.II and 
 ASPECT by default have a great deal of internal
 checking to make sure that the code's state is valid. For example, if
 you write a new postprocessing plugin (see
@@ -22,7 +22,7 @@ As mentioned above, the default is to have all of these assertions in the code
 to catch those places where we may otherwise silently access invalid memory
 locations. However, once you have a plugin running and verified that your
 input file runs without problems, you can switch off all of these checks by
-switching from debug to optimized mode. This means re-compiling <span
+switching from debug to optimized mode. This means re-compiling 
 ASPECT and linking against a version of the <span
 class="smallcaps">deal.II</span> library without all of these internal checks.
 Because this is the first thing you will likely want to do, we have already

--- a/doc/sphinx/user/run-aspect/run-faster/index.md
+++ b/doc/sphinx/user/run-aspect/run-faster/index.md
@@ -6,10 +6,10 @@ principle that the default for all settings should be *safe*. In particular,
 this means that you should get errors when something goes wrong, the program
 should not let you choose an input file parameter so that it doesn't
 make any sense, and we should solve the equations to best ability without
-cutting corners. The goal is that when you start working with <span
+cutting corners. The goal is that when you start working with 
 ASPECT that we give you the best answer we can. The
 downside is that this also makes ASPECT run
-slower than may be possible. This section describes ways of making <span
+slower than may be possible. This section describes ways of making 
 ASPECT run faster - assuming that you know what
 you are doing and are making conscious decisions.
 

--- a/doc/sphinx/user/run-aspect/run-faster/limiting-postprocessing.md
+++ b/doc/sphinx/user/run-aspect/run-faster/limiting-postprocessing.md
@@ -9,7 +9,7 @@ at the `List of postprocessors` parameter that can be set in the input file,
 see {ref}`parameters:Postprocess`50].
 
 Many of these postprocessors take a non-negligible amount of time. How much
-they collectively use can be inferred from the timing report <span
+they collectively use can be inferred from the timing report 
 ASPECT prints periodically among its output, see for
 example the output shown in {ref}`5.2.1][]. So, if your computations
 take too long, consider limiting which postprocessors you run to those you

--- a/doc/sphinx/user/run-aspect/run-faster/multithreading.md
+++ b/doc/sphinx/user/run-aspect/run-faster/multithreading.md
@@ -15,13 +15,13 @@ available memory per core. Running with for example two threads per process
 will offset some of the performance loss you will see in these situations.
 
 Multithreading is controlled by setting the command line parameter `-j` or
-`--threads`. If the parameter is not set, <span
+`--threads`. If the parameter is not set, 
 ASPECT will create exactly one thread per MPI
-process, i.e. multithreading is disabled. Appending the parameter allows <span
+process, i.e. multithreading is disabled. Appending the parameter allows 
 ASPECT to spawn several threads per MPI process. Note
 that the internally used TBB library will determine the number of threads
 based on the number of available cores, i.e., if you start 2&nbsp;MPI
-processes on a quadcore machine with hyperthreading (8 logical cores), <span
+processes on a quadcore machine with hyperthreading (8 logical cores), 
 ASPECT will spawn 4 threads on each MPI process. Also
 note that there is no guarantee that the final number of threads will exactly
 match the number of available logical cores if you start with a number of

--- a/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
@@ -3,7 +3,7 @@
 #### Adjusting solver preconditioner tolerances
 
 To solve the Stokes equations it is necessary to lower the condition number of
-the Stokes matrix by preconditioning it. In <span
+the Stokes matrix by preconditioning it. In 
 ASPECT a right preconditioner $Y^{-1} =
 \begin{pmatrix}
 \widetilde{A^{-1}} & -\widetilde{A^{-1}}B^{T}\widetilde{S^{-1}} \\

--- a/doc/sphinx/user/run-aspect/run-faster/solver-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/solver-tolerance.md
@@ -18,7 +18,7 @@ Obviously, the smaller we choose $\varepsilon$, the more accurate the
 approximation $x^{(k)}$ will be. On the other hand, it will also take more
 iterations and, consequently, more CPU time to reach the stopping criterion
 with a smaller tolerance. The default value of these tolerances are chosen so
-that the approximation is typically sufficient. You can make <span
+that the approximation is typically sufficient. You can make 
 ASPECT run faster if you choose these tolerances
 larger. The parameters you can adjust are all listed in
 {ref}`parameters:Solver_20parameters`64] and are located in the

--- a/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
+++ b/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
@@ -12,7 +12,7 @@ single time step can run into the range of gigabytes that somehow have to get
 from compute nodes to disk. This stresses both the cluster interconnect as
 well as the data storage array.
 
-There are essentially two strategies supported by <span
+There are essentially two strategies supported by 
 ASPECT for this scenario:
 
 -   If your cluster has a fast interconnect, for example Infiniband, and if

--- a/doc/sphinx/user/run-aspect/visualizing-results/stat-data.md
+++ b/doc/sphinx/user/run-aspect/visualizing-results/stat-data.md
@@ -2,7 +2,7 @@
 
 #### Visualizing statistical data
 
-In addition to the graphical output discussed above, <span
+In addition to the graphical output discussed above, 
 ASPECT produces a statistics file that collects
 information produced during each time step. For the remainder of this section,
 let us assume that we have run ASPECT with the


### PR DESCRIPTION
We had all of these occurrences of `<span` at the end of the line when there is ASPECT first on the next line. I don't know where that came from (to mark up ASPECT in a specific way?) but either way it's wrong. This fixes it.

/rebuild