### PR TITLE
Release initial conditions objects when possible.

### DIFF
--- a/benchmarks/entropy_adiabat/plugins/prescribed_temperature.cc
+++ b/benchmarks/entropy_adiabat/plugins/prescribed_temperature.cc
@@ -31,6 +31,17 @@ namespace aspect
   namespace InitialTemperature
   {
     template <int dim>
+    void
+    PrescribedTemperature<dim>::initialize()
+    {
+      // Make sure we keep track of the initial composition manager and
+      // that it continues to live beyond the time when the simulator
+      // class releases its pointer to it.
+      initial_composition = this->get_initial_composition_manager_pointer();
+    }
+
+
+    template <int dim>
     double
     PrescribedTemperature<dim>::
     initial_temperature (const Point<dim> &position) const
@@ -40,13 +51,13 @@ namespace aspect
       MaterialModel::MaterialModelOutputs<dim> out(1, this->n_compositional_fields());
       in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
-      in.position[0]=position;
-      in.temperature[0]=this->get_adiabatic_conditions().temperature(position);
-      in.pressure[0]=this->get_adiabatic_conditions().pressure(position);
-      in.velocity[0]= Tensor<1,dim> ();
+      in.position[0] = position;
+      in.temperature[0] = this->get_adiabatic_conditions().temperature(position);
+      in.pressure[0] = this->get_adiabatic_conditions().pressure(position);
+      in.velocity[0] = Tensor<1,dim> ();
 
       for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-        in.composition[0][c] = this->get_initial_composition_manager().initial_composition(position, c);
+        in.composition[0][c] = initial_composition->initial_composition(position, c);
 
       in.strain_rate.resize(0);
 

--- a/benchmarks/entropy_adiabat/plugins/prescribed_temperature.h
+++ b/benchmarks/entropy_adiabat/plugins/prescribed_temperature.h
@@ -42,9 +42,29 @@ namespace aspect
     {
       public:
         /**
+         * Initialization function. This function is called once at the
+         * beginning of the program after parse_parameters is run.
+         *
+         * This specific function makes sure that the objects that describe
+         * initial conditions remain available throughout the run of the
+         * program.
+         */
+        void
+        initialize () override;
+
+        /**
          * Return the initial temperature as a function of position.
          */
         double initial_temperature (const Point<dim> &position) const override;
+
+      private:
+        /**
+         * A shared pointer to the initial composition object
+         * that ensures that the current object can continue
+         * to access the initial composition object beyond the
+         * first time step.
+         */
+        std::shared_ptr<const aspect::InitialComposition::Manager<dim>> initial_composition;
     };
   }
 }

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -381,10 +381,17 @@ namespace aspect
 
         virtual double reference_darcy_coefficient () const
         {
+          // Make sure we keep track of the initial composition manager and
+          // that it continues to live beyond the time when the simulator
+          // class releases its pointer to it.
+          if (initial_composition_manager == nullptr)
+            const_cast<std::shared_ptr<const aspect::InitialComposition::Manager<dim>>&>(initial_composition_manager)
+              = this->get_initial_composition_manager_pointer();
+
           // Note that this number is based on the background porosity in the
           // solitary wave initial condition.
           const SolitaryWaveInitialCondition<dim> &initial_composition =
-            this->get_initial_composition_manager().template
+            initial_composition_manager->template
             get_matching_initial_composition_model<SolitaryWaveInitialCondition<dim>>();
 
           return reference_permeability * pow(initial_composition.get_background_porosity(), 3.0) / eta_f;
@@ -460,6 +467,14 @@ namespace aspect
         double xi_0;
         double eta_f;
         double reference_permeability;
+
+        /**
+         * A shared pointer to the initial composition object
+         * that ensures that the current object can continue
+         * to access the initial composition object beyond the
+         * first time step.
+         */
+        std::shared_ptr<const aspect::InitialComposition::Manager<dim>> initial_composition_manager;
     };
 
     template <int dim>

