### PR TITLE
Remove duplicate math environments

### DIFF
--- a/cookbooks/burnman/doc/burnman.md
+++ b/cookbooks/burnman/doc/burnman.md
@@ -29,9 +29,9 @@ Hence, we have to provide the directory and file name of the data to be used in 
 
 The viscosity in this model is computed as the product of a profile $\eta_r(z)$, where $z$ corresponds to the depth direction of the chosen geometry model, and a term that describes the dependence on temperature:
 ```{math}
-\begin{align}
+\begin{aligned}
 \eta(z,T) = \eta_r(z) \eta_0 \exp\left(-A \frac{T - T_{\text{adi}}}{T_{\text{adi}}}\right),
-\end{align}
+\end{aligned}
 ```
 where $A$ and $\eta_0$ are constants determined in the input file via the parameters `Viscosity` and `Thermal viscosity exponent`, and $\eta_r(z)$ is a stepwise constant function that determines the viscosity profile.
 This function can be specified by providing a list of `Viscosity prefactors` and a list of depths that describe in which depth range each prefactor should be applied, in other words, at which depth the viscosity changes. By default, it is set to viscosity jumps at 150 km depth, between upper mantle and transition zone, and between transition zone and lower mantle). The prefactors used here lead to a low-viscosity asthenosphere, and high viscosities in the lower mantle.

--- a/doc/sphinx/quickref.md
+++ b/doc/sphinx/quickref.md
@@ -419,15 +419,15 @@ F = ma
 ```
 ````
 
-The aligned environment is built into the math directive; be sure to add the same number of align operators (`&`) to each line and use `\\` to denote a new line.
+The split environment is built into the math directive; which allows you to use one align operator (`&`).
 
 ````md
 ```{math}
 :label: eq:aligned
   -\nabla \cdot \left[2\eta
    \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)\right]
-   + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g & \qquad  & \textrm{in $\Omega$},  \\
-  \nabla \cdot (\bar\rho \mathbf u) &= 0  & \qquad  & \textrm{in $\Omega$}.
+   + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g \qquad \textrm{in $\Omega$},  \\
+  \nabla \cdot (\bar\rho \mathbf u) &= 0  \qquad  \textrm{in $\Omega$}.
 ```
 ````
 
@@ -436,8 +436,33 @@ becomes:
 :label: eq:aligned
   -\nabla \cdot \left[2\eta
    \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)\right]
+   + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g \qquad \textrm{in $\Omega$},  \\
+  \nabla \cdot (\bar\rho \mathbf u) &= 0  \qquad \textrm{in $\Omega$}.
+```
+
+If you require more than one alignment character you need to start and end an additional `aligned` environment. Be sure to add the same number of align operators (`&`) to each line and use `\\` to denote a new line.
+
+````md
+```{math}
+:label: eq:aligned
+\begin{aligned}
+  -\nabla \cdot \left[2\eta
+   \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)\right]
    + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g & \qquad  & \textrm{in $\Omega$},  \\
   \nabla \cdot (\bar\rho \mathbf u) &= 0  & \qquad  & \textrm{in $\Omega$}.
+\end{aligned}
+```
+````
+
+becomes:
+```{math}
+:label: eq:multi-aligned
+\begin{aligned}
+  -\nabla \cdot \left[2\eta
+   \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)\right]
+   + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g & \qquad  & \textrm{in $\Omega$},  \\
+  \nabla \cdot (\bar\rho \mathbf u) &= 0  & \qquad  & \textrm{in $\Omega$}.
+\end{aligned}
 ```
 
 ## Links

--- a/doc/sphinx/user/methods/approximate-equations/ala.md
+++ b/doc/sphinx/user/methods/approximate-equations/ala.md
@@ -4,13 +4,13 @@
 The *anelastic liquid approximation (ALA)* is based on two assumptions.
 First, that the density variations relative to the adiabatic reference state at any given depth $\rho(p,T)-\bar\rho (z)$ are small and in particular can be accurately described by a Taylor expansion in pressure and temperature {cite}`schubert:etal:2001`:
 ```{math}
-\begin{align}
+\begin{aligned}
   \rho(p,T) &\approx  \bar\rho
   + \left( \frac{\partial \rho(\bar p,\bar T)}{\partial T} \right)_{p} T'
   + \left( \frac{\partial \rho(\bar p,\bar T)}{\partial P} \right)_{T} p' \\
   \left( \frac{\partial \rho(\bar p,\bar T)}{\partial T} \right)_{p} &= -\bar \alpha \bar \rho(\bar p,\bar T) \\
   \left( \frac{\partial \rho(\bar p,\bar T)}{\partial P} \right)_{T} &= \bar \beta_T \bar \rho(\bar p,\bar T)
-\end{align}
+\end{aligned}
 ```
 where $\bar \alpha$ is the thermal expansion coefficient ($\alpha = -\frac{1}{\rho}\left(\frac{\partial \rho}{\partial T}\right)_p$) and $\bar \beta_T$ is the isothermal compressibility ($\beta_T = \frac{1}{\rho}\left(\frac{\partial \rho}{\partial p}\right)_T$), both on the adiabatic reference curve.
 The subscripts ($p$ or $T$) indicate the variable that is held fixed. The second assumption is that the variation of the density from the reference density can be neglected in the mass balance and temperature equations.

