### PR TITLE
GMG: evaluate level data of Newton and free surface (WIP)

### DIFF
--- a/tests/free_surface_blob_gmg.prm
+++ b/tests/free_surface_blob_gmg.prm
@@ -10,6 +10,9 @@ subsection Solver parameters
     set Linear solver tolerance = 1.e-7
     set Number of cheap Stokes solver steps = 0
   end
+  subsection Matrix Free
+    set Use level free surface stabilization = true
+  end
 end
 
 subsection Material model

--- a/tests/free_surface_iterated_stokes_gmg.prm
+++ b/tests/free_surface_iterated_stokes_gmg.prm
@@ -14,6 +14,9 @@ subsection Solver parameters
     set Linear solver tolerance = 1.e-7
     set Number of cheap Stokes solver steps = 0
   end
+  subsection Matrix Free
+    set Use level free surface stabilization = true
+  end
 end
 
 subsection Material model

--- a/tests/tosi_benchmark_gmg_newton_solver.prm
+++ b/tests/tosi_benchmark_gmg_newton_solver.prm
@@ -9,6 +9,9 @@ subsection Solver parameters
   subsection Stokes solver parameters
     set Stokes solver type = block GMG
   end
+  subsection Matrix Free
+    set Use level Newton derivatives = true
+  end
 end
 
 subsection Material model


### PR DESCRIPTION
Added the level data of the Newton derivatives and free surface stabilization to ABlock for the GMG preconditioner, 
but it seems to increases the number of iterations based of the test results. Maybe there is a bug in the code. 
@tjhei can you take a look?