### PR TITLE
Documentation: Parameter overview

### DIFF
--- a/doc/sphinx/user/run-aspect/parameters-overview/index.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/index.md
@@ -6,7 +6,7 @@ What ASPECT computes is driven by two things:
 -   The models implemented in ASPECT. This
     includes the geometries, the material laws, or the initial conditions
     currently supported. Which of these models are currently implemented is
-    discussed below; {ref}`sec:extending`9] discusses in great
+    discussed below; {ref}`sec:extending` discusses in great
     detail the process of implementing additional models.
 
 -   The run-time parameters of the selected model. For example, you could select a model that prescribes
@@ -14,7 +14,7 @@ What ASPECT computes is driven by two things:
     currently implemented; you could then select appropriate values for all of
     these constants. Both of these selections happen from a parameter file
     that is read at run time and whose name is specified on the command line.
-    (See also {ref}`4.2`[].)
+    (See also {ref}`4.2`.)
 
 In this section, let us give an overview of what can be selected in the
 parameter file. Specific parameters, their default values, and allowed values

--- a/doc/sphinx/user/run-aspect/parameters-overview/index.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/index.md
@@ -9,17 +9,16 @@ What ASPECT computes is driven by two things:
     discussed below; {ref}`sec:extending`9] discusses in great
     detail the process of implementing additional models.
 
--   Which of the implemented models is selected, and what their run-time
-    parameters are. For example, you could select a model that prescribes
+-   The run-time parameters of the selected model. For example, you could select a model that prescribes
     constant coefficients throughout the domain from all the material models
     currently implemented; you could then select appropriate values for all of
     these constants. Both of these selections happen from a parameter file
     that is read at run time and whose name is specified on the command line.
-    (See also {ref}`4.2][].)
+    (See also {ref}`4.2`[].)
 
 In this section, let us give an overview of what can be selected in the
 parameter file. Specific parameters, their default values, and allowed values
-for these parameters are documented in {ref}`sec:parameters`8].
+for these parameters are documented in {ref}`sec:parameters`.
 An index with page numbers for all run-time parameters can be found on
 page&nbsp;.
 


### PR DESCRIPTION
I found the bullet points confusing as it referred to the "implemented models" in both bullets and the point was unclear. I rewrote it to remove the "which" that starts the phrase. Is this what is really meant?
Still needs properly referenced links.
