### PR TITLE
add diffusion viscosity to DislocationViscosityOutputs

### DIFF
--- a/doc/modules/changes/20220523_jdannberg
+++ b/doc/modules/changes/20220523_jdannberg
@@ -1,0 +1,9 @@
+New: The DislocationViscosityOutputs now also contain the
+diffusion viscosity in addition to the dislocation viscosity
+and the boundary area change work fraction. This is useful
+to compute the ratio of diffusion and dislocation creep in 
+cases where the viscosity is averaged cell-wise, because in
+these cases this ratio can not be recovered accurately from
+just the dislocation and effective viscosity.
+<br>
+(Juliane Dannberg, 2022/05/23)

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -56,6 +56,13 @@ namespace aspect
         std::vector<double> dislocation_viscosities;
 
         /**
+         * Diffusion viscosities at the evaluation points passed to
+         * the instance of MaterialModel::Interface::evaluate() that fills
+         * the current object.
+         */
+        std::vector<double> diffusion_viscosities;
+
+        /**
          * This contains the fraction of the deformation work that is
          * converted to surface energy of grains instead of thermal energy.
          * It is used to reduce the shear heating by this fraction. If it

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -42,6 +42,7 @@ namespace aspect
       {
         std::vector<std::string> names;
         names.emplace_back("dislocation_viscosity");
+        names.emplace_back("diffusion_viscosity");
         names.emplace_back("boundary_area_change_work_fraction");
         return names;
       }
@@ -54,6 +55,7 @@ namespace aspect
       :
       NamedAdditionalMaterialOutputs<dim>(make_dislocation_viscosity_outputs_names()),
       dislocation_viscosities(n_points, numbers::signaling_nan<double>()),
+      diffusion_viscosities(n_points, numbers::signaling_nan<double>()),
       boundary_area_change_work_fractions(n_points, numbers::signaling_nan<double>())
     {}
 
@@ -70,6 +72,9 @@ namespace aspect
             return dislocation_viscosities;
 
           case 1:
+            return diffusion_viscosities;
+
+          case 2:
             return boundary_area_change_work_fractions;
 
           default:
@@ -851,7 +856,10 @@ namespace aspect
               out.viscosities[i] = std::min(std::max(min_eta,effective_viscosity),max_eta);
 
               if (DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
-                disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
+                {
+                  disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
+                  disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
+                }
             }
 
           out.densities[i] = density(in.temperature[i], pressure, in.composition[i], in.position[i]);


### PR DESCRIPTION
The DislocationViscosityOutputs now also contain the diffusion viscosity in addition to the dislocation viscosity and the boundary area change work fraction. This is useful to compute the ratio of diffusion and dislocation creep in cases where the viscosity is averaged cell-wise, because in these cases this ratio can not be recovered accurately from just the dislocation and effective viscosity.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
