### PR TITLE
Add label to global parameters. Improve formatting.

### DIFF
--- a/contrib/utilities/jsontomarkdown.py
+++ b/contrib/utilities/jsontomarkdown.py
@@ -38,7 +38,8 @@ def handle_subsection(data, cur_path, output_file):
             print("(parameters:" + path_str + ")=", file=output_file)
             new_path = cur_path + [key]
             section_name = path_str.replace("_20", " ")
-            print("## **Parameters in section** " + section_name, file=output_file)
+            section_name = section_name.replace("/"," / ")
+            print("## **Subsection:** " + section_name, file=output_file)
             handle_subsection(data[key], new_path, output_file)
 
 def handle_parameters(data):
@@ -58,8 +59,8 @@ def handle_parameters(data):
                              "---\n"
                              "global.md\n")
     global_parameters = open("doc/sphinx/parameters/global.md", "w")
-    print("# Global \n\n", file=global_parameters)
-    print("## **Parameters in section** global \n\n", file=global_parameters)
+    print("(parameters:global)=", file=global_parameters)
+    print("# Global parameters\n\n", file=global_parameters)
 
     cur_path = []
     keys = list(data.keys())
@@ -100,7 +101,7 @@ def handle_parameters(data):
             new_path = cur_path + [key]
             section_name = path_str.replace("_20", " ").replace(":", "/")
             print("# " + section_name + "\n\n", file=subfile)
-            print("## **Parameters in section** " + section_name + "\n\n", file=subfile)
+            print("## **Subsection:** " + section_name + "\n\n", file=subfile)
             handle_subsection(data[key], new_path, subfile)
             subfile.close()
     global_output_file.write(":::\n")

--- a/doc/sphinx/parameters/Adiabatic_20conditions_20model.md
+++ b/doc/sphinx/parameters/Adiabatic_20conditions_20model.md
@@ -2,7 +2,7 @@
 # Adiabatic conditions model
 
 
-## **Parameters in section** Adiabatic conditions model
+## **Subsection:** Adiabatic conditions model
 
 
 (parameters:Adiabatic_20conditions_20model/Model_20name)=
@@ -20,7 +20,7 @@
 `function': A model in which the adiabatic profile is specified by a user defined function. The supplied function has to contain temperature, pressure, and density as a function of depth in this order.
 
 (parameters:Adiabatic_20conditions_20model/Ascii_20data_20model)=
-## **Parameters in section** Adiabatic conditions model/Ascii data model
+## **Subsection:** Adiabatic conditions model / Ascii data model
 (parameters:Adiabatic_20conditions_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/tests/adiabatic-conditions/ascii-data/test/
@@ -46,7 +46,7 @@
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Adiabatic_20conditions_20model/Compute_20profile)=
-## **Parameters in section** Adiabatic conditions model/Compute profile
+## **Subsection:** Adiabatic conditions model / Compute profile
 (parameters:Adiabatic_20conditions_20model/Compute_20profile/Composition_20reference_20profile)=
 ### __Parameter name:__ Composition reference profile
 **Default value:** initial composition
@@ -100,7 +100,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Adiabatic_20conditions_20model/Compute_20profile/Surface_20condition_20function)=
-## **Parameters in section** Adiabatic conditions model/Compute profile/Surface condition function
+## **Subsection:** Adiabatic conditions model / Compute profile / Surface condition function
 (parameters:Adiabatic_20conditions_20model/Compute_20profile/Surface_20condition_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -130,7 +130,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Adiabatic_20conditions_20model/Function)=
-## **Parameters in section** Adiabatic conditions model/Function
+## **Subsection:** Adiabatic conditions model / Function
 (parameters:Adiabatic_20conditions_20model/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**

--- a/doc/sphinx/parameters/Boundary_20composition_20model.md
+++ b/doc/sphinx/parameters/Boundary_20composition_20model.md
@@ -2,7 +2,7 @@
 # Boundary composition model
 
 
-## **Parameters in section** Boundary composition model
+## **Subsection:** Boundary composition model
 
 
 (parameters:Boundary_20composition_20model/Allow_20fixed_20composition_20on_20outflow_20boundaries)=
@@ -94,7 +94,7 @@ Because this class simply takes what the initial composition had described, this
 \textbf{Warning}: This parameter provides an old and deprecated way of specifying boundary composition models and shouldn't be used. Please use 'List of model names' instead.
 
 (parameters:Boundary_20composition_20model/Ascii_20data_20model)=
-## **Parameters in section** Boundary composition model/Ascii data model
+## **Subsection:** Boundary composition model / Ascii data model
 (parameters:Boundary_20composition_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-composition/ascii-data/test/
@@ -152,7 +152,7 @@ Because this class simply takes what the initial composition had described, this
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Boundary_20composition_20model/Box)=
-## **Parameters in section** Boundary composition model/Box
+## **Subsection:** Boundary composition model / Box
 (parameters:Boundary_20composition_20model/Box/Bottom_20composition)=
 ### __Parameter name:__ Bottom composition
 **Default value:**
@@ -186,7 +186,7 @@ Because this class simply takes what the initial composition had described, this
 **Documentation:** A comma separated list of composition boundary values at the top boundary (at maximal $y$-value in 2d, or maximal $z$-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
 
 (parameters:Boundary_20composition_20model/Box_20with_20lithosphere_20boundary_20indicators)=
-## **Parameters in section** Boundary composition model/Box with lithosphere boundary indicators
+## **Subsection:** Boundary composition model / Box with lithosphere boundary indicators
 (parameters:Boundary_20composition_20model/Box_20with_20lithosphere_20boundary_20indicators/Bottom_20composition)=
 ### __Parameter name:__ Bottom composition
 **Default value:**
@@ -236,7 +236,7 @@ Because this class simply takes what the initial composition had described, this
 **Documentation:** A comma separated list of composition boundary values at the top boundary (at maximal $y$-value in 2d, or maximal $z$-value in 3d). This list must have as many entries as there are compositional fields. Units: none.
 
 (parameters:Boundary_20composition_20model/Function)=
-## **Parameters in section** Boundary composition model/Function
+## **Subsection:** Boundary composition model / Function
 (parameters:Boundary_20composition_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -274,7 +274,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Boundary_20composition_20model/Initial_20composition)=
-## **Parameters in section** Boundary composition model/Initial composition
+## **Subsection:** Boundary composition model / Initial composition
 (parameters:Boundary_20composition_20model/Initial_20composition/Maximal_20composition)=
 ### __Parameter name:__ Maximal composition
 **Default value:** 1.
@@ -292,7 +292,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Minimal composition. Units: none.
 
 (parameters:Boundary_20composition_20model/Spherical_20constant)=
-## **Parameters in section** Boundary composition model/Spherical constant
+## **Subsection:** Boundary composition model / Spherical constant
 (parameters:Boundary_20composition_20model/Spherical_20constant/Inner_20composition)=
 ### __Parameter name:__ Inner composition
 **Default value:** 1.

--- a/doc/sphinx/parameters/Boundary_20fluid_20pressure_20model.md
+++ b/doc/sphinx/parameters/Boundary_20fluid_20pressure_20model.md
@@ -2,7 +2,7 @@
 # Boundary fluid pressure model
 
 
-## **Parameters in section** Boundary fluid pressure model
+## **Subsection:** Boundary fluid pressure model
 
 
 (parameters:Boundary_20fluid_20pressure_20model/Plugin_20name)=
@@ -16,7 +16,7 @@
 `density': A plugin that prescribes the fluid pressure gradient at the boundary based on fluid/solid density from the material model.
 
 (parameters:Boundary_20fluid_20pressure_20model/Density)=
-## **Parameters in section** Boundary fluid pressure model/Density
+## **Subsection:** Boundary fluid pressure model / Density
 (parameters:Boundary_20fluid_20pressure_20model/Density/Density_20formulation)=
 ### __Parameter name:__ Density formulation
 **Default value:** solid density

--- a/doc/sphinx/parameters/Boundary_20heat_20flux_20model.md
+++ b/doc/sphinx/parameters/Boundary_20heat_20flux_20model.md
@@ -2,7 +2,7 @@
 # Boundary heat flux model
 
 
-## **Parameters in section** Boundary heat flux model
+## **Subsection:** Boundary heat flux model
 
 
 (parameters:Boundary_20heat_20flux_20model/Fixed_20heat_20flux_20boundary_20indicators)=
@@ -32,7 +32,7 @@ The formula you describe in the mentioned section is a scalar value for the heat
 The symbol $t$ indicating time that may appear in the formulas for the prescribed heat flux is interpreted as having units seconds unless the global parameter ``Use years in output instead of seconds'' has been set.
 
 (parameters:Boundary_20heat_20flux_20model/Function)=
-## **Parameters in section** Boundary heat flux model/Function
+## **Subsection:** Boundary heat flux model / Function
 (parameters:Boundary_20heat_20flux_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian

--- a/doc/sphinx/parameters/Boundary_20temperature_20model.md
+++ b/doc/sphinx/parameters/Boundary_20temperature_20model.md
@@ -2,7 +2,7 @@
 # Boundary temperature model
 
 
-## **Parameters in section** Boundary temperature model
+## **Subsection:** Boundary temperature model
 
 
 (parameters:Boundary_20temperature_20model/Allow_20fixed_20temperature_20on_20outflow_20boundaries)=
@@ -104,7 +104,7 @@ Because this class simply takes what the initial temperature had described, this
 \textbf{Warning}: This parameter provides an old and deprecated way of specifying boundary temperature models and shouldn't be used. Please use 'List of model names' instead.
 
 (parameters:Boundary_20temperature_20model/Ascii_20data_20model)=
-## **Parameters in section** Boundary temperature model/Ascii data model
+## **Subsection:** Boundary temperature model / Ascii data model
 (parameters:Boundary_20temperature_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-temperature/ascii-data/test/
@@ -162,7 +162,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Boundary_20temperature_20model/Box)=
-## **Parameters in section** Boundary temperature model/Box
+## **Subsection:** Boundary temperature model / Box
 (parameters:Boundary_20temperature_20model/Box/Bottom_20temperature)=
 ### __Parameter name:__ Bottom temperature
 **Default value:** 0.
@@ -196,7 +196,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Temperature at the top boundary (at maximal $x$-value). Units: \si{\kelvin}.
 
 (parameters:Boundary_20temperature_20model/Box_20with_20lithosphere_20boundary_20indicators)=
-## **Parameters in section** Boundary temperature model/Box with lithosphere boundary indicators
+## **Subsection:** Boundary temperature model / Box with lithosphere boundary indicators
 (parameters:Boundary_20temperature_20model/Box_20with_20lithosphere_20boundary_20indicators/Bottom_20temperature)=
 ### __Parameter name:__ Bottom temperature
 **Default value:** 0.
@@ -246,7 +246,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Temperature at the top boundary (at maximal $x$-value). Units: \si{\kelvin}.
 
 (parameters:Boundary_20temperature_20model/Constant)=
-## **Parameters in section** Boundary temperature model/Constant
+## **Subsection:** Boundary temperature model / Constant
 (parameters:Boundary_20temperature_20model/Constant/Boundary_20indicator_20to_20temperature_20mappings)=
 ### __Parameter name:__ Boundary indicator to temperature mappings
 **Default value:**
@@ -256,7 +256,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** A comma separated list of mappings between boundary indicators and the temperature associated with the boundary indicators. The format for this list is ``indicator1 : value1, indicator2 : value2, ...'', where each indicator is a valid boundary indicator (either a number or the symbolic name of a boundary as provided by the geometry model) and each value is the temperature of that boundary.
 
 (parameters:Boundary_20temperature_20model/Dynamic_20core)=
-## **Parameters in section** Boundary temperature model/Dynamic core
+## **Subsection:** Boundary temperature model / Dynamic core
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Alpha)=
 ### __Parameter name:__ Alpha
 **Default value:** 1.35e-5
@@ -410,7 +410,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Initial light composition changing rate. Units: 1/year.
 
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Geotherm_20parameters)=
-## **Parameters in section** Boundary temperature model/Dynamic core/Geotherm parameters
+## **Subsection:** Boundary temperature model / Dynamic core / Geotherm parameters
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Geotherm_20parameters/Composition_20dependency)=
 ### __Parameter name:__ Composition dependency
 **Default value:** true
@@ -460,7 +460,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** If using the Fe-FeS system solidus from Buono \& Walker (2011) instead.
 
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Other_20energy_20source)=
-## **Parameters in section** Boundary temperature model/Dynamic core/Other energy source
+## **Subsection:** Boundary temperature model / Dynamic core / Other energy source
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Other_20energy_20source/File_20name)=
 ### __Parameter name:__ File name
 **Default value:**
@@ -470,7 +470,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Data file name for other energy source into the core. The 'other energy source' is used for external core energy source.For example if someone want to test the early lunar core powered by precession (Dwyer, C. A., et al. (2011). A long-lived lunar dynamo driven by continuous mechanical stirring. Nature 479(7372): 212-214.)Format [Time(Gyr)   Energy rate(W)]
 
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Radioactive_20heat_20source)=
-## **Parameters in section** Boundary temperature model/Dynamic core/Radioactive heat source
+## **Subsection:** Boundary temperature model / Dynamic core / Radioactive heat source
 (parameters:Boundary_20temperature_20model/Dynamic_20core/Radioactive_20heat_20source/Half_20life_20times)=
 ### __Parameter name:__ Half life times
 **Default value:**
@@ -504,7 +504,7 @@ Because this class simply takes what the initial temperature had described, this
 **Documentation:** Number of different radioactive heating elements in core
 
 (parameters:Boundary_20temperature_20model/Function)=
-## **Parameters in section** Boundary temperature model/Function
+## **Subsection:** Boundary temperature model / Function
 (parameters:Boundary_20temperature_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -558,7 +558,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Boundary_20temperature_20model/Initial_20temperature)=
-## **Parameters in section** Boundary temperature model/Initial temperature
+## **Subsection:** Boundary temperature model / Initial temperature
 (parameters:Boundary_20temperature_20model/Initial_20temperature/Maximal_20temperature)=
 ### __Parameter name:__ Maximal temperature
 **Default value:** 3773.
@@ -576,7 +576,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Minimal temperature. Units: \si{\kelvin}.
 
 (parameters:Boundary_20temperature_20model/Spherical_20constant)=
-## **Parameters in section** Boundary temperature model/Spherical constant
+## **Subsection:** Boundary temperature model / Spherical constant
 (parameters:Boundary_20temperature_20model/Spherical_20constant/Inner_20temperature)=
 ### __Parameter name:__ Inner temperature
 **Default value:** 6000.

--- a/doc/sphinx/parameters/Boundary_20traction_20model.md
+++ b/doc/sphinx/parameters/Boundary_20traction_20model.md
@@ -2,7 +2,7 @@
 # Boundary traction model
 
 
