### PR TITLE
GitHub linguist language detection overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,13 @@ doc/release-tasklist export-ignore
 doc/update_parameters.sh export-ignore
 Jenkinsfile export-ignore
 .zenodo.json export-ignore
+
+# Documentation shouldn't count as part of the language percentages.
+**/doc/** linguist-documentation
+
+# All of these gnuplot files are generated, and not code. They shouldn't count towards the percent
+tests/**/*.gnuplot linguist-generated
+
+# The world builder code shouldnt' be counted to ASPECT.
+contrib/world_builder/** linguist-vendored
+


### PR DESCRIPTION
*Describe what you did in this PR and why you did it.*
I saw that GitHub found ASPECT to be programmed 81% in Gnuplot, and seaarched to see how that could be updated to reflect that this repository is not primarily written in Gnuplot.

- `**/doc/**` labels files like `benchmark/solcx/doc/solcx.tex` and `cookbooks/finite_strain/doc/finite_strain.cc` as documentation and not code. 
- `tests/**/*.gnuplot` label the test results as generated while leaving gnuplot figure generating scripts with benchmarks and cookbooks as code.
-  `contrib/world_builder/**` becomes labeled as vendored as it shouldn't be considered part of the code make up of ASPECT.
See the guide on other rules that could be added from [Linguist's documentation](https://github.com/github/linguist/blob/master/docs/overrides.md). 
### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.

This is the new report of ASPECT after this is applied.

|percent  |lines    |language        |
|---------|---------|----------------|
|91.55%   |8987905  |   C++          |
|3.24%    |317704   |  CMake         |
|1.61%    |158267   |Jupyter Notebook|
|1.19%    |117076   |Shell           |
|0.80%    |78828    |Python          |
|0.65%    |64098    |Makefile        |
|0.61%    |59807    |Gnuplot         |
|0.18%    |17633    |Sed             | 
|0.06%    |6264     |Dockerfile      |
|0.06%    |5541     |Perl            |
|0.05%    |4703     |MATLAB          |