### PR TITLE
Use 'include' instead of 'input' in latex

### DIFF
--- a/cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.tex
+++ b/cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.tex
@@ -28,7 +28,7 @@ Separate ascii files {\tt visc\_depth\_X.txt} with {\tt X=\{a,b,c,d\}} contain e
 
 \begin{figure}[tbp]
   \centering
-  \includegraphics[width=0.9\textwidth]{cookbooks/bunge_et_al_mantle_convection/doc/temps.png}
+  \includegraphics[width=0.9\textwidth]{temps.png}
   \caption{\it Bunge et al.~benchmark. From left to right: temperature field at time $t=5\cdot 10^9$ years obtained with viscosity profiles a, b, c and d.}
   \label{fig:bunge_et_al}
 \end{figure}

--- a/cookbooks/burnman/doc/burnman.tex
+++ b/cookbooks/burnman/doc/burnman.tex
@@ -16,7 +16,7 @@ gravity, thermal expansivity, specific heat capacity and compressibility. Using 
 to generate the reference profile has the advantage that all the material property data
 are consistent, for example, the gravity profile is computed using the reference density.
 \begin{figure}
-  \includesvg[width=\textwidth]{cookbooks/burnman/doc/reference_profile.svg}
+  \includesvg[width=\textwidth]{reference_profile.svg}
   \caption{\it Reference profile generated using BurnMan.}
   \label{fig:burnman-reference-profile}
 \end{figure}
@@ -53,20 +53,20 @@ and between transition zone and lower mantle). The prefactors used here lead to 
 asthenosphere, and high viscosities in the lower mantle. To make sure that these viscosity jumps
 do not lead to numerical problems in our computation (see Section~\ref{sec:sinker-with-averaging}),
 we also use harmonic averaging of the material properties.
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/material_model.part.prm.out}
+\lstinputlisting[language=prmfile]{material_model.part.prm.out}
 As the reference profile has a depth dependent density and also contains data for the compressibility,
 this material model supports compressible convection models.
 
 For the adiabatic conditions and the gravity model, we also specify that we want to use the respective
 \texttt{ascii data} plugin, and provide the data directory in the same way as for the material
 model. The gravity model automatically uses the same file as the adiabatic conditions model.
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/adiabatic_conditions.part.prm.out}
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/gravity_model.part.prm.out}
+\lstinputlisting[language=prmfile]{adiabatic_conditions.part.prm.out}
+\lstinputlisting[language=prmfile]{gravity_model.part.prm.out}
 
 To make use of the reference state we just imported from BurnMan, we choose a formulation of the
 equations that employs a reference state and compressible convection, in this case the anelastic
 liquid approximation (see Section~\ref{sec:ala}).
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/formulation.part.prm.out}
+\lstinputlisting[language=prmfile]{formulation.part.prm.out}
 This means that the reference profiles are used for all material properties in the model, except for
 the density in the buoyancy term (on the right-hand side of the force balance equation~\eqref{eq:stokes-1},
 which in the limit of the anelastic liquid approximation becomes Equation~\eqref{eq:stokes-ALA-1}).
@@ -87,9 +87,9 @@ the data we provided in the \url{data/adiabatic-conditions/ascii-data/isentrope_
 is used in our model.
 
 \begin{figure}
-  \includegraphics[width=0.48\textwidth]{cookbooks/burnman/doc/temperature.png}
+  \includegraphics[width=0.48\textwidth]{temperature.png}
   \hfill
-  \includegraphics[width=0.48\textwidth]{cookbooks/burnman/doc/viscosity.png}
+  \includegraphics[width=0.48\textwidth]{viscosity.png}
   \caption{\it Compressible convection in a 2d spherical shell, using a reference profile exported
                form BurnMan, which is based on the Birch-Murnaghan equation of state. The figure shows the
                state at the end of the model evolution over 260\,Ma.}
@@ -106,7 +106,7 @@ instead of the reference density is used. For the TALA, this density only depend
 (and not on the dynamic pressure, as in the ALA). Hence, we have to make this change in the appropriate
 place in the material model (while keeping the formulation of the equations set to
 \texttt{anelastic liquid approximation}):
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/tala.part.prm.out}
+\lstinputlisting[language=prmfile]{tala.part.prm.out}
 
 We now want to compare these commonly used approximations to the ``isothermal compression approximation''
 (see Section~\ref{sec:ica}) that is unique to \aspect{}. It does not require a reference state and uses
@@ -117,7 +117,7 @@ dependence of material properties on temperature and pressure in addition to tha
 deviations from the reference profile in both temperature and pressure. As this requires a modification
 of the equations outside of the material model, we have to specify this change in the
 \texttt{Formulation} (and remove the lines for the use of TALA discussed above).
-\lstinputlisting[language=prmfile]{cookbooks/burnman/doc/formulation_ica.part.prm.out}
+\lstinputlisting[language=prmfile]{formulation_ica.part.prm.out}
 As the ``isothermal compression approximation'' is also \aspect{}'s default for compressible models,
 the same model setup can also be achieved by just removing the lines that specify which \texttt{Formulation}
 should be used.
@@ -129,7 +129,7 @@ the state of the model -- such as the root mean square velocity -- are similar b
 
 \begin{figure}
 \centering
-  \includesvg[width=0.95\textwidth]{cookbooks/burnman/doc/comparison.svg}
+  \includesvg[width=0.95\textwidth]{comparison.svg}
   \caption{\it Comparison between the anelastic liquid approximation,
                the truncated anelastic liquid approximation
                and the isothermal compression approximation,
@@ -140,7 +140,7 @@ the state of the model -- such as the root mean square velocity -- are similar b
 
 \begin{figure}
 \centering
-  \includesvg[width=0.5\textwidth]{cookbooks/burnman/doc/vrms.svg}
+  \includesvg[width=0.5\textwidth]{vrms.svg}
   \caption{\it Comparison between the anelastic liquid approximation,
                the truncated anelastic liquid approximation
                and the isothermal compression approximation,

--- a/cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.tex
+++ b/cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.tex
@@ -24,14 +24,14 @@ The model in \cite{CY85} is nondimensional, but we want to use Earth-like parame
 Our input file is for a Rayleigh number of $Ra = 10^5$ and a phase buoyancy parameter of $P=-0.4$.                                  
 The material properties are therefore set as follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/christensen_yuen_phase_function/doc/material.part.prm.out}
+\lstinputlisting[language=prmfile]{material.part.prm.out}
 
 We run the model until a steady state heat flow is reached, or, in case the model does not reach steady state, until a time of 200 Myr. 
 Depending on the Rayleigh number and the phase buoyancy parameter, the flow pattern in steady state can be very different: For positive or low negative Clapeyron slopes, one large convection cell develops. The more negative the Clapeyron slope of the phase transition, the more it impedes the flow, leading to episodic, or completely layered convection (see Figure~\ref{fig:christensen_yuen}). 
 
 \begin{figure}
 \centering
-\includegraphics[width=0.8\textwidth]{cookbooks/christensen_yuen_phase_function/doc/flow_field.png}
+\includegraphics[width=0.8\textwidth]{flow_field.png}
 \caption{\it Phase function model: Flow field in steady state for two models with a Rayleigh number of $Ra = 10^5$, but different phase buoyancy. The model on the left has a Clapeyron slope of $-2.7~\si{\mega\pascal\per\kelvin}$ (corresponding to $P=-0.4$) as in the original input file, leading to layered convection. The model on the right has a Clapeyron slope of $+2.7~\si{\mega\pascal\per\kelvin}$ (corresponding to $P=0.4$), leading to one large convection cell.}
 \label{fig:christensen_yuen}
 \end{figure}

--- a/cookbooks/composition-reaction/doc/composition-reaction.tex
+++ b/cookbooks/composition-reaction/doc/composition-reaction.tex
@@ -6,26 +6,26 @@ In addition, there are setups where one wants the compositional fields to intera
 
 We will consider the exact same setup as in the previous paragraphs, except for the initial conditions and properties of the two compositional fields. There is one material that initially fills the bottom half of the domain and is less dense than the material above. In addition, there is another material that only gets created when the first material reaches the uppermost 20\% of the domain, and that has a higher density. This should cause the first material to move upwards, get partially converted to the second material, which then sinks down again. This means we want to change the initial conditions for the compositional fields:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition-reaction/doc/initial.part.prm.out}
+\lstinputlisting[language=prmfile]{initial.part.prm.out}
 
 
 Moreover, instead of the \texttt{simple} material model, we will use the \texttt{composition reaction} material model, which basically behaves in the same way, but can handle two active compositional field and a reaction between those two fields. In the input file, the user defines a depth and above this \texttt{reaction depth} the first compositional fields is converted to the second field. This can be done by changing the following section (the complete input file can be found in \url{cookbooks/composition-reaction/composition-reaction.prm}).
 
-\lstinputlisting[language=prmfile]{cookbooks/composition-reaction/doc/material.part.prm.out}
+\lstinputlisting[language=prmfile]{material.part.prm.out}
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/0.png}
+  \includegraphics[width=0.3\textwidth]{0.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/2.png}
+  \includegraphics[width=0.3\textwidth]{2.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/4.png}
+  \includegraphics[width=0.3\textwidth]{4.png}
   \\[6pt]
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/8.png}
+  \includegraphics[width=0.3\textwidth]{8.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/12.png}
+  \includegraphics[width=0.3\textwidth]{12.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition-reaction/doc/20.png}
+  \includegraphics[width=0.3\textwidth]{20.png}
   \caption{\it Reaction between compositional fields: Temperature fields at $t=0, 2, 4, 8,
   12, 20$. The black line is the isocontour line $c_1(\mathbf x,t)=0.5$
     delineating the position of the material starting at the bottom and the white line is the    isocontour line $c_2(\mathbf x,t)=0.5$

--- a/cookbooks/composition_active/doc/composition_active.tex
+++ b/cookbooks/composition_active/doc/composition_active.tex
@@ -38,21 +38,21 @@ completely unchanged from the passive case. The only difference is the use of
 the following section (the complete input file can be found in
 \url{cookbooks/composition\_active/composition\_active.prm}:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_active/doc/active.part.prm.out}
+\lstinputlisting[language=prmfile]{active.part.prm.out}
 
 To debug the model, we will also want to visualize the density in our
 graphical output files. This is done using the following addition to the
 postprocessing section, using the \texttt{density} visualization plugin:
-\lstinputlisting[language=prmfile]{cookbooks/composition_active/doc/postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{postprocess.part.prm.out}
 
 \begin{figure}
   \centering
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0007.png}
+  \includegraphics[width=0.3\textwidth]{visit0007.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0009.png}
+  \includegraphics[width=0.3\textwidth]{visit0009.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0008.png}
+  \includegraphics[width=0.3\textwidth]{visit0008.png}
   \caption{\it Active compositional fields: Compositional field 1 at the time
     $t=0, 10, 20$. Compared to the results shown in
     Fig.~\ref{fig:compositional-passive} it is clear that the heavy material
@@ -66,17 +66,17 @@ postprocessing section, using the \texttt{density} visualization plugin:
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0000.png}
+  \includegraphics[width=0.3\textwidth]{visit0000.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0001.png}
+  \includegraphics[width=0.3\textwidth]{visit0001.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0002.png}
+  \includegraphics[width=0.3\textwidth]{visit0002.png}
   \\[6pt]
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0003.png}
+  \includegraphics[width=0.3\textwidth]{visit0003.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0004.png}
+  \includegraphics[width=0.3\textwidth]{visit0004.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_active/doc/visit0006.png}
+  \includegraphics[width=0.3\textwidth]{visit0006.png}
   \caption{\it Active compositional fields: Temperature fields at $t=0, 2, 4, 8,
   12, 20$. The black line is the isocontour line $c_1(\mathbf x,t)=0.5$
     delineating the position of the dense material at the bottom.}

--- a/cookbooks/composition_active_particles/doc/composition_active_particles.tex
+++ b/cookbooks/composition_active_particles/doc/composition_active_particles.tex
@@ -14,11 +14,11 @@ A slightly modified version of the active-composition cookbook (\url{cookbooks/c
 
 This cookbook, \url{cookbooks/composition_active_particles/composition_active_particles.prm}, modifies two sections of the input file.  First, particles are added under the \texttt{Postprocess} section:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_active_particles/doc/particles.part.prm.out}
+\lstinputlisting[language=prmfile]{particles.part.prm.out}
 Here, each particle will carry the \texttt{velocity} and
 \texttt{initial composition} properties.  In order to use the particle initial composition value to modify the flow through the material model, we now modify the \texttt{Composition} section:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_active_particles/doc/composition.part.prm.out}
+\lstinputlisting[language=prmfile]{composition.part.prm.out}
 
 What this does is the following: It says that there will be two
 compositional fields, called \texttt{lower} and \texttt{upper}

--- a/cookbooks/composition_passive/doc/composition_passive.tex
+++ b/cookbooks/composition_passive/doc/composition_passive.tex
@@ -8,7 +8,7 @@ top, and the middle. The way to describe this situation is to simply add the
 following block of definitions to the parameter file (you can find the full
 parameter file in \url{cookbooks/composition_passive/composition_passive.prm}:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_passive/doc/passive.part.prm.out}
+\lstinputlisting[language=prmfile]{passive.part.prm.out}
 
 Running this simulation yields results such as the ones shown in
 Fig.~\ref{fig:compositional-passive} where we show the values of the functions
@@ -24,17 +24,17 @@ the domain we are interested in.}
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0007.png}
+  \includegraphics[width=0.3\textwidth]{visit0007.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0008.png}
+  \includegraphics[width=0.3\textwidth]{visit0008.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0009.png}
+  \includegraphics[width=0.3\textwidth]{visit0009.png}
   \\
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0010.png}
+  \includegraphics[width=0.3\textwidth]{visit0010.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0012.png}
+  \includegraphics[width=0.3\textwidth]{visit0012.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/composition_passive/doc/visit0014.png}
+  \includegraphics[width=0.3\textwidth]{visit0014.png}
   \caption{\it Passive compositional fields: The figures show, at
     different times in the simulation, the velocity field along with
     those locations where the first compositional field is larger than
@@ -49,9 +49,9 @@ the domain we are interested in.}
 
 \begin{figure}
   \centering
-  \includegraphics[height=0.3\textwidth]{cookbooks/composition_passive/doc/visit0015.png}
+  \includegraphics[height=0.3\textwidth]{visit0015.png}
   \hfill
-  \includegraphics[height=0.3\textwidth]{cookbooks/composition_passive/doc/visit0017.png}
+  \includegraphics[height=0.3\textwidth]{visit0017.png}
   \caption{\it Passive compositional fields: A later image of the simulation
     corresponding to the sequence shown in
     Fig.~\ref{fig:compositional-passive} (left) and zoom-in on the
@@ -87,7 +87,7 @@ This is an area in which \aspect{} may see improvements in the future.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.4\textwidth]{cookbooks/composition_passive/doc/mass-composition-1.png}
+  \includegraphics[width=0.4\textwidth]{mass-composition-1.png}
   \caption{\it Passive compositional fields: Minimum and maximum of the first
   compositional variable over time, as well as the mass $m_1(t)=\int_\Omega c_1(\mathbf x,t)$ stored in this variable.}
   \label{fig:compositional-passive-mass}
@@ -99,7 +99,7 @@ mass contained in the $i$th compositional field is $m_i(t)=\int_\Omega c_i(\math
 This can easily be achieve in the following way, by adding the \texttt{composition statistics}
 postprocessor:
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_passive/doc/postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{postprocess.part.prm.out}
 
 While the scheme we use to advect the compositional fields is not strictly
 conservative, it is almost perfectly so in practice. For example, in

--- a/cookbooks/composition_passive_particles/doc/composition_passive_particles.tex
+++ b/cookbooks/composition_passive_particles/doc/composition_passive_particles.tex
@@ -9,7 +9,7 @@ particular, the postprocess section now looks like this:
 \index[prmindex]{Number of particles}
 \index[prmindexfull]{Postprocess!Particles!Number of particles}
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_passive_particles/doc/particles.part.prm.out}
+\lstinputlisting[language=prmfile]{particles.part.prm.out}
 
 The 1000 particles we are asking here are initially uniformly distributed
 throughout the domain and are, at the end of each time step, advected along with
