### PR TITLE
GMG: Compute no normal flux constraints on levels (WIP)

### DIFF
--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -56,6 +56,65 @@ namespace aspect
   {
     namespace TangentialBoundaryFunctions
     {
+      /**
+       * A structure that stores the dim DoF indices that correspond to a
+       * vector-valued quantity at a single support point.
+       */
+      template <int dim>
+      struct VectorDoFTuple
+      {
+        types::global_dof_index dof_indices[dim];
+
+        VectorDoFTuple()
+        {
+          for (unsigned int i = 0; i < dim; ++i)
+            dof_indices[i] = numbers::invalid_dof_index;
+        }
+        VectorDoFTuple(std::array<types::global_dof_index,dim> dof_ids)
+        {
+          for (unsigned int i = 0; i < dim; ++i)
+            dof_indices[i] = dof_ids[i];
+        }
+
+
+        bool
+        operator<(const VectorDoFTuple<dim> &other) const
+        {
+          for (unsigned int i = 0; i < dim; ++i)
+            if (dof_indices[i] < other.dof_indices[i])
+              return true;
+            else if (dof_indices[i] > other.dof_indices[i])
+              return false;
+          return false;
+        }
+
+        bool
+        operator==(const VectorDoFTuple<dim> &other) const
+        {
+          for (unsigned int i = 0; i < dim; ++i)
+            if (dof_indices[i] != other.dof_indices[i])
+              return false;
+
+          return true;
+        }
+
+        bool
+        operator!=(const VectorDoFTuple<dim> &other) const
+        {
+          return !(*this == other);
+        }
+      };
+
+
+      template <int dim>
+      std::ostream &
+      operator<<(std::ostream &out, const VectorDoFTuple<dim> &vdt)
+      {
+        for (unsigned int d = 0; d < dim; ++d)
+          out << vdt.dof_indices[d] << (d < dim - 1 ? " " : "");
+        return out;
+      }
+
 
       template <int dim>
       void compute_no_normal_flux_constraints_box (const DoFHandler<dim>    &dof,
@@ -69,6 +128,14 @@ namespace aspect
                      AffineConstraints<double> &constraints,
                      const double inhomogeneity = 0);
 
+      template <int dim>
+      void
+      add_tangentiality_constraints(
+        const VectorDoFTuple<dim> &dof_indices,
+        const Tensor<1, dim>      &tangent_vector,
+        AffineConstraints<double> &constraints,
+        const Vector<double>      &b_values = Vector<double>(dim));
+
       template <int dim, int spacedim>
       void compute_no_normal_flux_constraints_shell(const DoFHandler<dim,spacedim> &dof_handler,
                                                     const MGConstrainedDoFs        &mg_constrained_dofs,
@@ -77,6 +144,15 @@ namespace aspect
                                                     const unsigned int first_vector_component,
                                                     const std::set<types::boundary_id> &boundary_ids,
                                                     AffineConstraints<double> &constraints);
+
+      template <int dim, int spacedim>
+      void compute_no_normal_flux_constraints_on_level(const DoFHandler<dim, spacedim> &dof_handler,
+                                                       const MGConstrainedDoFs &mg_constrained_dofs,
+                                                       const Mapping<dim> &mapping,
+                                                       const unsigned int level,
+                                                       const unsigned int first_vector_component,
+                                                       const std::set<types::boundary_id> &boundary_ids,
+                                                       AffineConstraints<double> &constraints);
     }
 
     /**

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1059,14 +1059,22 @@ namespace aspect
             {
               AffineConstraints<double> user_level_constraints;
               user_level_constraints.reinit(relevant_dofs);
-
-              internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_shell(mesh_deformation_dof_handler,
-                                                                                              mg_constrained_dofs,
-                                                                                              mapping,
-                                                                                              level,
-                                                                                              0,
-                                                                                              no_flux_boundary,
-                                                                                              user_level_constraints);
+              if (no_flux_boundary.size() == 1)
+                internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_shell(mesh_deformation_dof_handler,
+                                                                                                mg_constrained_dofs,
+                                                                                                mapping,
+                                                                                                level,
+                                                                                                0,
+                                                                                                no_flux_boundary,
+                                                                                                user_level_constraints);
+              else
+                internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_on_level(mesh_deformation_dof_handler,
+                    mg_constrained_dofs,
+                    mapping,
+                    level,
+                    0,
+                    no_flux_boundary,
+                    user_level_constraints);
               user_level_constraints.close();
               mg_constrained_dofs.add_user_constraints(level,user_level_constraints);
 

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -224,6 +224,73 @@ namespace aspect
       }
 
 
+      /**
+       * Add the constraint $(\vec u-\vec u_\Gamma) \| \vec t$ to the list of
+       * constraints. In 2d, this is a single constraint, in 3d these are two
+       * constraints.
+       *
+       * Here, $\vec u$ is represented by the set of given DoF indices, and
+       * $\vec t$ by the vector specified as the second argument.
+       *
+       * The function does not add constraints if a degree of freedom is already
+       * constrained in the constraints object.
+       */
+      template <int dim>
+      void
+      add_tangentiality_constraints(
+        const VectorDoFTuple<dim> &dof_indices,
+        const Tensor<1, dim>      &tangent_vector,
+        AffineConstraints<double> &constraints,
+        const Vector<double>      &b_values)
+      {
+        // choose the DoF that has the
+        // largest component in the
+        // tangent_vector as the
+        // independent component, and
+        // then constrain the others to
+        // it. specifically, if, say,
+        // component 0 of the tangent
+        // vector t is largest by
+        // magnitude, then
+        // x1=(b[1]*t[0]-b[0]*t[1])/t[0]+t[1]/t[0]*x_0, etc.
+        unsigned int largest_component = 0;
+        for (unsigned int d = 1; d < dim; ++d)
+          if (std::fabs(tangent_vector[d]) >
+              std::fabs(tangent_vector[largest_component]) + 1e-10)
+            largest_component = d;
+
+        // then constrain all of the
+        // other degrees of freedom in
+        // terms of the one just found
+        for (unsigned int d = 0; d < dim; ++d)
+          if (d != largest_component)
+            if (!constraints.is_constrained(dof_indices.dof_indices[d]) &&
+                constraints.can_store_line(dof_indices.dof_indices[d]))
+              {
+                constraints.add_line(dof_indices.dof_indices[d]);
+
+                if (std::fabs(tangent_vector[d] /
+                              tangent_vector[largest_component]) >
+                    std::numeric_limits<double>::epsilon())
+                  constraints.add_entry(
+                    dof_indices.dof_indices[d],
+                    dof_indices.dof_indices[largest_component],
+                    tangent_vector[d] / tangent_vector[largest_component]);
+
+                const double inhomogeneity =
+                  (b_values(d) * tangent_vector[largest_component] -
+                   b_values(largest_component) * tangent_vector[d]) /
+                  tangent_vector[largest_component];
+
+                if (std::fabs(inhomogeneity) >
+                    std::numeric_limits<double>::epsilon())
+                  constraints.set_inhomogeneity(dof_indices.dof_indices[d],
+                                                inhomogeneity);
+              }
+      }
+
+
+
       template <int dim, int spacedim>
       void compute_no_normal_flux_constraints_shell(const DoFHandler<dim,spacedim> &dof_handler,
                                                     const MGConstrainedDoFs        &mg_constrained_dofs,
@@ -302,6 +369,436 @@ namespace aspect
                           add_constraint<dim>(dof_indices, normal_vector, constraints, 0.0);
                         }
                 }