-## **Parameters in section** Boundary traction model
+## **Subsection:** Boundary traction model
 
 
 (parameters:Boundary_20traction_20model/Prescribed_20traction_20boundary_20indicators)=
@@ -16,7 +16,7 @@
 The format of valid entries for this parameter is that of a map given as ``key1 [selector]: value1, key2 [selector]: value2, key3: value3, ...'' where each key must be a valid boundary indicator (which is either an integer or the symbolic name the geometry model in use may have provided for this part of the boundary) and each value must be one of the currently implemented boundary traction models. ``selector'' is an optional string given as a subset of the letters `xyz' that allows you to apply the boundary conditions only to the components listed. As an example, '1 y: function' applies the type `function' to the y component on boundary 1. Without a selector it will affect all components of the traction.
 
 (parameters:Boundary_20traction_20model/Ascii_20data_20model)=
-## **Parameters in section** Boundary traction model/Ascii data model
+## **Subsection:** Boundary traction model / Ascii data model
 (parameters:Boundary_20traction_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-traction/ascii-data/test/
@@ -74,7 +74,7 @@ The format of valid entries for this parameter is that of a map given as ``key1 
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Boundary_20traction_20model/Function)=
-## **Parameters in section** Boundary traction model/Function
+## **Subsection:** Boundary traction model / Function
 (parameters:Boundary_20traction_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -112,7 +112,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Boundary_20traction_20model/Initial_20lithostatic_20pressure)=
-## **Parameters in section** Boundary traction model/Initial lithostatic pressure
+## **Subsection:** Boundary traction model / Initial lithostatic pressure
 (parameters:Boundary_20traction_20model/Initial_20lithostatic_20pressure/Number_20of_20integration_20points)=
 ### __Parameter name:__ Number of integration points
 **Default value:** 1000

--- a/doc/sphinx/parameters/Boundary_20velocity_20model.md
+++ b/doc/sphinx/parameters/Boundary_20velocity_20model.md
@@ -2,7 +2,7 @@
 # Boundary velocity model
 
 
-## **Parameters in section** Boundary velocity model
+## **Subsection:** Boundary velocity model
 
 
 (parameters:Boundary_20velocity_20model/Prescribed_20velocity_20boundary_20indicators)=