--- a/include/aspect/adiabatic_conditions/compute_profile.h
+++ b/include/aspect/adiabatic_conditions/compute_profile.h
@@ -179,6 +179,14 @@ namespace aspect
         Functions::ParsedFunction<1> surface_condition_function;
 
         /**
+         * A shared pointer to the initial composition object
+         * that ensures that the current object can continue
+         * to access the initial composition object beyond the
+         * first time step.
+         */
+        std::shared_ptr<const aspect::InitialComposition::Manager<dim>> initial_composition_manager;
+
+        /**
          * Internal helper function. Returns the reference property at a
          * given point of the domain.
          */

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -22,6 +22,7 @@
 #ifndef _aspect_boundary_composition_initial_composition_h
 #define _aspect_boundary_composition_initial_composition_h
 
+#include <aspect/initial_composition/interface.h>
 #include <aspect/boundary_composition/interface.h>
 #include <aspect/simulator_access.h>
 
@@ -42,6 +43,17 @@ namespace aspect
     class InitialComposition : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
+        /**
+         * Initialization function. This function is called once at the
+         * beginning of the program after parse_parameters is run.
+         *
+         * This specific function makes sure that the objects that describe
+         * initial conditions remain available throughout the run of the
+         * program.
+         */
+        void
+        initialize () override;
+
         /**
          * This function returns the boundary compositions that are defined
          * by the initial conditions.
@@ -86,6 +98,14 @@ namespace aspect
          */
         double min_composition;
         double max_composition;
+
+        /**
+         * A shared pointer to the initial composition object
+         * that ensures that the current object can continue
+         * to access the initial composition object beyond the
+         * first time step.
+         */
+        std::shared_ptr<const aspect::InitialComposition::Manager<dim>> initial_composition;
     };
   }
 }

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -23,6 +23,7 @@
 #define _aspect_boundary_temperature_initial_temperature_h
 
 #include <aspect/boundary_temperature/interface.h>
+#include <aspect/initial_temperature/interface.h>
 #include <aspect/simulator_access.h>
 
 namespace aspect
@@ -40,6 +41,17 @@ namespace aspect
     class InitialTemperature : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
+        /**
+         * Initialization function. This function is called once at the
+         * beginning of the program after parse_parameters is run.
+         *
+         * This specific function makes sure that the objects that describe
+         * initial conditions remain available throughout the run of the
+         * program.
+         */
+        void
+        initialize () override;
+
         /**
          * This function returns the boundary temperatures that are defined
          * by the initial conditions.
@@ -87,6 +99,14 @@ namespace aspect
          */
         double min_temperature;
         double max_temperature;
+
+        /**
+         * A shared pointer to the initial temperature object
+         * that ensures that the current object can continue
+         * to access the initial temperature object beyond the
+         * first time step.
+         */
+        std::shared_ptr<const aspect::InitialTemperature::Manager<dim>> initial_temperature;
     };
   }
 }

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -45,6 +45,17 @@ namespace aspect
         public:
           /**
            * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           *
+           * This specific function makes sure that the objects that describe
+           * initial conditions remain available throughout the run of the
+           * program.
+           */
+          void
+          initialize () override;
+
+          /**
+           * Initialization function. This function is called once at the
            * creation of every particle for every property to initialize its
            * value.
            *
@@ -91,6 +102,15 @@ namespace aspect
            */
           std::vector<std::pair<std::string, unsigned int>>
           get_property_information() const override;
+
+        private:
+          /**
+           * A shared pointer to the initial temperature object
+           * that ensures that the current object can continue
+           * to access the initial temperature object beyond the
+           * first time step.
+           */
+          std::shared_ptr<const aspect::InitialTemperature::Manager<dim>> initial_temperature;
       };
     }
   }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1885,19 +1885,31 @@ namespace aspect
        */
       const std::unique_ptr<InitialTopographyModel::Interface<dim>>          initial_topography_model;
       const std::unique_ptr<GeometryModel::Interface<dim>>                   geometry_model;
-      const IntermediaryConstructorAction                                     post_geometry_model_creation_action;
+      const IntermediaryConstructorAction                                    post_geometry_model_creation_action;
       const std::unique_ptr<MaterialModel::Interface<dim>>                   material_model;
       const std::unique_ptr<GravityModel::Interface<dim>>                    gravity_model;
-      BoundaryTemperature::Manager<dim>                                       boundary_temperature_manager;
-      BoundaryComposition::Manager<dim>                                       boundary_composition_manager;
+      BoundaryTemperature::Manager<dim>                                      boundary_temperature_manager;
+      BoundaryComposition::Manager<dim>                                      boundary_composition_manager;
       const std::unique_ptr<PrescribedStokesSolution::Interface<dim>>        prescribed_stokes_solution;
