### PR TITLE
allow use with currect dealii master version

### DIFF
--- a/source/postprocess/pressure_statistics.cc
+++ b/source/postprocess/pressure_statistics.cc
@@ -40,7 +40,7 @@ namespace aspect
       //
       // iterate it 'degree' times to make sure our evaluation points are
       // in fact the support points.
-      const QIterated<dim> quadrature_formula (QTrapez<1>(),
+      const QIterated<dim> quadrature_formula (QTrapezoid<1>(),
                                                this->get_fe().base_element(this->introspection().base_elements.pressure).degree);
       const unsigned int n_q_points = quadrature_formula.size();
 

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -308,7 +308,7 @@ namespace aspect
                                   QGauss<dim>(advection_field.polynomial_degree(introspection)
                                               +
                                               (parameters.stokes_velocity_degree+1)/2),
-                                  QTrapez<dim-1> (),
+                                  QTrapezoid<dim-1> (),
                                   update_flags,
                                   face_update_flags,
                                   introspection.n_compositional_fields,

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -476,7 +476,7 @@ namespace aspect
     // use a quadrature formula that has one point at
     // the location of each degree of freedom in the
     // velocity element
-    const QIterated<dim> quadrature_formula (QTrapez<1>(),
+    const QIterated<dim> quadrature_formula (QTrapezoid<1>(),
                                              parameters.stokes_velocity_degree);
     const unsigned int n_q_points = quadrature_formula.size();
 
@@ -713,7 +713,7 @@ namespace aspect
   Simulator<dim>::
   get_extrapolated_advection_field_range (const AdvectionField &advection_field) const
   {
-    const QIterated<dim> quadrature_formula (QTrapez<1>(),
+    const QIterated<dim> quadrature_formula (QTrapezoid<1>(),
                                              advection_field.polynomial_degree(introspection));
 
     const unsigned int n_q_points = quadrature_formula.size();

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1605,9 +1605,15 @@ namespace aspect
     // Explicitly pick the version with template argument double to convert
     // double-valued active_viscosity_vector to GMGNumberType-valued
     // level_viscosity_vector:
+#if DEAL_II_VERSION_GTE(9,5,0)
+    transfer.template interpolate_to_mg<dealii::LinearAlgebra::distributed::Vector<double>>(dof_handler_projection,
+        level_viscosity_vector,
+        active_viscosity_vector);
+#else
     transfer.template interpolate_to_mg<double>(dof_handler_projection,
                                                 level_viscosity_vector,
                                                 active_viscosity_vector);
+#endif
 
     for (unsigned int level=0; level<n_levels; ++level)
       {

--- a/source/time_stepping/conduction_time_step.cc
+++ b/source/time_stepping/conduction_time_step.cc
@@ -33,7 +33,7 @@ namespace aspect
     {
       double min_local_conduction_timestep = std::numeric_limits<double>::max();
 
-      const QIterated<dim> quadrature_formula (QTrapez<1>(),
+      const QIterated<dim> quadrature_formula (QTrapezoid<1>(),
                                                this->get_parameters().stokes_velocity_degree);
 
       FEValues<dim> fe_values (this->get_mapping(),

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -30,7 +30,7 @@ namespace aspect
     double
     ConvectionTimeStep<dim>::execute()
     {
-      const QIterated<dim> quadrature_formula (QTrapez<1>(),
+      const QIterated<dim> quadrature_formula (QTrapezoid<1>(),
                                                this->get_parameters().stokes_velocity_degree);
 
       FEValues<dim> fe_values (this->get_mapping(),


### PR DESCRIPTION
This PR allows it to use the current ASPECT version with the current deal.ii version. Specifically, it updates `QTrapez` to `QTrapezoid`, and takes into account the changes made to the `interpolate_to_mg` function. 

@tjhei Is this something that would be relevant for the release? I wanted to test the current main version on my laptop, but it didn't work with my deal.ii version, so I installed the most recent deal.ii version (rather than the last release, which is probably what I should have done...) and these were the things that didn't work for me. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
