### PR TITLE
Drop duplicate markdown headers.

### DIFF
--- a/doc/sphinx/user/install/docker-container/index.md
+++ b/doc/sphinx/user/install/docker-container/index.md
@@ -2,8 +2,6 @@
 # Docker Container
 
 
-
-
 :::{toctree}
 installing-docker.md
 running-models.md

--- a/doc/sphinx/user/install/docker-container/running-models.md
+++ b/doc/sphinx/user/install/docker-container/running-models.md
@@ -1,8 +1,6 @@
 
 # Running ASPECT models
 
-#### Running ASPECT models
-
 Although it is possible to use the downloaded
 ASPECT docker image in a number of different ways, we
 recommend the following workflow:

--- a/doc/sphinx/user/install/local-installation/compiling.md
+++ b/doc/sphinx/user/install/local-installation/compiling.md
@@ -1,8 +1,6 @@
 
 # Compiling ASPECT and generating documentation
 
-#### Compiling ASPECT and generating documentation
-
 After downloading ASPECT and having built the
 libraries it builds on, you can compile it by typing
 

--- a/doc/sphinx/user/install/local-installation/index.md
+++ b/doc/sphinx/user/install/local-installation/index.md
@@ -1,8 +1,6 @@
 
 # Local installation
 
-### Local installation
-
 This is a brief explanation of how to compile and install the required
 dependencies and ASPECT itself. This
 installation procedure guarantees fastest runtimes, and largest flexibility,

--- a/doc/sphinx/user/install/local-installation/obtaining.md
+++ b/doc/sphinx/user/install/local-installation/obtaining.md
@@ -1,8 +1,6 @@
 
 # Obtaining ASPECT and initial configuration
 
-#### Obtaining ASPECT and initial configuration
-
 The development version of ASPECT can be
 downloaded by executing the command
 

--- a/doc/sphinx/user/install/local-installation/system-prereqs.md
+++ b/doc/sphinx/user/install/local-installation/system-prereqs.md
@@ -1,8 +1,6 @@
 
 # System prerequisites
 
-#### System prerequisites
-
 `candi` will show system specific instructions on startup, but its
 prerequisites are relatively widely used and packaged for most operating
 systems. You will need compilers for C, C++ and Fortran, the GNU make system,

--- a/doc/sphinx/user/install/local-installation/using-candi.md
+++ b/doc/sphinx/user/install/local-installation/using-candi.md
@@ -1,8 +1,6 @@
 
 # Using candi to compile dependencies
 
-#### Using candi to compile dependencies
-
 In its default configuration `candi` downloads and compiles a <span
 class="smallcaps">deal.II</span> configuration that is able to run
 ASPECT, but it also contains a number of packages

--- a/doc/sphinx/user/methods/advection-stabilization/entropy-viscosity.md
+++ b/doc/sphinx/user/methods/advection-stabilization/entropy-viscosity.md
@@ -1,8 +1,6 @@
 
 # Entropy viscosity
 