-      InitialComposition::Manager<dim>                                        initial_composition_manager;
-      InitialTemperature::Manager<dim>                                        initial_temperature_manager;
+
+      /**
+       * The following two variables are pointers to objects that describe
+       * the initial temperature and composition values. The Simulator
+       * class itself releases these pointers once they are no longer
+       * needed, somewhere during the first time step once it is known
+       * that they are no longer needed. However, plugins can have their
+       * own shared pointers to these objects, and the lifetime of the
+       * objects pointed to is then until the last of these plugins
+       * gets deleted.
+       */
+      std::shared_ptr<InitialTemperature::Manager<dim>>                      initial_temperature_manager;
+      std::shared_ptr<InitialComposition::Manager<dim>>                      initial_composition_manager;
+
       const std::unique_ptr<AdiabaticConditions::Interface<dim>>             adiabatic_conditions;
 #ifdef ASPECT_WITH_WORLD_BUILDER
-      const std::unique_ptr<WorldBuilder::World>                              world_builder;
+      const std::unique_ptr<WorldBuilder::World>                             world_builder;
 #endif
-      BoundaryVelocity::Manager<dim>                                          boundary_velocity_manager;
+      BoundaryVelocity::Manager<dim>                                         boundary_velocity_manager;
       std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim>>> boundary_traction;
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim>>                boundary_heat_flux;
 

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -637,6 +637,43 @@ namespace aspect
        * This can then, for example, be used to get the names of the initial temperature
        * models used in a computation, or to compute the initial temperature
        * for a given position.
+       *
+       * While the Simulator class creates a shared pointer to an initial
+       * temperature manager before the first time step, it releases
+       * the pointer once it no longer needs access to the initial
+       * compositions. As a consequence, you can only call this function
+       * during the first time step.
+       *
+       * If the Simulator's shared pointer were the only
+       * one that points to the initial temperature manager object, that
+       * would also destroy the object pointed to. However, plugin classes
+       * can have member variables that are *also* shared pointers to
+       * these manager objects, and if you initialize such a shared
+       * pointer from the result of this function -- typically in the
+       * `initialize()` function of a plugin class -- then the Simulator
+       * giving up its shared pointer does not actually destroy the
+       * manager object but extends its lifetime until the last plugin
+       * that has a pointer to it is destroyed itself. As a consequence,
+       * if you need access to the initial temperature in a plugin, you
+       * will need to keep a shared pointer to it around for as long
+       * as you need it.
+       */
+      std::shared_ptr<const InitialTemperature::Manager<dim>>
+      get_initial_temperature_manager_pointer () const;
+
+      /**
+       * Return a reference to the manager of the initial temperature model.
+       * This can then, for example, be used to get the names of the initial temperature
+       * models used in a computation.
+       *
+       * While the Simulator class creates a shared pointer to an initial
+       * temperature manager before the first time step, it releases
+       * the pointer once it no longer needs access to the initial
+       * temperature. As a consequence, you can only call this function
+       * during the first time step. If a plugin needs access to the initial
+       * temperature at a later time, it has to store its own shared
+       * pointer to that object, and that is what can be achieved using
+       * the get_initial_temperature_manager_pointer() function above.
        */
       const InitialTemperature::Manager<dim> &
       get_initial_temperature_manager () const;
@@ -653,6 +690,43 @@ namespace aspect
        * Return a pointer to the manager of the initial composition model.
        * This can then, for example, be used to get the names of the initial composition
        * models used in a computation.
