### PR TITLE
Use ASCII quotes.

### DIFF
--- a/doc/sphinx/user/cookbooks/cookbooks-overview.md
+++ b/doc/sphinx/user/cookbooks/cookbooks-overview.md
@@ -1,6 +1,6 @@
 ### How to set up computations
 
-<span class="smallcaps">ASPECT</span>&rsquo;s computations are controlled by
+<span class="smallcaps">ASPECT</span>'s computations are controlled by
 input parameter files such as those we will discuss in the following
 sections.[1] Basically, these are just regular text files you can edit with
 programs like `gedit`, `kwrite` or `kate` when working on Linux, or something

--- a/doc/sphinx/user/cookbooks/geophysical-setups.md
+++ b/doc/sphinx/user/cookbooks/geophysical-setups.md
@@ -12,7 +12,7 @@ by one:
 
 -   *What internal forces act on the medium (the equation)?* This may in fact
     be the most difficult to answer part of it all. The real material in
-    Earth&rsquo;s mantle is certainly no Newtonian fluid where the stress is a
+    Earth's mantle is certainly no Newtonian fluid where the stress is a
     linear function of the strain with a proportionality constant (the
     viscosity) $\eta$ that only depends on the temperature. Rather, the real
     viscosity almost surely also depends on the pressure and the strain rate.

--- a/doc/sphinx/user/extending/idea-of-plugins.md
+++ b/doc/sphinx/user/extending/idea-of-plugins.md
@@ -146,7 +146,7 @@ kinds of plugins.
 
 All of this information is of course part of the core of
 ASPECT, as part of the [aspect::Simulator class][].
-However, this is a rather heavy class: it&rsquo;s got dozens of member
+However, this is a rather heavy class: it's got dozens of member
 variables and functions, and it is the one that does all of the numerical
 heavy lifting. Furthermore, to access data in this class would require that
 you need to learn about the internals, the data structures, and the design of
@@ -234,7 +234,7 @@ to indicate that we want the pressure component can be accessed as
 `this->introspection().component_indices.pressure`. While this is certainly
 not shorter than just writing `dim`, it may in fact be easier to remember. It
 is most definitely less prone to errors and makes it simpler to extend the
-code in the future because we don&rsquo;t litter the sources with "magic
+code in the future because we don't litter the sources with "magic
 constants" like the one above.
 
 This [aspect::Introspection][] class has a significant number of variables

--- a/doc/sphinx/user/extending/plugin-types/geometry-models.md
+++ b/doc/sphinx/user/extending/plugin-types/geometry-models.md
@@ -92,7 +92,7 @@ describes the purpose of boundary indicators as follows:
 > By default, all boundary indicators of a mesh are zero, unless you are
 > reading from a mesh file that specifically sets them to something different,
 > or unless you use one of the mesh generation functions in namespace
-> `GridGenerator` that have a &rsquo;colorize&rsquo; option. A typical piece
+> `GridGenerator` that have a 'colorize' option. A typical piece
 > of code that sets the boundary indicator on part of the boundary to
 > something else would look like this, here setting the boundary indicator to
 > 42 for all faces located at $x=-1$:
@@ -132,7 +132,7 @@ describes the purpose of boundary indicators as follows:
 > indicators is also presented in a section of the documentation of the
 > Triangulation class.
 
-Two comments are in order here. First, if a coarse triangulation&rsquo;s faces
+Two comments are in order here. First, if a coarse triangulation's faces
 already accurately represent where you want to pose which boundary condition
 (for example to set temperature values or determine which are no-flow and
 which are tangential flow boundary conditions), then it is sufficient to set

--- a/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
+++ b/doc/sphinx/user/extending/plugin-types/mesh-refinement.md
@@ -1,6 +1,6 @@
 # Mesh refinement criteria
 
-Despite research since the mid-1980s, it isn&rsquo;t completely clear how to
+Despite research since the mid-1980s, it isn't completely clear how to
 refine meshes for complex situations like the ones modeled by
 ASPECT. The basic problem is that mesh refinement
 criteria either can refine based on some variable such as the temperature, the

