### PR TITLE
References fix

### DIFF
--- a/cookbooks/finite_strain/doc/finite_strain.md
+++ b/cookbooks/finite_strain/doc/finite_strain.md
@@ -1,4 +1,5 @@
-#### Tracking finite strain
+(sec:cookbooks:finite_strain)=
+# Tracking finite strain
 
 *This section was contributed by Juliane Dannberg and Rene Gassm&ouml;ller*
 

--- a/doc/sphinx/user/methods/compositional-fields.md
+++ b/doc/sphinx/user/methods/compositional-fields.md
@@ -12,14 +12,14 @@ Compositional fields were originally intended to track what their name suggest, 
 However, the compositional fields may also participate in determining the values of the various coefficients as discussed in {ref}`sec:methods:coefficients`, and in this sense the equation above describes a composition that is *passively advected*, but an *active participant* in the equations.
 
 That said, over time compositional fields have shown to be a much more useful tool than originally intended.
-For example, they can be used to track where material comes from and goes to (see {ref}`sec:cookbooks:simple-setups:passive-active`) and, if one allows for a reaction rate $\mathfrak q$ on the right hand side,
+For example, they can be used to track where material comes from and goes to (see {ref}`sec:cookbooks-composition`) and, if one allows for a reaction rate $\mathfrak q$ on the right hand side,
 ```{math}
 \begin{aligned}
   \frac{\partial \mathfrak c}{\partial t} + \mathbf u \cdot \nabla \mathfrak c = \mathfrak q,
 \end{aligned}
 ```
 then one can also model interaction between species - for example to simulate phase changes where one compositional field, indicating a particular phase, transforms into another phase depending on pressure and temperature, or where several phases combine to other phases.
-Another example of using a right hand side - quite outside what the original term *compositional field* was supposed to indicate - is to track the accumulation of finite strain, see {ref}`sec:cookbooks:simple-setups:tracking-finite-strain`.
+Another example of using a right hand side - quite outside what the original term *compositional field* was supposed to indicate - is to track the accumulation of finite strain, see {ref}`sec:cookbooks:finite_strain`.
 
 In actual practice, one finds that it is often useful to allow $\mathfrak q$ to be a function that has both a smooth (say, continuous) in time component, and one that is singular in time (i.e., contains Dirac delta, or "impulse" functions).
 Typical time integrators require the evaluation of the right hand side at specific points in time, but this would preclude the use of delta functions.

--- a/doc/sphinx/user/methods/dimensionalize/index.md
+++ b/doc/sphinx/user/methods/dimensionalize/index.md
@@ -14,7 +14,7 @@ For details, see {ref}`sec:methods:dimensionalize:years-or-seconds`.
 
 That said, in reality, ASPECT has no preferred system of units as long as every material constant, geometry, time, etc., are all expressed in the same system.
 In other words, it is entirely legitimate to implement geometry and material models in which the dimension of the domain is one, density and viscosity are one, and the density variation as a function of temperature is scaled by the Rayleigh number - i.e., to use the usual non-dimensionalization of the equations {math:numref}`eq:stokes-1` - {math:numref}`eq:temperature`.
-Some of the cookbooks in {ref}`cha:cookbooks` use this non-dimensional form; for example, the simplest cookbook in {ref}`sec:cookbooks:simple-setups:2d-box-convection` as well as the SolCx, SolKz and inclusion benchmarks in {ref}`sec:cookbooks:benchmarks:solcx`, are such cases.
+Some of the cookbooks in {ref}`cha:cookbooks` use this non-dimensional form; for example, the simplest cookbook in {ref}`sec:cookbooks:convection-box` as well as the SolCx, SolKz and inclusion benchmarks in {ref}`sec:benchmarks:solcx`, are such cases.
 Whenever this is the case, output showing units `m/s` or `W/m^2` clearly no longer have a literal meaning.
 Rather, the unit postfix must in this case simply be interpreted to mean that the number that precedes the first is a velocity and a heat flux in the second case.
 


### PR DESCRIPTION
Some minor edits I noticed: some references weren't correct in early pages of the methods section (which were the first pages I converted, weeks ago, and I didn't have a system down yet)