--- a/doc/sphinx/user/methods/approximate-equations/ba.md
+++ b/doc/sphinx/user/methods/approximate-equations/ba.md
@@ -5,11 +5,11 @@ If we further assume that the reference temperature and the reference density ar
 This means that the density in all other parts of the equations is not only independent of the pressure variations $p'$ as assumed in the TALA, but also does not depend on the much larger hydrostatic pressure $\bar p$ nor on the reference temperature $\bar T$.
 We then obtain the following set of equations that also uses the incompressibility in the definition of the strain rate:
 ```{math}
-\begin{align}
+\begin{aligned}
   -\nabla \cdot \left[2\eta \varepsilon(\mathbf u) \right] + \nabla p' &=
   -\bar \alpha \bar\rho T' \mathbf g  & \qquad  & \textrm{in $\Omega$}, \\
   \nabla \cdot \mathbf u &= 0  & \qquad  & \textrm{in $\Omega$}.
-\end{align}
+\end{aligned}
 ```
 In addition, as the reference temperature is constant, one needs to neglect the adiabatic and shear heating in the energy equation
 ```{math}

--- a/doc/sphinx/user/methods/approximate-equations/index.md
+++ b/doc/sphinx/user/methods/approximate-equations/index.md
@@ -18,31 +18,31 @@ The fact that someone else in the past used a simplified formulation does not me
 
 The three approximations mentioned all start by writing the pressure and temperature as the sum of a (possibly depth dependent) reference state plus a perturbation, i.e., we will write
 ```{math}
-\begin{align}
+\begin{aligned}
   p(\mathbf x,t) &= \bar p(z) + p'(\mathbf x,t), \\
   T(\mathbf x,t) &= \bar T(z) + T'(\mathbf x,t).
-\end{align}
+\end{aligned}
 ```
 Here, barred quantities are reference states and may depend on the depth $z$ (not necessarily the third component of $\mathbf x$) whereas primed quantities are the spatially and temporally variable deviations of the temperature and pressure fields from this reference state.
 In particular, the reference pressure is given by solving the hydrostatic equation,
 ```{math}
 :label: eq:hydrostatic-pressure
-\begin{align}
+\begin{aligned}
   \nabla \bar p = \bar\rho \mathbf g,
-\end{align}
+\end{aligned}
 ```
 where $\bar\rho=\rho(\bar p,\bar T)$ is a *reference density* that depends on depth and represents a typical change of material parameters and solution variables with depth.
 $\bar T(z)$ is chosen as an adiabatic profile accounting for the fact that the temperature increases as the pressure increases.
 With these definitions, equations {math:numref}`eq:stokes-1`-{math:numref}`eq:stokes-2` can equivalently be written as follows:
 ```{math}
