### PR TITLE
json2markdown: mangle/demangle for special characters

### DIFF
--- a/doc/sphinx/parameters/Geometry_20model.md
+++ b/doc/sphinx/parameters/Geometry_20model.md
@@ -470,7 +470,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** The number of subdivisions of the coarse (initial) mesh in depth.
 
 (parameters:Geometry_20model/Ellipsoidal_20chunk/East_2dWest_20subdivisions)=
-### __Parameter name:__ East_2dWest subdivisions
+### __Parameter name:__ East-West subdivisions
 **Default value:** 1
 
 **Pattern:** [Integer range 0...2147483647 (inclusive)]
@@ -502,7 +502,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Longitude:latitude in degrees of the North-West corner point of model region. The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
 
 (parameters:Geometry_20model/Ellipsoidal_20chunk/North_2dSouth_20subdivisions)=
-### __Parameter name:__ North_2dSouth subdivisions
+### __Parameter name:__ North-South subdivisions
 **Default value:** 1
 
 **Pattern:** [Integer range 0...2147483647 (inclusive)]
@@ -526,7 +526,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 **Documentation:** Longitude:latitude in degrees of the South-West corner point of model region. The North-East direction is positive. If one of the three corners is not provided the missing corner value will be calculated so all faces are parallel.
 
 (parameters:Geometry_20model/Ellipsoidal_20chunk/Semi_2dmajor_20axis)=
-### __Parameter name:__ Semi_2dmajor axis
+### __Parameter name:__ Semi-major axis
 **Default value:** 6378137.0
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]

--- a/doc/sphinx/parameters/Initial_20temperature_20model.md
+++ b/doc/sphinx/parameters/Initial_20temperature_20model.md
@@ -334,7 +334,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** List of the 3 thicknesses of the lithospheric layers &rsquo;upper\_crust&rsquo;, &rsquo;lower\_crust&rsquo; and &rsquo;mantle\_lithosphere&rsquo;. If only one thickness is given, then the same thickness is used for all layers. Units: \si{meter}.
 
 (parameters:Initial_20temperature_20model/Continental_20geotherm/Lithosphere_2dAsthenosphere_20boundary_20isotherm)=
-### __Parameter name:__ Lithosphere_2dAsthenosphere boundary isotherm
+### __Parameter name:__ Lithosphere-Asthenosphere boundary isotherm
 **Default value:** 1673.15
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
@@ -864,7 +864,7 @@ If the function you are describing represents a vector-valued function with mult
 **Documentation:** The file from which the initial geotherm table is to be read. The format of the file is defined by what is read in source/initial\_temperature/spherical\_shell.cc.
 
 (parameters:Initial_20temperature_20model/Spherical_20gaussian_20perturbation/Non_2ddimensional_20depth)=
-### __Parameter name:__ Non_2ddimensional depth
+### __Parameter name:__ Non-dimensional depth
 **Default value:** 0.7
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]

--- a/doc/sphinx/parameters/Postprocess.md
+++ b/doc/sphinx/parameters/Postprocess.md
@@ -615,7 +615,7 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 (parameters:Postprocess/Memory_20statistics)=
 ## **Subsection:** Postprocess / Memory statistics
 (parameters:Postprocess/Memory_20statistics/Output_20peak_20virtual_20memory_20_28VmPeak_29)=
-### __Parameter name:__ Output peak virtual memory _28VmPeak_29
+### __Parameter name:__ Output peak virtual memory (VmPeak)
 **Default value:** true
 
 **Pattern:** [Bool]
@@ -1433,7 +1433,7 @@ Physical units: \si{\per\second}.
 **Documentation:** For computations with deforming meshes, ASPECT uses an Arbitrary-Lagrangian-Eulerian formulation to handle deforming the domain, so the mesh has its own velocity field.  This may be written as an output field by setting this parameter to true.
 
 (parameters:Postprocess/Visualization/Point_2dwise_20stress_20and_20strain)=
-### __Parameter name:__ Point_2dwise stress and strain
+### __Parameter name:__ Point-wise stress and strain
 **Default value:** false
 
 **Pattern:** [Bool]

--- a/doc/sphinx/parameters/Solver_20parameters.md
+++ b/doc/sphinx/parameters/Solver_20parameters.md
@@ -104,7 +104,7 @@
 **Documentation:** The maximum number of line search iterations allowed. If the criterion is not reached after this number of iterations, we apply the scaled increment even though it does not satisfy the necessary criteria and simply continue with the next Newton iteration.
 
 (parameters:Solver_20parameters/Newton_20solver_20parameters/Max_20pre_2dNewton_20nonlinear_20iterations)=
-### __Parameter name:__ Max pre_2dNewton nonlinear iterations
+### __Parameter name:__ Max pre-Newton nonlinear iterations
 **Default value:** 10
 
 **Pattern:** [Integer range 0...2147483647 (inclusive)]
@@ -206,7 +206,7 @@ Once derivatives are used in a Newton method, ASPECT always uses the Eisenstat W
 **Documentation:** This is the number of iterations that define the GMRES solver restart length. Increasing this parameter helps with convergence issues arising from high localized viscosity jumps in the domain. Be aware that increasing this number increases the memory usage of the Stokes solver, and makes individual Stokes iterations more expensive.
 
 (parameters:Solver_20parameters/Stokes_20solver_20parameters/IDR_28s_29_20parameter)=
-### __Parameter name:__ IDR_28s_29 parameter
+### __Parameter name:__ IDR(s) parameter
 **Default value:** 2
 
 **Pattern:** [Integer range 1...2147483647 (inclusive)]

--- a/doc/sphinx/parameters/global.md
+++ b/doc/sphinx/parameters/global.md
@@ -55,7 +55,7 @@ For more information, see the section in the manual that discusses the general m
 **Documentation:** The maximal number of nonlinear iterations to be performed.
 
 (parameters:Max_20nonlinear_20iterations_20in_20pre_2drefinement)=
-### __Parameter name:__ Max nonlinear iterations in pre_2drefinement
+### __Parameter name:__ Max nonlinear iterations in pre-refinement
 **Default value:** 2147483647
 
 **Pattern:** [Integer range 0...2147483647 (inclusive)]


### PR DESCRIPTION
Correctly support all special characters in parameter names. Before we
were only handling space (" ") correctly.
