### PR TITLE
fix global refinement

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1569,6 +1569,17 @@ namespace aspect
       get_extrapolated_advection_field_range (const AdvectionField &advection_field) const;
 
       /**
+       * Exchange coarsen/refinement flags set between processors so that
+       * we have the correct settings on all ghost cells.
+       *
+       * This function is implemented in
+       * <code>source/simulator/helper_functions.cc</code>.
+       *
+       */
+      void exchange_refinement_flags();
+
+
+      /**
        * Check if timing output should be written in this timestep, and if so
        * write it.
        *

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1670,34 +1670,10 @@ namespace aspect
 
 
       {
-        // Communicate refinement flags on ghost cells from the owner of the
-        // cell. This is necessary to get consistent refinement, as mesh
-        // smoothing would undo some of the requested coarsening/refinement.
-
-        auto pack
-        = [] (const typename DoFHandler<dim>::active_cell_iterator &cell) -> unsigned int
-        {
-          if (cell->refine_flag_set())
-            return 1;
-          if (cell->coarsen_flag_set())
-            return 2;
-          return 0;
-        };
-        auto unpack
-        = [] (const typename DoFHandler<dim>::active_cell_iterator &cell, const unsigned int &flag) -> void
-        {
-          cell->clear_coarsen_flag();
-          cell->clear_refine_flag();
-          if (flag==1)
-            cell->set_refine_flag();
-          else if (flag==2)
-            cell->set_coarsen_flag();
-        };
-
-        GridTools::exchange_cell_data_to_ghosts<unsigned int, DoFHandler<dim>>
-        (dof_handler, pack, unpack);
 
       }
+      exchange_refinement_flags();
+
       triangulation.prepare_coarsening_and_refinement();
       system_trans.prepare_for_coarsening_and_refinement(x_system);
 
@@ -1954,6 +1930,9 @@ namespace aspect
                 cell->set_refine_flag ();
 
             mesh_refinement_manager.tag_additional_cells ();
+
+            exchange_refinement_flags();
+
             triangulation.execute_coarsening_and_refinement();
             if (MappingQCache<dim> *map = dynamic_cast<MappingQCache<dim>*>(&(*mapping)))
               map->initialize(MappingQGeneric<dim>(4), triangulation);

--- a/tests/global_refine_bug.prm
+++ b/tests/global_refine_bug.prm
@@ -1,0 +1,85 @@
+# Simple setup showing a bug with global refinement
+#
+# When running a model with many MPI ranks and very few cells on each
+# rank, mesh smoothing would stop us from refining all cells correctly.
+# Here, we would have 1,444 DoFs with < 8 ranks and 1,418 with 8 ranks.
+#
+# MPI: 8
+
+set Dimension                              = 2
+set End time                               = 0
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X repetitions = 5
+    set Y repetitions = 5
+  end
+end
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = 2, 3
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 0, 1, 2
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = 3: function
+end
+
+subsection Heating model
+  set List of model names = shear heating
+end
+
+subsection Boundary temperature model
+  set List of model names = box
+
+  subsection Box
+    set Bottom temperature = 1
+    set Top temperature    = 0
+  end
+end
+
+
+subsection Boundary velocity model
+  subsection Function
+    set Variable names      = x,z,t
+    set Function constants  = pi=3.1415926
+    set Function expression = if(x>1+sin(0.5*pi*t), 1, -1); 0
+  end
+end
+
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = (1-z)
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Thermal conductivity                           = 1e-6
+    set Thermal expansion coefficient                  = 0.01
+    set Viscosity                                      = 1
+    set Reference density                              = 1
+    set Reference temperature                          = 0
+  end
+end

--- a/tests/global_refine_bug/screen-output
+++ b/tests/global_refine_bug/screen-output
@@ -1,11 +1,11 @@
 
-Number of active cells: 94 (on 2 levels)
-Number of degrees of freedom: 1,418 (866+119+433)
+Number of active cells: 100 (on 2 levels)
+Number of degrees of freedom: 1,444 (882+121+441)
 
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 13+0 iterations.
+   Solving Stokes system... 10+0 iterations.
 
    Postprocessing:
 

--- a/tests/global_refine_bug/screen-output
+++ b/tests/global_refine_bug/screen-output
@@ -1,0 +1,15 @@
+
+Number of active cells: 94 (on 2 levels)
+Number of degrees of freedom: 1,418 (866+119+433)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 13+0 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
Requesting global refinement when running with many MPI ranks often
resulted in cells that we forget to refine.

fixes #4524
also see #4513
also see various forum posts about continental_extension cookbook with
16 MPI ranks and others.

continental_extension:
```
$ grep Number *ranksafter-16-ranks:Number of active cells: 3,200 (on 4 levels)
before-16-ranks:Number of active cells: 3,056 (on 4 levels)
before-16-ranks:Number of degrees of freedom: 103,689 (25,122+3,201+12,561+12,561+12,561+12,561+12,561+12,561)
before-16-ranks:Number of mesh deformation degrees of freedom: 6402
before-8-ranks:Number of active cells: 3,200 (on 4 levels)
before-8-ranks:Number of degrees of freedom: 107,649 (26,082+3,321+13,041+13,041+13,041+13,041+13,041+13,041)
before-8-ranks:Number of mesh deformation degrees of freedom: 6642

after-16-ranks:Number of active cells: 3,200 (on 4 levels)
after-16-ranks:Number of degrees of freedom: 107,649 (26,082+3,321+13,041+13,041+13,041+13,041+13,041+13,041)
after-16-ranks:Number of mesh deformation degrees of freedom: 6642
after-8-ranks:Number of active cells: 3,200 (on 4 levels)
after-8-ranks:Number of degrees of freedom: 107,649 (26,082+3,321+13,041+13,041+13,041+13,041+13,041+13,041)
after-8-ranks:Number of mesh deformation degrees of freedom: 6642

```