### PR TITLE
remove reference viscosity from the material model interface

### DIFF
--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -52,9 +52,6 @@ namespace aspect
         bool is_compressible () const;
 
         virtual
-        double reference_viscosity () const;
-
-        virtual
         void
         evaluate (const MaterialModelInputs<dim> &in,
                   MaterialModelOutputs<dim> &out) const;
@@ -114,16 +111,6 @@ namespace aspect
     CompressibilityFormulations<dim>::update()
     {
       base_model->update();
-    }
-
-
-
-    template <int dim>
-    double
-    CompressibilityFormulations<dim>::
-    reference_viscosity () const
-    {
-      return base_model->reference_viscosity();
     }
 
 

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -45,7 +45,6 @@ namespace aspect
         virtual void parse_parameters(ParameterHandler &prm);
 
         virtual bool is_compressible () const;
-        virtual double reference_viscosity () const;
 
         virtual void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
 
@@ -98,14 +97,6 @@ namespace aspect
     is_compressible () const
     {
       return base_model->is_compressible();
-    }
-
-    template <int dim>
-    double
-    ExponentialDecay<dim>::
-    reference_viscosity() const
-    {
-      return base_model->reference_viscosity();
     }
 
 

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -43,7 +43,6 @@ namespace aspect
         virtual void parse_parameters(ParameterHandler &prm);
 
         virtual bool is_compressible () const;
-        virtual double reference_viscosity () const;
 
         virtual void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
 
@@ -96,14 +95,6 @@ namespace aspect
     is_compressible () const
     {
       return base_model->is_compressible();
-    }
-
-    template <int dim>
-    double
-    ExponentialDecay<dim>::
-    reference_viscosity() const
-    {
-      return base_model->reference_viscosity();
     }
 
 

--- a/doc/modules/changes/20220520_jdannberg
+++ b/doc/modules/changes/20220520_jdannberg
@@ -1,0 +1,8 @@
+Changed: The reference viscosity function is no longer part
+of the material model interface (because we do not require 
+it anymore for the pressure scaling or anywhere else). The
+One material model affected by this is the depth-dependent
+model, which now has its own reference viscosity parameter
+rather than use the reference viscosity of the base model.
+<br>
+(Juliane Dannberg, 2022/05/20)

--- a/doc/modules/changes/20220520_jdannberg
+++ b/doc/modules/changes/20220520_jdannberg
@@ -1,7 +1,7 @@
 Changed: The reference viscosity function is no longer part
 of the material model interface (because we do not require 
 it anymore for the pressure scaling or anywhere else). The
-One material model affected by this is the depth-dependent
+one material model affected by this is the depth-dependent
 model, which now has its own reference viscosity parameter
 rather than use the reference viscosity of the base model.
 <br>

--- a/include/aspect/material_model/ascii_reference_profile.h
+++ b/include/aspect/material_model/ascii_reference_profile.h
@@ -79,7 +79,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         /**
          * @}

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -122,13 +122,6 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        /**
-         * Method to calculate reference viscosity for the depth-dependent model. The reference
-         * viscosity is determined by evaluating the depth-dependent part of the viscosity at
-         * the mean depth of the model.
-         */
-        double reference_viscosity () const override;
-
 
 
       private:

--- a/include/aspect/material_model/compositing.h
+++ b/include/aspect/material_model/compositing.h
@@ -101,13 +101,6 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        /**
-         * @copydoc MaterialModel::Interface::reference_viscosity()
-         *
-         * Taken from the material model providing viscosities
-         */
-        double reference_viscosity () const override;
-
 
 
       private:

--- a/include/aspect/material_model/composition_reaction.h
+++ b/include/aspect/material_model/composition_reaction.h
@@ -74,7 +74,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -82,13 +82,6 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        /**
-         * Method to calculate reference viscosity for the depth-dependent model. The reference
-         * viscosity is determined by evaluating the depth-dependent part of the viscosity at
-         * the mean depth of the model.
-         */
-        double reference_viscosity () const override;
-
       private:
 
         /**
@@ -101,6 +94,10 @@ namespace aspect
           List,
           None
         };
+
+        // The viscosity that will be used as a reference for scaling the depth-dependent
+        // prefactor.
+        double reference_viscosity;
 
         /**
          * Currently chosen source for the viscosity.
@@ -137,6 +134,7 @@ namespace aspect
          */
         std::vector<double> depth_values;
         std::vector<double> viscosity_values;