+       *
+       * While the Simulator class creates a shared pointer to an initial
+       * composition manager before the first time step, it releases
+       * the pointer once it no longer needs access to the initial
+       * compositions. As a consequence, you can only call this function
+       * during the first time step.
+       *
+       * If the Simulator's shared pointer were the only
+       * one that points to the initial composition manager object, that
+       * would also destroy the object pointed to. However, plugin classes
+       * can have member variables that are *also* shared pointers to
+       * these manager objects, and if you initialize such a shared
+       * pointer from the result of this function -- typically in the
+       * `initialize()` function of a plugin class -- then the Simulator
+       * giving up its shared pointer does not actually destroy the
+       * manager object but extends its lifetime until the last plugin
+       * that has a pointer to it is destroyed itself. As a consequence,
+       * if you need access to the initial compositions in a plugin, you
+       * will need to keep a shared pointer to it around for as long
+       * as you need it.
+       */
+      std::shared_ptr<const InitialComposition::Manager<dim>>
+      get_initial_composition_manager_pointer () const;
+
+      /**
+       * Return a reference to the manager of the initial composition model.
+       * This can then, for example, be used to get the names of the initial composition
+       * models used in a computation.
+       *
+       * While the Simulator class creates a shared pointer to an initial
+       * composition manager before the first time step, it releases
+       * the pointer once it no longer needs access to the initial
+       * compositions. As a consequence, you can only call this function
+       * during the first time step. If a plugin needs access to the initial
+       * composition at a later time, it has to store its own shared
+       * pointer to that object, and that is what can be achieved using
+       * the get_initial_composition_manager_pointer() function above.
        */
       const InitialComposition::Manager<dim> &
       get_initial_composition_manager () const;

--- a/source/adiabatic_conditions/compute_profile.cc
+++ b/source/adiabatic_conditions/compute_profile.cc
@@ -60,6 +60,15 @@ namespace aspect
       if (initialized)
         return;
 
+      // The simulator only keeps the initial conditions around for
+      // the first time step. As a consequence, we have to save a
+      // shared pointer to that object ourselves the first time we get
+      // here.
+      if ((reference_composition == initial_composition)
+          &&
+          (initial_composition_manager == nullptr))
+        initial_composition_manager = this->get_initial_composition_manager_pointer();
+
       temperatures.resize(n_points, numbers::signaling_nan<double>());
       pressures.resize(n_points, numbers::signaling_nan<double>());
       densities.resize(n_points, numbers::signaling_nan<double>());
@@ -144,7 +153,7 @@ namespace aspect
 
           if (reference_composition == initial_composition)
             for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-              in.composition[0][c] = this->get_initial_composition_manager().initial_composition(representative_point, c);
+              in.composition[0][c] = initial_composition_manager->initial_composition(representative_point, c);
           else if (reference_composition == reference_function)
             {
               const double depth = this->get_geometry_model().depth(representative_point);
@@ -326,6 +335,7 @@ namespace aspect
       }
       prm.leave_subsection();
     }
+
 
 
     template <int dim>

--- a/source/boundary_composition/initial_composition.cc
+++ b/source/boundary_composition/initial_composition.cc
@@ -30,13 +30,25 @@ namespace aspect
 // ------------------------------ InitialComposition -------------------
 
     template <int dim>
+    void
+    InitialComposition<dim>::initialize()
+    {
+      // Make sure we keep track of the initial composition manager and
+      // that it continues to live beyond the time when the simulator
+      // class releases its pointer to it.
+      initial_composition = this->get_initial_composition_manager_pointer();
+    }
+
+
+
+    template <int dim>
     double
     InitialComposition<dim>::
     boundary_composition (const types::boundary_id /*boundary_indicator*/,
                           const Point<dim> &position,
                           const unsigned int compositional_field) const
     {
-      return this->get_initial_composition_manager().initial_composition(position, compositional_field);
+      return initial_composition->initial_composition(position, compositional_field);
     }
 
 

--- a/source/boundary_temperature/initial_temperature.cc
+++ b/source/boundary_temperature/initial_temperature.cc
@@ -30,12 +30,24 @@ namespace aspect
 // ------------------------------ InitialTemperature -------------------
 
     template <int dim>
+    void
+    InitialTemperature<dim>::initialize()
+    {
+      // Make sure we keep track of the initial temperature manager and
+      // that it continues to live beyond the time when the simulator
+      // class releases its pointer to it.
+      initial_temperature = this->get_initial_temperature_manager_pointer();
+    }
+
+
+
+    template <int dim>
     double
     InitialTemperature<dim>::
     boundary_temperature (const types::boundary_id,
                           const Point<dim> &position) const
     {
-      return this->get_initial_temperature_manager().initial_temperature(position);
+      return initial_temperature->initial_temperature(position);
     }
 
 

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -19,6 +19,7 @@
  */
 
 #include <aspect/particle/property/pT_path.h>
+#include <aspect/simulator_signals.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/initial_temperature/interface.h>
 
