### PR TITLE
mesh deformation: specify correct flags

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -106,6 +106,7 @@ namespace aspect
                                                           this->introspection(),
                                                           this->get_solution(),
                                                           false);
+              scratch.face_material_model_inputs.requested_properties = MaterialModel::MaterialProperties::density;
 
               this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
 


### PR DESCRIPTION
Specify correct MaterialProperties to request for the surface
stabilization.

Fixes #4859