+
         /**
          * Parsed function that specifies viscosity depth-dependence when using the Function
          * method.

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -27,6 +27,8 @@
 #include <deal.II/base/parsed_function.h>
 #include <aspect/material_model/rheology/ascii_depth_profile.h>
 
+#include <boost/lexical_cast.hpp>
+
 namespace aspect
 {
   namespace MaterialModel

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -98,7 +98,7 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         static
         void

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -114,7 +114,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -108,7 +108,7 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
                       typename Interface<dim>::MaterialModelOutputs &out) const override;

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1188,7 +1188,7 @@ namespace aspect
      * argument struct instead of implementing the functions viscosity(),
      * density(), etc.. In this case, all other functions are being ignored.
      *
-     * In all cases, model_dependence values, is_compressible(), reference_viscosity()
+     * In all cases, model_dependence values, is_compressible()
      * need to be implemented.
      *
      * @ingroup MaterialModels
@@ -1257,33 +1257,6 @@ namespace aspect
          * (incompressible Stokes).
          */
         virtual bool is_compressible () const = 0;
-        /**
-         * @}
-         */
-
-        /**
-         * @name Reference quantities
-         * @{
-         */
-        /**
-         * Return a reference value typical of the viscosities that appear in
-         * this model. This value is not actually used in the material
-         * description itself, but is used in scaling variables to the same
-         * numerical order of magnitude when solving linear systems.
-         * Specifically, the reference viscosity appears in the factor scaling
-         * the pressure against the velocity. It is also used in computing
-         * dimension-less quantities. You may want to take a look at the
-         * Kronbichler, Heister, Bangerth 2012 paper that describes the
-         * design of ASPECT for a description of this pressure scaling.
-         *
-         * @note The reference viscosity should take into account the complete
-         * constitutive relationship, defined as the scalar viscosity times the
-         * constitutive tensor. In most cases, the constitutive tensor will simply
-         * be the identity tensor (this is the default case), but this may become
-         * important for material models with anisotropic viscosities, if the
-         * constitutive tensor is not normalized.
-         */
-        virtual double reference_viscosity () const = 0;
         /**
          * @}
          */

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -77,7 +77,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -76,7 +76,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         /**
          * @}

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -75,7 +75,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         double reference_darcy_coefficient () const override;
 

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -83,7 +83,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         double reference_darcy_coefficient () const override;
 

--- a/include/aspect/material_model/modified_tait.h
+++ b/include/aspect/material_model/modified_tait.h
@@ -77,7 +77,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/multicomponent.h
+++ b/include/aspect/material_model/multicomponent.h
@@ -91,7 +91,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/multicomponent_compressible.h
+++ b/include/aspect/material_model/multicomponent_compressible.h
@@ -92,7 +92,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/nondimensional.h
+++ b/include/aspect/material_model/nondimensional.h
@@ -71,7 +71,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/perplex_lookup.h
+++ b/include/aspect/material_model/perplex_lookup.h
@@ -72,7 +72,7 @@ namespace aspect
 
         bool is_compressible () const override;
 
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                       MaterialModel::MaterialModelOutputs<dim> &out) const override;

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -77,12 +77,6 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        /**
-         * Method to calculate reference viscosity for the model. The reference
-         * viscosity is simply the reference  viscosity from the base model.
-         */
-        double reference_viscosity () const override;
-
       private:
 
         /**

--- a/include/aspect/material_model/simple.h
+++ b/include/aspect/material_model/simple.h
@@ -70,7 +70,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/simple_compressible.h
+++ b/include/aspect/material_model/simple_compressible.h
@@ -82,7 +82,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -48,7 +48,7 @@ namespace aspect
 
         bool is_compressible () const override;
 
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                       MaterialModel::MaterialModelOutputs<dim> &out) const override;

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -175,7 +175,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -197,7 +197,7 @@ namespace aspect
          */
         bool is_compressible () const override;
 
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
 
         static
         void

--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -173,7 +173,7 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        double reference_viscosity () const override;
+        double reference_viscosity () const;
         /**
          * @}
          */

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -418,14 +418,6 @@ namespace aspect
     {
       return base_model->is_compressible();
     }
-
-    template <int dim>
-    double
-    Averaging<dim>::
-    reference_viscosity() const
-    {
-      return base_model->reference_viscosity();
-    }
   }
 }
 

--- a/source/material_model/compositing.cc
+++ b/source/material_model/compositing.cc
@@ -222,17 +222,6 @@ namespace aspect
       const unsigned int ind = model_property_map.find(Property::compressibility)->second;
       return models[ind]->is_compressible();
     }
