### PR TITLE
Fix a number of sphinx markdown problems.

### DIFF
--- a/doc/sphinx/user/methods/advection-stabilization/entropy-viscosity.md
+++ b/doc/sphinx/user/methods/advection-stabilization/entropy-viscosity.md
@@ -7,11 +7,17 @@ The entropy viscosity method ((Guermond, Pasquetti, and Popov 2011;
 Kronbichler, Heister, and Bangerth 2012)) adds an artificial diffusion $\nu_h$
 to the weak form [\[eqn:weak-form-for-advection`35], where the diffusion
 term $\left (k\nabla T, \nabla \varphi \right)$ is replaced by
-```{math}\left(\max (k, \nu_h) \nabla T, \nabla \varphi \right).``` The parameter
+```{math}
+\left(\max (k, \nu_h) \nabla T, \nabla \varphi \right).
+```
+The parameter
 $\nu_h$ is chosen as a constant per cell as
-```v_h \vert_K = \min \left( v_h^\text{max} \vert_K, v_h^E \vert_K \right),```
+```{math}
+v_h \vert_K = \min \left( v_h^\text{max} \vert_K, v_h^E \vert_K \right),
+```
 where $v_h^\text{max}$ is the maximum dissipation defined as
-```v_h^\text{max} \vert_K = \alpha_\text{max} h \| \mathbf u \|_{\infty,K}
+```{math}
+v_h^\text{max} \vert_K = \alpha_\text{max} h \| \mathbf u \|_{\infty,K}
 ```
  on
 each cell $K$ with parameter $\alpha_\text{max}$ (known as "beta"
@@ -22,7 +28,8 @@ scheme, which is effective at stabilization, but too diffusive to be used by
 itself. In fact, one can show that this reduces the convergence order of
 smooth solutions to be only first order. This is avoided by taking the minimum
 with the entropy viscosity $v_h^E|_K$ above. It is defined as
-```v_h^E \vert_K = \alpha_E \frac{h^2 \| r_E \|_{\infty, K}}{\| E - E_\text{avg} \|_{\infty, \Omega}}.
+```{math}
+v_h^E \vert_K = \alpha_E \frac{h^2 \| r_E \|_{\infty, K}}{\| E - E_\text{avg} \|_{\infty, \Omega}}.
 ```
 The constant $\alpha_E$ is given by "cR" in the parameter files,
 see {ref}`parameters:Discretization/Stabilization_20parameters/cR`37]. In the
@@ -31,7 +38,8 @@ the temperature entropy $E=\frac{1}{2}(T-T_m)^2$ with
 $T_m = \frac{1}{2}(T_\text{min}+T_\text{max})$ from the spatial average
 $E_\text{avg} = \frac{1}{| \Omega |}\int E \;\text{d}x$. The residual $r_E$ of
 the entropy equation for $E$ is defined as
-```r_E = \frac{\partial E}{\partial t} + (T-T_m)(\mathbf{u}\cdot \nabla T - k\triangle T - F).
+```{math}
+r_E = \frac{\partial E}{\partial t} + (T-T_m)(\mathbf{u}\cdot \nabla T - k\triangle T - F).
 ```
 This residual is defined in such a way, that it is zero for the exact
 solution, large where the numerical approximation is poor (for example in
@@ -43,7 +51,8 @@ The above definition assumes the entropy residual exponent
 {ref}`parameters:Discretization/Stabilization_20parameters/alpha`38]) is set
 to 2 (the default and recommended). For the choice of 1 for
 "alpha," the entropy viscosity is defined as
-```v_h^E \vert_K = \alpha_E \frac{h |\Omega| \cdot \| \mathbf u \|_{\infty,K} \cdot \| r_E \|_{\infty, K}}
+```{math}
+v_h^E \vert_K = \alpha_E \frac{h |\Omega| \cdot \| \mathbf u \|_{\infty,K} \cdot \| r_E \|_{\infty, K}}
  {\| \mathbf u \|_{\infty,\Omega} \cdot (T_\text{max} - T_\text{min})}.
  ```
 instead.
@@ -51,7 +60,8 @@ instead.
 An additional parameter is the strain rate scaling factor "gamma"
 (see {ref}`parameters:Discretization/Stabilization_20parameters/gamma`39]),
 which changes the definition of the maximum dissipation $\nu_h^\text{max}$ to
-```v_h^\text{max} \vert_K = \alpha_\text{max} h \|\lvert\mathbf u\rvert + \gamma h_K \lvert\varepsilon (\mathbf u)\rvert\|_{\infty,K},
+```{math}
+v_h^\text{max} \vert_K = \alpha_\text{max} h \|\lvert\mathbf u\rvert + \gamma h_K \lvert\varepsilon (\mathbf u)\rvert\|_{\infty,K},
 ```
 where $\gamma\geq 0$ is the aforementioned parameter in front of the strain
 rate.

--- a/doc/sphinx/user/methods/advection-stabilization/index.md
+++ b/doc/sphinx/user/methods/advection-stabilization/index.md
@@ -20,14 +20,15 @@ equation reads
 ```{math}
 \rho C_p \frac{\partial T}{\partial t} + \rho C_p \mathbf{u} \cdot \nabla T - \nabla \cdot k\nabla T = F,
 ```
-where $F$ is the combination of source and reaction terms, while the weak form
-- with test function $\varphi$ and L2 inner product $(\cdot,\cdot)$
-- is ```a(T,\varphi) =
+where $F$ is the combination of source and reaction terms, while the weak
+form - with test function $\varphi$ and L2 inner product $(\cdot,\cdot)$ - is
+```{math}
+a(T,\varphi) =
  \left(\rho C_p \frac{\partial T}{\partial t}, \varphi \right)
  + \left(\rho C_p \mathbf{u} \cdot \nabla T, \varphi \right)
  + \left( k \nabla T, \nabla \varphi \right) = (F,\varphi) = f(\varphi).
  \label{eqn:weak-form-for-advection}
- ```
+```
 
 :::{toctree}
 supg.md

--- a/doc/sphinx/user/methods/advection-stabilization/index.md
+++ b/doc/sphinx/user/methods/advection-stabilization/index.md
@@ -17,7 +17,9 @@ equation. We will discuss the case for the temperature equation here. The
 compositional fields only differ in having a zero conductivity, fewer
 right-hand side terms, and $\rho C_p=1$. The strong form of the temperature
 equation reads
-```{math}\rho C_p \frac{\partial T}{\partial t} + \rho C_p \mathbf{u} \cdot \nabla T - \nabla \cdot k\nabla T = F,```
+```{math}
+\rho C_p \frac{\partial T}{\partial t} + \rho C_p \mathbf{u} \cdot \nabla T - \nabla \cdot k\nabla T = F,
+```
 where $F$ is the combination of source and reaction terms, while the weak form
 - with test function $\varphi$ and L2 inner product $(\cdot,\cdot)$
 - is ```a(T,\varphi) =

--- a/doc/sphinx/user/methods/advection-stabilization/supg.md
+++ b/doc/sphinx/user/methods/advection-stabilization/supg.md
@@ -26,7 +26,8 @@ the right-hand side of the PDE.
 
 We use the parameter design presented in (John and Knobloch 2006) for
 $\delta_K$:
-```{math}\delta_K = \frac{h}{2d\|\mathbf{\beta}\|_{\infty,K}} \left( \coth(Pe)-\frac{1}{Pe} \right)
+```{math}
+\delta_K = \frac{h}{2d\|\mathbf{\beta}\|_{\infty,K}} \left( \coth(Pe)-\frac{1}{Pe} \right)
 ```
 where the Peclet number is given by
 ```Pe = \frac{ h \| \mathbf{\beta} \|_{\infty,K}}{2 d k_\text{max}},

--- a/doc/sphinx/user/methods/advection-stabilization/supg.md
+++ b/doc/sphinx/user/methods/advection-stabilization/supg.md
@@ -6,10 +6,11 @@
 For streamline upwind/Petrov-Galerkin (SUPG) (see for example (John and
 Knobloch 2006; Clevenger and Heister 2019)), we add to the weak form
 $a(\cdot,\cdot)$ the cell-wise defined weak form
-```a_{\text{SUPG}} (T, \varphi) =
+```{math}
+a_{\text{SUPG}} (T, \varphi) =
  \sum_{K \in \mathcal{T}_h}
   \delta_K \left( \rho C_p \frac{\partial T}{\partial t} - k \triangle T + \mathbf{\beta} \cdot \nabla T - F, \mathbf{\beta} \cdot \nabla \varphi \right)_K,
-  ```
+```
 where $K \in \mathcal{T}_h$ are the cells in the computation,
 $\delta_K \geq 0$ is a stabilization coefficient defined on each cell,
 $\mathbf{\beta} = \rho C_p \mathbf{u}$ is the effective advection velocity.
@@ -30,7 +31,8 @@ $\delta_K$:
 \delta_K = \frac{h}{2d\|\mathbf{\beta}\|_{\infty,K}} \left( \coth(Pe)-\frac{1}{Pe} \right)
 ```
 where the Peclet number is given by
-```Pe = \frac{ h \| \mathbf{\beta} \|_{\infty,K}}{2 d k_\text{max}},
+```{math}
+Pe = \frac{ h \| \mathbf{\beta} \|_{\infty,K}}{2 d k_\text{max}},
 ```
 $d$ is
 the polynomial degree of the temperature or composition element (typically 2),

--- a/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
+++ b/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
@@ -33,10 +33,11 @@ advection system with the mesh velocity (see, e.g. (Donea et al. 2004)). For
 instance, the temperature equation {math:numref}`eq:temperature-Boussinesq-linear`27]
 becomes
 
-```{math}\rho C_p \left(\frac{\partial T}{\partial t} + \left(\mathbf u - \mathbf u_m \right) \cdot\nabla T\right)
+```{math}
+\rho C_p \left(\frac{\partial T}{\partial t} + \left(\mathbf u - \mathbf u_m \right) \cdot\nabla T\right)
   - \nabla\cdot k\nabla T
   =
   \rho H
    \quad
    \textrm{in $\Omega$}.
-   ```
+```

--- a/doc/sphinx/user/methods/melt-transport.md
+++ b/doc/sphinx/user/methods/melt-transport.md
@@ -150,7 +150,9 @@ described above and assume again that the change in density is dominated by
 the change in static pressure
 ```{math}
 \frac{1}{\rho_s} \nabla \rho_s \cdot \mathbf{u}_s
-\approx \beta_s \rho_s \textbf{g} \cdot \mathbf{u}_s``` so we get
+\approx \beta_s \rho_s \textbf{g} \cdot \mathbf{u}_s
+```
+so we get
 ```{math}
 \frac{\partial \phi}{\partial t} + \mathbf{u}_s \cdot \nabla \phi
 = \frac{\Gamma}{\rho_s}

--- a/doc/sphinx/user/methods/melt-transport.md
+++ b/doc/sphinx/user/methods/melt-transport.md
@@ -14,7 +14,6 @@ the advection of a compositional field representing the volume fraction of
 melt present at any given time (the porosity $\phi$), and also a change of the
 mechanical part of the system. The latter is implemented using the approach of
 (Keller, May, and Kaus 2013) and changes the Stokes system to
-
 ```{math}
 \begin{align}
   \label{eq:stokes-1-melt}
@@ -73,11 +72,15 @@ user, we can use the same method as for the mass conservation (described in
 {ref}`2.10.3][]) and assume the change in solid density is dominated
 by the change in static pressure, which can be written as
 $\nabla p_s \approx \nabla p_{\text{static}} \approx \rho_s \textbf{g}$. This
-finally allows us to write ```{math}\frac{1}{\rho_s} \nabla \rho_s
+finally allows us to write
+```{math}
+\frac{1}{\rho_s} \nabla \rho_s
 \approx \frac{1}{\rho_s} \frac{\partial \rho_s}{\partial p_s} \nabla p_s
 \approx \frac{1}{\rho_s} \frac{\partial \rho_s}{\partial p_s} \nabla p_s
 \approx \frac{1}{\rho_s} \frac{\partial \rho_s}{\partial p_s} \rho_s \textbf{g}
-\approx \beta_s \rho_s \textbf{g}.``` where $\beta_s$ is the compressibility of
+\approx \beta_s \rho_s \textbf{g}.
+```
+where $\beta_s$ is the compressibility of
 the solid. In the paper that describes the implementation (Dannberg and
 Heister 2016), $\kappa$ is used for the compressibility. We change the
 variable here to be consistent throughout the manual.
@@ -109,7 +112,9 @@ second equation by
 \end{align}
 ```
 The melt velocity is computed as
-```{math}\mathbf{u}_f =  \mathbf{u}_s - \frac{K_D}{\phi} (\nabla p_f - \rho_f g),```
+```{math}
+\mathbf{u}_f =  \mathbf{u}_s - \frac{K_D}{\phi} (\nabla p_f - \rho_f g),
+```
 but is only used for postprocessing purposes and for computing the time step
 length.
 
@@ -134,17 +139,23 @@ $\phi$:
 In order to solve this equation in the same way as the other advection
 equations, we replace the second term of the equation by:
 
-```{math}\nabla \cdot \left[ \rho_s (1 - \phi) \mathbf{u}_s \right]
+```{math}
+\nabla \cdot \left[ \rho_s (1 - \phi) \mathbf{u}_s \right]
 = \left( 1-\phi \right) \left( \rho_s \nabla \cdot \mathbf{u}_s
 + \nabla \rho_s \cdot \mathbf{u}_s \right)
-- \nabla \phi \cdot \rho_s \mathbf{u}_s``` Then we use the same method as
+- \nabla \phi \cdot \rho_s \mathbf{u}_s
+```
+Then we use the same method as
 described above and assume again that the change in density is dominated by
 the change in static pressure
-```{math}\frac{1}{\rho_s} \nabla \rho_s \cdot \mathbf{u}_s
+```{math}
+\frac{1}{\rho_s} \nabla \rho_s \cdot \mathbf{u}_s
 \approx \beta_s \rho_s \textbf{g} \cdot \mathbf{u}_s``` so we get
-```{math}\frac{\partial \phi}{\partial t} + \mathbf{u}_s \cdot \nabla \phi
+```{math}
+\frac{\partial \phi}{\partial t} + \mathbf{u}_s \cdot \nabla \phi
 = \frac{\Gamma}{\rho_s}
-+ (1 - \phi) (\nabla \cdot \mathbf{u}_s + \beta_s \rho_s \textbf{g} \cdot \mathbf{u}_s ).```
++ (1 - \phi) (\nabla \cdot \mathbf{u}_s + \beta_s \rho_s \textbf{g} \cdot \mathbf{u}_s ).
+```
 
 More details on the implementation can be found in (Dannberg and Heister
 2016). A benchmark case demonstrating the propagation of solitary waves can be


### PR DESCRIPTION
This addresses all occurrences of ` ` `{math} not starting at the top of the line.

The patch also contains a number of fixes where the `{math}` tag was missing from ` ` `. I suspect that there are many places, and I'm afraid they all need to be fixed by hand.

/rebuild