@@ -28,6 +29,19 @@ namespace aspect
   {
     namespace Property
     {
+      template <int dim>
+      void
+      PTPath<dim>::initialize()
+      {
+        // Make sure we keep track of the initial temperature manager and
+        // that it continues to live beyond the time when the simulator
+        // class releases its pointer to it.
+        initial_temperature = this->get_initial_temperature_manager_pointer();
+      }
+
+
+
+
       template <int dim>
       void
       PTPath<dim>::initialize_one_particle_property(const Point<dim> &position,
@@ -44,7 +58,7 @@ namespace aspect
         // all following time steps, we set temperature and pressure to
         // their correct then-current values.
         data.push_back(this->get_adiabatic_conditions().pressure(position));
-        data.push_back(this->get_initial_temperature_manager().initial_temperature(position));
+        data.push_back(initial_temperature->initial_temperature(position));
       }
 
 

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -440,7 +440,17 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::resume_from_snapshot()
   {
-    // first check existence of the two restart files
+    // By definition, a checkpoint is past the first time step. As a consequence,
+    // the Simulator object will not need the initial conditions objects, and
+    // we can release the pointers to these objects that we have created in
+    // the constructor of this class. If some of the other plugins created there
+    // still need access to these initial conditions, they will have created
+    // their own shared pointers.
+    initial_temperature_manager.reset();
+    initial_composition_manager.reset();
+
+    // Then start with the actual deserialization.
+    // First check existence of the two restart files
     AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh"),
                  ExcMessage ("You are trying to restart a previous computation, "
                              "but the restart file <"

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -310,13 +310,21 @@ namespace aspect
     gravity_model->parse_parameters (prm);
     gravity_model->initialize ();
 
-    // Create the initial condition plugins
-    initial_temperature_manager.initialize_simulator(*this);
-    initial_temperature_manager.parse_parameters (prm);
+    // Create the initial temperature and condition plugins, and then
+    // initialize them. Some of these objects store std::shared_ptrs
+    // to the initial temperature and composition objects, so it is
+    // important that we have the pointers of the current class
+    // already set by the time we call the initialize() functions.
+    initial_temperature_manager
+      = std::make_shared<InitialTemperature::Manager<dim>>();
+    initial_composition_manager
+      = std::make_shared<InitialComposition::Manager<dim>>();
 
-    // Create the initial composition plugins
-    initial_composition_manager.initialize_simulator(*this);
-    initial_composition_manager.parse_parameters (prm);
+    initial_temperature_manager->initialize_simulator(*this);
+    initial_temperature_manager->parse_parameters (prm);
+
+    initial_composition_manager->initialize_simulator(*this);
+    initial_composition_manager->parse_parameters (prm);
 
     // Create a boundary temperature manager
     boundary_temperature_manager.initialize_simulator (*this);

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2024,6 +2024,14 @@ namespace aspect
               }
           }
 
+        // We're now definitely past the point where we need the initial
+        // conditions objects, and we can release the pointers to these objects
+        // that we have created in the constructor of this class. If some of the
+        // other plugins created there still need access to these initial
+        // conditions, they will have created their own shared pointers.
+        initial_temperature_manager.reset();
+        initial_composition_manager.reset();
+
         // Prepare the next time step:
         time_stepping_manager.update();
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -97,7 +97,7 @@ namespace aspect
              VectorFunctionFromScalarFunctionObject<dim, double>(
                [&](const Point<dim> &p) -> double
         {
-          return initial_temperature_manager.initial_temperature(p);
+          return initial_temperature_manager->initial_temperature(p);
         },
         introspection.component_indices.temperature,
         introspection.n_components)
@@ -105,7 +105,7 @@ namespace aspect
         VectorFunctionFromScalarFunctionObject<dim, double>(
           [&](const Point<dim> &p) -> double
         {
-          return initial_composition_manager.initial_composition(p, n-1);
+          return initial_composition_manager->initial_composition(p, n-1);
         },
         introspection.component_indices.compositional_fields[n-1],
         introspection.n_components));
@@ -136,8 +136,8 @@ namespace aspect
                     // must not exceed one, this should be checked
                     double sum = 0;
                     for (unsigned int m=0; m<parameters.normalized_fields.size(); ++m)
-                      sum += initial_composition_manager.initial_composition(fe_values.quadrature_point(i),
-                                                                             parameters.normalized_fields[m]);
+                      sum += initial_composition_manager->initial_composition(fe_values.quadrature_point(i),
+                                                                              parameters.normalized_fields[m]);
 
                     if (std::abs(sum) > 1.0+std::numeric_limits<double>::epsilon())
                       {

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -579,12 +579,45 @@ namespace aspect
   }
 
 
+
+  template <int dim>
+  std::shared_ptr<const InitialTemperature::Manager<dim>>
+  SimulatorAccess<dim>::get_initial_temperature_manager_pointer () const
+  {
+    Assert (simulator->initial_temperature_manager,
+            ExcMessage ("You are trying to access the initial temperature manager "
+                        "object, but the Simulator object is no longer keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return simulator->initial_temperature_manager;
+  }
+
+
+
   template <int dim>
   const InitialTemperature::Manager<dim> &
   SimulatorAccess<dim>::get_initial_temperature_manager () const
   {
-    return simulator->initial_temperature_manager;
+    Assert (simulator->initial_temperature_manager,
+            ExcMessage ("You are trying to access the initial temperature manager "
+                        "object, but the Simulator object is no longer keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return *simulator->initial_temperature_manager;
   }
+
 
 
   template <int dim>
@@ -597,12 +630,45 @@ namespace aspect
   }
 
 
+
+  template <int dim>
+  std::shared_ptr<const InitialComposition::Manager<dim>>
+  SimulatorAccess<dim>::get_initial_composition_manager_pointer () const
+  {
+    Assert (simulator->initial_composition_manager,
+            ExcMessage ("You are trying to access the initial composition manager "
+                        "object, but the Simulator object is no longer keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return simulator->initial_composition_manager;
+  }
+
+
+
   template <int dim>
   const InitialComposition::Manager<dim> &
   SimulatorAccess<dim>::get_initial_composition_manager () const
   {
-    return simulator->initial_composition_manager;
+    Assert (simulator->initial_composition_manager,
+            ExcMessage ("You are trying to access the initial composition manager "
+                        "object, but the Simulator object is no longer keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return *simulator->initial_composition_manager;
   }
+
 
 
   template <int dim>

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -659,7 +659,7 @@ namespace aspect
             ExcMessage ("You are trying to access the initial composition manager "
                         "object, but the Simulator object is no longer keeping "
                         "track of it because the initial time has passed. If "
-                        "you need to access to this object after the first time "
+                        "you need access to this object after the first time "
                         "step, you need to copy the object returned by "
                         "this function before or during the first time step "
                         "into a std::shared_ptr that lives long enough to "

--- a/tests/prescribed_temperature_in_field.cc
+++ b/tests/prescribed_temperature_in_field.cc
@@ -89,6 +89,13 @@ namespace aspect
   void constrain_internal_temperature (const SimulatorAccess<dim> &simulator_access,
                                        AffineConstraints<double> &current_constraints)
   {
+    // Save access to the initial temperature manager the first time
+    // we get here so that we can access it past the first time step
+    // as well.
+    static std::shared_ptr<const aspect::InitialTemperature::Manager<dim>> initial_temperature_manager;
+    if (initial_temperature_manager == nullptr)
+      initial_temperature_manager = simulator_access.get_initial_temperature_manager_pointer();
+
     if (prescribe_internal_temperature)
       {
         const std::vector<Point<dim>> points = aspect::Utilities::get_unit_support_points(simulator_access);
@@ -138,7 +145,7 @@ namespace aspect
                             {
 
                               // Set the temperature to be equal to the initial temperature
-                              in.temperature[q] = simulator_access.get_initial_temperature_manager().initial_temperature(in.position[q]);
+                              in.temperature[q] = initial_temperature_manager->initial_temperature(in.position[q]);
                               // Update the constraints
                               current_constraints.add_line (local_dof_indices[q]);
                               current_constraints.set_inhomogeneity (local_dof_indices[q], in.temperature[q]);


### PR DESCRIPTION
I've tried to break this into individual commits that might be easier to review separately. The first n-1 commits provide the infrastructure and use it, and the last one actually releases the objects when possible.

It is not easy to identify when one can release these objects because we sometimes call `set_initial_temperature_and_compositional_fields ()` multiple times, depending on whether we are still in the initial refinement phase. As a consequence, these objects have to live at least until the last `goto start_time_iteration`, even though we do solve full time steps during that time. That means that I can't release them until after the first full solve, but that might still be worth it.

Let's see what happens with the testers.

/rebuild