### PR TITLE
Add MappingCartesian compatibility implementation

### DIFF
--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -29,7 +29,7 @@
 #include <memory>
 
 #if DEAL_II_VERSION_GTE(9,4,0)
-#if !DEAL_II_VERSION_GTE(9,5,0)
+#if !DEAL_II_VERSION_GTE(9,4,1)
 #include <aspect/compat/mapping_cartesian.h>
 #endif
 #endif

--- a/include/aspect/compat/mapping_cartesian.h
+++ b/include/aspect/compat/mapping_cartesian.h
@@ -16,7 +16,6 @@
 #ifndef aspect_compat_mapping_cartesian_h
 #define aspect_compat_mapping_cartesian_h
 
-
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/qprojector.h>
@@ -25,6 +24,8 @@
 
 #include <cmath>
 
+#if DEAL_II_VERSION_GTE(9,4,0)
+#if !DEAL_II_VERSION_GTE(9,4,1)
 
 namespace aspect
 {
@@ -421,5 +422,8 @@ namespace aspect
   /*@}*/
 
 }
+
+#endif
+#endif
 
 #endif

--- a/source/simulator/compat/mapping_cartesian.cc
+++ b/source/simulator/compat/mapping_cartesian.cc
@@ -35,6 +35,9 @@
 #include <cmath>
 #include <memory>
 
+#if DEAL_II_VERSION_GTE(9,4,0)
+#if !DEAL_II_VERSION_GTE(9,4,1)
+
 namespace aspect
 {
   using namespace dealii;
@@ -1246,3 +1249,6 @@ namespace aspect
 #undef INSTANTIATE
 
 }
+
+#endif
+#endif


### PR DESCRIPTION
This PR moves a copy of the fixed MappingCartesian from dealii/dealii#14092 into our compatibility system. I have checked that this works with deal.II 9.4.0 and the version of dealii/dealii#14092. The tester will tell us if it works with 9.3. I think we need something like this in our release, otherwise a lot of models will break with 9.4.0.

I have put the compat .cc file into the simulator subfolder to hide it, but I am open to instead make an aspect/source/compat folder. Alternatively, I could also add everything to the header, it is just a lot of lines.