@@ -57,7 +57,7 @@ Fig.~\ref{fig:composition_passive_particles}.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.5\textwidth]{cookbooks/composition_passive_particles/doc/solution-00072.png}
+  \includegraphics[width=0.5\textwidth]{solution-00072.png}
   \caption{\it Passively advected quantities visualized through both a
   \label{fig:composition_passive_particles}
   compositional field and a set of 1,000 particles, at $t=7.2$.}
@@ -102,7 +102,7 @@ following lines to the \texttt{Particles} subsection (we also increase the numbe
 of particles compared to the previous section to make the visualizations below
 more obvious):
 
-\lstinputlisting[language=prmfile]{cookbooks/composition_passive_particles/doc/particle-properties.part.prm.out}
+\lstinputlisting[language=prmfile]{particle-properties.part.prm.out}
 
 These commands make sure that every particle will carry four different
 properties (\texttt{function}, \texttt{pT path}, \texttt{initial
@@ -177,16 +177,16 @@ Section~\ref{sec:write-plugin}.) The properties selected above do the following:
   \centering
   \phantom{.}
   \hfill
-  \includegraphics[width=0.45\textwidth]{cookbooks/composition_passive_particles/doc/composition-C1.png}
+  \includegraphics[width=0.45\textwidth]{composition-C1.png}
   \hfill
-  \includegraphics[width=0.45\textwidth]{cookbooks/composition_passive_particles/doc/particles-C1.png}
+  \includegraphics[width=0.45\textwidth]{particles-C1.png}
   \phantom{.}
   \\
   \phantom{.}
   \hfill
-  \includegraphics[width=0.45\textwidth]{cookbooks/composition_passive_particles/doc/initial-position-00000.png}
+  \includegraphics[width=0.45\textwidth]{initial-position-00000.png}
   \hfill
-  \includegraphics[width=0.45\textwidth]{cookbooks/composition_passive_particles/doc/initial-position-00199.png}
+  \includegraphics[width=0.45\textwidth]{initial-position-00199.png}
   \phantom{.}
   \caption{\it Passively advected particle properties visualized. Top row:
   Composition $C_1$ and particle property ``initial $C_1$''. The blue line in both

--- a/cookbooks/continental_extension/doc/continental_extension.tex
+++ b/cookbooks/continental_extension/doc/continental_extension.tex
@@ -4,23 +4,23 @@
 
 In the crustal deformation examples above, the viscosity depends solely on the Drucker Prager yield criterion defined by the cohesion and internal friction angle. While this approximation works reasonably well for the uppermost crust, deeper portions of the lithosphere may undergo either brittle or viscous deformation, with the latter depending on a combination of composition, temperature, pressure and strain-rate. In effect, a combination of the Drucker-Prager and Diffusion dislocation material models is required. The visco-plastic material model is designed to take into account both brittle (plastic) and non-linear viscous deformation, thus providing a template for modeling complex lithospheric processes. Such a material model can be used in \aspect{} using the following set of input parameters:
 
-\lstinputlisting[language=prmfile]{cookbooks/continental_extension/doc/continental_extension_material_model.prm.out}
+\lstinputlisting[language=prmfile]{continental_extension_material_model.prm.out}
 
 This cookbook provides one such example where the continental lithosphere undergoes extension. Notably, the model design follows that of numerous previously published continental extension studies~\cite[and references therein]{Hui11,Bru14,Nal15}.
 
 \paragraph{Continental Extension}
 The 2D Cartesian model spans 200 ($x$) by 100 ($y$) km and has a finite element grid with 1.25 and 2.5 km grid spacing, respectively, above and  below 50 km depth. This variation in grid spacing is achieved with a single initial adaptive refinement step using the minimum refinement function strategy. Unlike the crustal deformation cookbook (see Section~\ref{sec:cookbooks-crustal-deformation}, the mesh is not refined with time.
 
-\lstinputlisting[language=prmfile]{cookbooks/continental_extension/doc/continental_extension_geometry_mesh.prm.out}
+\lstinputlisting[language=prmfile]{continental_extension_geometry_mesh.prm.out}
 
 
 Similar to the crustal deformation examples above, this model contains a free surface. However, in this example the free surface is advected using the full velocity (e.g., normal projection) rather than only the vertical component. As this projection can lead to signficant surface mesh deformation and associated solver convergence issues, diffusion is applied to the free surface at each time step. Deformation is driven by constant horizontal ($x$-component) velocities (0.25 cm/yr) on the side boundaries ($y$-velocity component unconstrained), while the bottom boundary has vertical inflow to balance the lateral outflow. The top, and bottom boundaries have fixed temperatures, while the sides are insulating. The bottom boundary is also assigned a fixed composition, while the top and sides are unconstrained.
 
-\lstinputlisting[language=prmfile]{cookbooks/continental_extension/doc/continental_extension_boundary_conditions.prm.out}
+\lstinputlisting[language=prmfile]{continental_extension_boundary_conditions.prm.out}
 
 Sections of the lithosphere with distinct properties are represented by compositional fields for the upper crust (20 km thick), lower crust (20 km thick) and mantle lithosphere (60 km thick). Material (viscous flow law parameters, cohesion, internal friction angle) and thermodynamic properties for each compositional field are based largely on previous numerical studies. Dislocation creep viscous flow parameters are taken from published deformation experiments for wet quartzite \cite{RB04}, wet anorthite \cite{RGWD06} and dry olivine \cite{HK04}. Additional compositional fields are used to track plastic strain and the non-initial plastic strain, with the latter value tracking the same quantity as the plastic strain absent the initial plastic strain values. As discussed further on, the plastic strain is used to soften (e.g., reduce) the friction and cohesion through time based on user-specified bounds and magnitudes. The initial randomized values of plastic strain in the model center localize distributed deformation in this region.
 
-\lstinputlisting[language=prmfile]{cookbooks/continental_extension/doc/continental_extension_composition.prm.out}
+\lstinputlisting[language=prmfile]{continental_extension_composition.prm.out}
 
 The initial thermal structure, radiogenic heating model and associated thermal properties are consistent with the prescribed thermal boundary conditions and produce a geotherm characteristic of the continental lithosphere. The equations defining the initial geotherm \cite{Cha86} follow the form
 \begin{align}
@@ -48,12 +48,12 @@ With further extension for millions of years, significant crustal thinning and s
 
 \begin{figure}
 \centering
-\includegraphics[width=\textwidth]{cookbooks/continental_extension/doc/continental_extension_cookbook_0myr.png}
+\includegraphics[width=\textwidth]{continental_extension_cookbook_0myr.png}
 \caption{\it Initial active deformation field (strain rate second invariant in units of $\si{s}^{-1}$) and distribution of plastic strain. The white line marks the (\SI{893}{K}) isotherm (initial Moho temperature).}
 \label{fig:continental_extension_cookbook_0myr}
 \end{figure}
 \begin{figure}
-\includegraphics[width=\textwidth]{cookbooks/continental_extension/doc/continental_extension_cookbook_5myr.png}
+\includegraphics[width=\textwidth]{continental_extension_cookbook_5myr.png}
 \caption{\it Active (strain rate second invariant in units of $\si{s}^{-1}$) and finite (plastic) deformation after \num{5e6} years of extension. The white line marks the (\SI{893}{K}) isotherm (initial Moho temperature).}
 \label{fig:continental_extension_cookbook_5myr}
 \end{figure}

--- a/cookbooks/convection-box-particles/doc/convection-box-particles.tex
+++ b/cookbooks/convection-box-particles/doc/convection-box-particles.tex
@@ -13,7 +13,7 @@ computer, and to demonstrate how to visualize models results.
 \begin{figure}[h]
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box-particles/doc/convection-box.png}
+\includegraphics[width=0.4\textwidth]{convection-box.png}
 \hfill
 \phantom.
 \caption{\it Setup of the tutorial model. Background colors show temperature, gray spheres illustrate particle positions.}

--- a/cookbooks/convection-box/doc/convection-box.tex
+++ b/cookbooks/convection-box/doc/convection-box.tex
@@ -80,7 +80,7 @@ and the indices at the end of this manual if you want to find a particular
 parameter; you can find the input file to run this cookbook example in
 \url{cookbooks/convection-box.prm}):
 
-\lstinputlisting[language=prmfile]{cookbooks/convection-box/doc/convection-box.prm.out}
+\lstinputlisting[language=prmfile]{convection-box.prm.out}
 
 
 \paragraph{Running the program.}
@@ -186,9 +186,9 @@ simulation.
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/visit0000.png}
+\includegraphics[width=0.4\textwidth]{visit0000.png}
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/visit0001.png}
+\includegraphics[width=0.4\textwidth]{visit0001.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Initial temperature and velocity field (left)
@@ -261,9 +261,9 @@ through these two boundaries disappears as we refine the mesh further.
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/velocity.png}
+\includegraphics[width=0.4\textwidth]{velocity.png}
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/heatflux.png}
+\includegraphics[width=0.4\textwidth]{heatflux.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Root mean square and maximal velocity as a
@@ -288,7 +288,7 @@ more iterations to solve these equations.
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/iterations.png}
+\includegraphics[width=0.4\textwidth]{iterations.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Number of linear iterations required to solve
@@ -323,9 +323,9 @@ The structures of the flow pattern also become smaller and smaller.
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/ra_1e2_visit0000.png}
+\includegraphics[width=0.4\textwidth]{ra_1e2_visit0000.png}
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/ra_1e6_visit0001.png}
+\includegraphics[width=0.4\textwidth]{ra_1e6_visit0001.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Temperature fields at the end of a
@@ -338,9 +338,9 @@ The mesh on the right is clearly too coarse to resolve the structure of the solu
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/ra_1e6_velocity.png}
+\includegraphics[width=0.4\textwidth]{ra_1e6_velocity.png}
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/ra_1e6_heatflux.png}
+\includegraphics[width=0.4\textwidth]{ra_1e6_heatflux.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Velocities (left) and heat flux across the
@@ -363,7 +363,7 @@ To generate these results, remember that we have chosen
 $g=Ra$ in our input file. In other words, changing the input file to
 contain the parameter setting
 %
-\lstinputlisting[language=prmfile]{cookbooks/convection-box/doc/gravity.part.prm.out}
+\lstinputlisting[language=prmfile]{gravity.part.prm.out}
 %
 will achieve the desired effect of computing with $Ra=10^6$.
 
@@ -376,7 +376,7 @@ interesting to think about computing even more accurately. This is easily done
 by using a finer mesh, for example. In the parameter file above, we have chosen
 the mesh setting as follows:
 %
-\lstinputlisting[language=prmfile]{cookbooks/convection-box/doc/refine.part.prm.out}
+\lstinputlisting[language=prmfile]{refine.part.prm.out}
 %
 We start out with a box geometry consisting of a single cell that is refined
 four times. Each time we split each cell into its 4 children, obtaining the
@@ -402,7 +402,7 @@ a particular time at least 8 times as expensive, assuming that all solvers in
 parameter in the \aspect{} input file that let's us increase the mesh resolution
 at later times. To this end, let us use the following snippet for the input
 file:
-\lstinputlisting[language=prmfile]{cookbooks/convection-box/doc/refine2.part.prm.out}
+\lstinputlisting[language=prmfile]{refine2.part.prm.out}
 
 What this does is the following: We start with an $8\times 8$ mesh (3 times
 globally refined) but then at times $t=0.2,0.3$ and $0.4$ we refine the mesh
@@ -416,9 +416,9 @@ do another global refinement, bringing us to refinement levels 4, 5 and finally
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/steps_unknowns.png}
+\includegraphics[width=0.4\textwidth]{steps_unknowns.png}
 \hfill
-\includegraphics[width=0.4\textwidth]{cookbooks/convection-box/doc/steps_heatflux.png}
+\includegraphics[width=0.4\textwidth]{steps_heatflux.png}
 \hfill
 \phantom.
 \caption{\it Convection in a box: Refinement in stages. Total number
@@ -485,7 +485,7 @@ cheaper of the two options.
 
 Following these considerations, let us add the following section to the
 parameter file:
-\lstinputlisting[language=prmfile]{cookbooks/convection-box/doc/disc.part.prm.out}
+\lstinputlisting[language=prmfile]{disc.part.prm.out}
 
 This leaves the velocity and pressure shape functions at quadratic and linear
 polynomial degree but increases the polynomial degree of the temperature from

--- a/cookbooks/convection_box_3d/doc/convection_box_3d.tex
+++ b/cookbooks/convection_box_3d/doc/convection_box_3d.tex
@@ -17,32 +17,32 @@ numbered as follows: ``\textit{in 3d, boundary indicators 0 through 5 indicate
 left, right, front, back, bottom and top boundaries}.'' Recalling that we want
 tangential flow all around and want to fix the temperature to known values at
 the bottom and top, the following will make sense:
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/start.part.prm.out}
+\lstinputlisting[language=prmfile]{start.part.prm.out}
 
 
 The next step is to describe the initial conditions. As before, we will use an
 unstably layered medium but the perturbation now needs to be both in $x$- and
 $y$-direction
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/initial.part.prm.out}
+\lstinputlisting[language=prmfile]{initial.part.prm.out}
 
 The third issue we need to address is that we can likely not afford a mesh as
 fine as in 2d. We choose a mesh that is refined 3 times globally at the
 beginning, then 3 times adaptively, and is then adapted every 15 time steps. We
 also allow one additional mesh refinement in the first time step following
 $t=0.003$ once the initial instability has given way to a more stable pattern:
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/amr.part.prm.out}
+\lstinputlisting[language=prmfile]{amr.part.prm.out}
 
 Finally, as we have seen in the previous section, a computation with $Ra=10^4$
 does not lead to a simulation that is exactly exciting. Let us choose $Ra=10^6$
 instead (the mesh chosen above with up to 7 refinement levels after some time
 is fine enough to resolve this). We can achieve this in the same way as in the
 previous section by choosing $\alpha=10^{-10}$ and setting
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/gravity.part.prm.out}
+\lstinputlisting[language=prmfile]{gravity.part.prm.out}
 This has some interesting implications. First, a higher Rayleigh number makes
 time scales correspondingly smaller; where we generated graphical output only
 once every 0.01 time units before, we now need to choose the corresponding
 increment smaller by a factor of 100:
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{postprocess.part.prm.out}
 Secondly, a simulation like this -- in 3d, with a significant number of cells,
 and for a significant number of time steps -- will likely take a good amount of
 time. The computations for which we show results below was run using 64
@@ -51,7 +51,7 @@ processors by running it using the command
 during such a run, a significant amount of compute time would be lost if we had
 to run everything from the start. However, we can avoid this by periodically
 checkpointing the state of the computation:
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/checkpoint.part.prm.out}
+\lstinputlisting[language=prmfile]{checkpoint.part.prm.out}
 If the computation does crash (or if a computation runs out of the time limit
 imposed by a scheduling system), then it can be restarted from such
 checkpointing files (see the parameter {\tt Resume computation}
@@ -123,17 +123,17 @@ the simulation is also clearly non-stationary.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0010.png}
+  \includegraphics[width=0.3\textwidth]{movie0010.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0040.png}
+  \includegraphics[width=0.3\textwidth]{movie0040.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0060.png}
+  \includegraphics[width=0.3\textwidth]{movie0060.png}
   \\
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0100.png}
+  \includegraphics[width=0.3\textwidth]{movie0100.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0130.png}
+  \includegraphics[width=0.3\textwidth]{movie0130.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/movie0180.png}
+  \includegraphics[width=0.3\textwidth]{movie0180.png}
   \caption{\it Convection in a 3d box: Temperature isocontours and some
   velocity vectors at the first time step after times $t=0.001, 0.004, 0.006$
   (top row, left to right) an $t=0.01, 0.013, 0.018$ (bottom row).}