-\begin{align}
+\begin{aligned}
   -\nabla \cdot \left[2\eta \left(\varepsilon(\mathbf u)
                                   - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
                 \right] + \nabla p' &=  (\rho-\bar\rho) \mathbf g  & \qquad  & \textrm{in $\Omega$},  \\
   \nabla \cdot (\rho \mathbf u) &= 0
   & \qquad
   & \textrm{in $\Omega$}.
-\end{align}
+\end{aligned}
 ```
 The temperature equation, when omitting entropic effects, still reads as
 ```{math}

--- a/doc/sphinx/user/methods/approximate-equations/tala.md
+++ b/doc/sphinx/user/methods/approximate-equations/tala.md
@@ -3,9 +3,9 @@
 
 The *truncated anelastic liquid approximation (TALA)* further simplifies the ALA by assuming that the variation of the density due to pressure variations is small, i.e., that
 ```{math}
-\begin{align}
+\begin{aligned}
   \rho(p,T) \approx  \bar\rho (1 - \bar \alpha T').
-\end{align}
+\end{aligned}
 ```
 This does not mean that the density is not pressure dependent - it will, for example, continue to be
 depth dependent because the hydrostatic pressure grows with depth.
@@ -14,12 +14,12 @@ Because the pressure variation $p'$ is induced by the flow field (the static com
 
 This further assumption then transforms{math:numref}`eq:stokes-ALA-1`-{math:numref}`eq:stokes-ALA-2` into the following equations:
 ```{math}
-\begin{align}
+\begin{aligned}
   -\nabla \cdot \left[2\eta \left(\varepsilon(\mathbf u)
                                   - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
                 \right] + \nabla p' &=  -\bar \alpha \bar\rho T' \mathbf g
                 & \qquad  & \textrm{in $\Omega$},  \\
   \nabla \cdot (\bar\rho \mathbf u) &= 0  & \qquad  & \textrm{in $\Omega$}.
-\end{align}
+\end{aligned}
 ```
 The energy equation is the same as in the ALA case.

--- a/doc/sphinx/user/methods/basic-equations/2d-models.md
+++ b/doc/sphinx/user/methods/basic-equations/2d-models.md
@@ -13,19 +13,19 @@ If one adopts this point of view, the Stokes equations {math:numref}`eq:stokes-1
 
 It is interesting to realize that this compressible strain rate indeed requires a $3\times 3$ tensor. While under the assumptions above, we have
 ```{math}
-\begin{align}
+\begin{aligned}
   \varepsilon(\mathbf u) = \begin{pmatrix} \tfrac{\partial u_x}{\partial x} & \tfrac 12 \tfrac{\partial u_x}{\partial y} + \tfrac 12 \tfrac{\partial u_y}{\partial x} & 0 \\
     \tfrac 12 \tfrac{\partial u_x}{\partial y} + \tfrac 12 \tfrac{\partial u_y}{\partial x} & \tfrac{\partial u_y}{\partial y} & 0 \\
     0 & 0 & 0 \end{pmatrix}
-\end{align}
+\end{aligned}
 ```
 with the expected zeros in the last row and column, the full compressible strain rate tensor reads
 ```{math}
-\begin{align}
+\begin{aligned}
   \varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1 = \begin{pmatrix} \tfrac 23 \tfrac{\partial u_x}{\partial x}  - \tfrac 13 \tfrac{\partial u_y}{\partial y} & \tfrac 12 \tfrac{\partial u_x}{\partial y} + \tfrac 12 \tfrac{\partial u_y}{\partial x} & 0 \\
     \tfrac 12 \tfrac{\partial u_x}{\partial y} +  \tfrac 12 \tfrac{\partial u_y}{\partial x}  & \tfrac 23 \tfrac{\partial u_y}{\partial y} - \tfrac 13 \tfrac{\partial u_x}{\partial x}  & 0 \\
   0 & 0 & - \tfrac 13 \tfrac{\partial u_y}{\partial y} - \tfrac 13 \tfrac{\partial u_x}{\partial x} \end{pmatrix}.
-\end{align}
+\end{aligned}
 ```
 The entry in the $(3,3)$ position of this tensor may be surprising.
 It disappears, however, when taking the (three-dimensional) divergence of the stress, as is done in {math:numref}`eq:stokes-1`, because the divergence applies the $z$ derivative to all elements of the last row - and the assumption above was that all $z$ derivatives are zero; consequently, whatever lives in the third row of the strain rate tensor does not matter.

--- a/doc/sphinx/user/methods/basic-equations/adiabatic-heating.md
+++ b/doc/sphinx/user/methods/basic-equations/adiabatic-heating.md
@@ -3,13 +3,7 @@
 Other codes and texts sometimes make a simplification to the adiabatic heating term in the previous equation.
 If you assume the vertical component of the gradient of the *dynamic* pressure to be small compared to the gradient of the *total* pressure (in other words, the gradient is dominated by the gradient of the hydrostatic pressure), then $-\rho \mathbf g \approx \nabla \mathbf{p}$, and we have the following relation (the negative sign is due to $\mathbf g$ pointing downwards)
 ```{math}
-<<<<<<< HEAD
-\begin{align}
- \alpha T \left( \mathbf u \cdot \nabla \mathbf p \right)   & \approx -\alpha \rho T \mathbf u \cdot \mathbf g.
-\end{align}
-=======
  \alpha T \left( \mathbf u \cdot \nabla \mathbf p \right) \approx -\alpha \rho T \mathbf u \cdot \mathbf g.
->>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
 While this simplification is possible, it is not necessary if you have access to the total pressure.
 ASPECT therefore by default implements the original term without this simplification, but allows to simplify this term by setting the "`Use simplified adiabatic heating`" parameter in {ref}`parameters:Heating_20model/Adiabatic_20heating`.

--- a/doc/sphinx/user/methods/basic-equations/adiabatic-heating.md
+++ b/doc/sphinx/user/methods/basic-equations/adiabatic-heating.md
@@ -3,9 +3,13 @@
 Other codes and texts sometimes make a simplification to the adiabatic heating term in the previous equation.
 If you assume the vertical component of the gradient of the *dynamic* pressure to be small compared to the gradient of the *total* pressure (in other words, the gradient is dominated by the gradient of the hydrostatic pressure), then $-\rho \mathbf g \approx \nabla \mathbf{p}$, and we have the following relation (the negative sign is due to $\mathbf g$ pointing downwards)
 ```{math}
+<<<<<<< HEAD
 \begin{align}
  \alpha T \left( \mathbf u \cdot \nabla \mathbf p \right)   & \approx -\alpha \rho T \mathbf u \cdot \mathbf g.
 \end{align}
+=======
+ \alpha T \left( \mathbf u \cdot \nabla \mathbf p \right) \approx -\alpha \rho T \mathbf u \cdot \mathbf g.
+>>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
 While this simplification is possible, it is not necessary if you have access to the total pressure.
 ASPECT therefore by default implements the original term without this simplification, but allows to simplify this term by setting the "`Use simplified adiabatic heating`" parameter in {ref}`parameters:Heating_20model/Adiabatic_20heating`.

--- a/doc/sphinx/user/methods/basic-equations/bc.md
+++ b/doc/sphinx/user/methods/basic-equations/bc.md
@@ -9,14 +9,14 @@ Several of the cookbooks in {ref}`cha:cookbooks` consider compositional fields i
 
 These equations are augmented by boundary conditions that can either be of Dirichlet, Neumann, or tangential type on subsets of the boundary $\Gamma=\partial\Omega$:
 ```{math}
-\begin{align}
+\begin{aligned}
   \mathbf u &= 0 & \qquad &\textrm{on $\Gamma_{0,\mathbf u}$}, \\
   \mathbf u &= \mathbf u_{\text{prescribed}} & \qquad &\textrm{on $\Gamma_{\text{prescribed},\mathbf u}$}, \\
   \mathbf n \cdot \mathbf u &= 0 & \qquad &\textrm{on $\Gamma_{\parallel,\mathbf u}$}, \\
   (2\eta \varepsilon(\mathbf u) -p I)\mathbf n  &= \mathbf t & \qquad &\textrm{on $\Gamma_{\text{traction},\mathbf u}$}, \\
   T &= T_{\text{prescribed}} & \qquad &\textrm{on $\Gamma_{D,T}$}, \\
   \mathbf n \cdot k\nabla T &= 0  & \qquad &\textrm{on $\Gamma_{N,T}$}. \\
-\end{align}
+\end{aligned}
 ```
 ```{math}
 :label: eq:gamma-in-composition

--- a/doc/sphinx/user/methods/basic-equations/index.md
+++ b/doc/sphinx/user/methods/basic-equations/index.md
@@ -19,8 +19,12 @@ Specifically, we consider the following set of equations for velocity $\mathbf{u
   \rho C_p \left(\frac{\partial T}{\partial t} + \mathbf u\cdot\nabla T\right) - \nabla\cdot k\nabla T &= \rho H \notag \\
   &\quad + 2\eta \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right): \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right) \\
   & \quad +\alpha T \left( \mathbf u \cdot \nabla p \right) \notag \\
