### PR TITLE
Ascii data velocity boundary conditions for the chunk_with_lithosphere_boundary_indicators geometry model

### DIFF
--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -26,6 +26,7 @@
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/initial_topography_model/ascii_data.h>
+#include <aspect/geometry_model/two_merged_chunks.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -719,6 +720,7 @@ namespace aspect
     {
       AssertThrow ((Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()))
+                   || (Plugins::plugin_type_matches<const GeometryModel::TwoMergedChunks<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model())),
@@ -796,7 +798,7 @@ namespace aspect
       switch (dim)
         {
           case 2:
-            if ((boundary_id == 2) || (boundary_id == 3))
+            if ((boundary_id == 2) || (boundary_id == 3) || (boundary_id == 4) || (boundary_id == 5))
               {
                 boundary_dimensions[0] = 0;
               }
@@ -809,11 +811,10 @@ namespace aspect
                 boundary_dimensions[0] = numbers::invalid_unsigned_int;
                 AssertThrow(false,ExcNotImplemented());
               }
-
             break;
 
           case 3:
-            if ((boundary_id == 4) || (boundary_id == 5))
+            if ((boundary_id == 4) || (boundary_id == 5) || (boundary_id == 8) || (boundary_id == 9))
               {
                 boundary_dimensions[0] = 0;
                 boundary_dimensions[1] = 1;
@@ -823,7 +824,7 @@ namespace aspect
                 boundary_dimensions[0] = 1;
                 boundary_dimensions[1] = 2;
               }
-            else if ((boundary_id == 2) || (boundary_id == 3))
+            else if ((boundary_id == 2) || (boundary_id == 3) || (boundary_id == 6) || (boundary_id == 7))
               {
                 boundary_dimensions[0] = 0;
                 boundary_dimensions[1] = 2;
@@ -1214,6 +1215,7 @@ namespace aspect
     {
       AssertThrow ((Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model()) ||
                     Plugins::plugin_type_matches<GeometryModel::Chunk<dim>>(this->get_geometry_model()) ||
+                    Plugins::plugin_type_matches<GeometryModel::TwoMergedChunks<dim>>(this->get_geometry_model()) ||
                     Plugins::plugin_type_matches<GeometryModel::Sphere<dim>>(this->get_geometry_model()) ||
                     Plugins::plugin_type_matches<GeometryModel::Box<dim>>(this->get_geometry_model())) ||
                    Plugins::plugin_type_matches<GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()),
@@ -1383,6 +1385,7 @@ namespace aspect
     {
       AssertThrow ((Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()))
+                   || (Plugins::plugin_type_matches<const GeometryModel::TwoMergedChunks<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
                    || (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model())),


### PR DESCRIPTION
Recently, the two_merged_chunks geometry model was added to ASPECT. Unfortunately the ascii data function is not compatible with the two_merged_chunks geometry model in the current version of ASPECT. As I needed this for my research, @anne-glerum helped me some time ago to fix this by sending me the modifications that are incorporated in this pull request. 

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