@@ -143,11 +143,11 @@ the simulation is also clearly non-stationary.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/mesh0060.png}
+  \includegraphics[width=0.3\textwidth]{mesh0060.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/mesh0100.png}
+  \includegraphics[width=0.3\textwidth]{mesh0100.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/convection_box_3d/doc/mesh0180.png}
+  \includegraphics[width=0.3\textwidth]{mesh0180.png}
   \caption{\it Convection in a 3d box: Meshes and large-scale velocity field
   for the third, fourth and sixth of the snapshots shown in
   Fig.~\ref{fig:box-3d-solution}.}
@@ -182,7 +182,7 @@ postprocessors.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.6\textwidth]{cookbooks/convection_box_3d/doc/heat-flux.png}
+  \includegraphics[width=0.6\textwidth]{heat-flux.png}
   \caption{\it Convection in a 3d box: Upward heat flux through the bottom and
   top boundaries as a function of time.}
   \label{fig:box-3d-heat-flux}

--- a/cookbooks/crustal_deformation/doc/crustal_deformation.tex
+++ b/cookbooks/crustal_deformation/doc/crustal_deformation.tex
@@ -19,7 +19,7 @@ material model (see Section \ref{parameters:Material_20model}) in the
 The layer is assumed to have dimensions of $\SI{80}{km} \times \SI{16}{km}$ and to have a density  $\rho=\SI{2800}{kg/m^3}$.
 The plasticity parameters are specified as follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/doc/crustal_model_2D_part1.prm.out}
+\lstinputlisting[language=prmfile]{crustal_model_2D_part1.prm.out}
 
 The yield strength $\sigma_y$ is a function of pressure, cohesion and angle of friction
 (see Drucker-Prager material model in Section \ref{parameters:Material_20model}),
@@ -38,7 +38,7 @@ we avoid dividing by zero by setting the strain rate to {\tt Reference strain ra
 The top boundary is a free surface while the left, right and bottom boundaries are subjected
 to the following boundary conditions:
 
-\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/doc/crustal_model_2D_part2.prm.out}
+\lstinputlisting[language=prmfile]{crustal_model_2D_part2.prm.out}
 
 Note that compressive boundary conditions are simply achieved by reversing
 the sign of the imposed velocity.
@@ -50,11 +50,11 @@ For small deformations, these directions are almost the same, but in this exampl
 are quite large. We have found that when the deformation is large, advecting the surface vertically
 results in a better behaved mesh, so we set the following in the free surface subsection:
 
-\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/doc/crustal_model_2D_part3.prm.out}
+\lstinputlisting[language=prmfile]{crustal_model_2D_part3.prm.out}
 
 We also make use of the strain rate-based mesh refinement plugin:
 
-\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/doc/crustal_model_2D_part4.prm.out}
+\lstinputlisting[language=prmfile]{crustal_model_2D_part4.prm.out}
 
 Setting
 {\tt   set Initial adaptive refinement        = 4}
@@ -71,7 +71,7 @@ shown in Fig. (\ref{fig:extcompr}).
 
 \begin{figure}
    \centering
-   \includegraphics[width=0.7\textwidth]{cookbooks/crustal_deformation/doc/grids.png}
+   \includegraphics[width=0.7\textwidth]{grids.png}
    \caption{\it Mesh evolution during the first timestep (refinement is based on strain rate).}
    \label{fig:meshes}
 \end{figure}
@@ -84,7 +84,7 @@ $35\degree$ in compression, both of which correspond to the reported Arthur angl
 
 \begin{figure}
   \centering
-  \includegraphics[width=\textwidth]{cookbooks/crustal_deformation/doc/both.png}
+  \includegraphics[width=\textwidth]{both.png}
   \caption{\it Finite element mesh, velocity, viscosity and strain rate fields
   in the case of extensional boundary conditions (top) and compressive boundary conditions (bottom) at t=500kyr.}
   \label{fig:extcompr}
@@ -101,7 +101,7 @@ The domain is now
 $128\times96\times16$km and the boundary conditions are implemented as
 follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/crustal_deformation/doc/crustal_model_3D_part1.prm.out}
+\lstinputlisting[language=prmfile]{crustal_model_3D_part1.prm.out}
 
 The presence of
 an offset between the two velocity discontinuity zones leads to a transform
@@ -109,7 +109,7 @@ fault which connects them.
 
 \begin{figure}
   \centering
-  \includegraphics[width=\textwidth]{cookbooks/crustal_deformation/doc/bottombc2.png}
+  \includegraphics[width=\textwidth]{bottombc2.png}
   \caption{\it Basal velocity boundary conditions and corresponding
   strain rate field for the 3D model.}
   \label{fig:bottombc}
@@ -122,7 +122,7 @@ of their initial offset \cite{alht11,alht12,alhf13}.
 
 \begin{figure}
 \centering
-\includegraphics[width=\textwidth]{cookbooks/crustal_deformation/doc/all3D.png}
+\includegraphics[width=\textwidth]{all3D.png}
 \caption{\it Finite element mesh, velocity, viscosity and strain rate fields at
 the end of the first time step after one level of strain rate-based adaptive mesh refinement.}
 \label{fig:ext3D}

--- a/cookbooks/finite_strain/doc/finite_strain.tex
+++ b/cookbooks/finite_strain/doc/finite_strain.tex
@@ -16,7 +16,7 @@ Here, we use a material model plugin that defines the compositional fields as th
 gradient tensor $\mathbf F_{ij}$, and modifies the right-hand side of
 the corresponding advection equations to accumulate strain over time. This is done by adjusting the
 \verb!out.reaction_terms! variable:
-\lstinputlisting[language=C++]{cookbooks/finite_strain/doc/finite_strain.cc}
+\lstinputlisting[language=C++]{finite_strain.cc}
 
 Let us denote the accumulated deformation at time step $n$ as $\mathbf F^n$. We can calculate its time derivative
 as the product of two tensors, namely the current velocity gradient $\mathbf G_{ij} = \frac{\partial u_i}{\partial x_j}$ and the deformation gradient $\mathbf F^{n-1}$ accumulated up to the previous time step, in other words $\frac{\partial \mathbf F}{\partial t} = \mathbf G \mathbf F$, and $\mathbf F^0 = \mathbf I$, with $\mathbf I$ being the identity tensor.
@@ -31,11 +31,11 @@ with \texttt{cmake . \&\& make} in the \url{cookbooks/finite_strain} directory.
 It can be loaded in a parameter file as an ``Additional shared library'', and selected as material
 model. As it is derived from the ``simple'' material model, all input parameters for the material
 properties are read in from the subsection \texttt{Simple model}.
-\lstinputlisting[language=prmfile]{cookbooks/finite_strain/doc/finite_strain.part.prm.out}
+\lstinputlisting[language=prmfile]{finite_strain.part.prm.out}
 
 \begin{figure}
     \centering