@@ -52,7 +52,7 @@ The names of the boundaries listed here can either by numbers (in which case the
 The names of the boundaries listed here can either by numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
 
 (parameters:Boundary_20velocity_20model/Ascii_20data_20model)=
-## **Parameters in section** Boundary velocity model/Ascii data model
+## **Subsection:** Boundary velocity model / Ascii data model
 (parameters:Boundary_20velocity_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/
@@ -118,7 +118,7 @@ The names of the boundaries listed here can either by numbers (in which case the
 **Documentation:** Specify velocity as r, phi, and theta components instead of x, y, and z. Positive velocities point up, east, and north (in 3D) or out and clockwise (in 2D). This setting only makes sense for spherical geometries.
 
 (parameters:Boundary_20velocity_20model/Function)=
-## **Parameters in section** Boundary velocity model/Function
+## **Subsection:** Boundary velocity model / Function
 (parameters:Boundary_20velocity_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -164,7 +164,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Boundary_20velocity_20model/GPlates_20model)=
-## **Parameters in section** Boundary velocity model/GPlates model
+## **Subsection:** Boundary velocity model / GPlates model
 (parameters:Boundary_20velocity_20model/GPlates_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/

--- a/doc/sphinx/parameters/Checkpointing.md
+++ b/doc/sphinx/parameters/Checkpointing.md
@@ -2,7 +2,7 @@
 # Checkpointing
 
 
-## **Parameters in section** Checkpointing
+## **Subsection:** Checkpointing
 
 
 (parameters:Checkpointing/Steps_20between_20checkpoint)=

--- a/doc/sphinx/parameters/Compositional_20fields.md
+++ b/doc/sphinx/parameters/Compositional_20fields.md
@@ -2,14 +2,14 @@
 # Compositional fields
 
 
-## **Parameters in section** Compositional fields
+## **Subsection:** Compositional fields
 
 
 (parameters:Compositional_20fields/Compositional_20field_20methods)=
 ### __Parameter name:__ Compositional field methods
 **Default value:**
 
-**Pattern:** [List of <[Selection field|particles|volume of fluid|static|melt field|prescribed field|prescribed field with diffusion ]> of length 0...4294967295 (inclusive)]
+**Pattern:** [List of <[Selection field|particles|volume of fluid|static|melt field|darcy field|prescribed field|prescribed field with diffusion ]> of length 0...4294967295 (inclusive)]
 
 **Documentation:** A comma separated list denoting the solution method of each compositional field. Each entry of the list must be one of the currently implemented field methods.
 
@@ -18,6 +18,7 @@ These choices correspond to the following methods by which compositional fields 
 \item ``volume of fluid``: If a compositional field is marked with this method, then its values are obtained in each timestep by reconstructing a polynomial finite element approximation on each cell from a volume of fluid interface tracking method, which is used to compute the advection updates.
 \item ``static'': If a compositional field is marked this way, then it does not evolve at all. Its values are simply set to the initial conditions, and will then never change.
 \item ``melt field'': If a compositional field is marked with this method, then its values are computed in each time step by advecting along the values of the previous time step using the melt velocity, and applying reaction rates to it. In other words, this corresponds to the usual notion of a composition field as mentioned in Section~\ref{sec:compositional}, except that it is advected with the melt velocity instead of the solid velocity. This method can only be chosen if melt transport is active in the model.
+\item ``darcy field'': If a compositional field is marked with this method, then its values are computed in each time step by advecting along the values of the previous time step using the fluid velocity prescribed by Darcy's Law, and applying reaction rates to it. In other words this corresponds to the usual notion of a composition field as mentioned in Section~\ref{sec:compositional}, except that it is advected with the Darcy velocity instead of the solid velocity. This method requires there to be a compositional field named porosity that is advected the darcy field method. We calculate the fluid velocity $u_f$ using an approximation of Darcy's Law: $u_f = u_s - K_D / \phi * (rho_s * g - rho_f * g)$.
 \item ``prescribed field'': The value of these fields is determined in each time step from the material model. If a compositional field is marked with this method, then the value of a specific additional material model output, called the `PrescribedFieldOutputs' is interpolated onto the field. This field does not change otherwise, it is not advected with the flow.
 \item ``prescribed field with diffusion'': If a compositional field is marked this way, the value of a specific additional material model output, called the `PrescribedFieldOutputs' is interpolated onto the field, as in the ``prescribed field'' method. Afterwards, the field is diffused based on a solver parameter, the diffusion length scale, smoothing the field. Specifically, the field is updated by solving the equation $(I-l^2 \Delta) C_\text{smoothed} = C_\text{prescribed}$, where $l$ is the diffusion length scale. Note that this means that the amount of diffusion is independent of the time step size, and that the field is not advected with the flow.\end{itemize}
 

--- a/doc/sphinx/parameters/Discretization.md
+++ b/doc/sphinx/parameters/Discretization.md
@@ -2,7 +2,7 @@
 # Discretization
 
 
-## **Parameters in section** Discretization
+## **Subsection:** Discretization
 
 
 (parameters:Discretization/Composition_20polynomial_20degree)=
@@ -80,7 +80,7 @@ On the other hand, if this parameter is set to ``false''(the default), then the 
 For an in-depth discussion of these issues and a quantitative evaluation of the different choices, see \cite{KHB12}.
 
 (parameters:Discretization/Stabilization_20parameters)=
-## **Parameters in section** Discretization/Stabilization parameters
+## **Subsection:** Discretization / Stabilization parameters
 (parameters:Discretization/Stabilization_20parameters/Discontinuous_20penalty)=
 ### __Parameter name:__ Discontinuous penalty
 **Default value:** 10.

--- a/doc/sphinx/parameters/Formulation.md
+++ b/doc/sphinx/parameters/Formulation.md
@@ -2,7 +2,7 @@
 # Formulation
 
 
-## **Parameters in section** Formulation
+## **Subsection:** Formulation
 
 
 (parameters:Formulation/Enable_20additional_20Stokes_20RHS)=

--- a/doc/sphinx/parameters/Geometry_20model.md
+++ b/doc/sphinx/parameters/Geometry_20model.md
@@ -2,7 +2,7 @@
 # Geometry model
 
 
-## **Parameters in section** Geometry model
+## **Subsection:** Geometry model
 
 
 (parameters:Geometry_20model/Model_20name)=
@@ -52,7 +52,7 @@ The model assigns boundary indicators as follows: In 2d, inner and outer boundar
 In 3d, inner and outer indicators are treated as in 2d. If the opening angle is chosen as 90 degrees, i.e., the domain is the intersection of a spherical shell and the first octant, then indicator 2 is at the face $x=0$, 3 at $y=0$, and 4 at $z=0$. These last three boundaries can then also be referred to as `east', `west' and `south' symbolically in input files.
 
 (parameters:Geometry_20model/Box)=
-## **Parameters in section** Geometry model/Box
+## **Subsection:** Geometry model / Box
 (parameters:Geometry_20model/Box/Box_20origin_20X_20coordinate)=
 ### __Parameter name:__ Box origin X coordinate
 **Default value:** 0.
@@ -150,7 +150,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Number of cells in Z direction.
 
 (parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators)=
-## **Parameters in section** Geometry model/Box with lithosphere boundary indicators
+## **Subsection:** Geometry model / Box with lithosphere boundary indicators
 (parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Box_20origin_20X_20coordinate)=
 ### __Parameter name:__ Box origin X coordinate
 **Default value:** 0.
@@ -288,7 +288,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Number of cells in Z direction in the lithosphere. This value is ignored if the simulation is in 2d.
 
 (parameters:Geometry_20model/Chunk)=
-## **Parameters in section** Geometry model/Chunk
+## **Subsection:** Geometry model / Chunk
 (parameters:Geometry_20model/Chunk/Chunk_20inner_20radius)=
 ### __Parameter name:__ Chunk inner radius
 **Default value:** 0.
@@ -362,7 +362,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Number of cells in radius.
 
 (parameters:Geometry_20model/Chunk_20with_20lithosphere_20boundary_20indicators)=
-## **Parameters in section** Geometry model/Chunk with lithosphere boundary indicators
+## **Subsection:** Geometry model / Chunk with lithosphere boundary indicators
 (parameters:Geometry_20model/Chunk_20with_20lithosphere_20boundary_20indicators/Chunk_20inner_20radius)=
 ### __Parameter name:__ Chunk inner radius
 **Default value:** 0.
@@ -452,7 +452,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Number of cells in radial direction for the upper chunk.
 
 (parameters:Geometry_20model/Ellipsoidal_20chunk)=
-## **Parameters in section** Geometry model/Ellipsoidal chunk
+## **Subsection:** Geometry model / Ellipsoidal chunk
 (parameters:Geometry_20model/Ellipsoidal_20chunk/Depth)=
 ### __Parameter name:__ Depth
 **Default value:** 500000.0
@@ -534,7 +534,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** The semi-major axis (a) of an ellipsoid. This is the radius for a sphere (eccentricity=0). Default WGS84 semi-major axis.
 
 (parameters:Geometry_20model/Initial_20topography_20model)=
-## **Parameters in section** Geometry model/Initial topography model
+## **Subsection:** Geometry model / Initial topography model
 (parameters:Geometry_20model/Initial_20topography_20model/Model_20name)=
 ### __Parameter name:__ Model name
 **Default value:** zero topography
@@ -552,7 +552,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 `zero topography': Implementation of a model in which the initial topography is zero.
 
 (parameters:Geometry_20model/Initial_20topography_20model/Ascii_20data_20model)=
-## **Parameters in section** Geometry model/Initial topography model/Ascii data model
+## **Subsection:** Geometry model / Initial topography model / Ascii data model
 (parameters:Geometry_20model/Initial_20topography_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/geometry-model/initial-topography-model/ascii-data/test/
@@ -578,7 +578,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Geometry_20model/Initial_20topography_20model/Function)=
-## **Parameters in section** Geometry model/Initial topography model/Function
+## **Subsection:** Geometry model / Initial topography model / Function
 (parameters:Geometry_20model/Initial_20topography_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -624,7 +624,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Geometry_20model/Initial_20topography_20model/Prm_20polygon)=
-## **Parameters in section** Geometry model/Initial topography model/Prm polygon
+## **Subsection:** Geometry model / Initial topography model / Prm polygon
 (parameters:Geometry_20model/Initial_20topography_20model/Prm_20polygon/Topography_20parameters)=
 ### __Parameter name:__ Topography parameters
 **Default value:**
@@ -634,7 +634,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Set the topography height and the polygon which should be set to that height. The format is : "The topography height   extgreater The point list describing a polygon \& The next topography height   extgreater the next point list describing a polygon." The format for the point list describing the polygon is "x1,y1;x2,y2". For example for two triangular areas of 100 and -100 meters high set: '100   extgreater 0,0;5,5;0,10 \& -100   extgreater 10,10;10,15;20,15'. Units of the height are always in meters. The units of the coordinates are dependent on the geometry model. In the box model they are in meters, in the chunks they are in degrees, etc. Please refer to the manual of the individual geometry model to so see how the topography is implemented.
 
 (parameters:Geometry_20model/Sphere)=
-## **Parameters in section** Geometry model/Sphere
+## **Subsection:** Geometry model / Sphere
 (parameters:Geometry_20model/Sphere/Radius)=
 ### __Parameter name:__ Radius
 **Default value:** 6371000.
@@ -644,7 +644,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Radius of the sphere. Units: \si{\meter}.
 
 (parameters:Geometry_20model/Spherical_20shell)=
-## **Parameters in section** Geometry model/Spherical shell
+## **Subsection:** Geometry model / Spherical shell
 (parameters:Geometry_20model/Spherical_20shell/Cells_20along_20circumference)=
 ### __Parameter name:__ Cells along circumference
 **Default value:** 0

--- a/doc/sphinx/parameters/Gravity_20model.md
+++ b/doc/sphinx/parameters/Gravity_20model.md
@@ -2,7 +2,7 @@
 # Gravity model
 
 
-## **Parameters in section** Gravity model
+## **Subsection:** Gravity model
 
 
 (parameters:Gravity_20model/Model_20name)=
@@ -26,7 +26,7 @@
 `vertical': A gravity model in which the gravity direction is vertical (pointing downward for positive values) and at a constant magnitude by default equal to one.
 
 (parameters:Gravity_20model/Ascii_20data_20model)=
-## **Parameters in section** Gravity model/Ascii data model
+## **Subsection:** Gravity model / Ascii data model
 (parameters:Gravity_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/gravity-model/
@@ -52,7 +52,7 @@
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Gravity_20model/Function)=
-## **Parameters in section** Gravity model/Function
+## **Subsection:** Gravity model / Function
 (parameters:Gravity_20model/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -82,7 +82,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Gravity_20model/Radial_20constant)=
-## **Parameters in section** Gravity model/Radial constant
+## **Subsection:** Gravity model / Radial constant
 (parameters:Gravity_20model/Radial_20constant/Magnitude)=
 ### __Parameter name:__ Magnitude
 **Default value:** 9.81
@@ -92,7 +92,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Magnitude of the gravity vector in $m/s^2$. For positive values the direction is radially inward towards the center of the earth.
 
 (parameters:Gravity_20model/Radial_20linear)=
-## **Parameters in section** Gravity model/Radial linear
+## **Subsection:** Gravity model / Radial linear
 (parameters:Gravity_20model/Radial_20linear/Magnitude_20at_20bottom)=
 ### __Parameter name:__ Magnitude at bottom
 **Default value:** 10.7
@@ -110,7 +110,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Magnitude of the radial gravity vector at the surface of the domain. Units: \si{\meter\per\second\squared}.
 
 (parameters:Gravity_20model/Vertical)=
-## **Parameters in section** Gravity model/Vertical
+## **Subsection:** Gravity model / Vertical
 (parameters:Gravity_20model/Vertical/Magnitude)=
 ### __Parameter name:__ Magnitude
 **Default value:** 1.

--- a/doc/sphinx/parameters/Heating_20model.md
+++ b/doc/sphinx/parameters/Heating_20model.md
@@ -2,7 +2,7 @@
 # Heating model
 
 
-## **Parameters in section** Heating model
+## **Subsection:** Heating model
 
 
 (parameters:Heating_20model/List_20of_20model_20names)=
@@ -46,7 +46,7 @@ The formula is interpreted as having units W/kg.
 `shear heating with melt': Implementation of a standard model for shear heating of migrating melt, including bulk (compression) heating $\xi \left( \nabla \cdot \mathbf u_s \right)^2 $ and heating due to melt segregation $\frac{\eta_f \phi^2}{k} \left( \mathbf u_f - \mathbf u_s \right)^2 $. For full shear heating, this has to be used in combination with the heating model shear heating to also include shear heating for the solid part.
 
 (parameters:Heating_20model/Adiabatic_20heating)=
-## **Parameters in section** Heating model/Adiabatic heating
+## **Subsection:** Heating model / Adiabatic heating
 (parameters:Heating_20model/Adiabatic_20heating/Use_20simplified_20adiabatic_20heating)=
 ### __Parameter name:__ Use simplified adiabatic heating
 **Default value:** false
@@ -56,7 +56,7 @@ The formula is interpreted as having units W/kg.
 **Documentation:** A flag indicating whether the adiabatic heating should be simplified from $\alpha T (\mathbf u \cdot \nabla p)$ to $ \alpha \rho T (\mathbf u \cdot \mathbf g) $.
 
 (parameters:Heating_20model/Adiabatic_20heating_20of_20melt)=
-## **Parameters in section** Heating model/Adiabatic heating of melt
+## **Subsection:** Heating model / Adiabatic heating of melt
 (parameters:Heating_20model/Adiabatic_20heating_20of_20melt/Use_20simplified_20adiabatic_20heating)=
 ### __Parameter name:__ Use simplified adiabatic heating
 **Default value:** false
@@ -66,7 +66,7 @@ The formula is interpreted as having units W/kg.
 **Documentation:** A flag indicating whether the adiabatic heating should be simplified from $\alpha T (\mathbf u \cdot \nabla p)$ to $ \alpha \rho T (\mathbf u \cdot \mathbf g) $.
 
 (parameters:Heating_20model/Compositional_20heating)=
-## **Parameters in section** Heating model/Compositional heating
+## **Subsection:** Heating model / Compositional heating
 (parameters:Heating_20model/Compositional_20heating/Compositional_20heating_20values)=
 ### __Parameter name:__ Compositional heating values
 **Default value:** 0.
@@ -84,7 +84,7 @@ The formula is interpreted as having units W/kg.
 **Documentation:** A list of integers with as many entries as compositional fields plus one. The first entry corresponds to the background material, each following entry corresponds to a particular compositional field. If the entry for a field is '1' this field is considered during the computation of volume fractions, if it is '0' the field is ignored. This is useful if some compositional fields are used to track properties like finite strain that should not contribute to heat production. The first entry determines whether the background field contributes to heat production or not (essentially similar to setting its 'Compositional heating values' to zero, but included for consistency in the length of the input lists).
 
 (parameters:Heating_20model/Constant_20heating)=
-## **Parameters in section** Heating model/Constant heating
+## **Subsection:** Heating model / Constant heating
 (parameters:Heating_20model/Constant_20heating/Radiogenic_20heating_20rate)=
 ### __Parameter name:__ Radiogenic heating rate
 **Default value:** 0.
@@ -94,7 +94,7 @@ The formula is interpreted as having units W/kg.
 **Documentation:** The specific rate of heating due to radioactive decay (or other bulk sources you may want to describe). This parameter corresponds to the variable $H$ in the temperature equation stated in the manual, and the heating term is $ho H$. Units: W/kg.
 
 (parameters:Heating_20model/Function)=
-## **Parameters in section** Heating model/Function
+## **Subsection:** Heating model / Function
 (parameters:Heating_20model/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -124,7 +124,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Heating_20model/Latent_20heat_20melt)=
-## **Parameters in section** Heating model/Latent heat melt
+## **Subsection:** Heating model / Latent heat melt
 (parameters:Heating_20model/Latent_20heat_20melt/Melting_20entropy_20change)=
 ### __Parameter name:__ Melting entropy change
 **Default value:** -300.
@@ -134,7 +134,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The entropy change for the phase transition from solid to melt. Units: \si{\joule\per\kelvin\per\kilogram}.
 
 (parameters:Heating_20model/Radioactive_20decay)=
-## **Parameters in section** Heating model/Radioactive decay
+## **Subsection:** Heating model / Radioactive decay
 (parameters:Heating_20model/Radioactive_20decay/Crust_20composition_20number)=
 ### __Parameter name:__ Crust composition number
 **Default value:** 0

--- a/doc/sphinx/parameters/Initial_20composition_20model.md
+++ b/doc/sphinx/parameters/Initial_20composition_20model.md
@@ -2,7 +2,7 @@
 # Initial composition model
 
 
-## **Parameters in section** Initial composition model
+## **Subsection:** Initial composition model
 
 
 (parameters:Initial_20composition_20model/List_20of_20model_20names)=
@@ -70,7 +70,7 @@ The format of valid entries for this parameter is that of a map given as ``key1:
 When ``composition is specified, the initial model is treated as a standard composition field with bounds between 0 and 1 assumed, The initial fluid fractions are then based on an iterated midpoint quadrature. Resultant volume fractions outside of the bounds will be coerced to the nearest valid value (ie 0 or 1). If ``level set`` is specified, the intial data will be assumed to be in the form of a signed distance level set function (i.e. a function which is positive when in the fluid, negative outside, and zero on the interface and the magnitude is always the distance to the interface so the gradient is one everywhere).
 
 (parameters:Initial_20composition_20model/Ascii_20data_20model)=
-## **Parameters in section** Initial composition model/Ascii data model
+## **Subsection:** Initial composition model / Ascii data model
 (parameters:Initial_20composition_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-composition/ascii-data/test/
@@ -136,7 +136,7 @@ When ``composition is specified, the initial model is treated as a standard comp
 **Documentation:** Whether to use a 2D data slice of a 3D data file or the entire data file. Slicing a 3D dataset is only supported for 2D models.
 
 (parameters:Initial_20composition_20model/Function)=
-## **Parameters in section** Initial composition model/Function
+## **Subsection:** Initial composition model / Function
 (parameters:Initial_20composition_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -174,7 +174,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Initial_20composition_20model/World_20builder)=
-## **Parameters in section** Initial composition model/World builder
+## **Subsection:** Initial composition model / World builder
 (parameters:Initial_20composition_20model/World_20builder/List_20of_20relevant_20compositions)=
 ### __Parameter name:__ List of relevant compositions
 **Default value:**

--- a/doc/sphinx/parameters/Initial_20temperature_20model.md
+++ b/doc/sphinx/parameters/Initial_20temperature_20model.md
@@ -2,7 +2,7 @@
 # Initial temperature model
 
 
-## **Parameters in section** Initial temperature model
+## **Subsection:** Initial temperature model
 
 
 (parameters:Initial_20temperature_20model/List_20of_20model_20names)=
@@ -124,7 +124,7 @@ Make sure the top and bottom temperatures of the lithosphere agree with temperat
 \textbf{Warning}: This parameter provides an old and deprecated way of specifying initial temperature models and shouldn't be used. Please use 'List of model names' instead.
 
 (parameters:Initial_20temperature_20model/Adiabatic)=
-## **Parameters in section** Initial temperature model/Adiabatic
+## **Subsection:** Initial temperature model / Adiabatic
 (parameters:Initial_20temperature_20model/Adiabatic/Age_20bottom_20boundary_20layer)=
 ### __Parameter name:__ Age bottom boundary layer
 **Default value:** 0.
@@ -176,7 +176,7 @@ Make sure the top and bottom temperatures of the lithosphere agree with temperat
 The function object in the Function subsection represents the compositional fields that will be used as a reference profile for calculating the thermal diffusivity. This function is one-dimensional and depends only on depth. The format of this functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
 
 (parameters:Initial_20temperature_20model/Adiabatic/Function)=
-## **Parameters in section** Initial temperature model/Adiabatic/Function
+## **Subsection:** Initial temperature model / Adiabatic / Function
 (parameters:Initial_20temperature_20model/Adiabatic/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -206,7 +206,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Initial_20temperature_20model/Adiabatic_20boundary)=
-## **Parameters in section** Initial temperature model/Adiabatic boundary
+## **Subsection:** Initial temperature model / Adiabatic boundary
 (parameters:Initial_20temperature_20model/Adiabatic_20boundary/Adiabatic_20temperature_20gradient)=
 ### __Parameter name:__ Adiabatic temperature gradient
 **Default value:** 0.0005
@@ -256,7 +256,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The value of the surface temperature. Units: \si{\kelvin}.
 
 (parameters:Initial_20temperature_20model/Ascii_20data_20model)=
-## **Parameters in section** Initial temperature model/Ascii data model
+## **Subsection:** Initial temperature model / Ascii data model
 (parameters:Initial_20temperature_20model/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-data/test/
@@ -298,7 +298,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Initial_20temperature_20model/Ascii_20profile)=
-## **Parameters in section** Initial temperature model/Ascii profile
+## **Subsection:** Initial temperature model / Ascii profile
 (parameters:Initial_20temperature_20model/Ascii_20profile/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/ascii-profile/tests/
@@ -324,7 +324,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Initial_20temperature_20model/Continental_20geotherm)=
-## **Parameters in section** Initial temperature model/Continental geotherm
+## **Subsection:** Initial temperature model / Continental geotherm
 (parameters:Initial_20temperature_20model/Continental_20geotherm/Layer_20thicknesses)=
 ### __Parameter name:__ Layer thicknesses
 **Default value:** 30000.
@@ -350,7 +350,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The value of the surface temperature. Units: \si{\kelvin}.
 
 (parameters:Initial_20temperature_20model/Function)=
-## **Parameters in section** Initial temperature model/Function
+## **Subsection:** Initial temperature model / Function
 (parameters:Initial_20temperature_20model/Function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -388,7 +388,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Initial_20temperature_20model/Harmonic_20perturbation)=
-## **Parameters in section** Initial temperature model/Harmonic perturbation
+## **Subsection:** Initial temperature model / Harmonic perturbation
 (parameters:Initial_20temperature_20model/Harmonic_20perturbation/Lateral_20wave_20number_20one)=
 ### __Parameter name:__ Lateral wave number one
 **Default value:** 3
@@ -430,7 +430,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Doubled radial wave number of the harmonic perturbation.  One equals half of a sine period over the model domain.  This allows for single up-/downswings. Negative numbers  reverse the sign of the perturbation.
 
 (parameters:Initial_20temperature_20model/Inclusion_20shape_20perturbation)=
-## **Parameters in section** Initial temperature model/Inclusion shape perturbation
+## **Subsection:** Initial temperature model / Inclusion shape perturbation
 (parameters:Initial_20temperature_20model/Inclusion_20shape_20perturbation/Ambient_20temperature)=
 ### __Parameter name:__ Ambient temperature
 **Default value:** 1.0
@@ -496,7 +496,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The radius of the inclusion to be generated. For shapes with no radius (e.g. square), this will be the width, and for shapes with no width, this gives a general guideline for the size of the shape.
 
 (parameters:Initial_20temperature_20model/Lithosphere_20Mask)=
-## **Parameters in section** Initial temperature model/Lithosphere Mask
+## **Subsection:** Initial temperature model / Lithosphere Mask
 (parameters:Initial_20temperature_20model/Lithosphere_20Mask/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/lithosphere-mask/
@@ -538,7 +538,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Units: \si{\meter}.The maximum depth of the lithosphere. The model will be NaNs below this depth.
 
 (parameters:Initial_20temperature_20model/Patch_20on_20S40RTS)=
-## **Parameters in section** Initial temperature model/Patch on S40RTS
+## **Subsection:** Initial temperature model / Patch on S40RTS
 (parameters:Initial_20temperature_20model/Patch_20on_20S40RTS/Maximum_20grid_20depth)=
 ### __Parameter name:__ Maximum grid depth
 **Default value:** 700000.0
@@ -564,7 +564,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The depth range (above maximum grid depth) over which to smooth. The boundary is smoothed using a depth weighted combination of Vs values from the ascii grid and S40RTS at each point in the region of smoothing.
 
 (parameters:Initial_20temperature_20model/Patch_20on_20S40RTS/Ascii_20data_20model)=
-## **Parameters in section** Initial temperature model/Patch on S40RTS/Ascii data model
+## **Subsection:** Initial temperature model / Patch on S40RTS / Ascii data model
 (parameters:Initial_20temperature_20model/Patch_20on_20S40RTS/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/patch-on-S40RTS/test/
@@ -590,7 +590,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Initial_20temperature_20model/S40RTS_20perturbation)=
-## **Parameters in section** Initial temperature model/S40RTS perturbation
+## **Subsection:** Initial temperature model / S40RTS perturbation
 (parameters:Initial_20temperature_20model/S40RTS_20perturbation/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
@@ -688,7 +688,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Method that is used to specify how the vs-to-density scaling varies with depth.
 
 (parameters:Initial_20temperature_20model/S40RTS_20perturbation/Ascii_20data_20vs_20to_20density_20model)=
-## **Parameters in section** Initial temperature model/S40RTS perturbation/Ascii data vs to density model
+## **Subsection:** Initial temperature model / S40RTS perturbation / Ascii data vs to density model
 (parameters:Initial_20temperature_20model/S40RTS_20perturbation/Ascii_20data_20vs_20to_20density_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
@@ -714,7 +714,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Initial_20temperature_20model/SAVANI_20perturbation)=
-## **Parameters in section** Initial temperature model/SAVANI perturbation
+## **Subsection:** Initial temperature model / SAVANI perturbation
 (parameters:Initial_20temperature_20model/SAVANI_20perturbation/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/SAVANI/
@@ -812,7 +812,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Method that is used to specify how the vs-to-density scaling varies with depth.
 
 (parameters:Initial_20temperature_20model/SAVANI_20perturbation/Ascii_20data_20vs_20to_20density_20model)=
-## **Parameters in section** Initial temperature model/SAVANI perturbation/Ascii data vs to density model
+## **Subsection:** Initial temperature model / SAVANI perturbation / Ascii data vs to density model
 (parameters:Initial_20temperature_20model/SAVANI_20perturbation/Ascii_20data_20vs_20to_20density_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/initial-temperature/S40RTS/
@@ -838,7 +838,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Initial_20temperature_20model/Spherical_20gaussian_20perturbation)=
-## **Parameters in section** Initial temperature model/Spherical gaussian perturbation
+## **Subsection:** Initial temperature model / Spherical gaussian perturbation
 (parameters:Initial_20temperature_20model/Spherical_20gaussian_20perturbation/Amplitude)=
 ### __Parameter name:__ Amplitude
 **Default value:** 0.01
@@ -888,7 +888,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The sign of the perturbation.
 
 (parameters:Initial_20temperature_20model/Spherical_20hexagonal_20perturbation)=
-## **Parameters in section** Initial temperature model/Spherical hexagonal perturbation
+## **Subsection:** Initial temperature model / Spherical hexagonal perturbation
 (parameters:Initial_20temperature_20model/Spherical_20hexagonal_20perturbation/Angular_20mode)=
 ### __Parameter name:__ Angular mode
 **Default value:** 6

--- a/doc/sphinx/parameters/Material_20model.md
+++ b/doc/sphinx/parameters/Material_20model.md
@@ -2,7 +2,7 @@
 # Material model
 
 
-## **Parameters in section** Material model
+## **Subsection:** Material model
 
 
 (parameters:Material_20model/Material_20averaging)=
@@ -52,7 +52,7 @@ The implementation of this material model is somewhat expensive because it has t
 
 `depth dependent': The ``depth dependent'' Material model applies a depth-dependent scaling to any of the other available material models. In other words, it is a ``compositing material model''.
 
-Parameters related to the depth dependent model are read from a subsection ``Material model/Depth dependent model''. The user must specify a ``Base model'' from which material properties are derived. Currently the depth dependent model only allows depth dependence of viscosity - other material properties are taken from the ``Base model''. Viscosity $\eta$ at depth $z$ is calculated according to:\begin{equation}\eta(z,p,T,X,...) = \eta(z) \eta_b(p,T,X,..)/\eta_{rb}\end{equation}where $\eta(z)$ is the depth-dependence specified by the depth dependent model, $\eta_b(p,T,X,...)$ is the viscosity calculated from the base model, and $\eta_{rb}$ is the reference viscosity of the ``Base model''. In addition to the specification of the ``Base model'', the user must specify the method to be used to calculate the depth-dependent viscosity $\eta(z)$ as ``Material model/Depth dependent model/Depth dependence method'', which can be chosen among ``None|Function|File|List''. Each method and the associated parameters are as follows:
+Parameters related to the depth dependent model are read from a subsection ``Material model/Depth dependent model''. The user must specify a ``Base model'' from which material properties are derived. Currently the depth dependent model only allows depth dependence of viscosity - other material properties are taken from the ``Base model''. Viscosity $\eta$ at depth $z$ is calculated according to:\begin{equation}\eta(z,p,T,X,...) = \eta(z) \eta_b(p,T,X,..)/\eta_{r}\end{equation}where $\eta(z)$ is the depth-dependence specified by the depth dependent model, $\eta_b(p,T,X,...)$ is the viscosity calculated from the base model, and $\eta_{r}$ is the reference viscosity. In addition to the specification of the ``Base model'', the user must specify the method to be used to calculate the depth-dependent viscosity $\eta(z)$ as ``Material model/Depth dependent model/Depth dependence method'', which can be chosen among ``None|Function|File|List''. Each method and the associated parameters are as follows:
 
 ``Function'': read a user-specified parsed function from the input file in a subsection ``Material model/Depth dependent model/Viscosity depth function''. By default, this function is uniformly equal to 1.0e21. Specifying a function that returns a value less than or equal to 0.0 anywhere in the model domain will produce an error.
 
@@ -214,7 +214,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
  When more than one compositional field is present at a point, they are averaged arithmetically. An exception is viscosity, which may be averaged arithmetically, harmonically, geometrically, or by selecting the viscosity of the composition field with the greatest volume fraction.
 
 (parameters:Material_20model/Ascii_20reference_20profile)=
-## **Parameters in section** Material model/Ascii reference profile
+## **Subsection:** Material model / Ascii reference profile
 (parameters:Material_20model/Ascii_20reference_20profile/Thermal_20conductivity)=
 ### __Parameter name:__ Thermal conductivity
 **Default value:** 4.0
@@ -264,7 +264,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** A list of prefactors for the viscosity that determine the viscosity profile. Each prefactor is applied in a depth range specified by the list of `Transition depths', i.e. the first prefactor is applied above the first transition depth, the second one between the first and second transition depth, and so on. To compute the viscosity profile, this prefactor is multiplied by the reference viscosity specified through the parameter `Viscosity'. List must have one more entry than Transition depths. Units: non-dimensional.
 
 (parameters:Material_20model/Ascii_20reference_20profile/Ascii_20data_20model)=
-## **Parameters in section** Material model/Ascii reference profile/Ascii data model
+## **Subsection:** Material model / Ascii reference profile / Ascii data model
 (parameters:Material_20model/Ascii_20reference_20profile/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/adiabatic-conditions/ascii-data/
@@ -290,7 +290,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Material_20model/Averaging)=
-## **Parameters in section** Material model/Averaging
+## **Subsection:** Material model / Averaging
 (parameters:Material_20model/Averaging/Averaging_20operation)=
 ### __Parameter name:__ Averaging operation
 **Default value:** none
@@ -316,7 +316,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** The limit normalized distance between 0 and 1 where the bell shape becomes zero. See the manual for a more information.
 
 (parameters:Material_20model/Compositing)=
-## **Parameters in section** Material model/Compositing
+## **Subsection:** Material model / Compositing
 (parameters:Material_20model/Compositing/Compressibility)=
 ### __Parameter name:__ Compressibility
 **Default value:** unspecified
@@ -390,7 +390,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** Material model to use for Viscosity. Valid values for this parameter are the names of models that are also valid for the ``Material models/Model name'' parameter. See the documentation for that for more information.
 
 (parameters:Material_20model/Composition_20reaction_20model)=
-## **Parameters in section** Material model/Composition reaction model
+## **Subsection:** Material model / Composition reaction model
 (parameters:Material_20model/Composition_20reaction_20model/Composition_20viscosity_20prefactor_201)=
 ### __Parameter name:__ Composition viscosity prefactor 1
 **Default value:** 1.0
@@ -488,7 +488,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** The value of the constant viscosity. Units: \si{\kilogram\per\meter\per\second}.
 
 (parameters:Material_20model/Depth_20dependent_20model)=
-## **Parameters in section** Material model/Depth dependent model
+## **Subsection:** Material model / Depth dependent model
 (parameters:Material_20model/Depth_20dependent_20model/Base_20model)=
 ### __Parameter name:__ Base model
 **Default value:** simple
@@ -529,6 +529,14 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 
 **Documentation:** A comma-separated list of depth values for use with the ``List'' ``Depth dependence method''. The list must be provided in order of increasing depth, and the last value must be greater than or equal to the maximal depth of the model. The depth list is interpreted as a layered viscosity structure and the depth values specify the maximum depths of each layer.
 
+(parameters:Material_20model/Depth_20dependent_20model/Reference_20viscosity)=
+### __Parameter name:__ Reference viscosity
+**Default value:** 1.7976931348623157e+308
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The value of the constant reference viscosity $\eta_r$ that is used to scale the non-dimenional depth-dependent viscosity prefactor. Units: \si{\pascal\second}.
+
 (parameters:Material_20model/Depth_20dependent_20model/Scale_20factor)=
 ### __Parameter name:__ Scale factor
 **Default value:** 1.
@@ -552,7 +560,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 **Documentation:** A comma-separated list of viscosity values, corresponding to the depth values provided in ``Depth list''. The number of viscosity values specified here must be the same as the number of depths provided in ``Depth list''.
 
 (parameters:Material_20model/Depth_20dependent_20model/Viscosity_20depth_20function)=
-## **Parameters in section** Material model/Depth dependent model/Viscosity depth function
+## **Subsection:** Material model / Depth dependent model / Viscosity depth function
 (parameters:Material_20model/Depth_20dependent_20model/Viscosity_20depth_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -580,7 +588,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Material_20model/Diffusion_20dislocation)=
-## **Parameters in section** Material model/Diffusion dislocation
+## **Subsection:** Material model / Diffusion dislocation
 (parameters:Material_20model/Diffusion_20dislocation/Activation_20energies_20for_20diffusion_20creep)=
 ### __Parameter name:__ Activation energies for diffusion creep
 **Default value:** 375e3
@@ -770,7 +778,7 @@ Units: \si{\pascal\second}.
 **Documentation:** When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
 
 (parameters:Material_20model/Drucker_20Prager)=
-## **Parameters in section** Material model/Drucker Prager
+## **Subsection:** Material model / Drucker Prager
 (parameters:Material_20model/Drucker_20Prager/Reference_20density)=
 ### __Parameter name:__ Reference density
 **Default value:** 3300.
@@ -824,7 +832,7 @@ Units: \si{\pascal\second}.
 **Documentation:** The value of the thermal expansion coefficient $\alpha$. Units: \si{\per\kelvin}.
 
 (parameters:Material_20model/Drucker_20Prager/Viscosity)=
-## **Parameters in section** Material model/Drucker Prager/Viscosity
+## **Subsection:** Material model / Drucker Prager / Viscosity
 (parameters:Material_20model/Drucker_20Prager/Viscosity/Angle_20of_20internal_20friction)=
 ### __Parameter name:__ Angle of internal friction
 **Default value:** 0.
@@ -866,7 +874,7 @@ Units: \si{\pascal\second}.
 **Documentation:** The value of the initial strain rate prescribed during the first nonlinear iteration $\dot{\epsilon}_ref$. Units: \si{\per\second}.
 
 (parameters:Material_20model/Grain_20size_20model)=
-## **Parameters in section** Material model/Grain size model
+## **Subsection:** Material model / Grain size model
 (parameters:Material_20model/Grain_20size_20model/Advect_20logarithm_20of_20grain_20size)=
 ### __Parameter name:__ Advect logarithm of grain size
 **Default value:** false
@@ -1268,7 +1276,7 @@ Units: \si{\pascal\second}.
 **Documentation:** The fraction $\chi$ of work done by dislocation creep to change the grain boundary area. Units: \si{\joule\per\meter\squared}.
 
 (parameters:Material_20model/Latent_20heat)=
-## **Parameters in section** Material model/Latent heat
+## **Subsection:** Material model / Latent heat
 (parameters:Material_20model/Latent_20heat/Composition_20viscosity_20prefactor)=
 ### __Parameter name:__ Composition viscosity prefactor
 **Default value:** 1.0
@@ -1446,7 +1454,7 @@ Units: \si{\pascal\second}.
 **Documentation:** A list of prefactors for the viscosity for each phase. The reference viscosity will be multiplied by this factor to get the corresponding viscosity for each phase. List must have one more entry than Phase transition depths. Units: non-dimensional.
 
 (parameters:Material_20model/Latent_20heat_20melt)=
-## **Parameters in section** Material model/Latent heat melt
+## **Subsection:** Material model / Latent heat melt
 (parameters:Material_20model/Latent_20heat_20melt/A1)=
 ### __Parameter name:__ A1
 **Default value:** 1085.7
@@ -1712,7 +1720,7 @@ Units: \si{\pascal\second}.
 **Documentation:** Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: \si{\per\pascal}.
 
 (parameters:Material_20model/Melt_20global)=
-## **Parameters in section** Material model/Melt global
+## **Subsection:** Material model / Melt global
 (parameters:Material_20model/Melt_20global/Depletion_20density_20change)=
 ### __Parameter name:__ Depletion density change
 **Default value:** 0.0
@@ -1908,7 +1916,7 @@ Also note that the melting time scale has to be larger than or equal to the reac
 **Documentation:** The temperature dependence of the shear viscosity. Dimensionless exponent. See the general documentation of this model for a formula that states the dependence of the viscosity on this factor, which is called $\beta$ there.
 
 (parameters:Material_20model/Melt_20simple)=
-## **Parameters in section** Material model/Melt simple
+## **Subsection:** Material model / Melt simple
 (parameters:Material_20model/Melt_20simple/A1)=
 ### __Parameter name:__ A1
 **Default value:** 1085.7
@@ -2210,7 +2218,7 @@ Note that melt does not freeze unless the 'Freezing rate' parameter is set to a 
 **Documentation:** Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: \si{\per\pascal}.
 
 (parameters:Material_20model/Modified_20Tait_20model)=
-## **Parameters in section** Material model/Modified Tait model
+## **Subsection:** Material model / Modified Tait model
 (parameters:Material_20model/Modified_20Tait_20model/Einstein_20temperature)=
 ### __Parameter name:__ Einstein temperature
 **Default value:** 600.
@@ -2284,7 +2292,7 @@ Note that melt does not freeze unless the 'Freezing rate' parameter is set to a 
 **Documentation:** The value of the constant viscosity $\eta_0$. Units: \si{\pascal\second}.
 
 (parameters:Material_20model/Modified_20Tait_20model/Reference_20heat_20capacity_20function)=
-## **Parameters in section** Material model/Modified Tait model/Reference heat capacity function
+## **Subsection:** Material model / Modified Tait model / Reference heat capacity function
 (parameters:Material_20model/Modified_20Tait_20model/Reference_20heat_20capacity_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -2312,7 +2320,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Material_20model/Multicomponent)=
-## **Parameters in section** Material model/Multicomponent
+## **Subsection:** Material model / Multicomponent
 (parameters:Material_20model/Multicomponent/Densities)=
 ### __Parameter name:__ Densities
 **Default value:** 3300.
@@ -2376,7 +2384,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
 
 (parameters:Material_20model/Multicomponent_20compressible)=
-## **Parameters in section** Material model/Multicomponent compressible
+## **Subsection:** Material model / Multicomponent compressible
 (parameters:Material_20model/Multicomponent_20compressible/Isochoric_20specific_20heats)=
 ### __Parameter name:__ Isochoric specific heats
 **Default value:** 1250.
@@ -2450,7 +2458,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** When more than one compositional field is present at a point with different viscosities, we need to come up with an average viscosity at that point.  Select a weighted harmonic, arithmetic, geometric, or maximum composition.
 
 (parameters:Material_20model/Nondimensional_20model)=
-## **Parameters in section** Material model/Nondimensional model
+## **Subsection:** Material model / Nondimensional model
 (parameters:Material_20model/Nondimensional_20model/Di)=
 ### __Parameter name:__ Di
 **Default value:** 0.0
@@ -2516,7 +2524,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** Grueneisen parameter
 
 (parameters:Material_20model/PerpleX_20lookup_20model)=
-## **Parameters in section** Material model/PerpleX lookup model
+## **Subsection:** Material model / PerpleX lookup model
 (parameters:Material_20model/PerpleX_20lookup_20model/Maximum_20material_20pressure)=
 ### __Parameter name:__ Maximum material pressure
 **Default value:** 1.e12
@@ -2574,7 +2582,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The value of the viscosity $\eta$. Units: \si{\pascal\second}.
 
 (parameters:Material_20model/Replace_20lithosphere_20viscosity)=
-## **Parameters in section** Material model/Replace lithosphere viscosity
+## **Subsection:** Material model / Replace lithosphere viscosity
 (parameters:Material_20model/Replace_20lithosphere_20viscosity/Base_20model)=
 ### __Parameter name:__ Base model
 **Default value:** simple
@@ -2624,7 +2632,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** Units: \si{\meter}.The maximum depth of the lithosphere. The model will be NaNs below this depth.
 
 (parameters:Material_20model/Simple_20compressible_20model)=
-## **Parameters in section** Material model/Simple compressible model
+## **Subsection:** Material model / Simple compressible model
 (parameters:Material_20model/Simple_20compressible_20model/Reference_20compressibility)=
 ### __Parameter name:__ Reference compressibility
 **Default value:** 4e-12
@@ -2674,7 +2682,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The value of the viscosity $\eta$. Units: \si{\pascal\second}.
 
 (parameters:Material_20model/Simple_20model)=
-## **Parameters in section** Material model/Simple model
+## **Subsection:** Material model / Simple model
 (parameters:Material_20model/Simple_20model/Composition_20viscosity_20prefactor)=
 ### __Parameter name:__ Composition viscosity prefactor
 **Default value:** 1.0
@@ -2764,7 +2772,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The value of the constant viscosity $\eta_0$. This viscosity may be modified by both temperature and compositional dependencies. Units: \si{\pascal\second}.
 
 (parameters:Material_20model/Simpler_20model)=
-## **Parameters in section** Material model/Simpler model
+## **Subsection:** Material model / Simpler model
 (parameters:Material_20model/Simpler_20model/Reference_20density)=
 ### __Parameter name:__ Reference density
 **Default value:** 3300.
@@ -2814,7 +2822,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** The value of the viscosity $\eta$. Units: \si{\pascal\second}.
 
 (parameters:Material_20model/Steinberger_20model)=
-## **Parameters in section** Material model/Steinberger model
+## **Subsection:** Material model / Steinberger model
 (parameters:Material_20model/Steinberger_20model/Bilinear_20interpolation)=
 ### __Parameter name:__ Bilinear interpolation
 **Default value:** true
@@ -3012,7 +3020,7 @@ Units: \si{\pascal\second}.
 **Documentation:** Whether to use to use the laterally averaged temperature instead of the adiabatic temperature as reference for the viscosity calculation. This ensures that the laterally averaged viscosities remain more or less constant over the model runtime. This behaviour might or might not be desired.
 
 (parameters:Material_20model/Visco_20Plastic)=
-## **Parameters in section** Material model/Visco Plastic
+## **Subsection:** Material model / Visco Plastic
 (parameters:Material_20model/Visco_20Plastic/Activation_20energies_20for_20Peierls_20creep)=
 ### __Parameter name:__ Activation energies for Peierls creep
 **Default value:** 320e3
@@ -3684,7 +3692,7 @@ If a compositional field named 'noninitial\_plastic\_strain' is included in the 
 **Documentation:** Select what type of yield mechanism to use between Drucker Prager and stress limiter options.
 
 (parameters:Material_20model/Visco_20Plastic/Friction_20function)=
-## **Parameters in section** Material model/Visco Plastic/Friction function
+## **Subsection:** Material model / Visco Plastic / Friction function
 (parameters:Material_20model/Visco_20Plastic/Friction_20function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** cartesian
@@ -3722,7 +3730,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Material_20model/Viscoelastic)=
-## **Parameters in section** Material model/Viscoelastic
+## **Subsection:** Material model / Viscoelastic
 (parameters:Material_20model/Viscoelastic/Densities)=
 ### __Parameter name:__ Densities
 **Default value:** 3300.

--- a/doc/sphinx/parameters/Melt_20settings.md
+++ b/doc/sphinx/parameters/Melt_20settings.md
@@ -2,7 +2,7 @@
 # Melt settings
 
 
-## **Parameters in section** Melt settings
+## **Subsection:** Melt settings
 
 
 (parameters:Melt_20settings/Average_20melt_20velocity)=

--- a/doc/sphinx/parameters/Mesh_20deformation.md
+++ b/doc/sphinx/parameters/Mesh_20deformation.md
@@ -2,7 +2,7 @@
 # Mesh deformation
 
 
-## **Parameters in section** Mesh deformation
+## **Subsection:** Mesh deformation
 
 
 (parameters:Mesh_20deformation/Additional_20tangential_20mesh_20velocity_20boundary_20indicators)=
@@ -37,8 +37,10 @@ This surface velocity is used to deform the surface and as a boundary condition 
 
 `free surface': A plugin that computes the deformation of surface vertices according to the solution of the flow problem. In particular this means if the surface of the domain is left open to flow, this flow will carry the mesh with it. The implementation was described in \cite{rose_freesurface}, with the stabilization of the free surface originally described in \cite{KMM2010}.
 
+`initial boundary function': A plugin, which prescribes the surface mesh to deform according to an analytically prescribed function. Note that the function prescribes a deformation velocity, i.e. the return value of this plugin is later multiplied by the time step length to compute the displacement increment in this time step. Although the function's time variable is interpreted as years when Use years in output instead of seconds is set to true, the boundary deformation velocity should still be given in m/s. The format of the functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
+
 (parameters:Mesh_20deformation/Ascii_20data_20model)=
-## **Parameters in section** Mesh deformation/Ascii data model
+## **Subsection:** Mesh deformation / Ascii data model
 (parameters:Mesh_20deformation/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/geometry-model/initial-topography-model/ascii-data/test/
@@ -64,7 +66,7 @@ This surface velocity is used to deform the surface and as a boundary condition 
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Mesh_20deformation/Boundary_20function)=
-## **Parameters in section** Mesh deformation/Boundary function
+## **Subsection:** Mesh deformation / Boundary function
 (parameters:Mesh_20deformation/Boundary_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -94,7 +96,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Mesh_20deformation/Diffusion)=
-## **Parameters in section** Mesh deformation/Diffusion
+## **Subsection:** Mesh deformation / Diffusion
 (parameters:Mesh_20deformation/Diffusion/Hillslope_20transport_20coefficient)=
 ### __Parameter name:__ Hillslope transport coefficient
 **Default value:** 1e-6
@@ -112,7 +114,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The number of time steps between each application of diffusion.
 
 (parameters:Mesh_20deformation/Free_20surface)=
-## **Parameters in section** Mesh deformation/Free surface
+## **Subsection:** Mesh deformation / Free surface
 (parameters:Mesh_20deformation/Free_20surface/Free_20surface_20stabilization_20theta)=
 ### __Parameter name:__ Free surface stabilization theta
 **Default value:** 0.5
@@ -128,3 +130,33 @@ If the function you are describing represents a vector-valued function with mult
 **Pattern:** [Selection normal|vertical ]
 
 **Documentation:** After each time step the free surface must be advected in the direction of the velocity field. Mass conservation requires that the mesh velocity is in the normal direction of the surface. However, for steep topography or large curvature, advection in the normal direction can become ill-conditioned, and instabilities in the mesh can form. Projection of the mesh velocity onto the local vertical direction can preserve the mesh quality better, but at the cost of slightly poorer mass conservation of the domain.
+
+(parameters:Mesh_20deformation/Initial_20boundary_20function)=
+## **Subsection:** Mesh deformation / Initial boundary function
+(parameters:Mesh_20deformation/Initial_20boundary_20function/Function_20constants)=
+### __Parameter name:__ Function constants
+**Default value:**
+
+**Pattern:** [Anything]
+
+**Documentation:** Sometimes it is convenient to use symbolic constants in the expression that describes the function, rather than having to use its numeric value everywhere the constant appears. These values can be defined using this parameter, in the form `var1=value1, var2=value2, ...'.
+
+A typical example would be to set this runtime parameter to `pi=3.1415926536' and then use `pi' in the expression of the actual formula. (That said, for convenience this class actually defines both `pi' and `Pi' by default, but you get the idea.)
+
+(parameters:Mesh_20deformation/Initial_20boundary_20function/Function_20expression)=
+### __Parameter name:__ Function expression
+**Default value:** 0; 0
+
+**Pattern:** [Anything]
+
+**Documentation:** The formula that denotes the function you want to evaluate for particular values of the independent variables. This expression may contain any of the usual operations such as addition or multiplication, as well as all of the common functions such as `sin' or `cos'. In addition, it may contain expressions like `if(x>0, 1, -1)' where the expression evaluates to the second argument if the first argument is true, and to the third argument otherwise. For a full overview of possible expressions accepted see the documentation of the muparser library at http://muparser.beltoforion.de/.
+
+If the function you are describing represents a vector-valued function with multiple components, then separate the expressions for individual components by a semicolon.
+
+(parameters:Mesh_20deformation/Initial_20boundary_20function/Variable_20names)=
+### __Parameter name:__ Variable names
+**Default value:** x,y,t
+
+**Pattern:** [Anything]
+
+**Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.

--- a/doc/sphinx/parameters/Mesh_20refinement.md
+++ b/doc/sphinx/parameters/Mesh_20refinement.md
@@ -2,7 +2,7 @@
 # Mesh refinement
 
 
-## **Parameters in section** Mesh refinement
+## **Subsection:** Mesh refinement
 
 
 (parameters:Mesh_20refinement/Adapt_20by_20fraction_20of_20cells)=
@@ -219,7 +219,7 @@ For complex equations such as those we solve here, this observation may not be s
 **Documentation:** The number of time steps after which the mesh is to be adapted again based on computed error indicators. If 0 then the mesh will never be changed.
 
 (parameters:Mesh_20refinement/Artificial_20viscosity)=
-## **Parameters in section** Mesh refinement/Artificial viscosity
+## **Subsection:** Mesh refinement / Artificial viscosity
 (parameters:Mesh_20refinement/Artificial_20viscosity/Compositional_20field_20scaling_20factors)=
 ### __Parameter name:__ Compositional field scaling factors
 **Default value:**
@@ -239,7 +239,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 **Documentation:** A scaling factor for the artificial viscosity  of the temperature equation. Use 0.0 to disable.
 
 (parameters:Mesh_20refinement/Boundary)=
-## **Parameters in section** Mesh refinement/Boundary
+## **Subsection:** Mesh refinement / Boundary
 (parameters:Mesh_20refinement/Boundary/Boundary_20refinement_20indicators)=
 ### __Parameter name:__ Boundary refinement indicators
 **Default value:**
@@ -251,7 +251,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 The names of the boundaries listed here can either be numbers (in which case they correspond to the numerical boundary indicators assigned by the geometry object), or they can correspond to any of the symbolic names the geometry object may have provided for each part of the boundary. You may want to compare this with the documentation of the geometry model you use in your model.
 
 (parameters:Mesh_20refinement/Compaction_20length)=
-## **Parameters in section** Mesh refinement/Compaction length
+## **Subsection:** Mesh refinement / Compaction length
 (parameters:Mesh_20refinement/Compaction_20length/Mesh_20cells_20per_20compaction_20length)=
 ### __Parameter name:__ Mesh cells per compaction length
 **Default value:** 1.0
@@ -261,7 +261,7 @@ The names of the boundaries listed here can either be numbers (in which case the
 **Documentation:** The desired ratio between compaction length and size of the mesh cells, or, in other words, how many cells the mesh should (at least) have per compaction length. Every cell where this ratio is smaller than the value specified by this parameter (in places with fewer mesh cells per compaction length) is marked for refinement.
 
 (parameters:Mesh_20refinement/Composition)=
-## **Parameters in section** Mesh refinement/Composition
+## **Subsection:** Mesh refinement / Composition
 (parameters:Mesh_20refinement/Composition/Compositional_20field_20scaling_20factors)=
 ### __Parameter name:__ Compositional field scaling factors
 **Default value:**
@@ -273,7 +273,7 @@ The names of the boundaries listed here can either be numbers (in which case the
 If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
 
 (parameters:Mesh_20refinement/Composition_20approximate_20gradient)=
-## **Parameters in section** Mesh refinement/Composition approximate gradient
+## **Subsection:** Mesh refinement / Composition approximate gradient
 (parameters:Mesh_20refinement/Composition_20approximate_20gradient/Compositional_20field_20scaling_20factors)=
 ### __Parameter name:__ Compositional field scaling factors
 **Default value:**
@@ -285,7 +285,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
 
 (parameters:Mesh_20refinement/Composition_20gradient)=
-## **Parameters in section** Mesh refinement/Composition gradient
+## **Subsection:** Mesh refinement / Composition gradient
 (parameters:Mesh_20refinement/Composition_20gradient/Compositional_20field_20scaling_20factors)=
 ### __Parameter name:__ Compositional field scaling factors
 **Default value:**
@@ -297,7 +297,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 If the list of scaling factors given in this parameter is empty, then this indicates that they should all be chosen equal to one. If the list is not empty then it needs to have as many entries as there are compositional fields.
 
 (parameters:Mesh_20refinement/Composition_20threshold)=
-## **Parameters in section** Mesh refinement/Composition threshold
+## **Subsection:** Mesh refinement / Composition threshold
 (parameters:Mesh_20refinement/Composition_20threshold/Compositional_20field_20thresholds)=
 ### __Parameter name:__ Compositional field thresholds
 **Default value:**
@@ -307,7 +307,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 **Documentation:** A list of thresholds that every individual compositional field will be evaluated against.
 
 (parameters:Mesh_20refinement/Isosurfaces)=
-## **Parameters in section** Mesh refinement/Isosurfaces
+## **Subsection:** Mesh refinement / Isosurfaces
 (parameters:Mesh_20refinement/Isosurfaces/Isosurfaces)=
 ### __Parameter name:__ Isosurfaces
 **Default value:**
@@ -319,7 +319,7 @@ If the list of scaling factors given in this parameter is empty, then this indic
 The first two entries for each isosurface, describing the minimum and maximum grid levels, can be two numbers or contain one of the key values 'min' and 'max'. This indicates the key will be replaced with the global minimum and maximum refinement levels. The 'min' and 'max' keys also accept adding values to be added or substracted from them respectively. This is done by adding a '+' or '-' and a number behind them (e.g. min+2 or max-1). Note that you can't substract a value from a minimum value or add a value to the maximum value. If, for example, `max-4` drops below the minimum or `min+4` goes above the maximum, it will simply use the global minimum and maximum values respectively. The same holds for any mesh refinement level below the global minimum or above the global maximum.
 
 (parameters:Mesh_20refinement/Maximum_20refinement_20function)=
-## **Parameters in section** Mesh refinement/Maximum refinement function
+## **Subsection:** Mesh refinement / Maximum refinement function
 (parameters:Mesh_20refinement/Maximum_20refinement_20function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** depth
@@ -357,7 +357,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Mesh_20refinement/Minimum_20refinement_20function)=
-## **Parameters in section** Mesh refinement/Minimum refinement function
+## **Subsection:** Mesh refinement / Minimum refinement function
 (parameters:Mesh_20refinement/Minimum_20refinement_20function/Coordinate_20system)=
 ### __Parameter name:__ Coordinate system
 **Default value:** depth
@@ -395,7 +395,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Mesh_20refinement/Volume_20of_20fluid_20interface)=
-## **Parameters in section** Mesh refinement/Volume of fluid interface
+## **Subsection:** Mesh refinement / Volume of fluid interface
 (parameters:Mesh_20refinement/Volume_20of_20fluid_20interface/Strict_20coarsening)=
 ### __Parameter name:__ Strict coarsening
 **Default value:** false

--- a/doc/sphinx/parameters/Nullspace_20removal.md
+++ b/doc/sphinx/parameters/Nullspace_20removal.md
@@ -2,7 +2,7 @@
 # Nullspace removal
 
 
-## **Parameters in section** Nullspace removal
+## **Subsection:** Nullspace removal
 
 
 (parameters:Nullspace_20removal/Remove_20nullspace)=

--- a/doc/sphinx/parameters/Postprocess.md
+++ b/doc/sphinx/parameters/Postprocess.md
@@ -2,14 +2,14 @@
 # Postprocess
 
 
-## **Parameters in section** Postprocess
+## **Subsection:** Postprocess
 
 
 (parameters:Postprocess/List_20of_20postprocessors)=
 ### __Parameter name:__ List of postprocessors
 **Default value:**
 
-**Pattern:** [MultipleSelection Stokes residual|basic statistics|boundary densities|boundary pressures|boundary velocity residual statistics|command|composition statistics|core statistics|depth average|dynamic topography|entropy viscosity statistics|geoid|global statistics|gravity calculation|heat flux densities|heat flux map|heat flux statistics|heating statistics|load balance statistics|mass flux statistics|material statistics|matrix statistics|maximum depth of field|melt statistics|memory statistics|mobility statistics|particle count statistics|particles|point values|pressure statistics|rotation statistics|spherical velocity statistics|temperature statistics|topography|velocity boundary statistics|velocity statistics|viscous dissipation statistics|visualization|volume of fluid statistics ]
+**Pattern:** [MultipleSelection Stokes residual|basic statistics|boundary densities|boundary pressures|boundary strain rate residual statistics|boundary velocity residual statistics|command|composition statistics|core statistics|depth average|dynamic topography|entropy viscosity statistics|geoid|global statistics|gravity calculation|heat flux densities|heat flux map|heat flux statistics|heating statistics|load balance statistics|mass flux statistics|material statistics|matrix statistics|maximum depth of field|melt statistics|memory statistics|mobility statistics|particle count statistics|particles|point values|pressure statistics|rotation statistics|spherical velocity statistics|temperature statistics|topography|velocity boundary statistics|velocity statistics|viscous dissipation statistics|visualization|volume of fluid statistics ]
 
 **Documentation:** A comma separated list of postprocessor objects that should be run at the end of each time step. Some of these postprocessors will declare their own parameters which may, for example, include that they will actually do something only every so many time steps or years. Alternatively, the text `all' indicates that all available postprocessors should be run after each time step.
 
@@ -22,6 +22,8 @@ The following postprocessors are available:
 `boundary densities': A postprocessor that computes the laterally averaged density at the top and bottom of the domain.
 
 `boundary pressures': A postprocessor that computes the laterally averaged pressure at the top and bottom of the domain.
+
+`boundary strain rate residual statistics': A postprocessor that computes some statistics about the surface strain rate residual along the top boundary. The residual is the difference between the second invariant of the model strain rate and the second strain rate invariant read from the input data file. Currently, the strain residual statistics, i.e., min, max and the rms magnitude, are computed at the top suface.
 
 `boundary velocity residual statistics': A postprocessor that computes some statistics about the velocity residual along the top boundary. The velocity residual is the difference between the model solution velocities and the input velocities (GPlates model or ascii data). Currently, the velocity residual statistics, i.e., min, max and the rms magnitude, is computed at the top suface.
 
@@ -125,8 +127,34 @@ The file format then consists of lines with Euclidean coordinates followed by th
 
 **Documentation:** Whether or not the postprocessors should be executed after each of the nonlinear iterations done within one time step. As this is mainly an option for the purposes of debugging, it is not supported when the 'Time between graphical output' is larger than zero, or when the postprocessor is not intended to be run more than once per timestep.
 
+(parameters:Postprocess/Boundary_20strain_20rate_20residual_20statistics)=
+## **Subsection:** Postprocess / Boundary strain rate residual statistics
+(parameters:Postprocess/Boundary_20strain_20rate_20residual_20statistics/Data_20directory)=
+### __Parameter name:__ Data directory
+**Default value:** $ASPECT_SOURCE_DIR/data/postprocess/boundary-strain-rate-residual/
+
+**Pattern:** [DirectoryName]
+
+**Documentation:** The name of a directory that contains the ascii data. This path may either be absolute (if starting with a `/') or relative to the current directory. The path may also include the special text `$ASPECT_SOURCE_DIR' which will be interpreted as the path in which the ASPECT source files were located when ASPECT was compiled. This interpretation allows, for example, to reference files located in the `data/' subdirectory of ASPECT.
+
+(parameters:Postprocess/Boundary_20strain_20rate_20residual_20statistics/Data_20file_20name)=
+### __Parameter name:__ Data file name
+**Default value:** box_3d_boundary_strain_rate.txt
+
+**Pattern:** [Anything]
+
+**Documentation:** The file name of the input surface strain rate an ascii data. The file has one column in addition to the coordinate columns corresponding to the second invariant of strain rate.
+
+(parameters:Postprocess/Boundary_20strain_20rate_20residual_20statistics/Scale_20factor)=
+### __Parameter name:__ Scale factor
+**Default value:** 1.
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model.
+
 (parameters:Postprocess/Boundary_20velocity_20residual_20statistics)=
-## **Parameters in section** Postprocess/Boundary velocity residual statistics
+## **Subsection:** Postprocess / Boundary velocity residual statistics
 (parameters:Postprocess/Boundary_20velocity_20residual_20statistics/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/boundary-velocity/gplates/
@@ -168,7 +196,7 @@ The file format then consists of lines with Euclidean coordinates followed by th
 **Documentation:** Specify velocity as r, phi, and theta components instead of x, y, and z. Positive velocities point up, east, and north (in 3D) or out and clockwise (in 2D). This setting only makes sense for spherical geometries.GPlates data is always interpreted to be in east and north directions and is not affected by this parameter.
 
 (parameters:Postprocess/Command)=
-## **Parameters in section** Postprocess/Command
+## **Subsection:** Postprocess / Command
 (parameters:Postprocess/Command/Command)=
 ### __Parameter name:__ Command
 **Default value:**
@@ -194,7 +222,7 @@ The file format then consists of lines with Euclidean coordinates followed by th
 **Documentation:** Select whether \aspect{} should terminate if the command returns a non-zero exit status.
 
 (parameters:Postprocess/Depth_20average)=
-## **Parameters in section** Postprocess/Depth average
+## **Subsection:** Postprocess / Depth average
 (parameters:Postprocess/Depth_20average/Depth_20boundaries_20of_20zones)=
 ### __Parameter name:__ Depth boundaries of zones
 **Default value:**
@@ -241,7 +269,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** The time interval between each generation of graphical output files. A value of zero indicates that output should be generated in each time step. Units: years if the 'Use years in output instead of seconds' parameter is set; seconds otherwise.
 
 (parameters:Postprocess/Dynamic_20core_20statistics)=
-## **Parameters in section** Postprocess/Dynamic core statistics
+## **Subsection:** Postprocess / Dynamic core statistics
 (parameters:Postprocess/Dynamic_20core_20statistics/Excess_20entropy_20only)=
 ### __Parameter name:__ Excess entropy only
 **Default value:** false
@@ -251,7 +279,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** Output the excess entropy only instead the each entropy terms.
 
 (parameters:Postprocess/Dynamic_20topography)=
-## **Parameters in section** Postprocess/Dynamic topography
+## **Subsection:** Postprocess / Dynamic topography
 (parameters:Postprocess/Dynamic_20topography/Density_20above)=
 ### __Parameter name:__ Density above
 **Default value:** 0.
@@ -285,7 +313,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** Whether to output a file containing the surface dynamic topography.
 
 (parameters:Postprocess/Geoid)=
-## **Parameters in section** Postprocess/Geoid
+## **Subsection:** Postprocess / Geoid
 (parameters:Postprocess/Geoid/Also_20output_20the_20gravity_20anomaly)=
 ### __Parameter name__: Also output the gravity anomaly
 **Alias:** [Output gravity anomaly](parameters:Postprocess/Geoid/Output_20gravity_20anomaly)
@@ -421,7 +449,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** Option to output the spherical harmonic coefficients of the surface topography contribution to the maximum degree. The default is false.
 
 (parameters:Postprocess/Global_20statistics)=
-## **Parameters in section** Postprocess/Global statistics
+## **Subsection:** Postprocess / Global statistics
 (parameters:Postprocess/Global_20statistics/Write_20statistics_20for_20each_20nonlinear_20iteration)=
 ### __Parameter name:__ Write statistics for each nonlinear iteration
 **Default value:** false
@@ -431,7 +459,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** Whether to put every nonlinear iteration into a separate line in the statistics file (if true), or to output only one line per time step that contains the total number of iterations of the Stokes and advection linear system solver.
 
 (parameters:Postprocess/Gravity_20calculation)=
-## **Parameters in section** Postprocess/Gravity calculation
+## **Subsection:** Postprocess / Gravity calculation
 (parameters:Postprocess/Gravity_20calculation/List_20of_20latitude)=
 ### __Parameter name:__ List of latitude
 **Default value:**
@@ -585,7 +613,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** The maximum number of time steps between each generation of gravity output files.
 
 (parameters:Postprocess/Memory_20statistics)=
-## **Parameters in section** Postprocess/Memory statistics
+## **Subsection:** Postprocess / Memory statistics
 (parameters:Postprocess/Memory_20statistics/Output_20peak_20virtual_20memory_20_28VmPeak_29)=
 ### __Parameter name:__ Output peak virtual memory _28VmPeak_29
 **Default value:** true
@@ -595,14 +623,14 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** If set to 'true', also output the peak virtual memory usage (computed as the maximum over all processors).
 
 (parameters:Postprocess/Particles)=
-## **Parameters in section** Postprocess/Particles
+## **Subsection:** Postprocess / Particles
 (parameters:Postprocess/Particles/Allow_20cells_20without_20particles)=
 ### __Parameter name:__ Allow cells without particles
 **Default value:** false
 
 **Pattern:** [Bool]
 
-**Documentation:** By default, every cell needs to contain particles to use this interpolator plugin. If this parameter is set to true, cells are allowed to have no particles, In case both the current cell and its neighbors are empty, the interpolator will return 0 for the current cell's properties.
+**Documentation:** By default, every cell needs to contain particles to use this interpolator plugin. If this parameter is set to true, cells are allowed to have no particles. In case both the current cell and its neighbors are empty, the interpolator will return 0 for the current cell's properties.
 
 (parameters:Postprocess/Particles/Data_20output_20format)=
 ### __Parameter name:__ Data output format
@@ -799,7 +827,7 @@ Units: years if the 'Use years in output instead of seconds' parameter is set; s
 **Documentation:** File operations can potentially take a long time, blocking the progress of the rest of the model run. Setting this variable to `true' moves this process into a background thread, while the rest of the model continues.
 
 (parameters:Postprocess/Particles/Function)=
-## **Parameters in section** Postprocess/Particles/Function
+## **Subsection:** Postprocess / Particles / Function
 (parameters:Postprocess/Particles/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -837,9 +865,9 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Postprocess/Particles/Generator)=
-## **Parameters in section** Postprocess/Particles/Generator
+## **Subsection:** Postprocess / Particles / Generator
 (parameters:Postprocess/Particles/Generator/Ascii_20file)=
-## **Parameters in section** Postprocess/Particles/Generator/Ascii file
+## **Subsection:** Postprocess / Particles / Generator / Ascii file
 (parameters:Postprocess/Particles/Generator/Ascii_20file/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/particle/generator/ascii/
@@ -857,7 +885,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The name of the particle file.
 
 (parameters:Postprocess/Particles/Generator/Probability_20density_20function)=
-## **Parameters in section** Postprocess/Particles/Generator/Probability density function
+## **Subsection:** Postprocess / Particles / Generator / Probability density function
 (parameters:Postprocess/Particles/Generator/Probability_20density_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -903,7 +931,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Postprocess/Particles/Generator/Reference_20cell)=
-## **Parameters in section** Postprocess/Particles/Generator/Reference cell
+## **Subsection:** Postprocess / Particles / Generator / Reference cell
 (parameters:Postprocess/Particles/Generator/Reference_20cell/Number_20of_20particles_20per_20cell_20per_20direction)=
 ### __Parameter name:__ Number of particles per cell per direction
 **Default value:** 2
@@ -913,7 +941,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** List of number of particles to create per cell and spatial dimension. The size of the list is the number of spatial dimensions. If only one value is given, then each spatial dimension is set to the same value. The list of numbers are parsed as a floating point number (so that one can specify, for example, '1e4' particles) but it is interpreted as an integer, of course.
 
 (parameters:Postprocess/Particles/Generator/Uniform_20box)=
-## **Parameters in section** Postprocess/Particles/Generator/Uniform box
+## **Subsection:** Postprocess / Particles / Generator / Uniform box
 (parameters:Postprocess/Particles/Generator/Uniform_20box/Maximum_20x)=
 ### __Parameter name:__ Maximum x
 **Default value:** 1.
@@ -963,7 +991,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Minimum z coordinate for the region of particles.
 
 (parameters:Postprocess/Particles/Generator/Uniform_20radial)=
-## **Parameters in section** Postprocess/Particles/Generator/Uniform radial
+## **Subsection:** Postprocess / Particles / Generator / Uniform radial
 (parameters:Postprocess/Particles/Generator/Uniform_20radial/Center_20x)=
 ### __Parameter name:__ Center x
 **Default value:** 0.
@@ -1045,9 +1073,9 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The number of radial shells of particles that will be generated around the central point.
 
 (parameters:Postprocess/Particles/Interpolator)=
-## **Parameters in section** Postprocess/Particles/Interpolator
+## **Subsection:** Postprocess / Particles / Interpolator
 (parameters:Postprocess/Particles/Interpolator/Bilinear_20least_20squares)=
-## **Parameters in section** Postprocess/Particles/Interpolator/Bilinear least squares
+## **Subsection:** Postprocess / Particles / Interpolator / Bilinear least squares
 (parameters:Postprocess/Particles/Interpolator/Bilinear_20least_20squares/Use_20linear_20least_20squares_20limiter)=
 ### __Parameter name:__ Use linear least squares limiter
 **Default value:** false
@@ -1057,7 +1085,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Limit the interpolation of particle properties onto the cell so the value of each property is no smaller than its minimum and no larger than its maximum on the particles in each cell. If more than one value is specified, they will be treated as a list.
 
 (parameters:Postprocess/Particles/Interpolator/Quadratic_20least_20squares)=
-## **Parameters in section** Postprocess/Particles/Interpolator/Quadratic least squares
+## **Subsection:** Postprocess / Particles / Interpolator / Quadratic least squares
 (parameters:Postprocess/Particles/Interpolator/Quadratic_20least_20squares/Global_20particle_20property_20maximum)=
 ### __Parameter name:__ Global particle property maximum
 **Default value:** 1.7976931348623157e+308
@@ -1083,7 +1111,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Whether to apply a global particle property limiting scheme to the interpolated particle properties.
 
 (parameters:Postprocess/Particles/Melt_20particle)=
-## **Parameters in section** Postprocess/Particles/Melt particle
+## **Subsection:** Postprocess / Particles / Melt particle
 (parameters:Postprocess/Particles/Melt_20particle/Threshold_20for_20melt_20presence)=
 ### __Parameter name:__ Threshold for melt presence
 **Default value:** 1e-3
@@ -1093,7 +1121,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The minimum porosity that has to be present at the position of a particle for it to be considered a melt particle (in the sense that the melt presence property is set to 1).
 
 (parameters:Postprocess/Point_20values)=
-## **Parameters in section** Postprocess/Point values
+## **Subsection:** Postprocess / Point values
 (parameters:Postprocess/Point_20values/Evaluation_20points)=
 ### __Parameter name:__ Evaluation points
 **Default value:**
@@ -1119,7 +1147,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Whether or not the Evaluation points are specified in the natural coordinates of the geometry model, e.g. radius, lon, lat for the chunk model. Currently, natural coordinates for the spherical shell and sphere geometries are not supported.
 
 (parameters:Postprocess/Rotation_20statistics)=
-## **Parameters in section** Postprocess/Rotation statistics
+## **Subsection:** Postprocess / Rotation statistics
 (parameters:Postprocess/Rotation_20statistics/Output_20full_20moment_20of_20inertia_20tensor)=
 ### __Parameter name:__ Output full moment of inertia tensor
 **Default value:** false
@@ -1137,7 +1165,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** Whether to use a constant density of one for the computation of the angular momentum and moment of inertia. This is an approximation that assumes that the 'volumetric' rotation is equal to the 'mass' rotation. If this parameter is true this postprocessor computes 'net rotation' instead of 'angular momentum'.
 
 (parameters:Postprocess/Topography)=
-## **Parameters in section** Postprocess/Topography
+## **Subsection:** Postprocess / Topography
 (parameters:Postprocess/Topography/Output_20to_20file)=
 ### __Parameter name:__ Output to file
 **Default value:** false
@@ -1155,7 +1183,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The time interval between each generation of text output files. A value of zero indicates that output should be generated in each time step. Units: years if the 'Use years in output instead of seconds' parameter is set; seconds otherwise.
 
 (parameters:Postprocess/Visualization)=
-## **Parameters in section** Postprocess/Visualization
+## **Subsection:** Postprocess / Visualization
 (parameters:Postprocess/Visualization/Filter_20output)=
 ### __Parameter name:__ Filter output
 **Default value:** false
@@ -1182,7 +1210,7 @@ Of course, activating this option also greatly increases the amount of data \asp
 ### __Parameter name:__ List of output variables
 **Default value:**
 
-**Pattern:** [MultipleSelection ISA rotation timescale|Vp anomaly|Vs anomaly|adiabat|artificial viscosity|artificial viscosity composition|boundary indicators|boundary velocity residual|compositional vector|depth|dynamic topography|error indicator|geoid|grain lag angle|gravity|heat flux map|heating|material properties|maximum horizontal compressive stress|melt fraction|melt material properties|named additional outputs|nonadiabatic pressure|nonadiabatic temperature|particle count|partition|principal stress|shear stress|spd factor|spherical velocity components|strain rate|strain rate tensor|stress|stress second invariant|surface dynamic topography|surface stress|temperature anomaly|vertical heat flux|volume of fluid values|volumetric strain rate|density|specific heat|thermal conductivity|thermal diffusivity|thermal expansivity|viscosity ]
+**Pattern:** [MultipleSelection ISA rotation timescale|Vp anomaly|Vs anomaly|adiabat|artificial viscosity|artificial viscosity composition|boundary indicators|boundary strain rate residual|boundary velocity residual|compositional vector|depth|dynamic topography|error indicator|geoid|grain lag angle|gravity|heat flux map|heating|material properties|maximum horizontal compressive stress|melt fraction|melt material properties|named additional outputs|nonadiabatic pressure|nonadiabatic temperature|particle count|partition|principal stress|shear stress|spd factor|spherical velocity components|strain rate|strain rate tensor|stress|stress second invariant|surface dynamic topography|surface stress|temperature anomaly|vertical heat flux|volume of fluid values|volumetric strain rate|density|specific heat|thermal conductivity|thermal diffusivity|thermal expansivity|viscosity ]
 
 **Documentation:** A comma separated list of visualization objects that should be run whenever writing graphical output. By default, the graphical output files will always contain the primary variables velocity, pressure, and temperature. However, one frequently wants to also visualize derived quantities, such as the thermodynamic phase that corresponds to a given temperature-pressure value, or the corresponding seismic wave speeds. The visualization objects do exactly this: they compute such derived quantities and place them into the output file. The current parameter is the place where you decide which of these additional output variables you want to have in your output file.
 
@@ -1201,6 +1229,8 @@ The following postprocessors are available:
 `artificial viscosity composition': A visualization output object that generates output showing the value of the artificial viscosity for a compositional field on each cell.
 
 `boundary indicators': A visualization output object that generates output about the used boundary indicators. In a loop over the active cells, if a cell lies at a domain boundary, the boundary indicator of the face along the boundary is requested. In case the cell does not lie along any domain boundary, the cell is assigned the value of the largest used boundary indicator plus one. When a cell is situated in one of the corners of the domain, multiple faces will have a boundary indicator. This postprocessor returns the value of the first face along a boundary that is encountered in a loop over all the faces.
+
+`boundary strain rate residual': A visualization output object that generates output for the strain rate residual at the top surface. The residual is computed at each point at the surface as the difference between the strain rate invariant in the model and the input data, where the invariant is computed like in the 'strain rate' postprocessor. The user chooses the input data as ascii data files with coordinate columns and column corresponding to the surface strain rate norm.
 
 `boundary velocity residual': A visualization output object that generates output for the velocity residual at the top surface. The residual is computed at each point at the surface as the difference between the modeled velocities and the input data velocities for each vector component. The user has an option to choose the input data as ascii data files (e.g. GPS velocities) with columns in the same format as described for the 'ascii data' initial temperature plugin or a velocity field computed from the GPlates program as described in the gplates boundary velocity plugin.
 
@@ -1372,7 +1402,7 @@ The effect of using this option can be seen in the following picture:
 **Documentation:** File operations can potentially take a long time, blocking the progress of the rest of the model run. Setting this variable to `true' moves this process into a background thread, while the rest of the model continues.
 
 (parameters:Postprocess/Visualization/Artificial_20viscosity_20composition)=
-## **Parameters in section** Postprocess/Visualization/Artificial viscosity composition
+## **Subsection:** Postprocess / Visualization / Artificial viscosity composition
 (parameters:Postprocess/Visualization/Artificial_20viscosity_20composition/Name_20of_20compositional_20field)=
 ### __Parameter name:__ Name of compositional field
 **Default value:**
@@ -1382,7 +1412,7 @@ The effect of using this option can be seen in the following picture:
 **Documentation:** The name of the compositional field whose output should be visualized.
 
 (parameters:Postprocess/Visualization/Compositional_20fields_20as_20vectors)=
-## **Parameters in section** Postprocess/Visualization/Compositional fields as vectors
+## **Subsection:** Postprocess / Visualization / Compositional fields as vectors
 (parameters:Postprocess/Visualization/Compositional_20fields_20as_20vectors/Names_20of_20fields)=
 ### __Parameter name:__ Names of fields
 **Default value:**
@@ -1400,7 +1430,7 @@ The effect of using this option can be seen in the following picture:
 **Documentation:** Names of vectors as they will appear in the output.
 
 (parameters:Postprocess/Visualization/Heat_20flux_20map)=
-## **Parameters in section** Postprocess/Visualization/Heat flux map
+## **Subsection:** Postprocess / Visualization / Heat flux map
 (parameters:Postprocess/Visualization/Heat_20flux_20map/Output_20point_20wise_20heat_20flux)=
 ### __Parameter name:__ Output point wise heat flux
 **Default value:** false
@@ -1410,7 +1440,7 @@ The effect of using this option can be seen in the following picture:
 **Documentation:** A boolean flag that controls whether to output the heat flux map as a point wise value, or as a cell-wise averaged value. The point wise output is more accurate, but it currently omits prescribed heat flux values at boundaries and advective heat flux that is caused by velocities non-tangential to boundaries. If you do not use these two features it is recommended to switch this setting on to benefit from the increased output resolution.
 
 (parameters:Postprocess/Visualization/Material_20properties)=
-## **Parameters in section** Postprocess/Visualization/Material properties
+## **Subsection:** Postprocess / Visualization / Material properties
 (parameters:Postprocess/Visualization/Material_20properties/List_20of_20material_20properties)=
 ### __Parameter name:__ List of material properties
 **Default value:** density,thermal expansivity,specific heat,viscosity
@@ -1422,7 +1452,7 @@ The effect of using this option can be seen in the following picture:
 viscosity|density|thermal expansivity|specific heat|thermal conductivity|thermal diffusivity|compressibility|entropy derivative temperature|entropy derivative pressure|reaction terms|melt fraction
 
 (parameters:Postprocess/Visualization/Melt_20fraction)=
-## **Parameters in section** Postprocess/Visualization/Melt fraction
+## **Subsection:** Postprocess / Visualization / Melt fraction
 (parameters:Postprocess/Visualization/Melt_20fraction/A1)=
 ### __Parameter name:__ A1
 **Default value:** 1085.7
@@ -1568,7 +1598,7 @@ viscosity|density|thermal expansivity|specific heat|thermal conductivity|thermal
 **Documentation:** Prefactor of the linear pressure term in the linear function that approximates the clinopyroxene reaction coefficient. Units: \si{\per\pascal}.
 
 (parameters:Postprocess/Visualization/Melt_20material_20properties)=
-## **Parameters in section** Postprocess/Visualization/Melt material properties
+## **Subsection:** Postprocess / Visualization / Melt material properties
 (parameters:Postprocess/Visualization/Melt_20material_20properties/List_20of_20properties)=
 ### __Parameter name:__ List of properties
 **Default value:** compaction viscosity,permeability
@@ -1580,7 +1610,7 @@ viscosity|density|thermal expansivity|specific heat|thermal conductivity|thermal
 compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gradient|is melt cell|darcy coefficient|darcy coefficient no cutoff|compaction length
 
 (parameters:Postprocess/Visualization/Principal_20stress)=
-## **Parameters in section** Postprocess/Visualization/Principal stress
+## **Subsection:** Postprocess / Visualization / Principal stress
 (parameters:Postprocess/Visualization/Principal_20stress/Use_20deviatoric_20stress)=
 ### __Parameter name:__ Use deviatoric stress
 **Default value:** false
@@ -1590,7 +1620,7 @@ compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gr
 **Documentation:** Whether to use the deviatoric stress tensor instead of the full stress tensor to compute principal stress directions and values.
 
 (parameters:Postprocess/Visualization/Temperature_20anomaly)=
-## **Parameters in section** Postprocess/Visualization/Temperature anomaly
+## **Subsection:** Postprocess / Visualization / Temperature anomaly
 (parameters:Postprocess/Visualization/Temperature_20anomaly/Number_20of_20depth_20slices)=
 ### __Parameter name:__ Number of depth slices
 **Default value:** 20
@@ -1616,7 +1646,7 @@ compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gr
 **Documentation:** Whether to use the minimal specified boundary temperature as the bottom boundary temperature. This option will only work for models with a fixed bottom boundary temperature.
 
 (parameters:Postprocess/Visualization/Volume_20of_20Fluid)=
-## **Parameters in section** Postprocess/Visualization/Volume of Fluid
+## **Subsection:** Postprocess / Visualization / Volume of Fluid
 (parameters:Postprocess/Visualization/Volume_20of_20Fluid/Output_20interface_20normals)=
 ### __Parameter name:__ Output interface normals
 **Default value:** false
@@ -1634,7 +1664,7 @@ compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gr
 **Documentation:** Include fields defined such that the 0 contour is the fluid interface.
 
 (parameters:Postprocess/Visualization/Vp_20anomaly)=
-## **Parameters in section** Postprocess/Visualization/Vp anomaly
+## **Subsection:** Postprocess / Visualization / Vp anomaly
 (parameters:Postprocess/Visualization/Vp_20anomaly/Average_20velocity_20scheme)=
 ### __Parameter name:__ Average velocity scheme
 **Default value:** reference profile
@@ -1652,7 +1682,7 @@ compaction viscosity|fluid viscosity|permeability|fluid density|fluid density gr
 **Documentation:** Number of depth slices used to define average seismic compressional wave velocities from which anomalies are calculated. Units: non-dimensional.
 
 (parameters:Postprocess/Visualization/Vs_20anomaly)=
-## **Parameters in section** Postprocess/Visualization/Vs anomaly
+## **Subsection:** Postprocess / Visualization / Vs anomaly
 (parameters:Postprocess/Visualization/Vs_20anomaly/Average_20velocity_20scheme)=
 ### __Parameter name:__ Average velocity scheme
 **Default value:** reference profile

--- a/doc/sphinx/parameters/Prescribed_20Stokes_20solution.md
+++ b/doc/sphinx/parameters/Prescribed_20Stokes_20solution.md
@@ -2,7 +2,7 @@
 # Prescribed Stokes solution
 
 
-## **Parameters in section** Prescribed Stokes solution
+## **Subsection:** Prescribed Stokes solution
 
 
 (parameters:Prescribed_20Stokes_20solution/Model_20name)=
@@ -20,7 +20,7 @@
 `function': This plugin allows to prescribe the Stokes solution for the velocity and pressure field in terms of an explicit formula. The format of these functions follows the syntax understood by the muparser library, see Section~\ref{sec:muparser-format}.
 
 (parameters:Prescribed_20Stokes_20solution/Ascii_20data_20model)=
-## **Parameters in section** Prescribed Stokes solution/Ascii data model
+## **Subsection:** Prescribed Stokes solution / Ascii data model
 (parameters:Prescribed_20Stokes_20solution/Ascii_20data_20model/Data_20directory)=
 ### __Parameter name:__ Data directory
 **Default value:** $ASPECT_SOURCE_DIR/data/prescribed-stokes-solution/
@@ -46,7 +46,7 @@
 **Documentation:** Scalar factor, which is applied to the model data. You might want to use this to scale the input to a reference model. Another way to use this factor is to convert units of the input files. For instance, if you provide velocities in cm/yr set this factor to 0.01.
 
 (parameters:Prescribed_20Stokes_20solution/Compaction_20pressure_20function)=
-## **Parameters in section** Prescribed Stokes solution/Compaction pressure function
+## **Subsection:** Prescribed Stokes solution / Compaction pressure function
 (parameters:Prescribed_20Stokes_20solution/Compaction_20pressure_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -76,7 +76,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Prescribed_20Stokes_20solution/Fluid_20pressure_20function)=
-## **Parameters in section** Prescribed Stokes solution/Fluid pressure function
+## **Subsection:** Prescribed Stokes solution / Fluid pressure function
 (parameters:Prescribed_20Stokes_20solution/Fluid_20pressure_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -106,7 +106,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Prescribed_20Stokes_20solution/Fluid_20velocity_20function)=
-## **Parameters in section** Prescribed Stokes solution/Fluid velocity function
+## **Subsection:** Prescribed Stokes solution / Fluid velocity function
 (parameters:Prescribed_20Stokes_20solution/Fluid_20velocity_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -136,7 +136,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Prescribed_20Stokes_20solution/Pressure_20function)=
-## **Parameters in section** Prescribed Stokes solution/Pressure function
+## **Subsection:** Prescribed Stokes solution / Pressure function
 (parameters:Prescribed_20Stokes_20solution/Pressure_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -166,7 +166,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The names of the variables as they will be used in the function, separated by commas. By default, the names of variables at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then use these variable names in your function expression and they will be replaced by the values of these variables at which the function is currently evaluated. However, you can also choose a different set of names for the independent variables at which to evaluate your function expression. For example, if you work in spherical coordinates, you may wish to set this input parameter to `r,phi,theta,t' and then use these variable names in your function expression.
 
 (parameters:Prescribed_20Stokes_20solution/Velocity_20function)=
-## **Parameters in section** Prescribed Stokes solution/Velocity function
+## **Subsection:** Prescribed Stokes solution / Velocity function
 (parameters:Prescribed_20Stokes_20solution/Velocity_20function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**

--- a/doc/sphinx/parameters/Solver_20parameters.md
+++ b/doc/sphinx/parameters/Solver_20parameters.md
@@ -2,7 +2,7 @@
 # Solver parameters
 
 
-## **Parameters in section** Solver parameters
+## **Subsection:** Solver parameters
 
 
 (parameters:Solver_20parameters/Composition_20solver_20tolerance)=
@@ -22,7 +22,7 @@
 **Documentation:** The relative tolerance up to which the linear system for the temperature system gets solved. See `Stokes solver parameters/Linear solver tolerance' for more details.
 
 (parameters:Solver_20parameters/AMG_20parameters)=
-## **Parameters in section** Solver parameters/AMG parameters
+## **Subsection:** Solver parameters / AMG parameters
 (parameters:Solver_20parameters/AMG_20parameters/AMG_20aggregation_20threshold)=
 ### __Parameter name:__ AMG aggregation threshold
 **Default value:** 0.001
@@ -56,7 +56,7 @@
 **Documentation:** This parameter sets the type of smoother for the AMG. The default is strongly recommended for any normal runs with ASPECT. There are some indications that the symmetric Gauss-Seidel might be better and more stable for the Newton solver. For extensive benchmarking of various settings of the AMG parameters in this section for the Stokes problem and others, see https://github.com/geodynamics/aspect/pull/234.
 
 (parameters:Solver_20parameters/Advection_20solver_20parameters)=
-## **Parameters in section** Solver parameters/Advection solver parameters
+## **Subsection:** Solver parameters / Advection solver parameters
 (parameters:Solver_20parameters/Advection_20solver_20parameters/GMRES_20solver_20restart_20length)=
 ### __Parameter name:__ GMRES solver restart length
 **Default value:** 50
@@ -66,7 +66,7 @@
 **Documentation:** This is the number of iterations that define the GMRES solver restart length. Increasing this parameter makes the solver more robust and decreases the number of iterations. Be aware that increasing this number increases the memory usage of the advection solver, and makes individual iterations more expensive.
 
 (parameters:Solver_20parameters/Diffusion_20solver_20parameters)=
-## **Parameters in section** Solver parameters/Diffusion solver parameters
+## **Subsection:** Solver parameters / Diffusion solver parameters
 (parameters:Solver_20parameters/Diffusion_20solver_20parameters/Diffusion_20length_20scale)=
 ### __Parameter name:__ Diffusion length scale
 **Default value:** 1.e4
@@ -76,7 +76,7 @@
 **Documentation:** Set a length scale for the diffusion of advection fields if the ``prescribed field with diffusion'' method is selected for a field. More precisely, this length scale represents the square root of the product of diffusivity and time in the diffusion equation, and controls the distance over which features are diffused. Units: \si{\meter}.
 
 (parameters:Solver_20parameters/Matrix_20Free)=
-## **Parameters in section** Solver parameters/Matrix Free
+## **Subsection:** Solver parameters / Matrix Free
 (parameters:Solver_20parameters/Matrix_20Free/Execute_20solver_20timings)=
 ### __Parameter name:__ Execute solver timings
 **Default value:** false
@@ -94,7 +94,7 @@
 **Documentation:** Turns on extra information for the matrix free GMG solver to be printed.
 
 (parameters:Solver_20parameters/Newton_20solver_20parameters)=
-## **Parameters in section** Solver parameters/Newton solver parameters
+## **Subsection:** Solver parameters / Newton solver parameters
 (parameters:Solver_20parameters/Newton_20solver_20parameters/Max_20Newton_20line_20search_20iterations)=
 ### __Parameter name:__ Max Newton line search iterations
 **Default value:** 5
@@ -178,7 +178,7 @@ Once derivatives are used in a Newton method, \aspect{} always uses the Eisensta
 **Documentation:** This method allows to slowly introduce the derivatives based on the improvement of the residual. If set to false, the scaling factor for the Newton derivatives is set to one immediately when switching on the Newton solver. When this is set to true, the derivatives are slowly introduced by the following equation: $\max(0.0, (1.0-(residual/switch\_initial\_residual)))$, where switch\_initial\_residual is the residual at the time when the Newton solver is switched on.
 
 (parameters:Solver_20parameters/Operator_20splitting_20parameters)=
-## **Parameters in section** Solver parameters/Operator splitting parameters
+## **Subsection:** Solver parameters / Operator splitting parameters
 (parameters:Solver_20parameters/Operator_20splitting_20parameters/Reaction_20time_20step)=
 ### __Parameter name:__ Reaction time step
 **Default value:** 1000.0
@@ -196,7 +196,7 @@ Once derivatives are used in a Newton method, \aspect{} always uses the Eisensta
 **Documentation:** The number of reaction time steps done within one advection time step in case operator splitting is used. This is only used if the parameter ``Use operator splitting'' is set to true. If set to zero, this parameter is ignored. Otherwise, the reaction time step size is chosen according to this criterion and the ``Reaction time step'', whichever yields the smaller time step. Units: none.
 
 (parameters:Solver_20parameters/Stokes_20solver_20parameters)=
-## **Parameters in section** Solver parameters/Stokes solver parameters
+## **Subsection:** Solver parameters / Stokes solver parameters
 (parameters:Solver_20parameters/Stokes_20solver_20parameters/GMRES_20solver_20restart_20length)=
 ### __Parameter name:__ GMRES solver restart length
 **Default value:** 50

--- a/doc/sphinx/parameters/Temperature_20field.md
+++ b/doc/sphinx/parameters/Temperature_20field.md
@@ -2,7 +2,7 @@
 # Temperature field
 
 
-## **Parameters in section** Temperature field
+## **Subsection:** Temperature field
 
 
 (parameters:Temperature_20field/Temperature_20method)=

--- a/doc/sphinx/parameters/Termination_20criteria.md
+++ b/doc/sphinx/parameters/Termination_20criteria.md
@@ -2,7 +2,7 @@
 # Termination criteria
 
 
-## **Parameters in section** Termination criteria
+## **Subsection:** Termination criteria
 
 
 (parameters:Termination_20criteria/Checkpoint_20on_20termination)=
@@ -54,7 +54,7 @@ The criterion considers the total heat flux over all boundaries listed by their 
 **Documentation:** The wall time of the simulation. Unit: hours.
 
 (parameters:Termination_20criteria/Steady_20state_20heat_20flux)=
-## **Parameters in section** Termination criteria/Steady state heat flux
+## **Subsection:** Termination criteria / Steady state heat flux
 (parameters:Termination_20criteria/Steady_20state_20heat_20flux/Boundary_20indicators)=
 ### __Parameter name:__ Boundary indicators
 **Default value:**
@@ -82,7 +82,7 @@ The names of the boundaries listed here can either be numbers (in which case the
 **Documentation:** The minimum length of simulation time that the system should be in steady state before termination. Note that if the time step size is similar to or larger than this value, the termination criterion will only have very few (in the most extreme case, just two) heat flux values to check. To ensure that a larger number of time steps are included in the check for steady state, this value should be much larger than the time step size. Units: years if the 'Use years in output instead of seconds' parameter is set; seconds otherwise.
 
 (parameters:Termination_20criteria/Steady_20state_20temperature)=
-## **Parameters in section** Termination criteria/Steady state temperature
+## **Subsection:** Termination criteria / Steady state temperature
 (parameters:Termination_20criteria/Steady_20state_20temperature/Maximum_20relative_20deviation)=
 ### __Parameter name:__ Maximum relative deviation
 **Default value:** 0.05
@@ -100,7 +100,7 @@ The names of the boundaries listed here can either be numbers (in which case the
 **Documentation:** The minimum length of simulation time that the system should be in steady state before termination.Units: years if the 'Use years in output instead of seconds' parameter is set; seconds otherwise.
 
 (parameters:Termination_20criteria/Steady_20state_20velocity)=
-## **Parameters in section** Termination criteria/Steady state velocity
+## **Subsection:** Termination criteria / Steady state velocity
 (parameters:Termination_20criteria/Steady_20state_20velocity/Maximum_20relative_20deviation)=
 ### __Parameter name:__ Maximum relative deviation
 **Default value:** 0.05
@@ -118,7 +118,7 @@ The names of the boundaries listed here can either be numbers (in which case the
 **Documentation:** The minimum length of simulation time that the system should be in steady state before termination.Units: years if the 'Use years in output instead of seconds' parameter is set; seconds otherwise.
 
 (parameters:Termination_20criteria/User_20request)=
-## **Parameters in section** Termination criteria/User request
+## **Subsection:** Termination criteria / User request
 (parameters:Termination_20criteria/User_20request/File_20name)=
 ### __Parameter name:__ File name
 **Default value:** terminate-aspect

--- a/doc/sphinx/parameters/Time_20stepping.md
+++ b/doc/sphinx/parameters/Time_20stepping.md
@@ -2,7 +2,7 @@
 # Time stepping
 
 
-## **Parameters in section** Time stepping
+## **Subsection:** Time stepping
 
 
 (parameters:Time_20stepping/List_20of_20model_20names)=
@@ -33,7 +33,7 @@ A large reduction in time step size typically happens when velocities change abr
 **Documentation:** Specifiy a minimum time step size (or 0 to disable).
 
 (parameters:Time_20stepping/Function)=
-## **Parameters in section** Time stepping/Function
+## **Subsection:** Time stepping / Function
 (parameters:Time_20stepping/Function/Function_20constants)=
 ### __Parameter name:__ Function constants
 **Default value:**
@@ -61,7 +61,7 @@ A typical example would be to set this runtime parameter to `pi=3.1415926536' an
 **Documentation:** Name for the variable representing the current time.
 
 (parameters:Time_20stepping/Repeat_20on_20cutback)=
-## **Parameters in section** Time stepping/Repeat on cutback
+## **Subsection:** Time stepping / Repeat on cutback
 (parameters:Time_20stepping/Repeat_20on_20cutback/Cut_20back_20amount)=
 ### __Parameter name:__ Cut back amount
 **Default value:** 0.5

--- a/doc/sphinx/parameters/Volume_20of_20Fluid.md
+++ b/doc/sphinx/parameters/Volume_20of_20Fluid.md
@@ -2,7 +2,7 @@
 # Volume of Fluid
 
 
-## **Parameters in section** Volume of Fluid
+## **Subsection:** Volume of Fluid
 
 
 (parameters:Volume_20of_20Fluid/Number_20initialization_20samples)=

--- a/doc/sphinx/parameters/global.md
+++ b/doc/sphinx/parameters/global.md
@@ -1,7 +1,5 @@
-# Global
-
-
-## **Parameters in section** global
+(parameters:global)=
+# Global parameters
 
 
 (parameters:Additional_20shared_20libraries)=


### PR DESCRIPTION
A few improvements to the formatting of the parameter index.
1. Add a label for global parameters (this is referenced already in a few places).
2. Remove the misleading `parameters in section global` heading
3. Rename "global" to "Global parameters"
4. Shorten `Parameters in section ...` to `Subsection: ...`, which is also closer to https://aspect.geodynamics.org/doc/parameter_view/parameters.xml. (It is different from the current manual, but I think it is better).
5. Added spaces around "/" separating subsections to make subsection names more readable.

Let me know in case you want any of them reverted, I think the new format is much easier to read.