### PR TITLE
Fix Clang warnings

### DIFF
--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -77,7 +77,7 @@ namespace aspect
 
         virtual
         void
-        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
+        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
 
       private:
         // entropy change upon melting

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -574,10 +574,10 @@ namespace aspect
                     output_history.background_thread.join();
                   // ...then continue with writing our own data.
                   output_history.background_thread
-                    = std::thread([this,
-                                   my_filename = std::move(filename),
-                                   my_temporary_output_location = temporary_output_location,
-                                   my_file_contents = std::move(file_contents)]()
+                    = std::thread([ &,
+                                    my_filename = std::move(filename),
+                                    my_temporary_output_location = temporary_output_location,
+                                    my_file_contents = std::move(file_contents)]()
                   {
                     writer (my_filename, my_temporary_output_location, *my_file_contents);
                   });

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -574,8 +574,7 @@ namespace aspect
                     output_history.background_thread.join();
                   // ...then continue with writing our own data.
                   output_history.background_thread
-                    = std::thread([ &,
-                                    my_filename = std::move(filename),
+                    = std::thread([ my_filename = std::move(filename),
                                     my_temporary_output_location = temporary_output_location,
                                     my_file_contents = std::move(file_contents)]()
                   {


### PR DESCRIPTION
Fix the following warnings form Clang compiler:
```
In file included from /home/jiaqi2/aspect/build_clang/CMakeFiles/aspect.dir/Unity/unity_29_cxx.cxx:7:
/home/jiaqi2/aspect/aspect/source/postprocess/visualization.cc:577:36: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
                    = std::thread([this,
                                   ^
/home/jiaqi2/aspect/aspect/source/postprocess/visualization.cc:944:13: note: in instantiation of function template specialization 'aspect::Postprocess::Visualization<2>::write_data_out_data<dealii::DataOut<2>>' requested here
          = write_data_out_data(data_out, cell_output_history,
```

```
In file included from /home/jiaqi2/aspect/build_clang/CMakeFiles/aspect.dir/Unity/unity_7_cxx.cxx:10:
In file included from /home/jiaqi2/aspect/aspect/source/heating_model/latent_heat_melt.cc:22:
/home/jiaqi2/aspect/aspect/include/aspect/heating_model/latent_heat_melt.h:80:9: warning: 'create_additional_material_model_outputs' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
        ^
/home/jiaqi2/aspect/aspect/source/heating_model/latent_heat_melt.cc:178:35: note: in instantiation of template class 'aspect::HeatingModel::LatentHeatMelt<2>' requested here
    ASPECT_REGISTER_HEATING_MODEL(LatentHeatMelt,
                                  ^
/home/jiaqi2/aspect/aspect/include/aspect/heating_model/interface.h:216:9: note: overridden virtual function is here
        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
```