-    \includesvg[width=0.75\textwidth]{cookbooks/finite_strain/doc/finite_strain.svg}
+    \includesvg[width=0.75\textwidth]{finite_strain.svg}
     \caption{\it Accumulated finite strain in an example convection model, as described in Section
              \ref{sec:finite-strain} at a time of 67.6~Ma. Top panel: Temperature distribution. Bottom panel:
              Natural strain distribution. Additional black crosses are the scaled eigenvectors of the

--- a/cookbooks/free_surface/doc/free_surface.tex
+++ b/cookbooks/free_surface/doc/free_surface.tex
@@ -40,7 +40,7 @@ it is sufficient to reduce the time step size of the first few time steps.
 Following are the sections in the input file specific to this testcase.  The full parameter
 file may be found at \url{cookbooks/free_surface/free_surface.prm}.
 
-\lstinputlisting[language=prmfile]{cookbooks/free_surface/doc/free_surface.part.prm.out}
+\lstinputlisting[language=prmfile]{free_surface.part.prm.out}
 
 Running this input file will produce results like those in Figure~\ref{fig:freesurface}.
 The model starts with a single hot blob of rock which rises in the domain.  As it 
@@ -59,9 +59,9 @@ After running the cookbook, you may modify it in a number of ways:
 
 \begin{figure}
   \centering
-  \includegraphics[height=0.25\textwidth]{cookbooks/free_surface/doc/free_surface_blob.png}
+  \includegraphics[height=0.25\textwidth]{free_surface_blob.png}
   \hfill
-  \includegraphics[height=0.25\textwidth]{cookbooks/free_surface/doc/free_surface_topography.png}
+  \includegraphics[height=0.25\textwidth]{free_surface_topography.png}
   \caption{\it Evolution of surface topography due to a rising blob.  On the left is a 
            snapshot of the model setup.  The right shows the value of the highest 
            topography in the domain over 18 Myr of model time.  The topography peaks

--- a/cookbooks/free_surface_with_crust/doc/free_surface_with_crust.tex
+++ b/cookbooks/free_surface_with_crust/doc/free_surface_with_crust.tex
@@ -61,10 +61,10 @@ The following changes are necessary compared to the input file from the
 cookbook shown in Section~\ref{sec:cookbooks-freesurface} to include a crust:
 \begin{itemize}
   \item Load the plugin implementing the new material model:
-  \lstinputlisting[language=prmfile]{cookbooks/free_surface_with_crust/doc/free_surface_with_crust.part1.prm.out}
+  \lstinputlisting[language=prmfile]{free_surface_with_crust.part1.prm.out}
   
   \item Declare values for the new parameters:
-  \lstinputlisting[language=prmfile]{cookbooks/free_surface_with_crust/doc/free_surface_with_crust.part2.prm.out}
+  \lstinputlisting[language=prmfile]{free_surface_with_crust.part2.prm.out}
   Note that the height of the interface at 170km is interpreted in the
   coordinate system in which the box geometry of this cookbook lives. The box
   has dimensions $500\si{km}\times 200\si{km}$, so an interface height of
@@ -87,9 +87,9 @@ topography returns to zero after some time.
 
 \begin{figure}
   \centering
-  \includegraphics[height=0.25\textwidth]{cookbooks/free_surface_with_crust/doc/free_surface_with_crust.png}
+  \includegraphics[height=0.25\textwidth]{free_surface_with_crust.png}
   \hfill
-  \includegraphics[height=0.25\textwidth]{cookbooks/free_surface_with_crust/doc/topography.png}
+  \includegraphics[height=0.25\textwidth]{topography.png}
   \caption{\it Adding a viscous crust to a model with surface topography. The
   thermal anomaly spreads horizontally as it collides with the highly viscous crust (left, white solid line). The addition of a crustal layer both dampens and delays the appearance of the topographic maximum and minimum (right).}
   \label{fig:freesurfaceWC}

--- a/cookbooks/geomio/doc/geomio.tex
+++ b/cookbooks/geomio/doc/geomio.tex
@@ -33,11 +33,11 @@ index of the material that should be present in this region in the initial condi
   and only the outermost closed contour of a path will be considered. This means that, for example, for modeling a spherical
   annulus, you would have to draw two circles, and assign the inner one the same phase as the background of your drawing.}
 
-We will here use a drawing of a jellyfish located in \url{cookbooks/geomio/doc/jellyfish.svg}, where different phases
+We will here use a drawing of a jellyfish located in \url{jellyfish.svg}, where different phases
 have already been assigned to each path (Figure~\ref{fig:jelly-picture}).
 \begin{figure}[tb]
     \centering
-    \includesvg[width=0.2\textwidth]{cookbooks/geomio/doc/jellyfish.svg}
+    \includesvg[width=0.2\textwidth]{jellyfish.svg}
     \caption{\it Vector drawing of a jellyfish.}
     \label{fig:jelly-picture}
 \end{figure}
@@ -46,35 +46,35 @@ have already been assigned to each path (Figure~\ref{fig:jelly-picture}).
 After geomIO is initialized in MATLAB, we \href{http://geomio-doc.bitbucket.org/tuto2D.html#assigning-phase-to-markers}
 {run geomIO as described in the documentation}, loading the default options and then specifying all the option we want to
 change, such as the path to the input file, or the resolution:
-\lstinputlisting[language=matlab]{cookbooks/geomio/doc/run_geomio.part1.m}
+\lstinputlisting[language=matlab]{run_geomio.part1.m}
 You can view all of the options available by typing \texttt{opt} in MATLAB.
 
 In the next step we create the grid that is used for the coordinates in the \texttt{ascii data} initial conditions file
 and assign a phase to each grid point:
-\lstinputlisting[language=matlab]{cookbooks/geomio/doc/run_geomio.part2.m}
+\lstinputlisting[language=matlab]{run_geomio.part2.m}
 You can plot the \texttt{Phase} variable in MATLAB to see if the drawing was read in and all phases are assigned correctly
 (Figure~\ref{fig:jelly-plot}).
 \begin{figure}[tb]
     \centering
-    \includegraphics[width=0.45\textwidth]{cookbooks/geomio/doc/jelly.png}
+    \includegraphics[width=0.45\textwidth]{jelly.png}
     \caption{\it Plot of the \texttt{Phase} variable in MATLAB.}
     \label{fig:jelly-plot}
 \end{figure}
 Finally, we want to write output in a format that can be read in by \aspect{}'s \texttt{ascii data} compositional
 initial conditions plugin. We write the data into the file \texttt{jelly.txt}:
-\lstinputlisting[language=matlab]{cookbooks/geomio/doc/save_file_as_txt.m}
+\lstinputlisting[language=matlab]{save_file_as_txt.m}
 
 To read in the file we just created (a copy is located in \aspect{}'s data directory),
 we set up a model with a box geometry with the same extents we specified for the drawing in px
 and one compositional field. We choose the \texttt{ascii data} compositional initial conditions and specify that we
 want to read in our jellyfish. The relevant parts of the input file are listed below:
-\lstinputlisting[language=prmfile]{cookbooks/geomio/doc/geomIO.prm.out}
+\lstinputlisting[language=prmfile]{geomIO.prm.out}
 
 If we look at the output in \texttt{ParaView}, we can see our jellyfish, with the mesh refined at the
 boundaries between the different phases (Figure~\ref{fig:jelly-paraview}).
 \begin{figure}[tb]
     \centering
-    \includesvg[width=0.55\textwidth]{cookbooks/geomio/doc/jelly-paraview.svg}
+    \includesvg[width=0.55\textwidth]{jelly-paraview.svg}
     \caption{\it \aspect{} model output of the jellyfish and corresponding mesh in ParaView.}
     \label{fig:jelly-paraview}
 \end{figure}

--- a/cookbooks/global_melt/doc/global_melt.tex
+++ b/cookbooks/global_melt/doc/global_melt.tex
@@ -20,20 +20,20 @@ In the first model we will look at, melting and freezing is only included passiv
 The following input file (which can be found in \url{cookbooks/global_melt/global_no_melt.prm}) contains a detailed description of the
 different options required to set up such a model:
 
-\lstinputlisting[language=prmfile]{cookbooks/global_melt/doc/global_no_melt.prm.out}
+\lstinputlisting[language=prmfile]{global_no_melt.prm.out}
 
 When we look at visualization output of this model, we can see that over time, first upwellings, and then downwellings start to form. Both are more or less stable over time, and only change their positions slowly. As melt does not move relative to the solid, broad stable zones of melting with melt fraction of 10\% or more form in areas where material is upwelling.
 
 In the second model, melt is an active component of the model. Temperature, pressure and composition control how much of the rock melts, and as soon as that happens, melt can migrate relative to the solid rock. As material only melts partially, that means that the composition of the rock changes when it melts and melt is extracted, and we track this change in composition using a compositional field with the name \texttt{peridotite}. Positive values mark depletion (the composition of the residual host rock as more and more melt is extracted), and negative values mark enrichment (the composition of generated melt, or regions where melt freezes again). Both the fraction of melt (tracked by the compositional field with the name \texttt{porosity}) and the changes in composition influence the material properties such as density and viscosity. Moreover, there are additional material properties that describe how easily melt can move through the host rock, such as the \texttt{permeability}, or properties of the melt itself, such as the \texttt{fluid viscosity}.
 The following input file (a complete version of which can be found in \url{cookbooks/global_melt/global_melt.prm}) details the changes we have to make from the first model to set up a model with melt migration:
 
-\lstinputlisting[language=prmfile]{cookbooks/global_melt/doc/global_melt.prm.out}
+\lstinputlisting[language=prmfile]{global_melt.prm.out}
 
 In the first few tens of millions of years, this models evolves similarly to the model without melt migration. Upwellings rise in the same locations, and regions where material starts to melt are similar. However, once melt is formed, the model evolutions start to deviate. In the model with melt migration, melt moves upwards from the region where it is generated much faster than the flow of solid material, so that it reaches cold regions -- where it freezes again -- in a shorter amount of time. Because of that, the overall amount of melt is smaller in this model at any given point in time. In addition, enriched material, present in places where melt has crystallized, has a higher density than average or depleted mantle material. This means that in regions above stable upwellings, instabilities of dense, enriched material start to form, which leads to small-scale downwellings. Hence, both areas where material is partially molten and the location of the upwellings themselves have a much shorter wavelength and change much faster over time in comparison to the model without melt migration.
 
 \begin{figure}
     \centering
-    \includesvg[width=0.9\textwidth]{cookbooks/global_melt/doc/model_evolution.svg}
+    \includesvg[width=0.9\textwidth]{model_evolution.svg}
     \caption{\it Evolution of the model without (left) and with (right) melt migration.}
     \label{fig:global-melt}
 \end{figure}

--- a/cookbooks/gplates/doc/gplates.tex
+++ b/cookbooks/gplates/doc/gplates.tex
@@ -109,7 +109,7 @@ through the Earth with realistic boundary conditions.
 
 The relevant section of the input file is then as follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/gplates/doc/gplates.part.prm.out}
+\lstinputlisting[language=prmfile]{gplates.part.prm.out}
 
 In the ``Boundary velocity model'' subsection the user prescribes the boundary that is supposed to
 use the GPlates plugin. Although currently nothing forbids the user to use GPlates plugin for other
@@ -132,9 +132,9 @@ The top right plot of Fig.~\ref{fig:gv-1} shows an example of three independent
 two-dimensional computations of the same reduced resolution. The models were prescribed 
 to be orthogonal slices by setting:
 
-\lstinputlisting[language=prmfile]{cookbooks/gplates/doc/slice1.part.prm.out}
+\lstinputlisting[language=prmfile]{slice1.part.prm.out}
 and
-\lstinputlisting[language=prmfile]{cookbooks/gplates/doc/slice2.part.prm.out}
+\lstinputlisting[language=prmfile]{slice2.part.prm.out}
 
 
 The results of these models are plotted simultaneously in a single three-dimensional figure
@@ -164,7 +164,7 @@ as a proof-of-concept what is possible with the dimension independent approach o
 \aspect{} and its plugins.
 
 \begin{figure}
-  \includegraphics[width=\textwidth]{cookbooks/gplates/doc/gplates-comparison.png}
+  \includegraphics[width=\textwidth]{gplates-comparison.png}
   \hfill
   \caption{\it Using GPlates for velocity boundary conditions: The top left figure shows
   the results of a three-dimensional model using the present day plate velocities

--- a/cookbooks/heat_flow/doc/heat-flow.tex
+++ b/cookbooks/heat_flow/doc/heat-flow.tex
@@ -15,7 +15,7 @@ and temperature is fixed at the top, so that a cold thermal boundary develops ov
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.6\textwidth]{cookbooks/heat_flow/doc/mid-ocean-ridge.png}
+\includegraphics[width=0.6\textwidth]{mid-ocean-ridge.png}
 \hfill
 \phantom.
 \caption{\it Setup of the mid-ocean-ridge model that illustrates the cooling of the lithosphere.

--- a/cookbooks/initial-condition-S20RTS/doc/initial-condition-S20RTS.tex
+++ b/cookbooks/initial-condition-S20RTS/doc/initial-condition-S20RTS.tex
@@ -20,7 +20,7 @@ interpolation. The input files \texttt{S20RTS.sph} and \texttt{S40RTS.sph} were
 downloaded from \url{http://www.earth.lsa.umich.edu/~jritsema/Research.html}
 and have the following format (this example is S20RTS):
 
-\lstinputlisting[language=prmfile]{cookbooks/initial-condition-S20RTS/doc/S20RTS.input.sph}
+\lstinputlisting[language=prmfile]{S20RTS.input.sph}
 
 The first number in the first line denotes the maximum degree. This is followed in
 the next line by the spherical harmonic coefficients from the surface down to the
@@ -59,7 +59,7 @@ for a 3D spherical shell with Earth-like dimensions.
 
 The relevant section in the input file is as follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/initial-condition-S20RTS/doc/S20RTS.part.prm.out}
+\lstinputlisting[language=prmfile]{S20RTS.part.prm.out}
 
 For this initial condition model we need to first specify the data directory in which
 the input files are located as well as the initial condition file (S20RTS.sph or
@@ -152,7 +152,7 @@ and gravity anomalies from ASPECT and a spectral based code shows good agreement
 (see \texttt{benchmarks/spectral-comparison/} for figure and details).
 
 \begin{figure}
-  \includegraphics[width=\textwidth]{cookbooks/initial-condition-S20RTS/doc/Fig_cookbook_V4-01.png}
+  \includegraphics[width=\textwidth]{Fig_cookbook_V4-01.png}
   \hfill
   \caption{\it Panels (a) and (b) show the density distribution as prescribed from the shear
   wave velocity model S20RTS and the resulting flow for a global refinement of 4. This
@@ -165,7 +165,7 @@ and gravity anomalies from ASPECT and a spectral based code shows good agreement
 \end{figure}
 
 \begin{figure}
-  \includegraphics[width=\textwidth]{cookbooks/initial-condition-S20RTS/doc/Fig_cookbook_V4-02.png}
+  \includegraphics[width=\textwidth]{Fig_cookbook_V4-02.png}
   \hfill
   \caption{\it The first row of this figure shows the surface dynamic topography resulting
   from the flow shown in Figure~\ref{fig:ic-1} for a global

--- a/cookbooks/inner_core_convection/doc/inner_core_convection.tex
+++ b/cookbooks/inner_core_convection/doc/inner_core_convection.tex
@@ -78,7 +78,7 @@ Three main areas can be distinguished: the stable area, the plume convection are
 
 \begin{figure}[h]
 \begin{center}
-\includesvg[height=0.57\textwidth]{cookbooks/inner_core_convection/doc/Diagstab.svg}
+\includesvg[height=0.57\textwidth]{Diagstab.svg}
 	\caption{\it Stability diagram for convection in a sphere with phase change at its outer boundary. The stability curves for the first unstable mode (l=1) and the translation are obtained from \cite{Deguen2013}. Each dot (no convection) and triangle (blue: translation, yellow: plume convection) is one model run done with ASPECT. The highest the Ra and P are, the more refinement is required (see text).}
     \label{fig:diagramme-regime}
 \end{center}
@@ -87,27 +87,27 @@ Three main areas can be distinguished: the stable area, the plume convection are
 
 Changing the values of $Ra$ and $\mathcal{P}$ in the input file allows switching between the different regimes.
 The Rayleigh number can be changed by adjusting the magnitude of the gravity:
-\lstinputlisting[language=prmfile]{cookbooks/inner_core_convection/doc/inner_core_traction.part.2.prm.out}
+\lstinputlisting[language=prmfile]{inner_core_traction.part.2.prm.out}
 The phase change number is implemented as part of the material model, and as a function that can depend on the
 spatial coordinates and/or on time:
-\lstinputlisting[language=prmfile]{cookbooks/inner_core_convection/doc/inner_core_traction.part.1.prm.out}
+\lstinputlisting[language=prmfile]{inner_core_traction.part.1.prm.out}
 
 Figure~\ref{fig:inner-core-regimes} shows examples of the three regimes with $Ra=3000, \mathcal{P}=1000$ (plume convection),
 $Ra=10^5, \mathcal{P}=0.01$ (translation), $Ra=10, \mathcal{P}=30$ (no convection).
 
 \begin{figure}[h]
     \begin{center}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e0P0modif.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e2P-1modif.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e5P4modif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e0P0modif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e2P-1modif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e5P4modif.png}
    \vspace{1cm}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e0P0modif.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e2P-1rescalemodif.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/Ra1e5P4rescalemodif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e0P0modif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e2P-1rescalemodif.png}
+    \includegraphics[width=0.25\linewidth]{Ra1e5P4rescalemodif.png}
    \vspace{1cm}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/no_convection.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/translation.png}
-    \includegraphics[width=0.25\linewidth]{cookbooks/inner_core_convection/doc/convection.png}
+    \includegraphics[width=0.25\linewidth]{no_convection.png}
+    \includegraphics[width=0.25\linewidth]{translation.png}
+    \includegraphics[width=0.25\linewidth]{convection.png}
     \caption{\it Convection regimes in the inner core for different values of $Ra$ and $\mathcal{P}$. From left to right: no convection, translation, plume convection; the 2D slices at the top are with the default temperature scale for all panels, while in the second row an adaptive scale is used. The bottom row features slightly different model parameters (that are still in the same regime as the models in the respective panels above) and also shows the velocity as arrows.}
     \label{fig:inner-core-regimes}
        \end{center}
@@ -118,7 +118,7 @@ $Ra=10^5, \mathcal{P}=0.01$ (translation), $Ra=10, \mathcal{P}=30$ (no convectio
 The temperature is set to 0 at the outer boundary and a large temperature gradient can develop at the boundary layer, especially for the translation regime. The adaptive mesh refinement allows it to resolve this layer at the inner core boundary. Another solution is to apply a specific initial refinement, based on the boundary layer thickness scaling law $\delta \propto Ra^{-0.236}$, and to refine specifically the uppermost part of the inner core.
 
 In order to have a mesh that is much finer at the outer boundary than in the center of the domain, this expression for the mesh refinement subsection can be used in the input file:
-\lstinputlisting[language=prmfile]{cookbooks/inner_core_convection/doc/inner_core_traction.part.3.prm.out}
+\lstinputlisting[language=prmfile]{inner_core_traction.part.3.prm.out}
 
 \vspace{0.3cm}
 \textbf{Scaling laws.}
@@ -133,9 +133,9 @@ Both trends are shown in Figure~\ref{fig:inner-core-trends} and can be compared 
 
 \begin{figure}
     \centering
-    \includesvg[width=0.49\textwidth]{cookbooks/inner_core_convection/doc/translation_over_Ra_P.svg}
+    \includesvg[width=0.49\textwidth]{translation_over_Ra_P.svg}
     \hfill
-    \includesvg[width=0.49\textwidth]{cookbooks/inner_core_convection/doc/translation_over_P.svg}
+    \includesvg[width=0.49\textwidth]{translation_over_P.svg}
     \caption{\it Translation rate (approximated by the average of the velocity component in the direction of translation),
     normalized to the low $\mathcal{P}$
     limit estimate given in \cite{Deguen2013}, as a function of $\frac{Ra}{\mathcal{P}}$ for $\mathcal{P}=10^{-2}$

--- a/cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.tex
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.tex
@@ -7,7 +7,7 @@ This subduction example is based on the benchmark effort of Quinquis et al., of 
 
 \begin{figure}
     \centering
-    \includegraphics[width=0.8\textwidth]{cookbooks/kinematically_driven_subduction_2d/doc/setup_Quinquis2014.png}
+    \includegraphics[width=0.8\textwidth]{setup_Quinquis2014.png}
     \caption{Case 4 model setup. Copied from Quinquis (2014).}
     \label{fig:QQ_setup}
 \end{figure}
@@ -20,25 +20,25 @@ The Case 1 model setup considers three materials (compositional fields) apart fr
     \item the mantle lithosphere of the subducting plate (SHB and thermal layer combined).
 \end{enumerate}{}
 The geometry of these compositions is implemented as follows:
-\lstinputlisting[language=prmfile]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_compositions.prm.out}
+\lstinputlisting[language=prmfile]{Case1_compositions.prm.out}
 
 No differences in material properties exist, except for density and viscosity, so we use the multicomponent material model. To keep the boundaries between fields as sharp as possible in terms of viscosity, we use the maximum composition to determine the viscosity in each evaluation point (note that this can be harder on the solver):
-\lstinputlisting[language=prmfile]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_materialmodel.prm.out}
+\lstinputlisting[language=prmfile]{Case1_materialmodel.prm.out}
 
 Temperature effects are ignored. Subduction is driven by prescribed in- and outflow through the right boundary (with a gradual transition of the flow direction), all other boundaries are free slip. The volume of material that flows in is balanced by the volume that is prescribed to flow out (this is important as the model is incompressible). A weak crust along the plate interface and the subducting lithosphere facilitates subduction. Through the function plugin, we prescribe the in- and outflow:
-\lstinputlisting[language=prmfile]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_velocity.prm.out}
+\lstinputlisting[language=prmfile]{Case1_velocity.prm.out}
 
 To follow the slab on its descent into the mantle, we use adaptive mesh refinement based on viscosity in combination with the minimum refinement strategy to ensure sufficient resolution in the crust and weak zone that allow the slab to detach from the surface:
-\lstinputlisting[language=prmfile]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_meshrefinement.prm.out}
+\lstinputlisting[language=prmfile]{Case1_meshrefinement.prm.out}
 
 To monitor the model evolution, several diagnostic quantities are tracked over time: the depth of the tip of the slab, the position of the trench, the RMS velocity of the slab and the whole model domain, and the work done (viscous dissipation) in the slab and total model domain. The computation of these quantities in done in several new plugins:
-\lstinputlisting[language=prmfile]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_postprocessing.prm.out}
+\lstinputlisting[language=prmfile]{Case1_postprocessing.prm.out}
 
 \begin{figure}
     \centering
-    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_dens_t0.png}
-    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_visc_t0.png}
-    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_vel_t0.png}
+    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{Case1_dens_t0.png}
+    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{Case1_visc_t0.png}
+    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 8cm, clip=true]{Case1_vel_t0.png}
     \caption{\it Case 1 density, viscosity and velocity at time zero.}
     \label{fig:QQ_case1_setup}
 \end{figure}
@@ -47,15 +47,15 @@ We run the Case 1 setup for 15 My of model time. The diagnostic quantities in Fi
 
 \begin{figure}
     \centering
-    \includegraphics[trim=1cm 1cm 10cm 0cm,width=.8\textwidth]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_diagnostics}
+    \includegraphics[trim=1cm 1cm 10cm 0cm,width=.8\textwidth]{Case1_diagnostics}
     \caption{\it Case 1 diagnostic quantities of ASPECT, Sulec and Elefant results.}
     \label{fig:QQ_case1_diagnostics}
 \end{figure}
 
 \begin{figure}
     \centering
-    \includegraphics[width=0.6\textwidth,trim=1cm 10cm 1cm 9cm, clip=true]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_visc_8My.png}
-    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 9cm, clip=true]{cookbooks/kinematically_driven_subduction_2d/doc/Case1_visc_15My.png}
+    \includegraphics[width=0.6\textwidth,trim=1cm 10cm 1cm 9cm, clip=true]{Case1_visc_8My.png}
+    \includegraphics[width=0.6\textwidth,trim=1cm 7cm 1cm 9cm, clip=true]{Case1_visc_15My.png}
     \caption{\it Case 1 viscosity snapshots at 8 and 15 My.}
     \label{fig:QQ_case1_results}
 \end{figure}

--- a/cookbooks/magnetic_stripes/doc/magnetic_stripes.tex
+++ b/cookbooks/magnetic_stripes/doc/magnetic_stripes.tex
@@ -25,7 +25,7 @@ Slides with an introduction to the Earth's magnetic field can be found \href{htt
 \begin{figure}[h]
 \phantom.
 \hfill
