### PR TITLE
Documentation: large data

### DIFF
--- a/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
+++ b/doc/sphinx/user/run-aspect/visualizing-results/large-data-issues.md
@@ -1,7 +1,5 @@
 # Large data issues for parallel computations
 
-#### Large data issues for parallel computations
-
 Among the challenges in visualizing the results of parallel computations is
 dealing with the large amount of data. The first bottleneck this presents is
 during run-time when ASPECT wants to write the
@@ -19,7 +17,7 @@ ASPECT for this scenario:
     your cluster has a fast, distributed file system, then
     ASPECT can produce output files that are already
     located in the correct output directory (see the options in
-    {ref}`parameters:global`17]) on the global file system.
+    {ref}`parameters:global`) on the global file system.
     ASPECT uses MPI I/O calls to this end, ensuring
     that the local machines do not have to access these files using slow
     NFS-mounted global file systems.
@@ -32,10 +30,14 @@ ASPECT for this scenario:
     into such a file and then move it in the background to its final
     destination while already continuing computations. To select this mode,
     set the appropriate variables discussed in
-    {ref}`parameters:Postprocess/Visualization`52]. Note,
+    {ref}`parameters:Postprocess/Visualization`. Note,
     however, that this scheme only makes sense if every machine on which MPI
     processes run has fast local disk space for temporary storage.
 
-<div class="center">
-
-</div>
+:::{note}
+An alternative would be if every processor directly writes its own files into the global
+output directory (possibly in the background), without the intermediate step of the temporary
+file. In our experience, file servers are quickly overwhelmed when encountering a few hundred
+machines wanting to open, fill, flush and close their own file via NFS mounted file system calls,
+sometimes completely blocking the entire cluster environment for extended periods of time.
+:::


### PR DESCRIPTION
Removes a level 4 header (why are these still showing up?) and adds the notebox.  
Still needs to be fixed for references.