-
-
-
-    template <int dim>
-    double
-    Compositing<dim>::
-    reference_viscosity() const
-    {
-      const unsigned int ind = model_property_map.at(Property::viscosity);
-      return models[ind]->reference_viscosity();
-    }
   }
 }
 

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -134,15 +134,6 @@ namespace aspect
     {
       return base_model->is_compressible();
     }
-
-    template <int dim>
-    double
-    ReplaceLithosphereViscosity<dim>::
-    reference_viscosity() const
-    {
-      /* Return reference viscosity from base model*/
-      return base_model->reference_viscosity();
-    }
   }
 }
 

--- a/tests/depth_dependent_3d_shell_list_simple.prm
+++ b/tests/depth_dependent_3d_shell_list_simple.prm
@@ -18,6 +18,7 @@ subsection Material model
     set Depth dependence method = List
     set Depth list = 6.7e5, 3.481e6
     set Viscosity list = 1.0e21, 3.0e22
+    set Reference viscosity = 1e22
   end
 
   subsection Simple model

--- a/tests/depth_dependent_box_file_simple.prm
+++ b/tests/depth_dependent_box_file_simple.prm
@@ -121,6 +121,7 @@ subsection Material model
     set Depth dependence method = File
     set Data directory = $ASPECT_SOURCE_DIR/data/material-model/depth-dependent/
     set Viscosity depth file = visc_depth.txt
+    set Reference viscosity = 1e25
   end
   subsection Simple model
     set Reference density             = 3300.0

--- a/tests/depth_dependent_box_function_simple.prm
+++ b/tests/depth_dependent_box_function_simple.prm
@@ -123,6 +123,7 @@ subsection Material model
       set Variable names = d
       set Function expression = if(d>6.70e5,3.0e22,1.0e21);
     end
+    set Reference viscosity = 1e25
   end
   subsection Simple model
     set Reference density             = 3300.0

--- a/tests/depth_dependent_box_function_time_dependent.prm
+++ b/tests/depth_dependent_box_function_time_dependent.prm
@@ -122,6 +122,7 @@ subsection Material model
       set Variable names = d,t
       set Function expression = if(d>6.70e5,3.0e22*(1.0+t/1e8),1.0e21*(1.0+t/1e8));
     end
+    set Reference viscosity = 1e25
   end
   subsection Simple model
     set Reference density             = 3300.0

--- a/tests/depth_dependent_box_none_simple.prm
+++ b/tests/depth_dependent_box_none_simple.prm
@@ -119,6 +119,7 @@ subsection Material model
   subsection Depth dependent model
     set Base model = simple
     set Depth dependence method = None
+    set Reference viscosity = 1e25
   end
   subsection Simple model
     set Reference density             = 3300.0

--- a/tests/depth_dependent_initialize_base_model.prm
+++ b/tests/depth_dependent_initialize_base_model.prm
@@ -13,6 +13,7 @@ subsection Material model
   subsection Depth dependent model
     set Base model = ascii reference profile
     set Depth dependence method = None
+    set Reference viscosity = 1e21
   end
 
   subsection Ascii reference profile

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -108,8 +108,6 @@ namespace aspect
          * @name Reference quantities
          * @{
          */
-        virtual double reference_viscosity () const override;
-
         virtual double reference_darcy_coefficient () const override;
 
         virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
@@ -299,14 +297,6 @@ namespace aspect
         }
       // We will never get here, so just return something
       return cohesions;
-    }
-
-    template <int dim>
-    double
-    MeltViscoPlastic<dim>::
-    reference_viscosity () const
-    {
-      return ref_viscosity;
     }
 
     template <int dim>

--- a/tests/n_expensive_stokes_solver_steps.prm
+++ b/tests/n_expensive_stokes_solver_steps.prm
@@ -120,6 +120,7 @@ subsection Material model
   subsection Depth dependent model
     set Base model = simple
     set Depth dependence method = None
+    set Reference viscosity = 1e25
   end
   subsection Simple model
     set Reference density             = 3300.0

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -212,11 +212,6 @@ namespace aspect
           return false;
         }
 
-        double reference_viscosity() const override
-        {
-          return 1;
-        }
-
         void
         create_additional_named_outputs (MaterialModelOutputs<dim> &outputs) const override
         {


### PR DESCRIPTION
This PR removes the reference viscosity from the material model interface since we do not require it any more for the pressure scaling (or anywhere else in ASPECT). 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
