### PR TITLE
Only request needed material properties.

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1855,6 +1855,7 @@ namespace aspect
                                                 sim.introspection,
                                                 sim.solution,
                                                 false);
+                  face_material_inputs.requested_properties = MaterialModel::MaterialProperties::density;
                   sim.material_model->evaluate(face_material_inputs, face_material_outputs);
 
                   for (unsigned int q = 0; q < n_face_q_points; ++q)


### PR DESCRIPTION
This helps a bit with #4862 as far as I understand it. At the moment this does not provide strain_rate to the material model, but requests all properties, which should not be allowed.