### PR TITLE
Documentation: Fix missing command?

### DIFF
--- a/doc/sphinx/user/install/docker-container/developing-in-container.md
+++ b/doc/sphinx/user/install/docker-container/developing-in-container.md
@@ -29,6 +29,7 @@ following way:
 mkdir aspect-build
 cd aspect-build
 cmake -DCMAKE_BUILD_TYPE=Debug -DDEAL_II_DIR=$HOME/deal.II-install $HOME/aspect
+make
 ./aspect $HOME/aspect/cookbooks/shell_simple_2d/shell_simple_2d.prm
 ```
 


### PR DESCRIPTION
I *think* that the list of commands in this section is missing the call to `make`. 

/rebuild