### PR TITLE
Use deal.II v9.4 release

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -115,7 +115,7 @@ jobs:
         include:
           - image: "geodynamics/aspect-tester:focal-dealii-9.3-v2"
             tests: "ON"
-          - image: "geodynamics/aspect-tester:focal-dealii-9.4-v1"
+          - image: "geodynamics/aspect-tester:focal-dealii-9.4-v2"
             tests: "OFF"
     container: ${{ matrix.image }}
 

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -22,14 +22,13 @@ RUN cd /opt && \
     git clone https://github.com/dealii/candi && \
     cd candi && \
     mv /opt/local.cfg . && \
-    git checkout v9.3.2-r1 && \
     ./candi.sh -p /opt -j64 && \
     rm -rf /opt/tmp && \
     ln -s /opt/astyle-2.04/astyle /usr/bin/astyle
 
 # Set environment variables for this image to be used
 # by Github Actions
-ENV DEAL_II_DIR /opt/deal.II-v9.3.2
+ENV DEAL_II_DIR /opt/deal.II-v9.4.0
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 ENV OMPI_MCA_mpi_yield_when_idle=1
 ENV OMPI_MCA_rmaps_base_oversubscribe=1
@@ -38,7 +37,7 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 # Set environment variables for derived images, which
 # are build by Jenkins
-ONBUILD ENV DEAL_II_DIR /opt/deal.II-v9.3.2
+ONBUILD ENV DEAL_II_DIR /opt/deal.II-v9.4.0
 ONBUILD ENV OMPI_MCA_btl_base_warn_component_unused=0
 ONBUILD ENV OMPI_MCA_mpi_yield_when_idle=1
 ONBUILD ENV OMPI_MCA_rmaps_base_oversubscribe=1

--- a/contrib/docker/tester/build.sh
+++ b/contrib/docker/tester/build.sh
@@ -5,4 +5,4 @@
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 
-docker build -t geodynamics/aspect-tester:focal-dealii-9.3-v1 .
+docker build -t geodynamics/aspect-tester:focal-dealii-9.4-v2 .

--- a/contrib/docker/tester/local.cfg
+++ b/contrib/docker/tester/local.cfg
@@ -1,5 +1,9 @@
 # Compile with debug checks, but also with optimizations to make tests run fast
 USE_DEAL_II_CMAKE_MPI_COMPILER=ON
+BUILD_EXAMPLES=OFF
+
+DEAL_II_VERSION=v9.4.0
+
 DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DCMAKE_BUILD_TYPE='Debug' -DDEAL_II_CXX_FLAGS_DEBUG='-O3 -g0' -DDEAL_II_COMPONENT_EXAMPLES=OFF"
 
 # Minimize memory requirement and compile time


### PR DESCRIPTION
Update the 9.4 tester to the official release.

I saw a number of tests crashing with 9.4 tester (when I manually run all tests, not just the quick tests), but that is independent of this PR. 

Here is a list for my own later reference, I will try to look though them in the next days (the gmg tests are likely fixed by #4871 or #4862):

	289 - free_surface_VE_cylinder_2D_loading_fixed_elastic_dt_gmg (Failed)
	310 - global_latent_heat (Failed)
	313 - global_refine_amr (Failed)
	320 - gmg_mesh_deform_ghost_entries (Failed)
	411 - latent_heat_melt_transport (Failed)
	421 - mass_reaction_term (Failed)
	483 - melting_rate_operator_splitting2 (Failed)
	502 - multiple_named_additional_outputs (Failed)
	664 - prescribed_field_temperature_max_isotherm (Failed)
	665 - prescribed_field_with_diffusion (Failed)
	670 - prescribed_temperature_with_diffusion (Failed)
	862 - traction_ascii_data (Failed)
	936 - viscoelastic_bending_beam_gmg (Failed)
	946 - viscoelastic_stress_build-up_gmg (Failed)