+<<<<<<< HEAD
   &\quad + \rho T \Delta S \left(\frac{\partial X}{\partial t} + \mathbf u\cdot\nabla X\right) & & \textrm{in $\Omega$}, \notag \\
 \end{align}
+=======
+  &\quad + \rho T \Delta S \left(\frac{\partial X}{\partial t} + \mathbf u\cdot\nabla X\right) \textrm{in $\Omega$}, \notag \\
+>>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
 ```{math}
 :label: eq:compositional
@@ -58,8 +62,12 @@ With this reformulation, we can rewrite {math:numref}`eq:temperature` in the fol
   \left(\rho C_p - \rho T \Delta S \frac{\partial X}{\partial T}\right) \left(\frac{\partial T}{\partial t} + \mathbf u\cdot\nabla T\right) - \nabla\cdot k\nabla T &= \rho H \notag \\
   &\quad +  2\eta \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right): \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right) \\
   &\quad +\alpha T \left( \mathbf u \cdot \nabla p \right) \notag  \\
+<<<<<<< HEAD
   &\quad  + \rho T \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p & \quad & \textrm{in $\Omega$}.  \notag
 \end{align}
+=======
+  &\quad  + \rho T \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p \quad \textrm{in $\Omega$}.  \notag
+>>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
 
 The last of the equations above, equation {math:numref}`eq:compositional`, describes the evolution of additional fields that are transported along with the velocity field $\mathbf u$ and may react with each other and react to other features of the solution, but that do not diffuse.

--- a/doc/sphinx/user/methods/basic-equations/index.md
+++ b/doc/sphinx/user/methods/basic-equations/index.md
@@ -15,17 +15,13 @@ Specifically, we consider the following set of equations for velocity $\mathbf{u
 ```
 ```{math}
 :label: eq:temperature
-\begin{align}
+\begin{aligned}
   \rho C_p \left(\frac{\partial T}{\partial t} + \mathbf u\cdot\nabla T\right) - \nabla\cdot k\nabla T &= \rho H \notag \\
   &\quad + 2\eta \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right): \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right) \\
   & \quad +\alpha T \left( \mathbf u \cdot \nabla p \right) \notag \\
-<<<<<<< HEAD
-  &\quad + \rho T \Delta S \left(\frac{\partial X}{\partial t} + \mathbf u\cdot\nabla X\right) & & \textrm{in $\Omega$}, \notag \\
-\end{align}
-=======
   &\quad + \rho T \Delta S \left(\frac{\partial X}{\partial t} + \mathbf u\cdot\nabla X\right) \textrm{in $\Omega$}, \notag \\
->>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
+
 ```{math}
 :label: eq:compositional
   \frac{\partial c_i}{\partial t} + \mathbf u\cdot\nabla c_i = q_i \textrm{  in $\Omega$}, i=1\ldots C
@@ -50,24 +46,19 @@ This process applies both to solid-state phase transitions and to melting/solidi
 Here, $\Delta S$ is positive for exothermic phase transitions.
 As the phase of the material, for a given composition, depends on the temperature and pressure, the latent heat term can be reformulated:
 ```{math}
-\begin{gather}
+\begin{aligned}
 \frac{\partial X}{\partial t} + \mathbf u\cdot\nabla X = \frac{DX}{Dt} = \frac{\partial X}{\partial T} \frac{DT}{Dt} + \frac{\partial X}{\partial p} \frac{Dp}{Dt} = \frac{\partial X}{\partial T} \left(\frac{\partial T}{\partial t} + \mathbf u\cdot\nabla T \right) + \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p.
-\end{gather}
+\end{aligned}
 ```
 The last transformation results from the assumption that the flow field is always in equilibrium and consequently $\partial p/\partial t=0$ (this is the same assumption that underlies the fact that equation {math:numref}`eq:stokes-1` does not have a term $\partial \mathbf u / \partial t$).
 With this reformulation, we can rewrite {math:numref}`eq:temperature` in the following way in which it is in fact implemented:
 ```{math}
 :label: eq:temperature-reformulated
-\begin{align}
+\begin{aligned}
   \left(\rho C_p - \rho T \Delta S \frac{\partial X}{\partial T}\right) \left(\frac{\partial T}{\partial t} + \mathbf u\cdot\nabla T\right) - \nabla\cdot k\nabla T &= \rho H \notag \\
   &\quad +  2\eta \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right): \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right) \\
   &\quad +\alpha T \left( \mathbf u \cdot \nabla p \right) \notag  \\
-<<<<<<< HEAD
-  &\quad  + \rho T \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p & \quad & \textrm{in $\Omega$}.  \notag
-\end{align}
-=======
   &\quad  + \rho T \Delta S \frac{\partial X}{\partial p} \mathbf u\cdot\nabla p \quad \textrm{in $\Omega$}.  \notag
->>>>>>> 4e114a6a1 (Remove duplicated alignment characters)
 ```
 
 The last of the equations above, equation {math:numref}`eq:compositional`, describes the evolution of additional fields that are transported along with the velocity field $\mathbf u$ and may react with each other and react to other features of the solution, but that do not diffuse.