-#### Entropy viscosity
-
 The entropy viscosity method ((Guermond, Pasquetti, and Popov 2011;
 Kronbichler, Heister, and Bangerth 2012)) adds an artificial diffusion $\nu_h$
 to the weak form [\[eqn:weak-form-for-advection`35], where the diffusion

--- a/doc/sphinx/user/methods/advection-stabilization/index.md
+++ b/doc/sphinx/user/methods/advection-stabilization/index.md
@@ -1,8 +1,6 @@
 
 # Advection Stabilization
 
-### Advection Stabilization
-
 ASPECT implements several advection schemes for
 the temperature and compositional field equations. Specifically, the parameter
 {ref}`parameters:Discretization/Stabilization_20parameters/Stabilization_20method`34]

--- a/doc/sphinx/user/methods/advection-stabilization/supg.md
+++ b/doc/sphinx/user/methods/advection-stabilization/supg.md
@@ -1,8 +1,6 @@
 
 # SUPG Stabilization
 
-#### SUPG Stabilization
-
 For streamline upwind/Petrov-Galerkin (SUPG) (see for example (John and
 Knobloch 2006; Clevenger and Heister 2019)), we add to the weak form
 $a(\cdot,\cdot)$ the cell-wise defined weak form

--- a/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
+++ b/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
@@ -1,8 +1,6 @@
 
 # Arbitrary Lagrangian-Eulerian implementation
 
-#### Arbitrary Lagrangian-Eulerian implementation
-
 The question of how to handle the motion of the mesh with a free surface is
 challenging. Eulerian meshes are well behaved, but they do not move with the
 fluid motions, which makes them difficult for use with free surfaces.

--- a/doc/sphinx/user/methods/freesurface/stabilization.md
+++ b/doc/sphinx/user/methods/freesurface/stabilization.md
@@ -1,8 +1,6 @@
 
 # Free surface stabilization
 
-#### Free surface stabilization
-
 Small disequilibria in the location of a free surface can cause instabilities
 in the surface position and result in a "sloshing" instability.
 This may be countered with a quasi-implicit free surface integration scheme

--- a/doc/sphinx/user/methods/geometric-multigrid.md
+++ b/doc/sphinx/user/methods/geometric-multigrid.md
@@ -1,8 +1,6 @@
 
 # Geometric Multigrid
 
-### Geometric Multigrid
-
 ASPECT can optionally use a Geometric Multigrid
 Solver (GMG) for the efficient solution of the Stokes system (velocity and
 pressure). When used correctly, this can reduce the compute time spent in the

--- a/doc/sphinx/user/methods/particles.md
+++ b/doc/sphinx/user/methods/particles.md
@@ -1,9 +1,6 @@
 (sec:methods:particles)=
 # Particles
 
-
-### Particles
-
 ASPECT can, optionally, also deal with
 particles (sometimes called "tracers"). Particles can be thought
 of as point-like objects that are simply advected along with the flow. In

--- a/doc/sphinx/user/run-aspect/2d-vs-3d.md
+++ b/doc/sphinx/user/run-aspect/2d-vs-3d.md
@@ -1,8 +1,6 @@
 (sec:run-aspect:2d-vs-3d)=
 # Selecting between 2d and 3d runs
 
-### Selecting between 2d and 3d runs
-
 ASPECT can solve both two- and
 three-dimensional problems.[13] You select which one you want by putting a
 line like the following into the parameter file (see

--- a/doc/sphinx/user/run-aspect/checkpoint-restart.md
+++ b/doc/sphinx/user/run-aspect/checkpoint-restart.md
@@ -1,7 +1,5 @@
 # Checkpoint/restart support
 
-### Checkpoint/restart support
-
 If you do long runs, especially when using parallel computations, there are a
 number of reasons to periodically save the state of the program:
 

--- a/doc/sphinx/user/run-aspect/debug-mode.md
+++ b/doc/sphinx/user/run-aspect/debug-mode.md
@@ -1,7 +1,5 @@
 # Debug or optimized mode
 
-### Debug or optimized mode
-
 ASPECT utilizes a <span
 class="smallcaps">deal.II</span> feature called *debug mode*. By default,
 ASPECT uses debug mode, i.e., it calls a

--- a/doc/sphinx/user/run-aspect/gui/installing.md
+++ b/doc/sphinx/user/run-aspect/gui/installing.md
@@ -1,7 +1,5 @@
 # Installing parameter-GUI
 
-#### Installing parameter-GUI
-
 The deal.II parameter-GUI program can be
 downloaded at <https://github.com/dealii/parameter_gui>, and is compiled using
 the `cmake` program just like ASPECT itself.

--- a/doc/sphinx/user/run-aspect/gui/using.md
+++ b/doc/sphinx/user/run-aspect/gui/using.md
@@ -1,7 +1,5 @@
 # Using ASPECT-GUI
 
-#### Using ASPECT-GUI
-
 When configuring ASPECT after executing the
 above steps, it should automatically pick up the location of the
 parameter-GUI, and will create a new script named `aspect-gui` within the

--- a/doc/sphinx/user/run-aspect/overview.md
+++ b/doc/sphinx/user/run-aspect/overview.md
@@ -1,8 +1,6 @@
 (sec:run-aspect:overview)=
 # Overview
 
-### Overview
-
 After compiling ASPECT as described above, you
 should have an executable file in the build directory. It can be called in the
 build directory as follows:

--- a/doc/sphinx/user/run-aspect/parameters-overview/categories.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/categories.md
@@ -1,7 +1,5 @@
 # Categories of parameters
 
-#### Categories of parameters
-
 The parameters that can be provided in the input file can roughly be
 categorized into the following groups:
 

--- a/doc/sphinx/user/run-aspect/parameters-overview/compatibility.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/compatibility.md
@@ -1,7 +1,5 @@
 # Compatibility of input files with newer ASPECT versions
 
-#### Compatibility of input files with newer ASPECT versions
-
 We strive to maintain compatibility for options in input files as long as
 possible. However, occasionally we have to reorder, rename, or remove options
 from parameter files to improve ASPECT further.

--- a/doc/sphinx/user/run-aspect/parameters-overview/muparser-format.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/muparser-format.md
@@ -1,8 +1,6 @@
 (sec:run-aspect:parameters-overview:muparser-format)=
 # A note on the syntax of formulas in input files
 
-#### A note on the syntax of formulas in input files
-
 Input files have different ways of describing certain things to
 ASPECT. For example, you could select a plugin for
 the temperature initial values that prescribes a constant temperature, or a

--- a/doc/sphinx/user/run-aspect/parameters-overview/structure.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/structure.md
@@ -1,7 +1,5 @@
 # The structure of parameter files
 
-#### The structure of parameter files
-
 Most of the run-time behavior of ASPECT is
 driven by a parameter file that looks in essence like this:
 

--- a/doc/sphinx/user/run-aspect/run-faster/limiting-postprocessing.md
+++ b/doc/sphinx/user/run-aspect/run-faster/limiting-postprocessing.md
@@ -1,7 +1,5 @@
 # Limiting postprocessing
 
-#### Limiting postprocessing
-
 ASPECT has a lot of postprocessing
 capabilities, from generating graphical output to computing average
 temperatures or temperature fluxes. To see what all is possible, take a look

--- a/doc/sphinx/user/run-aspect/run-faster/lower-order-elements.md
+++ b/doc/sphinx/user/run-aspect/run-faster/lower-order-elements.md
@@ -1,7 +1,5 @@
 # Using lower order elements for the temperature/compositional discretization
 
-#### Using lower order elements for the temperature/compositional discretization
-
 The default settings of ASPECT use quadratic
 finite elements for the velocity. Given that the temperature and compositional
 fields essentially (up to material parameters) satisfy advection equations of

--- a/doc/sphinx/user/run-aspect/run-faster/multithreading.md
+++ b/doc/sphinx/user/run-aspect/run-faster/multithreading.md
@@ -1,7 +1,5 @@
 # Using multithreading
 
-#### Using multithreading
-
 In most cases using as many MPI processes as possible is the optimal
 parallelization strategy for ASPECT models, but
 if you are limited by the amount of MPI communication it can be beneficial to

--- a/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
@@ -1,7 +1,5 @@
 # Adjusting solver preconditioner tolerances
 
-#### Adjusting solver preconditioner tolerances
-
 To solve the Stokes equations it is necessary to lower the condition number of
 the Stokes matrix by preconditioning it. In
 ASPECT a right preconditioner $Y^{-1} =

--- a/doc/sphinx/user/run-aspect/run-faster/pressure-norm-off.md
+++ b/doc/sphinx/user/run-aspect/run-faster/pressure-norm-off.md
@@ -1,7 +1,5 @@
 # Switching off pressure normalization
 
-#### Switching off pressure normalization
-
 In most practically relevant cases, the Stokes equations
 {math:numref}`eq:stokes-1-{math:numref}`eq:stokes-2 only determine the pressure up
 to a constant because only the pressure gradient appears in the equations, not

--- a/doc/sphinx/user/run-aspect/run-faster/regularize.md
+++ b/doc/sphinx/user/run-aspect/run-faster/regularize.md
@@ -1,7 +1,5 @@
 # Regularizing models with large coefficient variation
 
-#### Regularizing models with large coefficient variation
-
 Models with large jumps in viscosity and other coefficients present
 significant challenges to both discretizations and solvers. In particular,
 they can lead to very long solver times. {ref}`5.2.8][] presents

--- a/doc/sphinx/user/run-aspect/run-faster/solver-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/solver-tolerance.md
@@ -1,7 +1,5 @@
 # Adjusting solver tolerances
 
-#### Adjusting solver tolerances
-
 At the heart of every time step lies the solution of linear systems for the
 Stokes equations, the temperature field, and possibly for compositional
 fields. In essence, each of these steps requires us to solve a linear system

--- a/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
+++ b/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
@@ -1,7 +1,5 @@
 # Large data issues for parallel computations
 
-#### Large data issues for parallel computations
-
 Among the challenges in visualizing the results of parallel computations is
 dealing with the large amount of data. The first bottleneck this presents is
 during run-time when ASPECT wants to write the

--- a/doc/sphinx/user/run-aspect/visualizing-results/stat-data.md
+++ b/doc/sphinx/user/run-aspect/visualizing-results/stat-data.md
@@ -1,7 +1,5 @@
 # Visualizing statistical data
 
-#### Visualizing statistical data
-
 In addition to the graphical output discussed above,
 ASPECT produces a statistics file that collects
 information produced during each time step. For the remainder of this section,


### PR DESCRIPTION
@cmills1095 -- FYI, the command line was this:
```
for i in `find . | grep .md` ; do cat $i | perl -e "local $/; my \$x = <>; \$x =~ s/\# (.*)\s+\#+ +\1/\# \1/g; print \$x;" > $i.tmp ; mv $i.tmp $i ; done
```
This probably took me ten minutes to figure out, though :-)

/rebuild