+      }
+
+      template <int dim, int spacedim>
+      void compute_no_normal_flux_constraints_on_level(const DoFHandler<dim, spacedim> &dof_handler,
+                                                       const MGConstrainedDoFs &mg_constrained_dofs,
+                                                       const Mapping<dim> &mapping,
+                                                       const unsigned int level,
+                                                       const unsigned int first_vector_component,
+                                                       const std::set<types::boundary_id> &boundary_ids,
+                                                       AffineConstraints<double> &constraints)
+      {
+        // TODO: This is a simplification of compute_no_normal_flux_constraints() from deal.II.
+        // The differences are:
+        // - It works on a specific level so we can ignore hanging nodes
+        // - We use the normal vector given by the manifold (instead of averaging surface vectors)
+        //
+        // This should go into deal.II at some point, but it is too specific right now.
+
+        // three cases:
+        // 1. one manifold normal vector for each vector dofs, compute_no_normal_flux_constraints_shell
+        // 2. dim manifold normal vector for each vector dofs, set each components to zero
+        // 3. dim -1 = 2 manifold normal vector for each vector dofs (dim = 3), v*n1 = 0, v*n2 = 0
+
+        const IndexSet &refinement_edge_indices = mg_constrained_dofs.get_refinement_edge_indices(level);
+
+        const auto &fe = dof_handler.get_fe();
+        const std::vector<Point<dim - 1>> &unit_support_points = fe.get_unit_face_support_points();
+        const Quadrature<dim - 1> quadrature(unit_support_points);
+        const unsigned int dofs_per_face = fe.dofs_per_face;
+        std::vector<types::global_dof_index> face_dofs(dofs_per_face);
+
+
+        FEFaceValues<dim, spacedim> fe_face_values(mapping,
+                                                   fe,
+                                                   quadrature,
+                                                   update_quadrature_points |
+                                                   update_normal_vectors);
+
+        std::set<types::boundary_id>::iterator b_id;
+        using DoFToNormalsMap = std::multimap<
+                                VectorDoFTuple<dim>,
+                                std::pair<Tensor<1, dim>,
+                                typename DoFHandler<dim, spacedim>::cell_iterator>>;
+        DoFToNormalsMap dof_to_normals_map;
+        for (const auto &cell : dof_handler.cell_iterators_on_level(level))
+          if (cell->level_subdomain_id() != numbers::artificial_subdomain_id
+              &&
+              cell->level_subdomain_id() != numbers::invalid_subdomain_id)
+            for (const unsigned int face_no : cell->face_indices())
+              if ((b_id = boundary_ids.find(cell->face(face_no)->boundary_id())) !=
+                  boundary_ids.end())
+                {
+                  typename DoFHandler<dim, spacedim>::level_face_iterator face = cell->face(face_no);
+                  face->get_mg_dof_indices(level, face_dofs);
+                  fe_face_values.reinit(cell, face_no);
+
+                  for (unsigned int i = 0; i < face_dofs.size(); ++i)
+                    if (fe.face_system_to_component_index(i).first ==
+                        first_vector_component)
+                      // Refinement edge indices are going to be constrained to 0 during a
+                      // multigrid cycle and do not need no-normal-flux constraints, so skip them:
+                      if (!refinement_edge_indices.is_element(face_dofs[i]))
+                        {
+                          const Point<dim> position = fe_face_values.quadrature_point(i);
+                          std::array<types::global_dof_index,dim> dof_indices;
+                          dof_indices[0] = face_dofs[i];
+                          for (unsigned int k = 0; k < dofs_per_face; ++k)
+                            if ((k != i) &&
+                                (quadrature.point(k) == quadrature.point(i)) &&
+                                (fe.face_system_to_component_index(k).first >=
+                                 first_vector_component) &&
+                                (fe.face_system_to_component_index(k).first <
+                                 first_vector_component + dim))
+                              dof_indices
+                              [fe.face_system_to_component_index(k).first -
+                               first_vector_component] = face_dofs[k];
+
+                          Tensor<1, dim> normal_vector =
+                            cell->face(face_no)->get_manifold().normal_vector(
+                              cell->face(face_no), position);
+
+                          // remove small entries:
+                          for (unsigned int d = 0; d < dim; ++d)
+                            if (std::fabs(normal_vector[d]) < 1e-13)
+                              normal_vector[d] = 0;
+                          normal_vector /= normal_vector.norm();
+
+                          dof_to_normals_map.insert(
+                            std::make_pair(
+                              VectorDoFTuple<dim>(dof_indices),
+                              std::make_pair(normal_vector, cell)));
+#ifdef DEBUG_NO_NORMAL_FLUX
+                          std::cout << "Adding normal vector:" << std::endl
+                                    << "   dofs=" << dof_indices << std::endl
+                                    << "   cell=" << cell << " at " << cell->center()
+                                    << std::endl
+                                    << "   normal=" << normal_vector << std::endl;
+#endif
+
+
+
+                        }
+                }
+        // Now do something with the collected information. To this end, loop
+        // through all sets of pairs (dofs,normal_vector) and identify which
+        // entries belong to the same set of dofs and then do as described in the
+        // documentation, i.e. either average the normal vector or don't for this
+        // particular set of dofs
+        typename DoFToNormalsMap::const_iterator p = dof_to_normals_map.begin();
+
+        while (p != dof_to_normals_map.end())
+          {
+            // first find the range of entries in the multimap that corresponds to
+            // the same vector-dof tuple. as usual, we define the range
+            // half-open. the first entry of course is 'p'
+            typename DoFToNormalsMap::const_iterator same_dof_range[2] = {p};
+            for (++p; p != dof_to_normals_map.end(); ++p)
+              if (p->first != same_dof_range[0]->first)
+                {
+                  same_dof_range[1] = p;
+                  break;
+                }
+            if (p == dof_to_normals_map.end())
+              same_dof_range[1] = dof_to_normals_map.end();
+
+#ifdef DEBUG_NO_NORMAL_FLUX
+            std::cout << "For dof indices <" << p->first
+                      << ">, found the following normals" << std::endl;
+            for (typename DoFToNormalsMap::const_iterator q = same_dof_range[0];
+                 q != same_dof_range[1];
+                 ++q)
+              std::cout << "   " << q->second.first << " from cell "
+                        << q->second.second << std::endl;
+#endif
+
+
+            // now compute the reverse mapping: for each of the cells that
+            // contributed to the current set of vector dofs, add up the normal
+            // vectors. the values of the map are pairs of normal vectors and
+            // number of cells that have contributed
+            using CellToNormalsMap =
+              std::map<typename DoFHandler<dim, spacedim>::cell_iterator,
+              std::pair<Tensor<1, dim>, unsigned int>>;
+
+            CellToNormalsMap cell_to_normals_map;
+            for (typename DoFToNormalsMap::const_iterator q = same_dof_range[0];
+                 q != same_dof_range[1];
+                 ++q)
+              if (cell_to_normals_map.find(q->second.second) ==
+                  cell_to_normals_map.end())
+                cell_to_normals_map[q->second.second] =
+                  std::make_pair(q->second.first, 1U);
+              else
+                {
+                  const Tensor<1, dim> old_normal =
+                    cell_to_normals_map[q->second.second].first;
+                  const unsigned int old_count =
+                    cell_to_normals_map[q->second.second].second;
+
+                  Assert(old_count > 0, ExcInternalError());
+
+                  // in the same entry, store again the now averaged normal vector
+                  // and the new count
+                  cell_to_normals_map[q->second.second] =
+                    std::make_pair((old_normal * old_count + q->second.first) /
+                                   (old_count + 1),
+                                   old_count + 1);
+                }
+            Assert(cell_to_normals_map.size() >= 1, ExcInternalError());
+
+#ifdef DEBUG_NO_NORMAL_FLUX
+            std::cout << "   cell_to_normals_map:" << std::endl;
+            for (typename CellToNormalsMap::const_iterator x =
+                   cell_to_normals_map.begin();
+                 x != cell_to_normals_map.end();
+                 ++x)
+              std::cout << "      " << x->first << " -> (" << x->second.first << ','
+                        << x->second.second << ')' << std::endl;
+#endif
+
+            // count the maximum number of contributions from each cell
+            unsigned int max_n_contributions_per_cell = 1;
+            for (typename CellToNormalsMap::const_iterator x =
+                   cell_to_normals_map.begin();
+                 x != cell_to_normals_map.end();
+                 ++x)
+              max_n_contributions_per_cell =
+                std::max(max_n_contributions_per_cell, x->second.second);
+
+            // verify that each cell can have only contributed at most dim times,
+            // since that is the maximum number of faces that come together at a
+            // single place
+            Assert(max_n_contributions_per_cell <= dim, ExcInternalError());
+
+            switch (max_n_contributions_per_cell)
+              {
+                case 1:
+                {
+                  // compute the average normal vector from all the ones that
+                  // have the same set of dofs. we could add them up and divide
+                  // them by the number of additions, or simply normalize them
+                  // right away since we want them to have unit length anyway
+                  Tensor<1, dim> normal;
+                  for (typename CellToNormalsMap::const_iterator x =
+                         cell_to_normals_map.begin();
+                       x != cell_to_normals_map.end();
+                       ++x)
+                    normal += x->second.first;
+                  normal /= normal.norm();
+
+                  // normalize again
+                  for (unsigned int d = 0; d < dim; ++d)
+                    if (std::fabs(normal[d]) < 1e-13)
+                      normal[d] = 0;
+                  normal /= normal.norm();
+
+                  const auto &dof_indices_tuple =
+                    same_dof_range[0]->first;
+                  std::array<types::global_dof_index,dim> dof_indices;
+                  for (unsigned int d=0; d<dim; ++d)
+                    dof_indices[d] = dof_indices_tuple.dof_indices[d];
+                  add_constraint<dim> (dof_indices,
+                                       normal,
+                                       constraints,
+                                       0.0);
+
+                  break;
+                }
+
+                case dim:
+                {
+                  // assert that indeed only a single cell has contributed
+                  Assert(cell_to_normals_map.size() == 1, ExcInternalError());
+
+                  // check linear independence by computing the determinant of
+                  // the matrix created from all the normal vectors. if they are
+                  // linearly independent, then the determinant is nonzero. if
+                  // they are orthogonal, then the matrix is in fact equal to 1
+                  // (since they are all unit vectors); make sure the
+                  // determinant is larger than 1e-3 to avoid cases where cells
+                  // are degenerate
+                  {
+                    Tensor<2, dim> t;
+
+                    typename DoFToNormalsMap::const_iterator x =
+                      same_dof_range[0];
+                    for (unsigned int i = 0; i < dim; ++i, ++x)
+                      for (unsigned int j = 0; j < dim; ++j)
+                        t[i][j] = x->second.first[j];
+
+                    Assert(
+                      std::fabs(determinant(t)) > 1e-3,
+                      ExcMessage(
+                        "Found a set of normal vectors that are nearly collinear."));
+                  }
+
+                  // so all components of this vector dof are constrained. enter
+                  // this into the AffineConstraints object
+                  //
+                  // ignore dofs already constrained
+                  const auto &dof_indices =
+                    same_dof_range[0]->first;
+
+                  for (unsigned int i = 0; i < dim; ++i)
+                    if (!constraints.is_constrained(
+                          same_dof_range[0]->first.dof_indices[i]) &&
+                        constraints.can_store_line(
+                          same_dof_range[0]->first.dof_indices[i]))
+                      {
+                        const types::global_dof_index line =
+                          dof_indices.dof_indices[i];
+                        constraints.add_line(line);
+                      }
+
+                  break;
+                }
+
+                // this is the case of an edge contribution in 3d, i.e. the vector
+                // is constrained in two directions but not the third.
+                default:
+                {
+                  Assert(dim >= 3, ExcNotImplemented());
+                  Assert(max_n_contributions_per_cell == 2, ExcInternalError());
+
+                  // as described in the documentation, let us first collect
+                  // what each of the cells contributed at the current point. we
+                  // use a std::list instead of a std::set (which would be more
+                  // natural) because std::set requires that the stored elements
+                  // are comparable with operator<
+                  using CellContributions = std::map<
+                                            typename DoFHandler<dim, spacedim>::cell_iterator,
+                                            std::list<Tensor<1, dim>>>;
+                  CellContributions cell_contributions;
+
+                  for (typename DoFToNormalsMap::const_iterator q =
+                         same_dof_range[0];
+                       q != same_dof_range[1];
+                       ++q)
+                    cell_contributions[q->second.second].push_back(
+                      q->second.first);
+                  Assert(cell_contributions.size() >= 1, ExcInternalError());
+
+                  // now for each cell that has contributed determine the number
+                  // of normal vectors it has contributed. we currently only
+                  // implement if this is dim-1 for all cells (if a single cell
+                  // has contributed dim, or if all adjacent cells have
+                  // contributed 1 normal vector, this is already handled
+                  // above).
+                  //
+                  // we only implement the case that all cells contribute
+                  // dim-1 because we assume that we are following an edge
+                  // of the domain (think: we are looking at a vertex
+                  // located on one of the edges of a refined cube where the
+                  // boundary indicators of the two adjacent faces of the
+                  // cube are both listed in the set of boundary indicators
+                  // passed to this function). in that case, all cells along
+                  // that edge of the domain are assumed to have contributed
+                  // dim-1 normal vectors. however, there are cases where
+                  // this assumption is not justified (see the lengthy
+                  // explanation in test no_flux_12.cc) and in those cases
+                  // we simply ignore the cell that contributes only
+                  // once. this is also discussed at length in the
+                  // documentation of this function.
+                  //
+                  // for each contributing cell compute the tangential vector
+                  // that remains unconstrained
+                  std::list<Tensor<1, dim>> tangential_vectors;
+                  for (typename CellContributions::const_iterator contribution =
+                         cell_contributions.begin();
+                       contribution != cell_contributions.end();
+                       ++contribution)
+                    {
+#ifdef DEBUG_NO_NORMAL_FLUX
+                      std::cout
+                          << "   Treating edge case with dim-1 contributions."
+                          << std::endl
+                          << "   Looking at cell " << contribution->first
+                          << " which has contributed these normal vectors:"
+                          << std::endl;
+                      for (typename std::list<Tensor<1, dim>>::const_iterator t =
+                             contribution->second.begin();
+                           t != contribution->second.end();
+                           ++t)
+                        std::cout << "      " << *t << std::endl;
+#endif
+
+                      // as mentioned above, simply ignore cells that only
+                      // contribute once
+                      if (contribution->second.size() < dim - 1)
+                        continue;
+
+                      Tensor<1, dim> normals[dim - 1];
+                      {
+                        unsigned int index = 0;
+                        for (typename std::list<Tensor<1, dim>>::const_iterator
+                             t = contribution->second.begin();
+                             t != contribution->second.end();
+                             ++t, ++index)
+                          normals[index] = *t;
+                        Assert(index == dim - 1, ExcInternalError());
+                      }
+
+                      // calculate the tangent as the outer product of the
+                      // normal vectors. since these vectors do not need to be
+                      // orthogonal (think, for example, the case of the
+                      // deal.II/no_flux_07 test: a sheared cube in 3d, with Q2
+                      // elements, where we have constraints from the two normal
+                      // vectors of two faces of the sheared cube that are not
+                      // perpendicular to each other), we have to normalize the
+                      // outer product
+                      Tensor<1, dim> tangent;
+                      switch (dim)
+                        {
+                          case 3:
+                            // take cross product between normals[0] and
+                            // normals[1]. write it in the current form (with
+                            // [dim-2]) to make sure that compilers don't warn
+                            // about out-of-bounds accesses -- the warnings are
+                            // bogus since we get here only for dim==3, but at
+                            // least one isn't quite smart enough to notice this
+                            // and warns when compiling the function in 2d
+                            tangent =
+                              cross_product_3d(normals[0], normals[dim - 2]);
+                            break;
+                          default:
+                            Assert(false, ExcNotImplemented());
+                        }
+
+                      Assert(
+                        std::fabs(tangent.norm()) > 1e-12,
+                        ExcMessage(
+                          "Two normal vectors from adjacent faces are almost "
+                          "parallel."));
+                      tangent /= tangent.norm();
+
+                      tangential_vectors.push_back(tangent);
+                    }
+
+                  // go through the list of tangents and make sure that they all
+                  // roughly point in the same direction as the first one (i.e.
+                  // have an angle less than 90 degrees); if they don't then
+                  // flip their sign
+                  {
+                    const Tensor<1, dim> first_tangent =
+                      tangential_vectors.front();
+                    typename std::list<Tensor<1, dim>>::iterator t =
+                      tangential_vectors.begin();
+                    ++t;
+                    for (; t != tangential_vectors.end(); ++t)
+                      if (*t * first_tangent < 0)
+                        *t *= -1;
+                  }
+
+                  // now compute the average tangent and normalize it
+                  Tensor<1, dim> average_tangent;
+                  for (typename std::list<Tensor<1, dim>>::const_iterator t =
+                         tangential_vectors.begin();
+                       t != tangential_vectors.end();
+                       ++t)
+                    average_tangent += *t;
+                  average_tangent /= average_tangent.norm();
+
+                  const auto  &dof_indices =
+                    same_dof_range[0]->first;
+                  add_tangentiality_constraints(dof_indices,
+                                                average_tangent,
+                                                constraints);
+                }
+              }
+          }
       }
 
       template <int dim>