--- a/doc/sphinx/user/methods/choosing-a-formulation/adiabatic-profile.md
+++ b/doc/sphinx/user/methods/choosing-a-formulation/adiabatic-profile.md
@@ -5,11 +5,11 @@ The reference temperature profile $\bar{T}$, reference density profile $\bar{\rh
 By default, these fields satisfy adiabatic conditions (if adiabatic heating is included in the model, see {ref}`parameters:Heating_20model/Adiabatic_20heating`):
 
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\textrm{d} \bar{T}(z)}{\textrm{d}z}  &=  \frac{\alpha \bar{T}(z) g_z}{C_p}, \\
   \frac{\textrm{d} \bar{p}(z)}{\textrm{d}z} &= \bar\rho g_z,\\
   \bar{\rho} &= \bar\rho (\bar{p}, \bar{T}, z) \qquad \text{(as defined by the material model)},
-\end{align}
+\end{aligned}
 ```
 where strictly speaking $g_z$ is the magnitude of the vertical component of the gravity vector field, but in practice we take the magnitude of the entire gravity vector.
 If there is no adiabatic heating in the model, $\bar{T}$ is constant by default and set to the adiabatic surface temperature.

--- a/doc/sphinx/user/methods/coefficients/averaging.md
+++ b/doc/sphinx/user/methods/coefficients/averaging.md
@@ -10,18 +10,18 @@ In the case of density, thermal expansivity, heat capacity and bulk compressibil
 Here we must consider conservation of mass and composition in a multicomponent rock $r$.
 If component $i$ has masses $M_i$ and densities $\rho_i$, we can consider the summation of volume fractions:
 ```{math}
-\begin{align}
+\begin{aligned}
 V_r &=& \frac{M_r}{\rho_r} = \sum_i \frac{M_i}{\rho_i} \\
 \frac{1}{\rho_r} &=& \sum_i \frac{x_i}{\rho_i}
-\end{align}
+\end{aligned}
 ```
 where $x_i$ are mass fractions of the components in the rock.
 
 Similarly, we can obtain averaging formulae for the other thermodynamic properties:
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\alpha}{\rho} &=& \sum_i x_i \frac{\alpha_i}{\rho_{i}} \\
   \frac{\beta_T}{\rho} &=& \sum_i x_i \frac{\beta_{Ti}}{\rho_{i}} \\
   C_p &=& \sum_i x_i C_{pi}
-\end{align}
+\end{aligned}
 ```

--- a/doc/sphinx/user/methods/coefficients/self-consistency.md
+++ b/doc/sphinx/user/methods/coefficients/self-consistency.md
@@ -58,20 +58,26 @@ class="smallcaps">ASPECT</span>.
 
 Using the chain rule to combine {math:numref}`eq:mm_density`, {math:numref}`eq:mm_alpha_g` and {math:numref}`eq:mm_betaT_g` yields the more familiar definitions of $\alpha$ and $\beta_T$:
 ```{math}
-\begin{align}
-  \alpha &=& -\frac{1}{\rho} \left( \frac{\partial \rho}{\partial T} \right)_{p}, \label{eq:mm_thermal_expansivity} \\
-  \beta_T &=& \frac{1}{\rho} \left( \frac{\partial \rho}{\partial p} \right)_{T}. \label{eq:mm_isothermal_compressibility}
-\end{align}
+:label: eq:mm_thermal_expansivity
+\begin{aligned}
+  \alpha &=& -\frac{1}{\rho} \left( \frac{\partial \rho}{\partial T} \right)_{p},
+\end{aligned}
+```
+```{math}
+:label: eq:mm_isothermal_compressibility
+\begin{aligned}
+  \beta_T &=& \frac{1}{\rho} \left( \frac{\partial \rho}{\partial p} \right)_{T}.
+\end{aligned}
 ```
 ## Isobaric heat capacity
 
 We start by taking the partial derivative of the isobaric heat capacity {math:numref}`eq:mm_isobaric_heat_capacity` with respect to pressure at constant temperature:
 ```{math}
 :label: eq:heat_capacity_p_dependence
-\begin{align}
+\begin{aligned}
   \left( \frac{\partial C_{p}}{\partial p} \right)_{T} &=& -T \frac{\partial^3 \mathcal{G}}{\partial {T}^2 \, \partial {p}} \\
   &=& -T \left( \frac{\partial \left(\alpha / \rho \right)}{\partial T} \right)_{p}.
-\end{align}
+\end{aligned}
 ```
 From this expression it becomes clear that if $\alpha / \rho$ has any temperature dependence, the heat capacity $C_p$ *cannot* be globally constant.
 One way to solve this issue is to define heat capacity at constant pressure, and then integrate {math:numref}`eq:heat_capacity_p_dependence` with respect
