### PR TITLE
No longer take arguments by value.

### DIFF
--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -558,8 +558,8 @@ namespace aspect
          * writing data is still continuing.
          */
         static
-        void writer (const std::string filename,
-                     const std::string temporary_filename,
+        void writer (const std::string &filename,
+                     const std::string &temporary_filename,
                      const std::string &file_contents);
 
         /**

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -832,9 +832,8 @@ namespace aspect
 
 
     template <int dim>
-    // We need to pass the arguments by value, as this function can be called on a separate thread:
-    void Visualization<dim>::writer (const std::string filename, //NOLINT(performance-unnecessary-value-param)
-                                     const std::string temporary_output_location, //NOLINT(performance-unnecessary-value-param)
+    void Visualization<dim>::writer (const std::string &filename,
+                                     const std::string &temporary_output_location,
                                      const std::string &file_contents)
     {
       std::string tmp_filename = filename;


### PR DESCRIPTION
Since we call this function from a lambda function (which may itself be run on a separate thread), we no longer need to worry about copying the function arguments -- the lambda function has to worry about it, and does in #4639 and #4645. (The style must have been a left-over when we didn't use lambda functions but used `Threads::new_thread()`.)

Follow-up to https://github.com/geodynamics/aspect/pull/4639.