### PR TITLE
Fix edit button in documentation

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -69,6 +69,7 @@ html_theme_options = {
     "show_toc_level": 3,
     "repository_url": "https://github.com/geodynamics/aspect/",
     "repository_branch": "main",
+    "path_to_docs":"doc/sphinx/",
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
#4735 broke the edit  button for the documentation, this is an attempt to fix it. Please do not merge until I have checked the live build.