### PR TITLE
Docs: Remove \texttt from references.bib

### DIFF
--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -317,7 +317,7 @@ Year      = {2002}
 
 @Article{p4est,
   author =       {Burstedde, C. and Wilcox, L. C. and Ghattas, O.},
-  title =        {\texttt{p4est}: {S}calable algorithms for parallel
+  title =        {{p4est}: {S}calable algorithms for parallel
                   adaptive mesh refinement on forests of octrees},
   journal =      {SIAM J. Sci. Comput.},
   year =         {2011},
@@ -2880,7 +2880,7 @@ at a material contact discontinuity},
 @Manual{Metis,
   title =        {METIS: A Family of Multilevel Partitioning Algorithms},
   key =          {metis},
-  address =      {Homepage at \texttt{http://www-users.cs.umn.edu/~karypis/metis/}}
+  address =      {Homepage at {http://www-users.cs.umn.edu/~karypis/metis/}}
 }
 
 @Article{Mil81,
@@ -3634,25 +3634,25 @@ source terms},
 }
 
 @Manual{bangerth:etal:2012,
-  title =        {{\tt deal.{I}{I}} Differential Equations Analysis Library,
+  title =        {{deal.{I}{I}} Differential Equations Analysis Library,
                   Technical Reference},
   author =       {Bangerth, W. and Heister, T. and Kanschat, G.},
   year =         {2012},
-  note =         {\texttt{http://www.dealii.org/}}
+  note =         {{http://www.dealii.org/}}
 }
 
 
 @Manual{deal.ii-publications,
   author =       {Bangerth W. and Kanschat, G.},
-  title =        {Publications based on the {\tt deal.{I}{I}} library},
-  note = {\texttt{http://www.dealii.org/developer/publications/toc.html}}
+  title =        {Publications based on the {deal.{I}{I}} library},
+  note = {{http://www.dealii.org/developer/publications/toc.html}}
 }
 
 
 @TechReport{BK99tr,
   author =       {Bangerth, W. and Kanschat, G.},
   title =        {Concepts for Object-Oriented Finite Element Software -- the
-                  \texttt{deal.II} library},
+                  {deal.II} library},
   institution =  {IWR Heidelberg},
   year =         1999,
   type =         {{P}reprint 99-43 ({SFB} 359)},
@@ -3888,7 +3888,7 @@ in finite element methods},
 
 @TechReport{Ban00mt,
   author =       {Bangerth, W.},
-  title =        {Multi-threading support in \texttt{deal.II}},
+  title =        {Multi-threading support in {deal.II}},
   institution =  SFB,
   year =         2000,
   type =         {{P}reprint},
@@ -4115,9 +4115,9 @@ in finite element methods},
 
 
 @Manual{DEAL,
-  title =        {\texttt{deal.II} Homepage},
+  title =        {{deal.II} Homepage},
   author =       {Bangerth, W. and Kanschat, G.},
-  address =      {{\texttt{http://gaia.iwr.uni-heidelberg.de/\~{}deal/}}}
+  address =      {{{http://gaia.iwr.uni-heidelberg.de/\~{}deal/}}}
 }
 
 
@@ -9533,7 +9533,7 @@ Approximations},
 @Misc{ACE,
   author =       {Douglas C. Schmidt et al.},
   title =        {{W}{W}{W} homepage of the {A}daptive {C}ommunications {E}nvironment {A}{C}{E},
-                  \texttt{http://www.cs.wustl.edu/\~{}schmidt/ACE.html}}
+                  {http://www.cs.wustl.edu/\~{}schmidt/ACE.html}}
 }
 
 @InCollection{BL97,
@@ -9561,7 +9561,7 @@ Approximations},
 @Misc{DEAL1,
   author =       {Roland Becker and Guido Kanschat and Franz-Theo Suttmeier},
   title =        {{DEAL} --- Dif\-fe\-ren\-tial Equa\-tions Ana\-ly\-sis Library},
-  howpublished = {Available via \texttt{http://gaia.iwr.uni-heidelberg.de/DEAL.html}},
+  howpublished = {Available via {http://gaia.iwr.uni-heidelberg.de/DEAL.html}},
   year =         1995
 }
 
@@ -9573,9 +9573,9 @@ Approximations},
 @Misc{FEMLists,
   note =         {Lists of available finite element software can, for example,
                   be found on ``The Object-Oriented Numerics Page''
-                  (\texttt{http://www.oonumerics.org/oon}), or the
+                  ({http://www.oonumerics.org/oon}), or the
                   ``Numerical Analysis \& Associated Fields Resource Guide''
-                  (\texttt{http://www.mathcom.com/nafaq/index.html})},
+                  ({http://www.mathcom.com/nafaq/index.html})},
 }
 
 @Book{LL98,
@@ -9730,7 +9730,7 @@ series = {PPoPP ’05}
 
 @Article{KPSC07,
   author = {B.~Kirk and J.~W.~Peterson and R.~H.~Stogner and G.~F.~Carey},
-  title = {{\texttt{libMesh}: A C++ Library for Parallel Adaptive Mesh
+  title = {{{libMesh}: A C++ Library for Parallel Adaptive Mesh
            Refinement/Coarsening Simulations}},
   journal = {Engineering with Computers},
   volume = {22},
@@ -10643,7 +10643,7 @@ journal = {2007 SPEC Benchmark Workshop}
 
 @MastersThesis{Sch95,
   author =       {Martin Schemann},
-  title =        {Eine adaptive \textsc{Rothe}-{M}ethode f"ur die
+  title =        {Eine adaptive {Rothe}-{M}ethode f"ur die
                   zweidimensionale {W}ellengleichung},
   school =       {Freie Universit"at Berlin, Institut f"ur Mathematik I},
   year =         {1995},
@@ -11463,7 +11463,7 @@ year = {1992}
 }
 
 @misc{aspectmanual,
-  title         = {{\textsc{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
+  title         = {{{ASPECT}: Advanced Solver for Problems in Earth's ConvecTion, User Manual}},
   author        = {Bangerth, Wolfgang and Dannberg, Juliane and Fraters, Menno and Gassmoeller, Rene and Glerum, Anne and Heister, Timo and Naliboff, John},
   year          = {2021},
   month         = {July},
@@ -11657,7 +11657,7 @@ DOI = {10.5194/se-5-1087-2014}
 
 
 @article{gltf18,
-TITLE = {Nonlinear viscoplasticity in \textsc{ASPECT}: benchmarking and applications to subduction},
+TITLE = {Nonlinear viscoplasticity in {ASPECT}: benchmarking and applications to subduction},
  author={A. Glerum and C. Thieulot and M. Fraters and C. Blom and W. Spakman},
  journal={Solid Earth},
  volume={9},


### PR DESCRIPTION
The \texttt and \tt and \textsc tags in references.bib were showing up in our sphinx references page, so I removed them. I don't think these were necessary... right?