### PR TITLE
Relax particle limiter tolerance a bit

### DIFF
--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -250,9 +250,10 @@ namespace aspect
                       }
                     if (use_linear_least_squares_limiter[property_index] == true)
                       {
-                        // If the limiter is working correctly, we should not be significantly more than machine error outside of the range of the property bounds
-                        Assert(interpolated_value >= property_minimums[property_index] - std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])) * 10. * std::numeric_limits<double>::epsilon(), ExcInternalError());
-                        Assert(interpolated_value <= property_maximums[property_index] + std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])) * 10. * std::numeric_limits<double>::epsilon(), ExcInternalError());
+                        // Assert that the limiter was reasonably effective. We can not expect perfect accuracy
+                        // due to inaccuracies e.g. in the inversion of the mapping.
+                        Assert(interpolated_value >= property_minimums[property_index] - 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
+                        Assert(interpolated_value <= property_maximums[property_index] + 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
                         interpolated_value = std::min(interpolated_value, property_maximums[property_index]);
                         interpolated_value = std::max(interpolated_value, property_minimums[property_index]);
                       }

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -519,8 +519,10 @@ namespace aspect
                     // Overshoot and undershoot correction of interpolated particle property.
                     if (use_quadratic_least_squares_limiter[property_index])
                       {
-                        Assert(interpolated_value >= property_minimums[property_index] - std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])) * 10. * std::numeric_limits<double>::epsilon(), ExcInternalError());
-                        Assert(interpolated_value <= property_maximums[property_index] + std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])) * 10. * std::numeric_limits<double>::epsilon(), ExcInternalError());
+                        // Assert that the limiter was reasonably effective. We can not expect perfect accuracy
+                        // due to inaccuracies e.g. in the inversion of the mapping.
+                        Assert(interpolated_value >= property_minimums[property_index] - 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
+                        Assert(interpolated_value <= property_maximums[property_index] + 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
                         // This chopping is done to avoid values that are just outside
                         // of the limiting bounds.
                         interpolated_value = std::min(interpolated_value, property_maximums[property_index]);


### PR DESCRIPTION
At the moment we assert a very strict tolerance for the new particle limiters (10 epsilon relative to the property boundaries). This works for mappings that are analytically invertible like all of our box geometries and the 2D MappingQ for spherical shells, but at least in 3D MappingQ spherical shell geometries I have observed cases for which we trigger this assert. The MappingQ inversion internally uses a Newton iteration with a tolerance of 1e-12 so we can not expect an accuracy as good as we currently enforce. So far  1e-9 seems to be a good tolerance, at least I have never triggered this so far in my models, which proves the algorithm works as intended, it just cannot be as accurate as we thought due inaccuracies outside of the algorithms control.

@sac-bsa FYI.


