### PR TITLE
Fix code block markup.

### DIFF
--- a/doc/sphinx/user/extending/idea-of-plugins.md
+++ b/doc/sphinx/user/extending/idea-of-plugins.md
@@ -35,7 +35,7 @@ The way this is achieved is through the following two steps:
     the [aspect::GravityModel::Interface][] class (documentation comments have
     been removed):
 
-    ``` c++
+    ```{code-block} c++
     class Interface
         {
           public:
@@ -71,7 +71,7 @@ The way this is achieved is through the following two steps:
     necessary into a class `aspect::GravityModel::GRACE`. Then you need a
     statement like this at the bottom of the file:
 
-    ``` c++
+    ```{code-block} c++
     ASPECT_REGISTER_GRAVITY_MODEL
         (GRACE,
          "grace",
@@ -118,7 +118,7 @@ consider things like postprocessors that can compute things like boundary heat
 fluxes. Taking this as an example (see {ref}`sec:1.4.8][]), you are
 required to write a function with the following interface
 
-``` c++
+```{code-block} c++
 template <int dim>
     class MyPostprocessor : public aspect::Postprocess::Interface
     {
@@ -156,7 +156,7 @@ classes that wish to access information about the state of the simulation
 inherit from the [aspect::SimulatorAccess class][]. This class has an
 interface that looks like this:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class SimulatorAccess
     {
@@ -193,7 +193,7 @@ function of the following kind (a nonsensical but instructive example; see
 {ref}`sec:1.4.8][] for more details on what postprocessors do and how they
 are implemented):[3]
 
-``` c++
+```{code-block} c++
 template <int dim>
     std::pair<std::string,std::string>
     MyPostprocessor<dim>::execute (TableHandler &statistics)

--- a/doc/sphinx/user/extending/plugin-types/geometry-models.md
+++ b/doc/sphinx/user/extending/plugin-types/geometry-models.md
@@ -30,7 +30,7 @@ implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::GeometryModel::Interface
     {
@@ -97,7 +97,7 @@ describes the purpose of boundary indicators as follows:
 > something else would look like this, here setting the boundary indicator to
 > 42 for all faces located at $x=-1$:
 >
-> ``` c++
+> ```{code-block} c++
 > for (typename Triangulation<dim>::active_cell_iterator
 >          cell = triangulation.begin_active();
 >        cell != triangulation.end();
@@ -160,7 +160,7 @@ provide a pointer to itself to the function being called, nor any other
 information, so the trick is to get this information into the function. C++
 provides a nice mechanism for this that is best explained using an example:
 
-``` c++
+```{code-block} c++
 #include <deal.II/base/std_cxx1x/bind.h>
 
     template <int dim>
@@ -199,7 +199,7 @@ achieved as follows: assuming the `set_boundary_indicators()` function has
 been declared as a (non-static, but possibly private) member function of the
 `MyGeometry` class, then the following will work:
 
-``` c++
+```{code-block} c++
 #include <deal.II/base/std_cxx1x/bind.h>
 
     template <int dim>

--- a/doc/sphinx/user/extending/plugin-types/gravity-models.md
+++ b/doc/sphinx/user/extending/plugin-types/gravity-models.md
@@ -9,7 +9,7 @@ The implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::GravityModel::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/heating-models.md
+++ b/doc/sphinx/user/extending/plugin-types/heating-models.md
@@ -23,7 +23,7 @@ implementation of the new class should be in namespace `aspect::HeatingModel`.
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::HeatingModel::Interface
     {
@@ -69,7 +69,7 @@ positions, so for each heating term (for example the heating source terms), a
 `std::vector` is returned. The following members of `HeatingModelOutputs` need
 to be filled:
 
-``` c++
+```{code-block} c++
 struct HeatingModelOutputs
 {
        std::vector<double> heating_source_terms;

--- a/doc/sphinx/user/extending/plugin-types/initial-conditions.md
+++ b/doc/sphinx/user/extending/plugin-types/initial-conditions.md
@@ -19,7 +19,7 @@ implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::InitialConditions::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/material-models.md
+++ b/doc/sphinx/user/extending/plugin-types/material-models.md
@@ -12,7 +12,7 @@ is given in {ref}`sec:davies-case23_BA`16].
 
 Specifically, your new class needs to implement the following interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::MaterialModel::Interface
     {
@@ -49,7 +49,7 @@ handling lookups at an arbitrary number of positions, so for each variable
 (for example viscosity), a std::vector is returned. The following members of
 MaterialModelOutputs need to be filled:
 
-``` c++
+```{code-block} c++
 struct MaterialModelOutputs
 {
           std::vector<double> viscosities;

--- a/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
+++ b/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
@@ -35,7 +35,7 @@ The implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::MeshRefinement::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/postprocessors.md
+++ b/doc/sphinx/user/extending/plugin-types/postprocessors.md
@@ -124,7 +124,7 @@ Primarily, this difficulty results from two facts:
 Given these comments, the interface a postprocessor class has to implement is
 rather basic:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::Postprocess::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/temp-bc.md
+++ b/doc/sphinx/user/extending/plugin-types/temp-bc.md
@@ -13,7 +13,7 @@ The implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::BoundaryTemperature::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/terminate-criteria.md
+++ b/doc/sphinx/user/extending/plugin-types/terminate-criteria.md
@@ -17,7 +17,7 @@ implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::TerminationCriteria::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/velocity-bc.md
+++ b/doc/sphinx/user/extending/plugin-types/velocity-bc.md
@@ -20,7 +20,7 @@ class. The implementation of the new class should be in namespace
 
 Specifically, your new class needs to implement the following basic interface:
 
-``` c++
+```{code-block} c++
 template <int dim>
     class aspect::VelocityBoundaryConditions::Interface
     {

--- a/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
+++ b/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
@@ -71,7 +71,7 @@ Visualization plugins can come in two flavors:
         nothing in the base class but can be overridden in a plugin.
         Specifically, the following functions exist:
 
-        ``` c++
+        ```{code-block} c++
         class Interface
             {
               public:
@@ -97,7 +97,7 @@ Visualization plugins can come in two flavors:
         the second of these classes, the following interface functions has to
         be implemented:
 
-        ``` c++
+        ```{code-block} c++
         class dealii::DataPostprocessorScalar
             {
               public:

--- a/doc/sphinx/user/extending/signals.md
+++ b/doc/sphinx/user/extending/signals.md
@@ -43,7 +43,7 @@ respective signals.
 In the first case, code that registers slots with global signals would look
 like this:
 
-``` c++
+```{code-block} c++
 // A function that will be called at the time when parameters are declared.
 // It receives the dimension in which ASPECT will be run as the first argument,
 // and the ParameterHandler object that holds the runtime parameter
@@ -96,7 +96,7 @@ The second kind of signal can be connected to once a simulator object has been
 created. As above, one needs to define the slots, define a connector function,
 and register the connector function. The following gives an example:
 
-``` c++
+```{code-block} c++
 // A function that is called at the end of creating the current constraints
 // on degrees of freedom (i.e., the constraints that describe, for example,
 // hanging nodes, boundary conditions, etc).
@@ -134,7 +134,7 @@ So what could one do in a place like this? One option would be to just monitor
 what is going on, e.g., in code like this that simply outputs into the
 statistics file (see {ref}`sec:viz-stat`10]):
 
-``` c++
+```{code-block} c++
 template <int dim>
 void post_constraints_creation (const SimulatorAccess<dim> &simulator_access,
                                 ConstraintMatrix &current_constraints)


### PR DESCRIPTION
See the correct syntax in quickref.md, and confirmed by @cmills1095 .

/rebuild