-\includegraphics[width=0.6\textwidth]{cookbooks/magnetic_stripes/doc/mid-ocean-ridge.png}
+\includegraphics[width=0.6\textwidth]{mid-ocean-ridge.png}
 \hfill
 \phantom.
 \caption{\it Setup of the mid-ocean ridge model. Background colors show temperature. Black and white colors at the top of the model illustrate the orientation of the magnetic field frozen in the rock when the melt generated at the mid-ocean ridge reaches the surface, crystallizes to form new sea floor, and the rock cools down. White lines illustrate the flow field.}

--- a/cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.tex
+++ b/cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.tex
@@ -31,7 +31,7 @@ the reaction time scale.
 The melting model we use here is the anhydrous mantle melting model of \cite{KSL2003} for a peridotitic
 rock composition, as implemented in the ``melt simple'' material model.
 
-\lstinputlisting[language=prmfile]{cookbooks/mid_ocean_ridge/doc/melting_and_freezing.part.prm.out}
+\lstinputlisting[language=prmfile]{melting_and_freezing.part.prm.out}
 
 To make sure we reproduce the characteristic triangular melting region of a mid-ocean ridge, we have to
 set up the boundary conditions in a way so that they will lead to corner flow. At the top boundary, we can
@@ -42,7 +42,7 @@ pressure as a boundary condition for the stress. We accomplish this by using the
 ``initial lithostatic pressure'' model. This plugin will automatically compute a 1d lithostatic pressure
 profile at a given point at the time of the model start and apply it as a boundary traction.
 
-\lstinputlisting[language=prmfile]{cookbooks/mid_ocean_ridge/doc/boundary_conditions.part.prm.out}
+\lstinputlisting[language=prmfile]{boundary_conditions.part.prm.out}
 
 Finally, we have to make sure that the resolution is high enough to model melt migration.
 This is particularly important in regions where the porosity is low, but still high enough that
@@ -62,7 +62,7 @@ As the length scale of melt migration is usually smaller than for mantle convect
 sure that regions where melt is present have a high resolution, and that this high resolution extends
 to all cells where the two-phase flow equations are solved.
 
-\lstinputlisting[language=prmfile]{cookbooks/mid_ocean_ridge/doc/mesh_refinement.part.prm.out}
+\lstinputlisting[language=prmfile]{mesh_refinement.part.prm.out}
 
 \aspect{} also supports an alternative method to make sure that regions with melt are sufficiently
 well resolved, relying directly on the compaction length, and we will discuss this method as a possible
@@ -74,7 +74,7 @@ The complete input file is located at \url{cookbooks/mid_ocean_ridge/mid_ocean_r
 
 \begin{figure}
     \centering
-    \includesvg[width=0.5\textwidth]{cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.svg}
+    \includesvg[width=0.5\textwidth]{mid_ocean_ridge.svg}
     \caption{\it Mid-ocean ridge model after 8 million years. The top panel shows the depletion
              and porosity fields (with the characteristic triangular melting region),
              the bottom panel shows the temperature distribution and the melt velocity, indicated
@@ -99,7 +99,7 @@ A vertical profile at a distance of 80 km from the ridge axis showing this compo
 
 \begin{figure}
     \centering
-    \includesvg[width=0.35\textwidth]{cookbooks/mid_ocean_ridge/doc/depletion_profile.svg}
+    \includesvg[width=0.35\textwidth]{depletion_profile.svg}
     \caption{\it Vertical profile through the model domain at a distance of 80 km from the ridge axis
              at the end of the model run, showing the distribution of depletion and enrichment as
              indicated by the peridotite field.}
@@ -111,7 +111,7 @@ Another option for making sure that melt migration is resolved properly in the m
 refinement criterion that directly relates to the compaction length. This can be done in the mesh
 refinement section of the input file:
 
-\lstinputlisting[language=prmfile]{cookbooks/mid_ocean_ridge/doc/compaction_length.part.prm.out}
+\lstinputlisting[language=prmfile]{compaction_length.part.prm.out}
 
 This will lead to a higher resolution particularly in regions with low (but not zero) porosity,
 and can be useful to resolve the strong gradients in the melt velocity and compaction pressure that
@@ -120,7 +120,7 @@ Of course it is also possible to combine both methods for refining the mesh.
 
 \begin{figure}
     \centering
-    \includesvg[width=0.6\textwidth]{cookbooks/mid_ocean_ridge/doc/refinement.svg}
+    \includesvg[width=0.6\textwidth]{refinement.svg}
     \caption{\it Mesh after a time of 3.6 million years for a model using the composition threshold
              refinement strategy (left) and the compaction length refinement strategy (right)
              Background colors indicate the melt velocity. Its sharp gradients at the interface

--- a/cookbooks/morency_doin_2004/doc/morency_doin_2004.tex
+++ b/cookbooks/morency_doin_2004/doc/morency_doin_2004.tex
@@ -42,10 +42,10 @@ In particular, the following sections of the input file are important to reprodu
     get very close. See Figure~\ref{fig:md-1} for an approximate reproduction of the
     original figure.}
 
-\lstinputlisting[language=prmfile]{cookbooks/morency_doin_2004/doc/morency_doin.part.prm.out}
+\lstinputlisting[language=prmfile]{morency_doin.part.prm.out}
 
 \begin{figure}[h!]
-  \includesvg[width=\textwidth]{cookbooks/morency_doin_2004/doc/morency_doin_2004_fig1.svg}
+  \includesvg[width=\textwidth]{morency_doin_2004_fig1.svg}
   \caption{\it Approximate reproduction of figure 1 from \cite{MD04} using the `morency doin'
   material model with almost all default parameters. Note the low-viscosity Moho, enabled by
   the low activation energy of the crustal component.}

--- a/cookbooks/muparser_temperature_example/doc/muparser_temperature_example.tex
+++ b/cookbooks/muparser_temperature_example/doc/muparser_temperature_example.tex
@@ -16,27 +16,27 @@ In the first syntax, both the true and false expression are evaluated (even thou
 \texttt{if ((x>0.0) \&\& (x<=xtr))  then T-sub else (if (x>xtr) then T-ov else Tm)}\\
 where T-sub is the function for the temperature of the subducting plate and T-ov is the function for the temperature of the
 overriding plate.
-\lstinputlisting[language=prmfile]{cookbooks/muparser_temperature_example/doc/temperature.part.prm.out}
+\lstinputlisting[language=prmfile]{temperature.part.prm.out}
 Notice also that the boundary conditions for the temperature are defined in a separate subsection and depend on the geometry.
 The boundary conditions are insulating (zero flux) side-walls and fixed temperature at the top and bottom. Figure \ref{lazy-expression-tempic} shows the initial temperature on the full domain.
 \begin{figure}
 \centering
-\includegraphics[width=0.8\textwidth]{cookbooks/muparser_temperature_example/doc/initial_temperature.png}
+\includegraphics[width=0.8\textwidth]{initial_temperature.png}
 \caption{\it Initial temperature condition for the lazy-expression syntax cookbook. \label{lazy-expression-tempic}}
 \end{figure}
 
 The structure and refinement of the mesh are determined in two subsections of the parameter file. First, because the model domain is not a square, it is necessary to subdivide the domain into sections that are equidimensional (or as close as possible): this is done using the \texttt{repetitions} parameters in the \texttt{Geometry} section. In this case because the model domain has an aspect ratio of 5:1, we use 5 repetitions in the $x$ direction, dividing the domain into 5 equidimensional elements each 1000 by 1000 \si{km}.
-\lstinputlisting[language=prmfile]{cookbooks/muparser_temperature_example/doc/repetitions.part.prm.out}
+\lstinputlisting[language=prmfile]{repetitions.part.prm.out}
 Further refinements will divide each sub-region multiple times keeping the aspect ratio of the sub-region. In this case, we refine the elements in each subregion 3 more times. We then use the \texttt{minimum refinement function} strategy and use the \texttt{if-then-else} statement in the function expression to refine 4 more times to a refinement level of 7, but only where the depth is less than \SI{150}{km}. Appropriate values of the minimum refinement level in this function expression could be the sum of initial global refinement level (3) and initial adaptive refinement level (4) in the `\texttt{then}' statement (i.e., 7 here) and the value of initial global refinement in the `\texttt{else}' statement.
-\lstinputlisting[language=prmfile]{cookbooks/muparser_temperature_example/doc/mesh-refinement.part.prm.out}
+\lstinputlisting[language=prmfile]{mesh-refinement.part.prm.out}
 Figure \ref{lazy-expression-tempic-zoom} zooms in on the region where the two plates meet and shows the temperature on a wireframe highlighting the element size refinement. Notice that the mesh refinement algorithm automatically adjusts the element size between the region that is specific to be a level 7 and the region at level 3 to create a smooth transition in element size.
 \begin{figure}
 \centering
-\includegraphics[width=0.5\textwidth]{cookbooks/muparser_temperature_example/doc/initial_temperature_on_mesh_zoom.png}
+\includegraphics[width=0.5\textwidth]{initial_temperature_on_mesh_zoom.png}
 \caption{\it Initial temperature condition for the lazy-expression syntax cookbook within the region where the two plates meet. The wireframe shows the element size refinement. \label{lazy-expression-tempic-zoom}}
 \end{figure}
 
 Finally, in order to just test whether the initial temperature structure has been properly defined, it is helpful to run the model for a single time-step and without actually waiting for the solvers to converge. In order to do this, the \texttt{End time} can be set to zero. If the model is very large (lots of refinement) or there are large viscosity jumps that take longer to converge in the Stokes solver, it can also be useful to set the solver tolerance parameters to large values as noted below. However, remember that in that case the solution will not be converged -- it is only useful for checking that the initial condition is set correctly.
-\lstinputlisting[language=prmfile]{cookbooks/muparser_temperature_example/doc/check-initial-condition.part.prm.out}
+\lstinputlisting[language=prmfile]{check-initial-condition.part.prm.out}
 
 

--- a/cookbooks/onset_of_convection/doc/onset_of_convection.tex
+++ b/cookbooks/onset_of_convection/doc/onset_of_convection.tex
@@ -14,7 +14,7 @@ More details can be found in the example assignment below.
 \begin{figure}[h]
 \phantom.
 \hfill
-\includegraphics[width=0.8\textwidth]{cookbooks/onset_of_convection/doc/convection_models.png}
+\includegraphics[width=0.8\textwidth]{convection_models.png}
 \hfill
 \phantom.
 \caption{\it Onset of convection model with different Rayleigh numbers. Background colors show temperature.}

--- a/cookbooks/platelike-boundary/doc/platelike-boundary.tex
+++ b/cookbooks/platelike-boundary/doc/platelike-boundary.tex
@@ -24,7 +24,7 @@ input file. It essentially extends the input file considered in the previous exa
 The part of this file that we are particularly interested in in the current
 context is the selection of the kind of velocity boundary conditions on the four
 sides of the box geometry, which we do using a section like this:
-\lstinputlisting[language=prmfile]{cookbooks/platelike-boundary/doc/boundary.part.prm.out}
+\lstinputlisting[language=prmfile]{boundary.part.prm.out}
 
 We use tangential flow at boundaries named left, right and bottom.
 Additionally, we specify a comma separated list (here with only a single
@@ -85,7 +85,7 @@ boundary without corresponding inflow anywhere else.}
 
 
 The remainder of the setup is described in the following, complete input file:
-\lstinputlisting[language=prmfile]{cookbooks/platelike-boundary/doc/platelike.prm.out}
+\lstinputlisting[language=prmfile]{platelike.prm.out}
 
 
 This model description yields a setup with a Rayleigh number of 200 (taking
@@ -100,17 +100,17 @@ yields images like the ones shown in Fig.~\ref{fig:platelike}.
 
 \begin{figure}
   \centering
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0000.png}
+  \includegraphics[width=0.3\textwidth]{visit0000.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0001.png}
+  \includegraphics[width=0.3\textwidth]{visit0001.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0003.png}
+  \includegraphics[width=0.3\textwidth]{visit0003.png}
   \\
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0004.png}
+  \includegraphics[width=0.3\textwidth]{visit0004.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0005.png}
+  \includegraphics[width=0.3\textwidth]{visit0005.png}
   \hfill
-  \includegraphics[width=0.3\textwidth]{cookbooks/platelike-boundary/doc/visit0006.png}
+  \includegraphics[width=0.3\textwidth]{visit0006.png}
   \caption{\it Variable velocity boundary conditions: Temperature and velocity
   fields at the initial time (top left) and at various other points in time during the
   simulation.}

--- a/cookbooks/plume_2D_chunk/doc/plume.tex
+++ b/cookbooks/plume_2D_chunk/doc/plume.tex
@@ -53,15 +53,15 @@ Steady-state fields are shown in Fig.~\ref{fig:plume-diff-creep}. We find that t
 
 \begin{figure}
   \centering
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/vel1}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/vel2}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/vel3}\\
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/T1}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/T2}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/T3}\\
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/eta1}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/eta2}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/eta3}
+  \includegraphics[width=5cm]{vel1}
+  \includegraphics[width=5cm]{vel2}
+  \includegraphics[width=5cm]{vel3}\\
+  \includegraphics[width=5cm]{T1}
+  \includegraphics[width=5cm]{T2}
+  \includegraphics[width=5cm]{T3}\\
+  \includegraphics[width=5cm]{eta1}
+  \includegraphics[width=5cm]{eta2}
+  \includegraphics[width=5cm]{eta3}
   \caption{\it Plume in a 2D chunk. Columns from left to right: isoviscous case, weakly temperature dependent case, and strongly temperature-dependent case. Rows from top to bottom: Velocity, temperature, and viscosity field at steady state. Angular opening of $\pi/8$.}
   \label{fig:plume-diff-creep}
 \end{figure}
@@ -70,9 +70,9 @@ Obtaining a steady state is contingent on the narrow angular opening. We find th
 
 \begin{figure}
   \centering
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/exp1_22}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/exp1_45}
-  \includegraphics[width=5cm]{cookbooks/plume_2D_chunk/doc/exp1_90}
+  \includegraphics[width=5cm]{exp1_22}
+  \includegraphics[width=5cm]{exp1_45}
+  \includegraphics[width=5cm]{exp1_90}
   \caption{\it Plume in a 2D chunk: Temperature at the end of the run. From left to right: Angular opening of
 $\pi/8$, $\pi/4$ and $\pi/2$. The first two have reached a steady state while the third one has not.}
   \label{fig:plume-angular-opening}
@@ -84,7 +84,7 @@ We find that the average velocities are smaller in the models with larger activa
 
 \begin{figure}
   \centering
-  \includesvg[width=10cm]{cookbooks/plume_2D_chunk/doc/vrms.svg}
+  \includesvg[width=10cm]{vrms.svg}
   \caption{\it Plume in a 2D chunk: Root mean square velocity for each experiment.}
   \label{fig:plume-diff-creep-vrms}
 \end{figure}

--- a/cookbooks/prescribed_velocity/doc/prescribed_velocity.tex
+++ b/cookbooks/prescribed_velocity/doc/prescribed_velocity.tex
@@ -30,15 +30,15 @@ The above plugin can be compiled with \texttt{cmake . \&\& make} in the
 as an ``Additional shared library.'' By setting parameters like those shown below,
 it is possible to produce many interesting flow fields such as the ones visualized in
 (Figure~\ref{fig:prescribed-velocity}).
-\lstinputlisting[language=prmfile]{cookbooks/prescribed_velocity/doc/minimal.prm.out}
+\lstinputlisting[language=prmfile]{minimal.prm.out}
 
 \begin{figure}
     \centering
   \subfigure[]{
-    \includegraphics[width=.48\textwidth]{cookbooks/prescribed_velocity/doc/corner_flow.png}}
+    \includegraphics[width=.48\textwidth]{corner_flow.png}}
   ~
   \subfigure[]{
-    \includegraphics[width=.48\textwidth]{cookbooks/prescribed_velocity/doc/circle.png}}
+    \includegraphics[width=.48\textwidth]{circle.png}}
     \caption{\it Examples of flows with prescribed internal velocities, as described in Section \ref{sec:prescribed-velocities}.}
     \label{fig:prescribed-velocity}
 \end{figure}