@@ -2837,14 +3334,22 @@ namespace aspect
             {
               AffineConstraints<double> user_level_constraints;
               user_level_constraints.reinit(relevant_dofs);
-
-              internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_shell(dof_handler_v,
-                                                                                              mg_constrained_dofs_A_block,
-                                                                                              mapping,
-                                                                                              level,
-                                                                                              0,
-                                                                                              no_flux_boundary,
-                                                                                              user_level_constraints);
+              if (no_flux_boundary.size() == 1)
+                internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_shell(dof_handler_v,
+                                                                                                mg_constrained_dofs_A_block,
+                                                                                                mapping,
+                                                                                                level,
+                                                                                                0,
+                                                                                                no_flux_boundary,
+                                                                                                user_level_constraints);
+              else
+                internal::TangentialBoundaryFunctions::compute_no_normal_flux_constraints_on_level(dof_handler_v,
+                    mg_constrained_dofs_A_block,
+                    mapping,
+                    level,
+                    0,
+                    no_flux_boundary,
+                    user_level_constraints);
               user_level_constraints.close();
               mg_constrained_dofs_A_block.add_user_constraints(level,user_level_constraints);
 

--- a/tests/compute-no-normal-flux-constraints.prm
+++ b/tests/compute-no-normal-flux-constraints.prm
@@ -1,0 +1,154 @@
+set Dimension = 2
+set Use years in output instead of seconds = true
+set Start time = 0
+set End time = 10e2
+set Output directory = output-no-flux-constraints
+set Pressure normalization = surface
+set Surface pressure = 0
+set Adiabatic surface temperature = 273
+
+set Nonlinear solver scheme                = single Advection, iterated Newton Stokes
+set Nonlinear solver tolerance             = 1e-4
+set Max nonlinear iterations               = 10
+set CFL number                             = 0.3
+set Timing output frequency                = 1
+
+subsection Discretization
+    set Composition polynomial degree = 2
+    set Stokes velocity polynomial degree = 2
+    set Temperature polynomial degree = 2
+end
+
+# here are John's settings
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+  end
+  subsection Newton solver parameters
+    set Max Newton line search iterations        = 5
+    set Max pre-Newton nonlinear iterations      = 20
+    set Maximum linear Stokes solver tolerance   = 1e-1
+    set Nonlinear Newton solver switch tolerance = 1e-5
+    set SPD safety factor                        = 0.9
+    set Stabilization preconditioner             = SPD
+    set Stabilization velocity block             = SPD
+    set Use Newton failsafe                      = false
+    set Use Newton residual scaling method       = false
+    set Use Eisenstat Walker method for Picard iterations = true
+  end
+end
+
+subsection Formulation
+    set Formulation = custom
+    set Mass conservation = incompressible
+    set Temperature equation = reference density profile
+end
+
+
+subsection Geometry model
+    set Model name = chunk
+    subsection Chunk
+        set Chunk inner radius = 3.481e6
+        set Chunk outer radius = 6.371e6
+        set Chunk maximum longitude = 61.0
+        set Chunk minimum longitude = 0.0
+        set Longitude repetitions = 2
+    end
+end
+
+subsection Mesh refinement
+    set Initial adaptive refinement        = 0
+    set Initial global refinement          = 3
+    set Time steps between mesh refinement = 0
+end
+
+
+subsection Boundary velocity model
+    set Tangential velocity boundary indicators = west, east, bottom, top
+end
+
+subsection Initial temperature model
+    set Model name = function
+    subsection Function
+        set Function expression = 273
+    end
+end
+
+subsection Boundary temperature model
+    set Fixed temperature boundary indicators = bottom, top
+    set List of model names = spherical constant
+    subsection Spherical constant
+        set Inner temperature = 1673
+        set Outer temperature = 273
+    end
+end
+
+
+subsection Material model
+
+  set Material averaging = harmonic average
+
+  set Model name = visco plastic
+
+  subsection Visco Plastic
+
+    set Reference temperature  = 273
+#    set Reference viscosity    = 1.e22
+
+    set Minimum strain rate = 1.e-20
+    set Reference strain rate = 1.e-15
+
+    set Minimum viscosity = 1e21
+    set Maximum viscosity = 1e25
+
+    set Viscosity averaging scheme = harmonic
+
+    set Thermal diffusivities = 0
+    set Heat capacities       = 750.
+    set Densities             = 3150
+    set Thermal expansivities = 0
+
+    set Viscous flow law = dislocation
+
+    set Prefactors for dislocation creep          =  1e-21
+    set Stress exponents for dislocation creep    =   4
+    set Activation energies for dislocation creep =   0
+    set Activation volumes for dislocation creep  =   0
+
+    # cohesion set really high to generate very large plastic
+    # viscosities which will not be taken into account
+    # by the material model.
+    set Angles of internal friction = 0
+    set Cohesions                   = 1e15
+
+  end
+end
+
+subsection Gravity model
+    set Model name = ascii data
+end
+
+subsection Postprocess
+    set List of postprocessors = visualization, velocity statistics, temperature statistics, depth average
+    subsection Depth average
+        set Number of zones = 50
+        set Output format = txt
+        set Time between graphical output = 0
+    end
+    subsection Visualization
+        set List of output variables = density, viscosity, error indicator
+        set Output format = vtu
+        set Time between graphical output = 0.1e6
+    end
+end
+
+
+subsection Termination criteria
+    set Checkpoint on termination = true
+    set End step = 20
+end
+
+
+subsection Checkpointing
+    set Steps between checkpoint = 100
+end

--- a/tests/compute-no-normal-flux-constraints/screen-output
+++ b/tests/compute-no-normal-flux-constraints/screen-output
@@ -1,0 +1,62 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 128 (on 4 levels)
+Number of degrees of freedom: 1,836 (1,122+153+561)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Initial Newton Stokes residual = 2.98201e+13, v = 2.98201e+13, p = 0
+
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 2.98201e+13
+
+   Solving Stokes system... 11+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.15139e-12, norm of the rhs: 64.1547, newton_derivative_scaling_factor: 0
+
+
+   Postprocessing:
+     Writing graphical output: output-compute-no-normal-flux-constraints/solution/solution-00000
+     RMS, max velocity:        0.00208 m/year, 0.00454 m/year
+     Temperature min/avg/max:  273 K, 293.6 K, 1673 K
+     Writing depth average:    output-compute-no-normal-flux-constraints/depth_average
+
+
+
++-----------------------------------------------+------------+------------+
++-----------------------------------+-----------+------------+------------+
++-----------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=1000 years, dt=1000 years
+   Solving temperature system... 7 iterations.
+   Initial Newton Stokes residual = 1.83248e+13, v = 1.83248e+13, p = 0
+
+   Solving Stokes system... 0+0 iterations.
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.89677e-12, norm of the rhs: 71.4076
+
+
+   Postprocessing:
+     RMS, max velocity:       0.00208 m/year, 0.00454 m/year
+     Temperature min/avg/max: 273 K, 293.6 K, 1673 K
+     Writing depth average:   output-compute-no-normal-flux-constraints/depth_average
+
+
+
++-----------------------------------------------+------------+------------+
++-----------------------------------+-----------+------------+------------+
++-----------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+*** Snapshot created!
+
+
+
++-----------------------------------------------+------------+------------+
++-----------------------------------+-----------+------------+------------+
++-----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/compute-no-normal-flux-constraints/statistics
+++ b/tests/compute-no-normal-flux-constraints/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 128 1275 561 2 0         21 25 25 output-compute-no-normal-flux-constraints/solution/solution-00000 2.08073036e-03 4.53863711e-03 2.73000000e+02 2.93610874e+02 1.67300000e+03 1.47220531e-02 
+1 1.000000000000e+03 1.000000000000e+03 128 1275 561 1 7 4294967295  0  0                                                                "" 2.08073036e-03 4.53863711e-03 2.72988730e+02 2.93610094e+02 1.67300000e+03 1.47295451e-02 


### PR DESCRIPTION
Trying to fix https://github.com/geodynamics/aspect/issues/3894. 
Currently only copying `dealii::VectorTools::compute_nonzero_normal_flux_constraints()` with slight modifications to make it work for level meshes, may need to optimize it in the future. 
It fixed (at least removed the cycle in constraints) the example @lhy11009  provided and I added it as a test, but I will need more tests. @tjhei  