### PR TITLE
Add inkscape to jenkins tester

### DIFF
--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -1,3 +1,3 @@
-FROM geodynamics/aspect-tester:focal-dealii-9.3-v2
+FROM geodynamics/aspect-tester:focal-dealii-9.3-v3
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && \
   texlive-plain-generic texlive-base texlive-latex-recommended \
   texlive-latex-base texlive-fonts-recommended \
   texlive-bibtex-extra lmodern texlive-latex-extra \
-  texlive-science graphviz python3-pip python-setuptools
+  texlive-science graphviz python3-pip python-setuptools inkscape
 
 RUN pip3 install cpp-coveralls
 

--- a/contrib/docker/tester/build.sh
+++ b/contrib/docker/tester/build.sh
@@ -5,4 +5,4 @@
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 
-docker build -t geodynamics/aspect-tester:focal-dealii-9.3-v1 .
+docker build -t geodynamics/aspect-tester:focal-dealii-9.3-v3 .


### PR DESCRIPTION
This adds inkscape to the docker container that is used as the tester and should prevent errors on the Jenkins tester such as https://jenkins.tjhei.info/blue/organizations/jenkins/aspect/detail/PR-4735/1/pipeline.