@@ -86,11 +92,11 @@ There is no guarantee that this expression will have a form for which the integr
 The material properties also define the slope of the adiabat (the change in temperature with pressure at constant entropy) at all pressures and temperatures.
 Using the cyclic relation, we can define this slope in terms of partial differentials of the entropy with respect to pressure and temperature:
 ```{math}
-\begin{align}
+\begin{aligned}
   \left( \frac{\partial T}{\partial p} \right)_{S} &=& - \left( \frac{\partial T}{\partial S} \right)_{p} \left( \frac{\partial S}{\partial p} \right)_{T} \\
   &=& - \left( \frac{T}{C_p} \right) \left( - \frac{\alpha}{\rho} \right) \\
   &=& \frac{\alpha T}{\rho C_p} \label{eq:mm_isentropic_gradient}
-\end{align}
+\end{aligned}
 ```
 This expression does not pose a constraint on the material properties, but in order to be self-consistent, the adiabat must be computed following this relation.
 

--- a/doc/sphinx/user/methods/compositional-fields.md
+++ b/doc/sphinx/user/methods/compositional-fields.md
@@ -5,18 +5,18 @@ The last of the basic equations, {math:numref}`eq:compositional`, describes the 
 
 Compositional fields were originally intended to track what their name suggest, namely the chemical composition of the convecting medium. In this interpretation, the composition is a non-diffusive quantity that is simply advected along passively, i.e., it would satisfy the equation
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\partial \mathfrak c}{\partial t} + \mathbf u \cdot \nabla \mathfrak c = 0.
-\end{align}
+\end{aligned}
 ```
 However, the compositional fields may also participate in determining the values of the various coefficients as discussed in {ref}`sec:methods:coefficients`, and in this sense the equation above describes a composition that is *passively advected*, but an *active participant* in the equations.
 
 That said, over time compositional fields have shown to be a much more useful tool than originally intended.
 For example, they can be used to track where material comes from and goes to (see {ref}`sec:cookbooks:simple-setups:passive-active`) and, if one allows for a reaction rate $\mathfrak q$ on the right hand side,
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\partial \mathfrak c}{\partial t} + \mathbf u \cdot \nabla \mathfrak c = \mathfrak q,
-\end{align}
+\end{aligned}
 ```
 then one can also model interaction between species - for example to simulate phase changes where one compositional field, indicating a particular phase, transforms into another phase depending on pressure and temperature, or where several phases combine to other phases.
 Another example of using a right hand side - quite outside what the original term *compositional field* was supposed to indicate - is to track the accumulation of finite strain, see {ref}`sec:cookbooks:simple-setups:tracking-finite-strain`.
@@ -29,9 +29,9 @@ Implementations often approximate this as $\triangle t \cdot \mathfrak q(t)$, or
 A second application for only providing integrated right hand sides comes from the fact that modeling reactions between different compositional fields often involves finding an equilibrium state between different fields because chemical reactions happen on a much faster time scale than transport.
 In other words, one then often assumes that there is a $\mathfrak c^\ast(p,T)$ so that
 ```{math}
-\begin{align}
+\begin{aligned}
   \mathfrak q(p,T,\varepsilon(\mathbf u),\mathfrak c^\ast(p,T)) = 0.
-\end{align}
+\end{aligned}
 ```
 Consequently, the material model methods that deal with source terms for the compositional fields need to compute an *increment* $\Delta\mathfrak c$ to the previous value of the compositional fields so that the sum of the previous values and the increment equals $\mathfrak c^\ast$.
 This corresponds to an *impulse change* in the compositions at every time step, as opposed to the usual approach of evaluating the right hand side term $\mathfrak q$ as a continuous function in time, which corresponds to a *rate*.
@@ -42,15 +42,15 @@ If the strain rate is high, then the grain size decreases as the rocks break.
 If the temperature is high enough, then grains heal and their size increases again.
 Such "damage models" would then introduce a quantity $c(t)$ describing the "damage" to the material (here assumed to be described by a single scalar field) that satisfies an equation of the form
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\partial c}{\partial t} + \mathbf u \cdot \nabla c = q(T,c),
-\end{align}
+\end{aligned}
 ```
 where in the simplest case (much simplified from real models) one could postulate
 ```{math}
-\begin{align}
+\begin{aligned}
   q(T,c) =  A \dot\varepsilon - B \max\{T-T_{\text{healing}},0\} c.
-\end{align}
+\end{aligned}
 ```
 Here, $\dot\varepsilon$ is the strain rate that causes damage; the first term then leads to growth of damage as strain continues to accumulate on the material.
 The second term *decreases* the damage if the temperature is high enough.

--- a/doc/sphinx/user/methods/constitutive-laws.md
+++ b/doc/sphinx/user/methods/constitutive-laws.md
@@ -11,11 +11,11 @@ For these cases ASPECT can optionally include a generalized, fourth-order tensor
 and the shear heating term in equation {math:numref}`eq:temperature` to
 ```{math}
 :label: eq:temperature-anisotropic
