### PR TITLE
Add 9.4 quick tester.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -110,7 +110,14 @@ jobs:
     #linux build including tests
     name: tests
     runs-on: [ubuntu-latest]
-    container: geodynamics/aspect-tester:focal-dealii-9.3-v2
+    strategy:
+      matrix:
+        include:
+          - image: "geodynamics/aspect-tester:focal-dealii-9.3-v2"
+            tests: "ON"
+          - image: "geodynamics/aspect-tester:focal-dealii-9.4-v1"
+            tests: "OFF"
+    container: ${{ matrix.image }}
 
     steps:
     - uses: actions/checkout@v2
@@ -125,7 +132,7 @@ jobs:
         -D ASPECT_TEST_GENERATOR='Ninja' \
         -D ASPECT_PRECOMPILE_HEADERS=ON \
         -D ASPECT_UNITY_BUILD=ON \
-        -D ASPECT_RUN_ALL_TESTS='ON' \
+        -D ASPECT_RUN_ALL_TESTS='${{ matrix.tests }}' \
         ..
         ninja
         ./aspect --test


### PR DESCRIPTION
This PR adds an additional tester that compiles ASPECT against deal.II v9.4.0-rc2 (in a docker image I created) and runs the quick tests (we already compile against deal.II master in a separate tester). 

The nice thing about this design is that when we want to transition to 9.4 reference results, we can simply update the test results, and switch the 'ON' and 'OFF' settings below and continue to test if 9.3 still compiles.