--- a/cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.tex
+++ b/cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.tex
@@ -6,23 +6,23 @@ Building on \ref{sec:prescribed-velocities}, the \url{cookbooks/prescribed_veloc
 directory contains a plugin which uses an ASCII data file to specify where to prescribe
 internal velocities. Velocities are prescribed wherever the field value indicated by the ASCII data file
 is greater than 0.5. As before, the plugin is loaded in parameter files as an additional shared library:
-\lstinputlisting[language=prmfile]{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.prm.0.out}
+\lstinputlisting[language=prmfile]{prescribed_velocity_ascii_data.prm.0.out}
 
 An example parameter file using this plugin can be found at
 \url{cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.prm}.
 In this file, the velocities are constrained to be zero within the letters ``ASPECT'' (Figure~\ref{fig:prescribed-velocity-ascii-data-init}).
 The part of this file which provides the location of the ASCII file and the
 prescribed velocity field function is:
-\lstinputlisting[language=prmfile]{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.prm.1.out}
+\lstinputlisting[language=prmfile]{prescribed_velocity_ascii_data.prm.1.out}
 A temperature gradient is applied within the letters, while the temperature field outside the letters is set to be constant.
 This initial temperature field is specified by another ASCII data file:
-\lstinputlisting[language=prmfile]{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.prm.2.out}
+\lstinputlisting[language=prmfile]{prescribed_velocity_ascii_data.prm.2.out}
 These two ASCII data files are generated from \texttt{aspect\_name.png} by the python file \texttt{make\_ascii\_files\_from\_png.py},
 both of which can be found in the same directory as the parameter file.
 
 \begin{figure}
     \centering
-    \includegraphics[width=\textwidth]{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocities_ascii_data_initial_conditions.png}
+    \includegraphics[width=\textwidth]{prescribed_velocities_ascii_data_initial_conditions.png}
     \caption{\it Initial composition and temperature conditions for the prescribed velocity ascii data cookbook,
              as described in Section \ref{sec:prescribed-velocities-ascii-data}.}
     \label{fig:prescribed-velocity-ascii-data-init}
@@ -34,7 +34,7 @@ part of the domain then generate convective flow. Figure~\ref{fig:prescribed-vel
 illustrates the resulting flow field.
 \begin{figure}
     \centering
-    \includegraphics[width=0.8\textwidth]{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.png}
+    \includegraphics[width=0.8\textwidth]{prescribed_velocity_ascii_data.png}
     \caption{\it Convective flow around the letters ASPECT, within which velocities are prescribed to be zero, as described in Section \ref{sec:prescribed-velocities-ascii-data}.}
     \label{fig:prescribed-velocity-ascii-data}
 \end{figure}

--- a/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.tex
+++ b/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.tex
@@ -15,7 +15,7 @@ shell geometry model and a simple material model.
 The relevant section in the input file that determines the postprocessed
 output is as follows:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{shell_3d_postprocess.part.prm.out}
 
 This initial condition results in distinct flow cells that cause local up- and
 downwellings (Figure~\ref{fig:pp}). This flow deflects the top and bottom boundaries
@@ -61,7 +61,7 @@ expansion and can therefore only be used with the 3D spherical shell geometry mo
 
 
 \begin{figure}
-  \includegraphics[width=\textwidth]{cookbooks/shell_3d_postprocess/doc/postprocess_cookbook-01.png}
+  \includegraphics[width=\textwidth]{postprocess_cookbook-01.png}
   \hfill
   \caption{\it Panel (a) shows an equatorial cross section of the temperature distribution and
   resulting flow from a harmonic perturbation. Panel (b) shows the resulting geoid, and panels

--- a/cookbooks/shell_simple_2d/doc/shell_simple_2d.tex
+++ b/cookbooks/shell_simple_2d/doc/shell_simple_2d.tex
@@ -15,11 +15,11 @@ player window to select the highest resolution to see all the details of this
 video.}
 
 \begin{figure}[tb]
-\includegraphics[width=0.32\textwidth]{cookbooks/shell_simple_2d/doc/x-movie0000.png}
+\includegraphics[width=0.32\textwidth]{x-movie0000.png}
 \hfill
-\includegraphics[width=0.32\textwidth]{cookbooks/shell_simple_2d/doc/x-movie0008.png}
+\includegraphics[width=0.32\textwidth]{x-movie0008.png}
 \hfill
-\includegraphics[width=0.32\textwidth]{cookbooks/shell_simple_2d/doc/x-movie1000.png}
+\includegraphics[width=0.32\textwidth]{x-movie1000.png}
 \caption{\it Simple convection in a quarter of an annulus: Snapshots of the
 temperature field at times $t=0$, $t=\num{1.2e7}$ years (time step 2135), and
 $t=10^9$ years (time step 25,662). The bottom right part of each figure shows an
@@ -30,7 +30,7 @@ overlay of the mesh used during that time step.}
 Let us just start by showing the input file (which you can find in
 \url{cookbooks/shell_simple_2d/shell_simple_2d.prm}):
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_2d/doc/shell.prm.out}
+\lstinputlisting[language=prmfile]{shell.prm.out}
 
 In the following, let us pick apart this input file:
 \begin{enumerate}
@@ -179,9 +179,9 @@ overturning has been mixed sufficiently to allow plumes to rise or sink through
 the entire depth of the mantle.
 
 \begin{figure}[tb]
-\includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_2d/doc/rms.png}
+\includegraphics[width=0.48\textwidth]{rms.png}
 \hfill
-\includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_2d/doc/depth_average_temperature.png}
+\includegraphics[width=0.48\textwidth]{depth_average_temperature.png}
 \caption{\it Simple convection in a quarter of an annulus. Left: Root mean
 square values of the velocity field. The initial spike (off the scale) is due to
 the overturning of the unstable layering of the temperature. Convection is suppressed for the
@@ -263,9 +263,9 @@ other.
 
 
 \begin{figure}[tb]
-  \includegraphics[width=.48\textwidth]{cookbooks/shell_simple_2d/doc/heat-flux.png}
+  \includegraphics[width=.48\textwidth]{heat-flux.png}
   \hfill
-  \includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_2d/doc/heat-flux-noshear.png}
+  \includegraphics[width=0.48\textwidth]{heat-flux-noshear.png}
   \caption{\it Simple convection in a quarter of an annulus. Left: Heat flux
   through the core-mantle and mantle-air boundaries of the domain for the
   model with shear heating. Right: Same for a model without shear heating.}
@@ -274,9 +274,9 @@ other.
 
 
 \begin{figure}[tb]
-  \includegraphics[width=.48\textwidth]{cookbooks/shell_simple_2d/doc/avg-temperature.png}
+  \includegraphics[width=.48\textwidth]{avg-temperature.png}
   \hfill
-  \includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_2d/doc/avg-temperature-noshear.png}
+  \includegraphics[width=0.48\textwidth]{avg-temperature-noshear.png}
   \caption{\it Simple convection in a quarter of an annulus. Left: Average
   temperature throughout the model for the
   model with shear heating. Right: Same for a model without shear heating.}
@@ -310,7 +310,7 @@ of Figs.~\ref{fig:simple-shell-2d-heatflux}
 and \ref{fig:simple-shell-2d-temperature} show heat fluxes and average
 temperatures for a model where we have switched off the shear heating by setting
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_2d/doc/shearheat.part.prm.out}
+\lstinputlisting[language=prmfile]{shearheat.part.prm.out}
 
 Indeed, doing so leads to a model where the heat flux from core to mantle is
 always positive, and where the average temperature strictly drops!

--- a/cookbooks/shell_simple_2d_smoothing/doc/shell_simple_2d_smoothing.tex
+++ b/cookbooks/shell_simple_2d_smoothing/doc/shell_simple_2d_smoothing.tex
@@ -15,17 +15,17 @@ This feature can be turned on by setting the \hyperref[parameters:Discretization
 To show how this can be used in practice, let us consider the simple convection in a quarter of a 2d annulus cookbook in Section \ref{sec:shell-simple-2d}, a radial compositional field was added to help show the advantages of using the artificial viscosity smoothing feature.
 
 By applying the following changes shown below to the parameters of the already existing file \begin{verbatim}cookbooks/shell_simple_2d/shell_simple_2d.prm, \end{verbatim}
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_2d_smoothing/doc/shell_simple_2d_smoothing.part.prm.out}
+\lstinputlisting[language=prmfile]{shell_simple_2d_smoothing.part.prm.out}
 it is possible to produce pictures of the simple convection in a quarter of a 2d annulus such as the ones visualized in
 Figure~\ref{fig:smoothing}.
 
 \begin{figure}
     \centering
   \subfigure[]{
-    \includegraphics[width=.48\textwidth]{cookbooks/shell_simple_2d_smoothing/doc/with_smoothing.png}}
+    \includegraphics[width=.48\textwidth]{with_smoothing.png}}
   ~
   \subfigure[]{
-    \includegraphics[width=.48\textwidth]{cookbooks/shell_simple_2d_smoothing/doc/without_smoothing.png}}
+    \includegraphics[width=.48\textwidth]{without_smoothing.png}}
     \caption{\it Artificial viscosity smoothing: Example of the output of two similar runs.  The run on the left has the artificial viscosity smoothing turned on and the run on the right does not, as described in Section \ref{sec:artificial-viscosity-smoothing}.}
     \label{fig:smoothing}
 \end{figure}

--- a/cookbooks/shell_simple_3d/doc/shell_simple_3d.tex
+++ b/cookbooks/shell_simple_3d/doc/shell_simple_3d.tex
@@ -10,7 +10,7 @@ corresponding movie can be found at \url{http://youtu.be/j63MkEc0RRw}.
 
 \begin{figure}[tb]
 \centering
-\includegraphics[width=0.7\textwidth]{cookbooks/shell_simple_3d/doc/x-movie0700.png}
+\includegraphics[width=0.7\textwidth]{x-movie0700.png}
 \caption{\it Convection in a spherical shell: Snapshot of
 isosurfaces of the temperature field at time $t\approx \num{1.06e9}$ years
 with a quarter of the geometry cut away. The surface shows
@@ -27,7 +27,7 @@ with comments (the full input file can also be found in
 \url{cookbooks/shell_simple_3d/shell_simple_3d.prm}). Let us start from the top where everything
 looks the same except that we set the dimension to 3:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/part1.part.prm.out}
+\lstinputlisting[language=prmfile]{part1.part.prm.out}
 
 The next section concerns the geometry. The geometry model remains unchanged at
 ``spherical shell'' but we omit the opening angle of 90 degrees as we would like
@@ -36,7 +36,7 @@ boundaries (the inner one has indicator zero, the outer one indicator one) and
 consequently these are the only ones we need to list in the ``Boundary velocity model''
 section:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/part2.part.prm.out}
+\lstinputlisting[language=prmfile]{part2.part.prm.out}
 
 Next, since we convinced ourselves that the temperature range from 973 to 4273
 was too large given that we do not take into account adiabatic effects in this
@@ -50,7 +50,7 @@ core mantle boundary than at the surface). What the real value for this
 temperature difference is, is unclear from current research, but it is thought
 to be around 1000 Kelvin, so let us choose these values.
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/part3.part.prm.out}
+\lstinputlisting[language=prmfile]{part3.part.prm.out}
 
 The second component to this is that we found that without adiabatic effects, an
 initial temperature profile that decreases the temperature from the inner to the
@@ -61,14 +61,14 @@ we opt to just assume a constant temperature in the middle between the inner and
 outer temperature boundary values and let the simulation find the exact shape of
 the boundary layers itself:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/part4.part.prm.out}
+\lstinputlisting[language=prmfile]{part4.part.prm.out}
 
 As before, we need to determine how many mesh refinement steps we want. In 3d,
 it is simply not possible to have as much mesh refinement as in 2d, so we choose
 the following values that lead to meshes that have, after an initial transitory
 phase, between 1.5 and 2.2 million cells and 50--75 million unknowns:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/amr.part.prm.out}
+\lstinputlisting[language=prmfile]{amr.part.prm.out}
 
 Second to last, we specify what we want \aspect{} to do with the solutions it
 computes. Here, we compute the same statistics as before, and we again generate
@@ -79,7 +79,7 @@ all of these into a single file to keep file systems reasonably happy. Likewise,
 to accommodate the large amount of data, we output depth averaged fields in VTU
 format since it is easier to visualize:
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{postprocess.part.prm.out}
 
 Finally, we realize that when we run very large parallel computations, nodes go
 down or the scheduler aborts programs because they ran out of time. With
@@ -87,7 +87,7 @@ computations this big, we cannot afford to just lose the results, so we
 checkpoint the computations every 50 time steps and can then resume it at the
 last saved state if necessary (see Section~\ref{sec:checkpoint-restart}):
 
-\lstinputlisting[language=prmfile]{cookbooks/shell_simple_3d/doc/checkpoint.part.prm.out}
+\lstinputlisting[language=prmfile]{checkpoint.part.prm.out}
 
 
 
@@ -133,9 +133,9 @@ TW for the core-mantle boundary, and an estimated heat loss due to cooling of
 the mantle of 7--15 TW (values again taken from Wikipedia).
 
 \begin{figure}
-  \includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_3d/doc/heatflux.png}
+  \includegraphics[width=0.48\textwidth]{heatflux.png}
   \hfill
-  \includegraphics[width=0.48\textwidth]{cookbooks/shell_simple_3d/doc/velocities.png}
+  \includegraphics[width=0.48\textwidth]{velocities.png}
   \caption{\it Evaluating the 3d spherical shell model. Left: Outward heat
   fluxes through the inner and outer boundaries of the shell. Right: Average
   and maximal velocities in the mantle.}

--- a/cookbooks/sinker-with-averaging/doc/sinker-with-averaging.tex
+++ b/cookbooks/sinker-with-averaging/doc/sinker-with-averaging.tex
@@ -71,10 +71,10 @@ one inside and zero outside the sphere, and assigning a compositional dependence
 to the viscosity and density. We run only a single time step for this benchmark.
 This is all modeled in the following input file that can also be found in
 \url{cookbooks/sinker-with-averaging/sinker-with-averaging.prm}:
-\lstinputlisting[language=prmfile]{cookbooks/sinker-with-averaging/doc/full.prm.out}
+\lstinputlisting[language=prmfile]{full.prm.out}
 
 The type of averaging on each cell is chosen using this part of the input file:
-\lstinputlisting[language=prmfile]{cookbooks/sinker-with-averaging/doc/harmonic.prm.out}
+\lstinputlisting[language=prmfile]{harmonic.prm.out}
 For the various different averaging options, and for different levels of mesh
 refinement, Fig.~\ref{fig:sinker-with-averaging-pressure} shows
 pressure plots that illustrate the problem with oscillations of the discrete
@@ -120,17 +120,17 @@ averaging.
 \begin{figure}[htb]
   \centering
   \begin{tabular}{cccccc}
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-none.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-none.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-arithmetic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-arithmetic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-harmonic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-harmonic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-geometric.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-geometric.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-largest.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-largest.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-7-project.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-7-project.png}
     \\
     $[-45.2,45.2]$
     &
@@ -145,17 +145,17 @@ averaging.
     $[-2.77,2.77]$
     \\
     \\
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-none.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-none.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-arithmetic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-arithmetic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-harmonic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-harmonic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-geometric.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-geometric.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-largest.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-largest.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1/sinker-8-project.png}
+    \includegraphics[width=0.14\textwidth]{q2q1/sinker-8-project.png}
     \\
     $[-44.5,44.5]$
     &
@@ -217,7 +217,7 @@ actually allowed for discontinuous pressures. This is in fact possible: We can
 use a finite element in which the pressure space contains piecewise constants
 (see Section~\ref{parameters:Discretization}). To do so, one simply needs to add
 the following piece to the input file:
-\lstinputlisting[language=prmfile]{cookbooks/sinker-with-averaging/doc/conservative.prm.out}
+\lstinputlisting[language=prmfile]{conservative.prm.out}
 Disappointingly, however, this makes no real difference: the pressure
 oscillations are no better (maybe even worse) than for the standard Stokes
 element we use, as shown in
