### PR TITLE
Fix typo in viscoelastic_beam_modified benchmark

### DIFF
--- a/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
+++ b/benchmarks/viscoelastic_beam_modified/20km_opentopbot.prm
@@ -69,7 +69,7 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function constants  =
-    set Function expression = 0; 0; 0; if ( 180e3>=x && y>=100e3 && y<=210e3, 1, 0)
+    set Function expression = 0; 0; 0; if ( 180e3>=x && y>=100e3 && y<=120e3, 1, 0)
   end
 end
 


### PR DESCRIPTION
*Describe what you did in this PR and why you did it.*
The beam described is supposed to be 9x as long as wide. It is also being described as 20km. Neither of which were true. Switching these numbers fixes that.
## For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