-\begin{align}
+\begin{aligned}
   \dots  \notag
   \\ + 2 \eta \left(C \varepsilon(\mathbf u) - \frac{1}{3}(tr(C \varepsilon(\mathbf u)))\mathbf 1\right)  : \left(\varepsilon(\mathbf u) - \frac{1}{3}(\nabla \cdot \mathbf u)\mathbf 1\right)
   \\ \dots \notag
-\end{align}
+\end{aligned}
 ```
 where $C = C_{ijkl}$ is defined by the material model.
 For physical reasons, $C$ needs to be a symmetric rank-4 tensor: i.e., when multiplied by a symmetric (strain rate) tensor of rank 2 it needs to return another symmetric tensor of rank 2.

--- a/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
+++ b/doc/sphinx/user/methods/freesurface/arbitrary-le-implementation.md
@@ -17,12 +17,12 @@ to keep the mesh as well behaved as possible.
 ASPECT uses a Laplacian scheme for calculating
 the mesh velocity. The mesh velocity is calculated by solving
 ```{math}
-\begin{align}
+\begin{aligned}
 -\Delta \textbf{u}_m &= 0 & \qquad & \textrm{in } \Omega, \\
 \textbf{u}_m &= \left( \textbf{u} \cdot \textbf{n} \right) \textbf{n} & \qquad & \textrm{on } \partial \Omega_{\textrm{free surface}}, \\
 \textbf{u}_m \cdot \textbf{n} &= 0 & \qquad & \textrm{on } \partial \Omega_{\textrm{free slip}}, \\
 \textbf{u}_m &= 0 & \qquad & \textrm{on } \partial \Omega_{\textrm{Dirichlet}}.
-\end{align}
+\end{aligned}
 ```
 After this mesh velocity is calculated, the mesh vertices are time-stepped
 explicitly. This scheme has the effect of choosing a minimally distorting

--- a/doc/sphinx/user/methods/initial-conditions.md
+++ b/doc/sphinx/user/methods/initial-conditions.md
@@ -14,7 +14,7 @@ Nevertheless, a nonlinear solver will have difficulty converging to the correct 
 To this end, ASPECT uses pressure and temperature fields $p_{\textrm{ad}}(z), T_{\textrm{ad}}(z)$ computed in the adiabatic conditions model (see {ref}`parameters:Adiabatic_20conditions_20model`).
 By default, these fields satisfy adiabatic conditions:
 ```{math}
-\begin{align}
+\begin{aligned}
   \rho C_p \frac{\textrm{d}}{\textrm{d}z} T_{\textrm{ad}}(z)
   &=
   \frac{\partial\rho}{\partial T} T_{\textrm{ad}}(z) g_z,
@@ -22,7 +22,7 @@ By default, these fields satisfy adiabatic conditions:
   \frac{\textrm{d}}{\textrm{d}z} p_{\textrm{ad}}(z)
   &=
   \rho g_z,
-\end{align}
+\end{aligned}
 ```
 where strictly speaking $g_z$ is the magnitude of the vertical component of the gravity vector field, but in practice we take the magnitude of the entire gravity vector.
 

--- a/doc/sphinx/user/methods/melt-transport.md
+++ b/doc/sphinx/user/methods/melt-transport.md
@@ -21,13 +21,13 @@ mechanical part of the system. The latter is implemented using the approach of
                                   - \frac{1}{3}(\nabla \cdot \mathbf{u}_s)\mathbf 1\right)
                 \right] + \nabla p_f + \nabla p_c  &=
   \rho \mathbf g
-  & \qquad
-  & \textrm{in $\Omega$},
+  \qquad
+  \textrm{in $\Omega$},
   \\
 ```
 ```{math}
 :label: eq:stokes-2-melt
-\begin{align}
+\begin{aligned}
   \nabla \cdot \mathbf{u}_s - \nabla \cdot K_D \nabla p_f
   - K_D \nabla p_f \cdot \frac{\nabla \rho_f}{\rho_f}
   &=
@@ -48,7 +48,7 @@ mechanical part of the system. The latter is implemented using the approach of
   & \textrm{in $\Omega$},
   \notag
   \\
-  \end{align}
+  \end{aligned}
 ```
 ```{math}
 :label: eq:stokes-3-melt
@@ -97,7 +97,7 @@ $\nabla \rho_{f}$ a model input parameter, which can be adapted based on the
 forces that are expected to be dominant in the model. We can then replace the
 second equation by
 ```{math}
-\begin{align}
+\begin{aligned}
 \nabla \cdot \mathbf{u}_s - \nabla \cdot K_D \nabla p_f
   - K_D \nabla p_f \cdot \frac{\nabla \rho_f}{\rho_f}
   &=
@@ -115,7 +115,7 @@ second equation by
   &\quad
   - K_D \mathbf g \cdot \nabla \rho_f .
   \notag
-\end{align}
+\end{aligned}
 ```
 The melt velocity is computed as
 ```{math}
