### PR TITLE
stokes assembler: do not request reaction_terms

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -524,14 +524,20 @@ namespace aspect
       data.local_pressure_shape_function_integrals = 0;
 
     // initialize the material model data on the cell
-    const bool update_strain_rate =
+    const bool need_viscosity =
       assemble_newton_stokes_system || this->parameters.enable_prescribed_dilation || rebuild_stokes_matrix;
 
     scratch.material_model_inputs.reinit  (scratch.finite_element_values,
                                            cell,
                                            this->introspection,
                                            current_linearization_point,
-                                           update_strain_rate);
+                                           need_viscosity);
+    scratch.material_model_inputs.requested_properties
+      =
+        MaterialModel::MaterialProperties::equation_of_state_properties |
+        MaterialModel::MaterialProperties::additional_outputs
+        |
+        (need_viscosity ? MaterialModel::MaterialProperties::viscosity : MaterialModel::MaterialProperties::uninitialized);
 
     for (unsigned int i=0; i<assemblers->stokes_system.size(); ++i)
       assemblers->stokes_system[i]->create_additional_material_model_outputs(scratch.material_model_outputs);


### PR DESCRIPTION
part of #4859

The visco-plastic material model uses the strain_rate when computing reaction terms, but they might not be available leading to floating point exceptions. Work around this for the 2.4 release.

Most notably visible in the test gmg_mesh_deform_adaptive_bug2.