### PR TITLE
Do not specify a template argument where not necessary.

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1602,18 +1602,9 @@ namespace aspect
     MGTransferMatrixFree<dim,GMGNumberType> transfer;
     transfer.build(dof_handler_projection);
 
-    // Explicitly pick the version with template argument double to convert
-    // double-valued active_viscosity_vector to GMGNumberType-valued
-    // level_viscosity_vector:
-#if DEAL_II_VERSION_GTE(9,5,0)
-    transfer.template interpolate_to_mg<dealii::LinearAlgebra::distributed::Vector<double>>(dof_handler_projection,
-        level_viscosity_vector,
-        active_viscosity_vector);
-#else
-    transfer.template interpolate_to_mg<double>(dof_handler_projection,
-                                                level_viscosity_vector,
-                                                active_viscosity_vector);
-#endif
+    transfer.interpolate_to_mg(dof_handler_projection,
+                               level_viscosity_vector,
+                               active_viscosity_vector);
 
     for (unsigned int level=0; level<n_levels; ++level)
       {


### PR DESCRIPTION
See https://github.com/geodynamics/aspect/pull/4875/files/7e3b76da4dd76cec4198146b1ef1b3b3b123b595#diff-18214df77d5d823d2bded9d4078820754b6245bde89d9cefa84e75df57e736e1 I believe that this should make the code compatible with both 9.4 and 9.5.

/rebuild