--- a/doc/sphinx/user/extending/plugin-types/postprocessors.md
+++ b/doc/sphinx/user/extending/plugin-types/postprocessors.md
@@ -90,7 +90,7 @@ written in a particular time step.
 ##### Implementing a postprocessor.
 
 Ultimately, implementing a new postprocessor is no different than any of the
-other plugins. Specifically, you&rsquo;ll have to write a class that overloads
+other plugins. Specifically, you'll have to write a class that overloads
 the [aspect::Postprocess::Interface][] base class and use the
 `ASPECT_REGISTER_POSTPROCESSOR` macro to register your new class. The
 implementation of the new class should be in namespace `aspect::Postprocess`.

--- a/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
+++ b/doc/sphinx/user/extending/plugin-types/vis-postprocessors.md
@@ -36,7 +36,7 @@ temperature and location of each visualization point (implemented in the
 other hand, a hypothetical plugin that simply outputs the norm of the strain
 rate $\sqrt{\varepsilon(\mathbf
   u):\varepsilon(\mathbf u)}$ would not need access to anything but the
-solution vector (which the plugin&rsquo;s main function is given as an
+solution vector (which the plugin's main function is given as an
 argument) and consequently is not derived from the
 [aspect::Postprocess::SimulatorAccess][] class.[7]
 

--- a/doc/sphinx/user/extending/signals.md
+++ b/doc/sphinx/user/extending/signals.md
@@ -4,11 +4,11 @@ Not all things you may want to do fit neatly into the list of plugins of the
 previous sections. Rather, there are cases where you may want to change things
 that are more of the one-off kind and that require code that is at a lower
 level and requires more knowledge about
-ASPECT&rsquo;s internal workings. For such changes,
+ASPECT's internal workings. For such changes,
 we still want to stick with the general principle outlined at the beginning of
 {ref}`sec:1][22]: You should be able to make all of your changes and
 extensions in your own files, without having to modify
-ASPECT&rsquo;s own sources.
+ASPECT's own sources.
 
 To support this, ASPECT uses a
 "signals" mechanism. Signals are, in essence, objects that

--- a/doc/sphinx/user/extending/testing/test-properties.md
+++ b/doc/sphinx/user/extending/testing/test-properties.md
@@ -1,6 +1,6 @@
 # Test properties
 
-ASPECT&rsquo;s test parameter files can contain
+ASPECT's test parameter files can contain
 certain special markers that indicate how this test should be executed.
 Placing such a marker at any point in the test parameter file will indicate to
 the test system what to do with this test. The following properties are

--- a/doc/sphinx/user/extending/write-a-cookbook/manual-section.md
+++ b/doc/sphinx/user/extending/write-a-cookbook/manual-section.md
@@ -81,7 +81,7 @@ follow this general structure:
     extend on these ideas by adding subsections that illustrate how these
     modifications influence the model results.
 
-And that&rsquo;s it, you have just created your first cookbook! Make a [pull
+And that's it, you have just created your first cookbook! Make a [pull
 request][] to contribute it to the main repository! You can find more
 information on how to do that on [our github page][].
 

--- a/doc/sphinx/user/extending/write-a-plugin.md
+++ b/doc/sphinx/user/extending/write-a-plugin.md
@@ -95,7 +95,7 @@ to do:
     shell environment variable `ASPECT_DIR`, or just one directory up. It then
     sets up compiler paths and similar, and the following lines simply define
     the name of a plugin, list the source files for it, and define everything
-    that&rsquo;s necessary to compile them into a shared library. Calling
+    that's necessary to compile them into a shared library. Calling
     `make` on the command line then simply compiles everything.
 
 <div class="center">


### PR DESCRIPTION
I suspect that these had gotten in there because someone used a non-American keyboard when writing the latex sources, inserting a unicode quote.

/rebuild