@@ -233,29 +233,29 @@ that the true pressure is in fact discontinuous along the edge of the circle.
 \begin{figure}[htb]
   \centering
   \begin{tabular}{cccccc}
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-none.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-none.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-arithmetic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-arithmetic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-harmonic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-harmonic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-geometric.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-geometric.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-pick-largest.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-pick-largest.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-7-project-to-Q1.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-7-project-to-Q1.png}
     \\
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-none.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-none.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-arithmetic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-arithmetic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-harmonic.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-harmonic.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-geometric.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-geometric.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-pick-largest.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-pick-largest.png}
     &
-    \includegraphics[width=0.14\textwidth]{cookbooks/sinker-with-averaging/doc/q2q1plus/sinker-8-project-to-Q1.png}
+    \includegraphics[width=0.14\textwidth]{q2q1plus/sinker-8-project-to-Q1.png}
   \end{tabular}
   \caption{\it Visualization of the pressure field for the ``sinker''
     problem. Like Fig.~\ref{fig:sinker-with-averaging-pressure} but using the

--- a/cookbooks/steinberger/doc/steinberger.tex
+++ b/cookbooks/steinberger/doc/steinberger.tex
@@ -11,9 +11,9 @@ In addition, this cookbook shows the use of periodic boundary conditions.
 
 \paragraph{Geometry and periodic boundaries.}
 The model setup is a quarter spherical shell with periodic side boundaries. The inner and outer radius are 3481~\si{\km} and 6371~\si{\km}, respectively, so that the mantle is 2900~\si{\km} deep. In the same section of the input file, we also need to specify that the model should have periodic boundaries in angular ($\phi$) direction:
-\lstinputlisting[language=prmfile]{cookbooks/steinberger/doc/geometry.part.prm.out}
+\lstinputlisting[language=prmfile]{geometry.part.prm.out}
 Both the top and bottom boundaries allow for free slip. Because the model has periodic side boundary conditions and free slip boundaries at top and bottom, the amount of rigid-body rotation in $\phi$ direction is not constrained. In other words: There is no unique solution. \aspect{} can remove this nullspace from the model (see Section~\ref{sec:nullspace}). Here, we do this by setting the net rotation to zero:
-\lstinputlisting[language=prmfile]{cookbooks/steinberger/doc/nullspace.part.prm.out}
+\lstinputlisting[language=prmfile]{nullspace.part.prm.out}
 The temperature is fixed to 273~\si{\K} at the top and 3773~\si{\K} at the bottom boundary.
 The initial temperature model consists of an adiabatic profile,
 thermal boundary layers at the surface and the core-mantle boundary, 
@@ -36,7 +36,7 @@ If the look-up table contains thermal expansivity and specific heat without the 
 temperature derivatives of the specific enthalpy (using the approach of \cite{nakagawa2009incorporating}).
 In our case, we simply do not include latent heat at all in our model.
 So the look-up table is computed without latent heat effects, and we set the ``Latent heat'' parameter to \texttt{false}.
-\lstinputlisting[language=prmfile]{cookbooks/steinberger/doc/lookup.part.prm.out}
+\lstinputlisting[language=prmfile]{lookup.part.prm.out}
 In an actual research application, it would be appropriate (and consistent with the projected density approximation, or any other compressible approximation) to compute latent heat instead of neglecting it as we do. This often leads to numerical instabilities that one typically addresses by ensuring that either the resolution is fine enough so that each phase transitions is resolved by several mesh cells,
 or the energy equations needs to be solved for entropy instead of pressure (which is an option available in \aspect{}; in this case, the look-up table needs to be given in terms of entropy and pressure). 
 
@@ -112,8 +112,8 @@ The default data directory already contains two radial viscosity files, one for 
 The file \url{data/material-model/steinberger/radial-visc.txt} is the original Steinberger and Calderwood \cite{stca06} profile (with an interpolation between the original discrete layers) and for use with the laterally averaged temperature. The file \url{data/material-model/steinberger/radial-visc-simple.txt} is for use with the adiabatic profile. To illustrate the difference, the content of both files is plotted in Figure~\ref{fig:steinberger-viscosity}. 
 
 \begin{figure}
-  \includesvg[width=0.48\textwidth]{cookbooks/steinberger/doc/radial-visc.svg}
-  \includesvg[width=0.48\textwidth]{cookbooks/steinberger/doc/radial-visc-simple.svg}
+  \includesvg[width=0.48\textwidth]{radial-visc.svg}
+  \includesvg[width=0.48\textwidth]{radial-visc-simple.svg}
   \caption{\it Left: Viscosity profile based on the original \cite{stca06} formulation, intended for use with a temperature-dependence of viscosity based on the laterally averaged temperature. Right: Modified viscosity profile without boundary layers, intended for use with a temperature-dependence of viscosity based on an adiabatic temperature profile.}
   \label{fig:steinberger-viscosity}
 \end{figure}
@@ -123,7 +123,7 @@ Because of the resolution in this cookbook we limit the lateral viscosity variat
 three orders of magnitude in both directions (for a total of six orders of
 magnitude), and we additionally limit the overall viscosity
 between $10^{20}$~\si{\pascal\second} and $5 \times 10^{23}$~\si{\pascal\second}. This allows the features of the flow field to be resolved. 
-\lstinputlisting[language=prmfile]{cookbooks/steinberger/doc/rheology.part.prm.out}
+\lstinputlisting[language=prmfile]{rheology.part.prm.out}
 In the Earth, we would expect higher viscosities in the lithosphere and 
 lower viscosities in plumes and near the core-mantle boundaries. 
 This type of viscosity formulation is appropriate for global convection models. 
@@ -156,17 +156,17 @@ equation for this field, it only needs to interpolate the density values onto it
 This is covered by the compositional field method `prescribed field'. 
 For fields of this type, the material model provides the values that should be 
 interpolated onto the field.
-\lstinputlisting[language=prmfile]{cookbooks/steinberger/doc/projected_density.part.prm.out}
+\lstinputlisting[language=prmfile]{projected_density.part.prm.out}
 
-The complete input file can be found in \url{cookbooks/steinberger/doc/steinberger.prm}. 
+The complete input file can be found in \url{steinberger.prm}. 
 
 \paragraph{Results.} We run the model for 300 million years. Over the time of the model evolution, some plumes rise and spread beneath the base of the lithosphere, and some cold downwellings detach from the base of the lithosphere. The temperature at the end of the model run and some of the material properties are shown in Figure~\ref{fig:steinberger-end-state}. 
 
 \begin{figure}
-  \includegraphics[width=0.48\textwidth]{cookbooks/steinberger/doc/temperature.png}
-  \includegraphics[width=0.48\textwidth]{cookbooks/steinberger/doc/viscosity.png}
-  \includegraphics[width=0.48\textwidth]{cookbooks/steinberger/doc/density.png}
-  \includegraphics[width=0.48\textwidth]{cookbooks/steinberger/doc/specific_heat.png}
+  \includegraphics[width=0.48\textwidth]{temperature.png}
+  \includegraphics[width=0.48\textwidth]{viscosity.png}
+  \includegraphics[width=0.48\textwidth]{density.png}
+  \includegraphics[width=0.48\textwidth]{specific_heat.png}
   \caption{\it End state of the model. From left to right and top to bottom: Temperature, viscosity, density, and specific heat capacity.}
   \label{fig:steinberger-end-state}
 \end{figure}

--- a/cookbooks/van-keken-vof/doc/van-keken-vof.tex
+++ b/cookbooks/van-keken-vof/doc/van-keken-vof.tex
@@ -22,7 +22,7 @@ in a neighborhood of the interface, rather than in the entire computational doma
 
 \begin{figure}
    \centering
-\includegraphics[width=0.5\textwidth]{cookbooks/van-keken-vof/doc/rms_vel_comparison.png}
+\includegraphics[width=0.5\textwidth]{rms_vel_comparison.png}
    \caption{\it Evolution of the root mean square velocity as a function of time for computations 
     of the van Keken problem made with the VOF interface tracking algorithm with five 
     different global mesh refinements.
@@ -37,7 +37,7 @@ in a neighborhood of the interface, rather than in the entire computational doma
 
 \begin{figure}
     \centering
-    \includegraphics[width=0.4\textwidth]{cookbooks/van-keken-vof/doc/vof_van_keken_refinement_comparison.png}
+    \includegraphics[width=0.4\textwidth]{vof_van_keken_refinement_comparison.png}
     \caption{\it The results of two computations of the van Keken problem made with the VOF 
         interface tracking algorithm overlaid upon each other at $t_\text{end}=2000$.
         This visualization shows the reconstructed boundary between the two
@@ -80,7 +80,7 @@ to more accurately reproduce the initial condition on a sub-grid scale than woul
 possible on the coarser grid on which we compute the time evolution of the interface. 
 
 
-\lstinputlisting[language=prmfile]{cookbooks/van-keken-vof/doc/main.part.prm.out}
+\lstinputlisting[language=prmfile]{main.part.prm.out}
 
 The relevant sections of the parameter file for this type of initialization of the VOF method 
 appears immediately above.
@@ -109,7 +109,7 @@ boundary as a contour are shown immediately below.
 The full configuration file for this version of the benchmark problem can be found at 
 \url{cookbooks/van-keken-vof/van-keken-vof.prm}.
 
-\lstinputlisting[language=prmfile]{cookbooks/van-keken-vof/doc/postprocess.part.prm.out}
+\lstinputlisting[language=prmfile]{postprocess.part.prm.out}
 \noindent
 
 We made a number of computations of the van Keken problem with the VOF method in order to 
@@ -189,11 +189,11 @@ in the initial conditions.
 Specifically, we vary the amplitude $a$ of the cosine function in the initial conditions, as 
 shown below.
 
-\lstinputlisting[language=prmfile]{cookbooks/van-keken-vof/doc/variation.part.prm.out}
+\lstinputlisting[language=prmfile]{variation.part.prm.out}
 
 \begin{figure}[htb]
     \centering
-    \includegraphics[width=0.5\textwidth]{cookbooks/van-keken-vof/doc/init_diff_rms_vel_comparison.png}
+    \includegraphics[width=0.5\textwidth]{init_diff_rms_vel_comparison.png}
     \caption{\it Computations of the van Keken problem made with the VOF
         interface tracking algorithm showing the evolution of the RMS velocity
         as a function of time for small changes in the amplitude $a$ of the

--- a/cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.tex
+++ b/cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.tex
@@ -27,7 +27,7 @@ A trick is needed to make this work: we assign the values of the density to the 
 To do this, We use the phase inputs implemented in the visco plastic plug-in.
 This serves the goal of visualizing values of reference densities of phases with the real density assigned with a constant value in the model.
 Inputs for this material model are listed here:
-\lstinputlisting[language=prmfile]{cookbooks/visualizing_phase_diagram/doc/material_model.prm.out}
+\lstinputlisting[language=prmfile]{material_model.prm.out}
 
 
 \paragraph{Results.}
@@ -42,7 +42,7 @@ The figure for $T = \SI{1173}{K}$ illustrates the buoyancy forces felt by a desc
 
 Next, we shift to harzburgite by changing the values of the initial compositional field from 0 to 1.  % harzburgite
 For this to occur, the following changes are needed:
-\lstinputlisting[language=prmfile]{cookbooks/visualizing_phase_diagram/doc/harzburgite.prm.out}
+\lstinputlisting[language=prmfile]{harzburgite.prm.out}
 With this change, we can also visualize the phase diagram of harzburgite in Figure \ref{fig:phase_diagram_ph_density}.
 
 Moreover, We tested the pyrolitic lookup table used in the Steinberg material model (Figure \ref{fig:phase_diagram_steinberg_density}).% steinberg model
@@ -51,7 +51,7 @@ The densities, however, are not assigned to the heat capacity anymore.
 Thus the vertical axis would deviate from the axis of pressure a little bit.
 This second setup serves the goal of illustrating a more complex and thus more realistic model of phase transitions.
 Modification for the material model is listed below:
-\lstinputlisting[language=prmfile]{cookbooks/visualizing_phase_diagram/doc/steinberg.prm.out}  % add 
+\lstinputlisting[language=prmfile]{steinberg.prm.out}  % add 
 
 Compared to the first example, pyrolitic phases are illustrated on a much finer scale.  % comparison 
 Meanwhile, we can still tell the phase transitions at 410, 520, and $\SI{660}{km}$ depth, respectively, marked by linear boundaries analogous to a constant Clapeyron slope.
@@ -62,7 +62,7 @@ Meanwhile, we can still tell the phase transitions at 410, 520, and $\SI{660}{km
 \begin{figure}
 \phantom.
 \hfill
-\includegraphics[width=0.9\textwidth]{cookbooks/visualizing_phase_diagram/doc/pyrolite_harzburgite.png}
+\includegraphics[width=0.9\textwidth]{pyrolite_harzburgite.png}
 \hfill
 \phantom.
 \caption{\it Visualization of phase diagrams: The field of heat capacity showing values of reference densities for pyrolitic and harzburgitic phases.}
@@ -72,14 +72,14 @@ Meanwhile, we can still tell the phase transitions at 410, 520, and $\SI{660}{km
 %%%%%%%%%% figures2: pyrolite profiles %%%%%%
 \begin{figure}
 \centering
-\includegraphics[width=0.4\textwidth]{cookbooks/visualizing_phase_diagram/doc/pyrolite_linear.png}
+\includegraphics[width=0.4\textwidth]{pyrolite_linear.png}
 \caption{\it Visualization of phase diagrams: Profiles of pyrolitic density at $T=\SI{1173}{K}$ (red) and $\SI{1673}{K}$ (blue).}
 \label{fig:phase_diagram_ph_profile}
 \end{figure}
 %%%%%%%%% figures3: lookup table %%%%%%
 \begin{figure}
 \centering
-\includegraphics[width=0.4\textwidth]{cookbooks/visualizing_phase_diagram/doc/steinberg.png}
+\includegraphics[width=0.4\textwidth]{steinberg.png}
 \caption{\it Visualization of phase diagrams: Density from lookup table of pyrolite from \cite{stixrude2011thermodynamics}.} % cite
 \label{fig:phase_diagram_steinberg_density}
 \end{figure}

--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -11,6 +11,7 @@
 \usepackage{siunitx}
 \usepackage{cite}
 \usepackage{svg}
+\usepackage{newclude}
 
 % This adds space between the Appendix number (e.g., A.101) and the title.
 
@@ -143,7 +144,7 @@ COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
   \begin{textblock*}{0in}(0.0in,0.8in)
     \begin{center}
       \vspace{1em}
-      \includegraphics[width=4.5in]{../logo/unlabeled_logo.pdf}
+      \includesvg[width=4.5in]{../logo/unlabeled_logo.svg}
       \hspace{5em}
     \end{center}
   \end{textblock*}
@@ -4602,7 +4603,7 @@ plugin that allows you to describe this formula in a symbolic way in the input f
 case is this snippet of code discussed in
 Section~\ref{sec:cookbooks-simple-box-3d}:
 %
-\lstinputlisting[language=prmfile]{cookbooks/convection_box_3d/doc/initial.part.prm.out}
+\lstinputlisting[language=prmfile]{../../cookbooks/convection_box_3d/doc/initial.part.prm.out}
 %
 The formulas you can enter here need to use a syntax that is understood by the
 functions and classes that interpret what you write. Internally, this is done
@@ -4862,14 +4863,14 @@ computed at the end of each time step -- affects what you get.}
 \subsection{Simple setups}
 \label{sec:cookbooks-simple}
 
-\input{cookbooks/convection-box/doc/convection-box.tex}
+\include*{cookbooks/convection-box/doc/convection-box.tex}
 
 % cookbooks/convection_box_3d
-\input{cookbooks/convection_box_3d/doc/convection_box_3d.tex}
+\include*{cookbooks/convection_box_3d/doc/convection_box_3d.tex}
 
 
 % cookbooks/platelike-boundary
-\input{cookbooks/platelike-boundary/doc/platelike-boundary.tex}
+\include*{cookbooks/platelike-boundary/doc/platelike-boundary.tex}
 
 
 \subsubsection{Using passive and active compositional fields}
@@ -4899,16 +4900,16 @@ cookbook, we will follow the route of advected fields.
 
 % cookbooks/composition_active/
 
-\input{cookbooks/composition_passive/doc/composition_passive.tex}
+\include*{cookbooks/composition_passive/doc/composition_passive.tex}
 
 
 % cookbooks/composition_active/
 
-\input{cookbooks/composition_active/doc/composition_active.tex}
+\include*{cookbooks/composition_active/doc/composition_active.tex}
 
 
 % cookbooks/composition-reaction
-\input{cookbooks/composition-reaction/doc/composition-reaction.tex}
+\include*{cookbooks/composition-reaction/doc/composition-reaction.tex}
 
 
 \subsubsection{Using particles}
@@ -4935,58 +4936,58 @@ way to go, \aspect{} supports both: using fields and using particles.
 
 % cookbooks/composition_passive_particles/
 
-\input{cookbooks/composition_passive_particles/doc/composition_passive_particles.tex}
+\include*{cookbooks/composition_passive_particles/doc/composition_passive_particles.tex}
 
 
 % cookbooks/composition_active_particles/
 
-\input{cookbooks/composition_active_particles/doc/composition_active_particles.tex}
+\include*{cookbooks/composition_active_particles/doc/composition_active_particles.tex}
 
 
 % cookbooks/free_surface
-\input{cookbooks/free_surface/doc/free_surface.tex}
+\include*{cookbooks/free_surface/doc/free_surface.tex}
 
 
 % cookbooks/free_surface_with_crust
-\input{cookbooks/free_surface_with_crust/doc/free_surface_with_crust.tex}
+\include*{cookbooks/free_surface_with_crust/doc/free_surface_with_crust.tex}
 
 
 % cookbooks/sinker-with-averaging
-\input{cookbooks/sinker-with-averaging/doc/sinker-with-averaging.tex}
+\include*{cookbooks/sinker-with-averaging/doc/sinker-with-averaging.tex}
 
 
 % cookbooks/prescribed_velocity
-\input{cookbooks/prescribed_velocity/doc/prescribed_velocity.tex}
+\include*{cookbooks/prescribed_velocity/doc/prescribed_velocity.tex}
 
 
 % cookbooks/prescribed_velocity_ascii_data
-\input{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.tex}
+\include*{cookbooks/prescribed_velocity_ascii_data/doc/prescribed_velocity_ascii_data.tex}
 
 
 % cookbooks/shell_simple_2d_smoothing
-\input{cookbooks/shell_simple_2d_smoothing/doc/shell_simple_2d_smoothing.tex}
+\include*{cookbooks/shell_simple_2d_smoothing/doc/shell_simple_2d_smoothing.tex}
 
 
 % cookbooks/finite_strain/
-\input{cookbooks/finite_strain/doc/finite_strain.tex}
+\include*{cookbooks/finite_strain/doc/finite_strain.tex}
 
 % cookbooks/geomio
-\input{cookbooks/geomio/doc/geomio.tex}
+\include*{cookbooks/geomio/doc/geomio.tex}
 
 
 % cookbooks/muparser_temperature_example
-\input{cookbooks/muparser_temperature_example/doc/muparser_temperature_example.tex}
+\include*{cookbooks/muparser_temperature_example/doc/muparser_temperature_example.tex}
 
 
-\input{cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.tex}
+\include*{cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.tex}
 
 
 % cookbooks/phase_diagram/
-\input{cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.tex}
+\include*{cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.tex}
 
 
 % cookbooks/plume_2D_chunk
-\input{cookbooks/plume_2D_chunk/doc/plume.tex}
+\include*{cookbooks/plume_2D_chunk/doc/plume.tex}
 
 
 \subsection{Geophysical setups}
@@ -5082,59 +5083,59 @@ asked for, say, the Rayleigh number of a simulation.
 
 
 % cookbooks/shell_simple_2d
-\input{cookbooks/shell_simple_2d/doc/shell_simple_2d.tex}
+\include*{cookbooks/shell_simple_2d/doc/shell_simple_2d.tex}
 
 
 % cookbooks/shell_simple_3d
-\input{cookbooks/shell_simple_3d/doc/shell_simple_3d.tex}
+\include*{cookbooks/shell_simple_3d/doc/shell_simple_3d.tex}
 
 
 % cookbooks/shell_3d_postprocess
-\input{cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.tex}
+\include*{cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.tex}
 
 
 % cookbooks/initial-condition-S20RTS
-\input{cookbooks/initial-condition-S20RTS/doc/initial-condition-S20RTS.tex}
+\include*{cookbooks/initial-condition-S20RTS/doc/initial-condition-S20RTS.tex}
 
 
 % cookbooks/gplates/
-\input{cookbooks/gplates/doc/gplates.tex}
+\include*{cookbooks/gplates/doc/gplates.tex}
 
 
 % cookbooks/burnman/
-\input{../../cookbooks/burnman/doc/burnman.tex}
+\include*{../../cookbooks/burnman/doc/burnman.tex}
 
 
 % cookbooks/steinberger/
-\input{../../cookbooks/steinberger/doc/steinberger.tex}
+\include*{../../cookbooks/steinberger/doc/steinberger.tex}
 
 
 % cookbooks/morency_doin_2004/
-\input{cookbooks/morency_doin_2004/doc/morency_doin_2004.tex}
+\include*{cookbooks/morency_doin_2004/doc/morency_doin_2004.tex}
 
 
 % cookbooks/crustal_deformation
-\input{cookbooks/crustal_deformation/doc/crustal_deformation.tex}
+\include*{cookbooks/crustal_deformation/doc/crustal_deformation.tex}
 
 
 % cookbooks/continental_extension
-\input{cookbooks/continental_extension/doc/continental_extension.tex}
+\include*{cookbooks/continental_extension/doc/continental_extension.tex}
 
 
 % cookbooks/inner_core_convection
-\input{cookbooks/inner_core_convection/doc/inner_core_convection.tex}
+\include*{cookbooks/inner_core_convection/doc/inner_core_convection.tex}
 
 
 % cookbooks/global_melt
-\input{cookbooks/global_melt/doc/global_melt.tex}
+\include*{cookbooks/global_melt/doc/global_melt.tex}
 
 
 % cookbooks/mid_ocean_ridge
-\input{cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.tex}
+\include*{cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.tex}
 
 
 % cookbooks/kinematically_driven_subduction_2d
-\input{cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.tex}
+\include*{cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.tex}
 
 
 \subsection{Benchmarks}
@@ -5225,122 +5226,122 @@ the current directory.
 
 
 % benchmarks/onset-of-convection
-\input{cookbooks/benchmarks/onset-of-convection/doc/onset-of-convection.tex}
+\include*{cookbooks/benchmarks/onset-of-convection/doc/onset-of-convection.tex}
 
 
 % cookbooks/benchamrks/van-keken
-\input{cookbooks/benchmarks/van-keken/doc/van-keken.tex}
+\include*{cookbooks/benchmarks/van-keken/doc/van-keken.tex}
 
 
 % cookbooks/van-keken-vof
-\input{cookbooks/van-keken-vof/doc/van-keken-vof.tex}
+\include*{cookbooks/van-keken-vof/doc/van-keken-vof.tex}
 
 % cookbooks/bunge_et_al_mantle_convection/
-\input{cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.tex}
+\include*{cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.tex}
 
 
 % cookbooks/benchmarks/rayleigh_taylor_instablility
-\input{cookbooks/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.tex}
+\include*{cookbooks/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.tex}
 
 
 % cookbooks/benchmarks/polydiapirs
-\input{cookbooks/benchmarks/polydiapirs/doc/polydiapirs.tex}
+\include*{cookbooks/benchmarks/polydiapirs/doc/polydiapirs.tex}
 
 
 % cookbooks/benchmarks/sinking_block
-\input{cookbooks/benchmarks/sinking_block/doc/sinking_block.tex}
+\include*{cookbooks/benchmarks/sinking_block/doc/sinking_block.tex}
 
 
 % cookbooks/benchmarks/solcx
-\input{cookbooks/benchmarks/solcx/doc/solcx.tex}
+\include*{cookbooks/benchmarks/solcx/doc/solcx.tex}
 
 
 % cookbooks/benchmarks/solkz
-\input{cookbooks/benchmarks/solkz/doc/solkz.tex}
+\include*{cookbooks/benchmarks/solkz/doc/solkz.tex}
 
 
 % cookbooks/benchmarks/inclusion
-\input{cookbooks/benchmarks/inclusion/doc/inclusion.tex}
+\include*{cookbooks/benchmarks/inclusion/doc/inclusion.tex}
 
 
 % cookbooks/benchmarks/burstedde
-\input{cookbooks/benchmarks/burstedde/doc/burstedde.tex}
+\include*{cookbooks/benchmarks/burstedde/doc/burstedde.tex}
 
 
 % cookbooks/benchmarks/slab_detachment
-\input{cookbooks/benchmarks/slab_detachment/doc/slab_detachment.tex}
+\include*{cookbooks/benchmarks/slab_detachment/doc/slab_detachment.tex}
 
 
 % cookbooks/benchmarks/hollow_sphere
-\input{cookbooks/benchmarks/hollow_sphere/doc/hollow_sphere.tex}
+\include*{cookbooks/benchmarks/hollow_sphere/doc/hollow_sphere.tex}
 
 
 % cookbooks/benchmarks/annulus
-\input{cookbooks/benchmarks/annulus/doc/annulus.tex}
+\include*{cookbooks/benchmarks/annulus/doc/annulus.tex}
 
 
 % cookbooks/benchmarks/stokes
-\input{cookbooks/benchmarks/stokes/doc/stokes.tex}
+\include*{cookbooks/benchmarks/stokes/doc/stokes.tex}
 
 
 % cookbooks/benchmarks/viscosity_grooves
-\input{cookbooks/benchmarks/viscosity_grooves/doc/viscosity_grooves.tex}
+\include*{cookbooks/benchmarks/viscosity_grooves/doc/viscosity_grooves.tex}
 
 
 % cookbooks/benchmarks/latent-heat
-\input{cookbooks/benchmarks/latent-heat/doc/latent-heat.tex}
+\include*{cookbooks/benchmarks/latent-heat/doc/latent-heat.tex}
 
 
 % cookbooks/benchmarks/davies_et_al
-\input{cookbooks/benchmarks/davies_et_al/doc/davies_et_al.tex}
+\include*{cookbooks/benchmarks/davies_et_al/doc/davies_et_al.tex}
 
 
 % cookbooks/benchmarks/crameri_et_al
-\input{cookbooks/benchmarks/crameri_et_al/doc/crameri_et_al.tex}
+\include*{cookbooks/benchmarks/crameri_et_al/doc/crameri_et_al.tex}
 
 
 % cookbooks/benchmarks/solitary_wave
-\input{cookbooks/benchmarks/solitary_wave/doc/solitary_wave.tex}
+\include*{cookbooks/benchmarks/solitary_wave/doc/solitary_wave.tex}
 
 
 % cookbooks/benchmarks/operator_splitting
-\input{cookbooks/benchmarks/operator_splitting/doc/operator_splitting.tex}
+\include*{cookbooks/benchmarks/operator_splitting/doc/operator_splitting.tex}
 
 
 % cookbooks/benchmarks/tosi_et_al_2015_gcubed
-\input{cookbooks/benchmarks/tosi_et_al_2015_gcubed/doc/tosi_et_al_2015_gcubed.tex}
+\include*{cookbooks/benchmarks/tosi_et_al_2015_gcubed/doc/tosi_et_al_2015_gcubed.tex}
 
 
 % cookbooks/benchmarks/layeredflow
-\input{cookbooks/benchmarks/layeredflow/doc/layeredflow.tex}
+\include*{cookbooks/benchmarks/layeredflow/doc/layeredflow.tex}
 
 
 % cookbooks/benchmarks/doneahuerta
-\input{cookbooks/benchmarks/doneahuerta/doc/doneahuerta.tex}
+\include*{cookbooks/benchmarks/doneahuerta/doc/doneahuerta.tex}
 
 
 % cookbooks/benchmarks/advection
-\input{cookbooks/benchmarks/advection/doc/advection.tex}
+\include*{cookbooks/benchmarks/advection/doc/advection.tex}
 
 
 % cookbooks/benchmarks/yamauchi_takei_2016_anelasticity
-\input{cookbooks/benchmarks/yamauchi_takei_2016_anelasticity/doc/yamauchi_takei_2016_anelasticity.tex}
+\include*{cookbooks/benchmarks/yamauchi_takei_2016_anelasticity/doc/yamauchi_takei_2016_anelasticity.tex}
 
 
 % cookbooks/benchmarks/gravity_thin_shell
-\input{cookbooks/benchmarks/gravity_thin_shell/doc/gravity_thin_shell.tex}
+\include*{cookbooks/benchmarks/gravity_thin_shell/doc/gravity_thin_shell.tex}
 
 
 % cookbooks/benchmarks/gravity_thick_shell
-\input{cookbooks/benchmarks/gravity_thick_shell/doc/gravity_thick_shell.tex}
+\include*{cookbooks/benchmarks/gravity_thick_shell/doc/gravity_thick_shell.tex}
 
 
 % cookbooks/benchmarks/gravity_mantle
-\input{cookbooks/benchmarks/gravity_mantle/doc/gravity_mantle.tex}
+\include*{cookbooks/benchmarks/gravity_mantle/doc/gravity_mantle.tex}
 
 
 % cookbooks/benchmarks/buiter_et_al_2016_jsg
-\input{cookbooks/benchmarks/buiter_et_al_2016_jsg/doc/buiter_et_al_2016_jsg.tex}
+\include*{cookbooks/benchmarks/buiter_et_al_2016_jsg/doc/buiter_et_al_2016_jsg.tex}
 
 
 \subsection{Setups for teaching}
@@ -5365,13 +5366,13 @@ The course is designed to teach general concepts of geophysics, and it includes 
   \item \nameref{sec:cookbooks-magnetic-stripes} (using the files in \url{cookbooks/magnetic_stripes/})
 \end{enumerate}
 
-\input{cookbooks/convection-box-particles/doc/convection-box-particles.tex}
+\include*{cookbooks/convection-box-particles/doc/convection-box-particles.tex}
 
-\input{cookbooks/heat_flow/doc/heat-flow.tex}
+\include*{cookbooks/heat_flow/doc/heat-flow.tex}
 
-\input{cookbooks/onset_of_convection/doc/onset_of_convection.tex}
+\include*{cookbooks/onset_of_convection/doc/onset_of_convection.tex}
 
-\input{cookbooks/magnetic_stripes/doc/magnetic_stripes.tex}
+\include*{cookbooks/magnetic_stripes/doc/magnetic_stripes.tex}
 
 \section{Extending and contributing to \aspect}
 \label{sec:extending}
@@ -7822,7 +7823,7 @@ of this document. There, each parameter is shown with all references
 to the parameter throughout the entire document.
 
 % now include a file that describes all currently available run-time parameters
-\input{parameters}
+\include*{parameters}
 
 
 \pagebreak


### PR DESCRIPTION
This also allows us to use paths relative to the local .tex files when further including .prm files and pictures. This makes sense because right now, when you're in `cookbooks/ABC/doc/something.tex` and you're trying to include a picture or a .prm file, you have to provide a path *relative to doc/manual* because, well, that's how the latex `\input` command works: It doesn't reset the directory you're in -- it works like the C preprocessor that just pastes text into the main document.

`\include` does set the path to where the included file is, but it has the downside that it also issues a `\clearpage` command, which nobody on the internet seems to think was ever a sensible default. So I use the `\include*` command from the `newclude` package, which does what `\include` does without the `\clearpage`.

All of this makes a bunch of things possible that I'd like to do next when converting the latex manual creation to cmake. In the end, this may not matter much any more, but it's a good testing ground for the rest of the infrastructure as already mentioned in #4656. 

Part of #3652.

/rebuild