@@ -141,14 +141,14 @@ Moreover, melt transport requires an advection equation for the porosity field
 $\phi$:
 ```{math}
 :label: eq:porosity
-\begin{align}
+\begin{aligned}
   \rho_s \frac{\partial (1 - \phi)}{\partial t} + \nabla \cdot \left[ \rho_s (1 - \phi) \mathbf{u}_s \right]
   &=
   - \Gamma
   & \quad
   & \textrm{in $\Omega$},
   i=1\ldots C
-\end{align}
+\end{aligned}
 ```
 
 In order to solve this equation in the same way as the other advection

--- a/doc/sphinx/user/methods/particles.md
+++ b/doc/sphinx/user/methods/particles.md
@@ -8,10 +8,10 @@ other words, if $\mathbf u(\mathbf x,t)$ is the flow field that results from
 solving equations {math:numref}`eq:stokes-1`-{math:numref}`eq:stokes-2`, then the
 $k$th particle's position satisfies the equations
 ```{math}
-\begin{align}
+\begin{aligned}
   \frac{\partial}{\partial t} \mathbf x_k(t)
   = \mathbf u(\mathbf x_k(t),t).
-\end{align}
+\end{aligned}
 ```
 The initial positions of all
 particles also need to be given and are usually either chosen randomly, based
@@ -29,13 +29,13 @@ each time step. In other words, if we denote by $\mathbf p_{k,m}(t)$ the value
 of the $m$th property attached to the $k$th particle, then
 $\mathbf p_{k,m}(t)$ will satisfy a differential equation of the form
 ```{math}
-\begin{align}
+\begin{aligned}
 \frac{\partial}{\partial t} \mathbf p_{k,m}(t)
 = \mathbf g_m\left(\mathbf p_{k,m},
 p(\mathbf x_k(t),t)), T(\mathbf x_k(t),t)),
 \varepsilon(\mathbf u(\mathbf x_k(t),t)),
 \mathfrak c(\mathbf x_k(t),t)\right).
-\end{align}
+\end{aligned}
 ```
 The exact form of
 $\mathbf g_m$ of course depends on what exactly a particular property

--- a/doc/sphinx/user/methods/pressure-static-dyn.md
+++ b/doc/sphinx/user/methods/pressure-static-dyn.md
@@ -5,23 +5,23 @@ One could reformulate equation {math:numref}`eq:stokes-1` somewhat.
 To this end, let us say that we would want to represent the pressure $p$ as the sum of two parts that we will call static and dynamic, $p=p_s+p_d$.
 If we assume that $p_s$ is already given, then we can replace {math:numref}`eq:stokes-1` by
 ```{math}
-\begin{gather}
+\begin{aligned}
   -\nabla \cdot 2\eta \nabla \mathbf u + \nabla p_d = \rho\mathbf g - \nabla p_s.
-\end{gather}
+\end{aligned}
 ```
 One typically chooses $p_s$ as the pressure one would get if the whole medium were at rest - i.e., as the hydrostatic pressure.
 This pressure can be computed noting that {math:numref}`eq:stokes-1` reduces to
 ```{math}
-\begin{gather}
+\begin{aligned}
   \nabla p_s = \rho(p_s,T_s,\mathbf x)\mathbf g = \bar\rho \mathbf g
-\end{gather}
+\end{aligned}
 ```
 in the absence of any motion where $T_s$ is some static temperature field (see also {ref}`sec:methods:initial-conditions`).
 This, our rewritten version of {math:numref}`eq:stokes-1` would look like this:
 ```{math}
-\begin{gather}
+\begin{aligned}
   -\nabla \cdot 2\eta   \nabla \mathbf u + \nabla p_d = \left[\rho(p,T,\mathbf x)-\rho(p_s,T_s,\mathbf x)\right]\mathbf g.
-\end{gather}
+\end{aligned}
 ```
 In this formulation, it is clear that the quantity that drives the fluid flow is in fact the *buoyancy* caused by the *variation* of densities, not the density itself.
 

--- a/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
@@ -2,11 +2,15 @@
 
 To solve the Stokes equations it is necessary to lower the condition number of
 the Stokes matrix by preconditioning it. In
-ASPECT a right preconditioner $Y^{-1} =
+ASPECT a right preconditioner 
+```{math}
+Y^{-1} =
 \begin{pmatrix}
 \widetilde{A^{-1}} & -\widetilde{A^{-1}}B^{T}\widetilde{S^{-1}} \\
 0 & \widetilde{S^{-1}}
-\end{pmatrix}$ is used to precondition the system, where $\widetilde{A^{-1}}$
+\end{pmatrix}
+```
+ is used to precondition the system, where $\widetilde{A^{-1}}$
 is the approximate inverse of the A block and $\widetilde{S^{-1}}$ is the
 approximate inverse of the Schur complement matrix. Matrix
 $\widetilde{A^{-1}}$ and $\widetilde{S^{-1}}$ are calculated through a CG

--- a/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
+++ b/doc/sphinx/user/run-aspect/run-faster/preconditioner-tolerance.md
@@ -2,7 +2,7 @@
 
 To solve the Stokes equations it is necessary to lower the condition number of
 the Stokes matrix by preconditioning it. In
-ASPECT a right preconditioner 
+ASPECT a right preconditioner
 ```{math}
 Y^{-1} =
 \begin{pmatrix}


### PR DESCRIPTION
The Sphinx `math` directive already includes the functionality of `align`, and while the duplicated math environments do not seem to be a problem for the html generation, it seems to crash the latexpdf build (if we want to build the sphinx documentation as pdf).