### PR TITLE
Documentation: docker - rm duplicate header

### DIFF
--- a/doc/sphinx/user/install/docker-container/index.md
+++ b/doc/sphinx/user/install/docker-container/index.md
@@ -1,7 +1,6 @@
 
 # Docker Container
 
-### Docker Container
 
 
 


### PR DESCRIPTION
Deletes the duplicate header inserted as ####
