### PR TITLE
Create the .prm.tex files from all .prm files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,6 +673,16 @@ ELSE()
 ENDIF()
 
 
+###########################################################
+# Having configured most of the compilation phase, now also
+# deal with other parts of the system.
+###########################################################
+
+# Start with the documentation
+
+ADD_SUBDIRECTORY(doc)
+
+
 # Find the deal.II parameter GUI and install helper script
 FIND_PROGRAM(PARAMETER_GUI_EXECUTABLE
         parameter_gui
@@ -680,7 +690,7 @@ FIND_PROGRAM(PARAMETER_GUI_EXECUTABLE
         PATH bin)
 MARK_AS_ADVANCED(CLEAR PARAMETER_GUI_EXECUTABLE)
 
-# did the user specify something that doesn't exist?
+# Did the user specify something that doesn't exist?
 IF (PARAMETER_GUI_EXECUTABLE
         AND
     (NOT EXISTS ${PARAMETER_GUI_EXECUTABLE} OR IS_DIRECTORY ${PARAMETER_GUI_EXECUTABLE}))

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,99 @@
+# Copyright (C) 2022 by the authors of the ASPECT code.
+#
+# This file is part of ASPECT.
+#
+# ASPECT is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# ASPECT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ASPECT; see the file doc/COPYING.  If not see
+# <http://www.gnu.org/licenses/>.
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1.0)
+
+MESSAGE(STATUS "===== Configuring ASPECT documentation =============")
+
+FIND_PACKAGE(Perl)
+
+
+####################################################
+# Generate input files for the manual
+####################################################
+
+# Step 1: Find all of the .prm files that will be used in
+#         the manual
+FILE(GLOB _dot_prm_directories_cookbooks
+     ${CMAKE_SOURCE_DIR}/cookbooks/*/doc)
+FILE(GLOB _dot_prm_directories_benchmarks
+     ${CMAKE_SOURCE_DIR}/benchmarks/*/doc)
+SET(_dot_prm_directories ${CMAKE_SOURCE_DIR}/doc/manual)
+LIST(APPEND _dot_prm_directories
+    ${_dot_prm_directories_cookbooks}
+    ${_dot_prm_directories_benchmarks})
+
+FOREACH(_dir ${_dot_prm_directories})
+  FILE(GLOB_RECURSE _my_dot_prm_files
+       RELATIVE ${CMAKE_SOURCE_DIR}
+       ${_dir}/*prm)
+
+  LIST(APPEND _dot_prm_files
+       ${_my_dot_prm_files})
+ENDFOREACH()
+
+
+# Step 2: Set up targets to run each of the .prm files
+#         through perl and process them
+ADD_CUSTOM_TARGET(build_dot_prm_dot_tex)
+
+FOREACH(_dot_prm ${_dot_prm_files})
+  # Set up a command to generate the .prm.tex file
+  #
+  # We do this using the annotate.pl script, and then processing
+  # index entries to contain at most three levels using a
+  # second perl script.
+  ADD_CUSTOM_COMMAND(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/${_dot_prm}.tex
+    COMMAND
+      ${PERL_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/manual/cookbooks/annotate.pl
+          ${CMAKE_SOURCE_DIR}/${_dot_prm}
+          > ${CMAKE_CURRENT_BINARY_DIR}/${_dot_prm}.tex
+    COMMAND
+      ${PERL_EXECUTABLE}
+         -pi
+          ${CMAKE_CURRENT_SOURCE_DIR}/manual/cookbooks/escape_index_entries.pl
+          ${CMAKE_CURRENT_BINARY_DIR}/${_dot_prm}.tex
+    DEPENDS
+      ${CMAKE_SOURCE_DIR}/${_dot_prm}
+      ${CMAKE_CURRENT_SOURCE_DIR}/manual/cookbooks/annotate.pl
+      ${CMAKE_CURRENT_SOURCE_DIR}/manual/cookbooks/escape_index_entries.pl
+    COMMENT
+      "Building marked up version of ${_dot_prm} in latex format."
+    )
+
+  # Then we also need a target for the operation above. Target
+  # names may not contain slashes, so we need to escape those
+  STRING(REGEX REPLACE "[^a-zA-Z0-9]" "" _dot_prm_escaped "${_dot_prm}")
+  ADD_CUSTOM_TARGET(build_dot_prm_dot_tex_${_dot_prm_escaped}
+    DEPENDS
+      ${CMAKE_CURRENT_BINARY_DIR}/${_dot_prm}.tex
+    )
+
+  # Finally add the target to the dependencies of the higher-level
+  # target
+  ADD_DEPENDENCIES(build_dot_prm_dot_tex build_dot_prm_dot_tex_${_dot_prm_escaped})
+ENDFOREACH()
+
+
+# Step 3: Say that creating the .prm.tex files is a dependency
+#         for the manual
+ADD_CUSTOM_TARGET(manual)
+ADD_DEPENDENCIES(manual build_dot_prm_dot_tex)

--- a/doc/manual/cookbooks/annotate.pl
+++ b/doc/manual/cookbooks/annotate.pl
@@ -1,5 +1,5 @@
-# a perl script that annotates a parameter file with index
-# entries for the ASPECT manual
+# A perl script that annotates a parameter file with index
+# entries for the ASPECT manual.
 
 $section = "";
 

--- a/doc/manual/cookbooks/escape_index_entries.pl
+++ b/doc/manual/cookbooks/escape_index_entries.pl
@@ -1,0 +1,27 @@
+# A perl script that annotates a parameter file with index
+# entries for the ASPECT manual.
+
+# Index entries have the form
+#   \index[prmindexfull]{Geometry model!Box!X extent}
+# What we have to achieve is that if there is a string of the
+# form
+#   {A!B!C!D!...}
+# with more than three exclamation points, then we want to replace
+# the fourth and all successive exclamation points by slashes.
+# The way we do this is to first check every line whether it
+# contains a string of the form
+#   {...!...!...!...(!...)+}
+# where ... can be any sequence of characters that do not contain
+# either a closing brace or an exclamation point. If that is so,
+# we replace all occurrences of ! by / in the parenthesized
+# expression.
+while (m/{[^!}]+![^!}]+![^!}]+!([^}]+![^}]+)}/)
+{
+    my $expr = $1;
+    my $substitution = $expr;
+    $substitution =~ s/\!/\//g;
+    s/$expr/$substitution/g;
+}
+
+# Whatever is left at this point will be printed and become part of
+# the output file.


### PR DESCRIPTION
We need to eventually process all of the `.prm` snippets as input to sphinx. Right now, for the latex manual, this is done with a separate `Makefile` in the `doc/` directory, but that needs to eventually be replaced by something we do in cmake. This is a first step towards it.

The patch right now really only gathers the `.prm` files and runs them through a couple of perl files. This is essentially the same as the current `Makefile`, except that I'm using perl for both scripts where the `Makefile` uses one perl and one sed script. The result of the current steps also ends up in a sub-directory of the build directory, rather than the source directory.

At the moment, no target depends on doing all of this, so unless you type `make manual` in your build directory, nothing happens. And if you do say `make manual`, all that happens is that the `.prm` snippets are converted into `.prm.tex` snippets which are not actually used anywhere. All of that will happen in follow-up patches, but I thought it easier to propose these as separate and individually reviewable pull requests.

This is a first step towards #3652. 

/rebuild