### PR TITLE
Remove stray symbolic link

### DIFF
--- a/cookbooks/shell_simple_2d/shell_simple_2d
+++ b/cookbooks/shell_simple_2d/shell_simple_2d
@@ -1,1 +1,0 @@
-shell_simple_2d


### PR DESCRIPTION
This was probably accidentally merged during the cookbook conversion.