### PR TITLE
Use std::unique_ptr for plugin creation, rather than raw pointers.

### DIFF
--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -245,7 +245,7 @@ namespace aspect
       // create the base model and initialize its SimulatorAccess base
       // class; it will get a chance to read its parameters below after we
       // leave the current section
-      base_model.reset(create_material_model<dim>("simple compressible"));
+      base_model = create_material_model<dim>("simple compressible");
       if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
         sim->initialize_simulator (this->get_simulator());
       base_model->parse_parameters(prm);

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -176,7 +176,7 @@ namespace aspect
           // create the base model and initialize its SimulatorAccess base
           // class; it will get a chance to read its parameters below after we
           // leave the current section
-          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          base_model = create_material_model<dim>(prm.get("Base model"));
           if (Plugins::plugin_type_matches<SimulatorAccess<dim>>(*base_model))
             Plugins::get_plugin_as_type<SimulatorAccess<dim>>(*base_model).initialize_simulator (this->get_simulator());
 

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -173,7 +173,7 @@ namespace aspect
           // create the base model and initialize its SimulatorAccess base
           // class; it will get a chance to read its parameters below after we
           // leave the current section
-          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          base_model = create_material_model<dim>(prm.get("Base model"));
           if (Plugins::plugin_type_matches<SimulatorAccess<dim>>(*base_model))
             Plugins::get_plugin_as_type<SimulatorAccess<dim>>(*base_model).initialize_simulator (this->get_simulator());
 

--- a/doc/modules/changes/20220707_bangerth
+++ b/doc/modules/changes/20220707_bangerth
@@ -1,0 +1,9 @@
+Changed: In our plugin systems, we have many factory functions
+that create objects and returned raw pointers; in many but not
+all places, these returned raw pointers were then converted to
+`std::unique_ptr`s. This has been changed now
+by (hopefully) consistently letting factory functions
+return `std::unique_ptr`s right away, and then dealing with them at
+the receiving end.
+<br>
+(Wolfgang Bangerth, 2022/07/07)

--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -186,7 +186,7 @@ namespace aspect
     register_adiabatic_conditions (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ());
+                                   std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -199,7 +199,7 @@ namespace aspect
      * @ingroup AdiabaticConditions
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_adiabatic_conditions (ParameterHandler &prm);
 
 

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -200,7 +200,7 @@ namespace aspect
         register_boundary_composition (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       Interface<dim> *(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -132,7 +132,7 @@ namespace aspect
     register_boundary_fluid_pressure (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -145,7 +145,7 @@ namespace aspect
      * @ingroup BoundaryFluidPressures
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_fluid_pressure (ParameterHandler &prm);
 
 

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -138,7 +138,7 @@ namespace aspect
     register_boundary_heat_flux (const std::string &name,
                                  const std::string &description,
                                  void (*declare_parameters_function) (ParameterHandler &),
-                                 Interface<dim> *(*factory_function) ());
+                                 std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -151,7 +151,7 @@ namespace aspect
      * @ingroup BoundaryHeatFlux
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_heat_flux (ParameterHandler &prm);
 
 

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -233,7 +233,7 @@ namespace aspect
         register_boundary_temperature (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       Interface<dim> *(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -153,7 +153,7 @@ namespace aspect
     register_boundary_traction (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                Interface<dim> *(*factory_function) ());
+                                std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -166,7 +166,7 @@ namespace aspect
      * @ingroup BoundaryTractions
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_traction (const std::string &name);
 
     /**

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -173,7 +173,7 @@ namespace aspect
         register_boundary_velocity (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    Interface<dim> *(*factory_function) ());
+                                    std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -122,7 +122,7 @@ namespace aspect
     register_initial_topography_model (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       Interface<dim> *(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -135,7 +135,7 @@ namespace aspect
      * @ingroup InitialTopographyModels
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_initial_topography_model (ParameterHandler &prm);
 
 

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -401,7 +401,7 @@ namespace aspect
     register_geometry_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             Interface<dim> *(*factory_function) ());
+                             std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -414,7 +414,7 @@ namespace aspect
      * @ingroup GeometryModels
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_geometry_model (ParameterHandler &prm);
 
     /**

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -120,7 +120,7 @@ namespace aspect
     register_gravity_model (const std::string &name,
                             const std::string &description,
                             void (*declare_parameters_function) (ParameterHandler &),
-                            Interface<dim> *(*factory_function) ());
+                            std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -133,7 +133,7 @@ namespace aspect
      * @ingroup GravityModels
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_gravity_model (ParameterHandler &prm);
 
 

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -327,7 +327,7 @@ namespace aspect
         register_heating_model (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                Interface<dim> *(*factory_function) ());
+                                std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -165,7 +165,7 @@ namespace aspect
         register_initial_composition (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -162,7 +162,7 @@ namespace aspect
         register_initial_temperature (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
 
 
         /**

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1401,7 +1401,7 @@ namespace aspect
     register_material_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             Interface<dim> *(*factory_function) ());
+                             std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -1414,7 +1414,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_material_model (const std::string &model_name);
 
 
@@ -1430,7 +1430,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_material_model (ParameterHandler &prm);
 
 

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -260,7 +260,7 @@ namespace aspect
         (const std::string &name,
          const std::string &description,
          void (*declare_parameters_function) (ParameterHandler &),
-         Interface<dim> *(*factory_function) ());
+         std::unique_ptr<Interface<dim>>(*factory_function) ());
 
         /**
          * Return a map of boundary indicators to the names of all mesh deformation models currently

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -265,7 +265,7 @@ namespace aspect
         register_mesh_refinement_criterion (const std::string &name,
                                             const std::string &description,
                                             void (*declare_parameters_function) (ParameterHandler &),
-                                            Interface<dim> *(*factory_function) ());
+                                            std::unique_ptr<Interface<dim>>(*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -222,7 +222,7 @@ namespace aspect
       register_particle_generator (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ());
+                                   std::unique_ptr<Interface<dim>>(*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an
@@ -235,7 +235,7 @@ namespace aspect
        * @ingroup ParticleGenerators
        */
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_generator (ParameterHandler &prm);
 
       /**

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -199,7 +199,7 @@ namespace aspect
       register_particle_integrator (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    Interface<dim> *(*factory_function) ());
+                                    std::unique_ptr<Interface<dim>>(*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an
@@ -212,7 +212,7 @@ namespace aspect
        * @ingroup ParticleIntegrators
        */
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_integrator (ParameterHandler &prm);
 
 

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -162,7 +162,7 @@ namespace aspect
       register_particle_interpolator (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an
@@ -175,7 +175,7 @@ namespace aspect
        * @ingroup ParticleInterpolators
        */
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_interpolator (ParameterHandler &prm);
 
 

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -716,7 +716,7 @@ namespace aspect
           register_particle_property (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Property::Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Property::Interface<dim>> (*factory_function) ());
 
 
           /**

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -125,7 +125,7 @@ namespace aspect
         RegisterHelper (void (*register_function) (const std::string &,
                                                    const std::string &,
                                                    void ( *)(ParameterHandler &),
-                                                   InterfaceClass * ( *)()),
+                                                   std::unique_ptr<InterfaceClass> ( *)()),
                         const char *name,
                         const char *description)
         {
@@ -140,9 +140,9 @@ namespace aspect
          * this class.
          */
         static
-        InterfaceClass *factory ()
+        std::unique_ptr<InterfaceClass> factory ()
         {
-          return new ModelClass();
+          return std::make_unique<ModelClass>();
         }
       };
 
@@ -167,7 +167,7 @@ namespace aspect
         = std::tuple<std::string,
         std::string,
         void ( *) (ParameterHandler &),
-        InterfaceClass *( *) ()>;
+        std::unique_ptr<InterfaceClass>( *) ()>;
 
         /**
          * A pointer to a list of all registered plugins.
@@ -197,7 +197,7 @@ namespace aspect
         void register_plugin (const std::string &name,
                               const std::string &description,
                               void (*declare_parameters_function) (ParameterHandler &),
-                              InterfaceClass * (*factory_function) ());
+                              std::unique_ptr<InterfaceClass> (*factory_function) ());
 
         /**
          * Generate a list of names of the registered plugins separated by '|'
@@ -235,7 +235,7 @@ namespace aspect
          * function.
          */
         static
-        InterfaceClass *
+        std::unique_ptr<InterfaceClass>
         create_plugin (const std::string  &name,
                        const std::string &documentation);
 
@@ -250,7 +250,7 @@ namespace aspect
          * function.
          */
         static
-        InterfaceClass *
+        std::unique_ptr<InterfaceClass>
         create_plugin (const std::string  &name,
                        const std::string &documentation,
                        ParameterHandler &prm);
@@ -313,7 +313,7 @@ namespace aspect
       register_plugin (const std::string &name,
                        const std::string &description,
                        void (*declare_parameters_function) (ParameterHandler &),
-                       InterfaceClass * (*factory_function) ())
+                       std::unique_ptr<InterfaceClass> (*factory_function) ())
       {
         // see if this is the first time we get into this
         // function and if so initialize the static member variable
@@ -431,7 +431,7 @@ namespace aspect
 
 
       template <typename InterfaceClass>
-      InterfaceClass *
+      std::unique_ptr<InterfaceClass>
       PluginList<InterfaceClass>::
       create_plugin (const std::string &name,
                      const std::string &documentation)
@@ -460,7 +460,7 @@ namespace aspect
              p != plugins->end(); ++p)
           if (std::get<0>(*p) == name)
             {
-              InterfaceClass *i = std::get<3>(*p)();
+              std::unique_ptr<InterfaceClass> i = std::get<3>(*p)();
               return i;
             }
 
@@ -471,13 +471,13 @@ namespace aspect
 
 
       template <typename InterfaceClass>
-      InterfaceClass *
+      std::unique_ptr<InterfaceClass>
       PluginList<InterfaceClass>::
       create_plugin (const std::string &name,
                      const std::string &documentation,
                      ParameterHandler  &prm)
       {
-        InterfaceClass *i = create_plugin(name, documentation);
+        std::unique_ptr<InterfaceClass> i = create_plugin(name, documentation);
         i->parse_parameters (prm);
         return i;
       }

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -322,7 +322,7 @@ namespace aspect
         register_postprocessor (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                Interface<dim> *(*factory_function) ());
+                                std::unique_ptr<Interface<dim>>(*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -400,7 +400,7 @@ namespace aspect
         register_visualization_postprocessor (const std::string &name,
                                               const std::string &description,
                                               void (*declare_parameters_function) (ParameterHandler &),
-                                              VisualizationPostprocessors::Interface<dim> *(*factory_function) ());
+                                              std::unique_ptr<VisualizationPostprocessors::Interface<dim>>(*factory_function) ());
 
         /**
          * A function that is used to indicate to the postprocessor manager which

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -140,7 +140,7 @@ namespace aspect
     register_prescribed_stokes_solution_model (const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               Interface<dim> *(*factory_function) ());
+                                               std::unique_ptr<Interface<dim>>(*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an
@@ -153,7 +153,7 @@ namespace aspect
      * @ingroup PrescribedStokesSolution
      */
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_prescribed_stokes_solution (ParameterHandler &prm);
 
 

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -225,7 +225,7 @@ namespace aspect
         register_termination_criterion (const std::string &name,
                                         const std::string &description,
                                         void (*declare_parameters_function) (ParameterHandler &),
-                                        Interface<dim> *(*factory_function) ());
+                                        std::unique_ptr<Interface<dim>>(*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -271,7 +271,7 @@ namespace aspect
         register_time_stepping_model (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
 
       private:
 

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -142,7 +142,7 @@ namespace aspect
     register_adiabatic_conditions (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ())
+                                   std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -152,7 +152,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_adiabatic_conditions (ParameterHandler &prm)
     {
       std::string model_name;
@@ -162,8 +162,8 @@ namespace aspect
       }
       prm.leave_subsection ();
 
-      Interface<dim> *plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
-                                                                                "Adiabatic Conditions model::Model name");
+      std::unique_ptr<Interface<dim>>plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
+                                               "Adiabatic Conditions model::Model name");
 
       return plugin;
 
@@ -230,7 +230,7 @@ namespace aspect
   register_adiabatic_conditions<dim> (const std::string &, \
                                       const std::string &, \
                                       void ( *) (ParameterHandler &), \
-                                      Interface<dim> *( *) ()); \
+                                      std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -241,7 +241,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_adiabatic_conditions<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -112,7 +112,7 @@ namespace aspect
     Manager<dim>::register_boundary_composition (const std::string &name,
                                                  const std::string &description,
                                                  void (*declare_parameters_function) (ParameterHandler &),
-                                                 Interface<dim> *(*factory_function) ())
+                                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -70,7 +70,7 @@ namespace aspect
     register_boundary_fluid_pressure (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ())
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -80,7 +80,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_fluid_pressure (ParameterHandler &prm)
     {
       std::string model_name;
@@ -152,7 +152,7 @@ namespace aspect
   register_boundary_fluid_pressure<dim> (const std::string &, \
                                          const std::string &, \
                                          void ( *) (ParameterHandler &), \
-                                         Interface<dim> *( *) ()); \
+                                         std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -163,7 +163,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_boundary_fluid_pressure<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -75,7 +75,7 @@ namespace aspect
     register_boundary_heat_flux (const std::string &name,
                                  const std::string &description,
                                  void (*declare_parameters_function) (ParameterHandler &),
-                                 Interface<dim> *(*factory_function) ())
+                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -85,7 +85,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_heat_flux (ParameterHandler &prm)
     {
       std::string model_name;
@@ -157,7 +157,7 @@ namespace aspect
   register_boundary_heat_flux<dim> (const std::string &, \
                                     const std::string &, \
                                     void ( *) (ParameterHandler &), \
-                                    Interface<dim> *( *) ()); \
+                                    std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -168,7 +168,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_boundary_heat_flux<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -110,7 +110,7 @@ namespace aspect
     Manager<dim>::register_boundary_temperature (const std::string &name,
                                                  const std::string &description,
                                                  void (*declare_parameters_function) (ParameterHandler &),
-                                                 Interface<dim> *(*factory_function) ())
+                                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -112,7 +112,7 @@ namespace aspect
     register_boundary_traction (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                Interface<dim> *(*factory_function) ())
+                                std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -122,12 +122,10 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_boundary_traction (const std::string &name)
     {
-      Interface<dim> *plugin = std::get<dim>(registered_plugins).create_plugin (name,
-                                                                                "Boundary traction conditions");
-      return plugin;
+      return std::get<dim>(registered_plugins).create_plugin (name, "Boundary traction conditions");
     }
 
 
@@ -186,7 +184,7 @@ namespace aspect
   register_boundary_traction<dim> (const std::string &, \
                                    const std::string &, \
                                    void ( *) (ParameterHandler &), \
-                                   Interface<dim> *( *) ()); \
+                                   std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -201,7 +199,7 @@ namespace aspect
   get_names<dim> (); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_boundary_traction<dim> (const std::string &);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -97,7 +97,7 @@ namespace aspect
     Manager<dim>::register_boundary_velocity (const std::string &name,
                                               const std::string &description,
                                               void (*declare_parameters_function) (ParameterHandler &),
-                                              Interface<dim> *(*factory_function) ())
+                                              std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -68,7 +68,7 @@ namespace aspect
     register_initial_topography_model (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       Interface<dim> *(*factory_function) ())
+                                       std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -78,7 +78,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_initial_topography_model (ParameterHandler &prm)
     {
       std::string model_name;
@@ -173,7 +173,7 @@ namespace aspect
   register_initial_topography_model<dim> (const std::string &, \
                                           const std::string &, \
                                           void ( *) (ParameterHandler &), \
-                                          Interface<dim> *( *) ()); \
+                                          std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -184,7 +184,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_initial_topography_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -268,7 +268,7 @@ namespace aspect
     register_geometry_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             Interface<dim> *(*factory_function) ())
+                             std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -278,7 +278,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_geometry_model (ParameterHandler &prm)
     {
       std::string model_name;
@@ -385,7 +385,7 @@ namespace aspect
   register_geometry_model<dim> (const std::string &, \
                                 const std::string &, \
                                 void ( *) (ParameterHandler &), \
-                                Interface<dim> *( *) ()); \
+                                std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -396,7 +396,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_geometry_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -75,7 +75,7 @@ namespace aspect
     register_gravity_model (const std::string &name,
                             const std::string &description,
                             void (*declare_parameters_function) (ParameterHandler &),
-                            Interface<dim> *(*factory_function) ())
+                            std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -85,7 +85,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_gravity_model (ParameterHandler &prm)
     {
       std::string model_name;
@@ -169,7 +169,7 @@ namespace aspect
   register_gravity_model<dim> (const std::string &, \
                                const std::string &, \
                                void ( *) (ParameterHandler &), \
-                               Interface<dim> *( *) ()); \
+                               std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -180,7 +180,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_gravity_model<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -153,7 +153,7 @@ namespace aspect
     Manager<dim>::register_heating_model (const std::string &name,
                                           const std::string &description,
                                           void (*declare_parameters_function) (ParameterHandler &),
-                                          Interface<dim> *(*factory_function) ())
+                                          std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -79,7 +79,7 @@ namespace aspect
     Manager<dim>::register_initial_composition (const std::string &name,
                                                 const std::string &description,
                                                 void (*declare_parameters_function) (ParameterHandler &),
-                                                Interface<dim> *(*factory_function) ())
+                                                std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -77,7 +77,7 @@ namespace aspect
     Manager<dim>::register_initial_temperature (const std::string &name,
                                                 const std::string &description,
                                                 void (*declare_parameters_function) (ParameterHandler &),
-                                                Interface<dim> *(*factory_function) ())
+                                                std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -394,7 +394,7 @@ namespace aspect
           // create the base model and initialize its SimulatorAccess base
           // class; it will get a chance to read its parameters below after we
           // leave the current section
-          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          base_model = create_material_model<dim>(prm.get("Base model"));
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
             sim->initialize_simulator (this->get_simulator());
 

--- a/source/material_model/compositing.cc
+++ b/source/material_model/compositing.cc
@@ -199,7 +199,7 @@ namespace aspect
       models.resize(model_names.size());
       for (unsigned int i=0; i<model_names.size(); ++i)
         {
-          models[i].reset(create_material_model<dim>(model_names[i]));
+          models[i] = create_material_model<dim>(model_names[i]);
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(models[i].get()))
             sim->initialize_simulator (this->get_simulator());
           models[i]->parse_parameters(prm);

--- a/source/material_model/depth_dependent.cc
+++ b/source/material_model/depth_dependent.cc
@@ -202,7 +202,7 @@ namespace aspect
           // create the base model and initialize its SimulatorAccess base
           // class; it will get a chance to read its parameters below after we
           // leave the current section
-          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          base_model = create_material_model<dim>(prm.get("Base model"));
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
             sim->initialize_simulator (this->get_simulator());
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -119,7 +119,7 @@ namespace aspect
     register_material_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             Interface<dim> *(*factory_function) ())
+                             std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -129,18 +129,16 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_material_model (const std::string &model_name)
     {
-      Interface<dim> *plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
-                                                                                "Material model::Model name");
-      return plugin;
+      return std::get<dim>(registered_plugins).create_plugin (model_name, "Material model::Model name");
     }
 
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_material_model (ParameterHandler &prm)
     {
       std::string model_name;
@@ -1130,7 +1128,7 @@ namespace aspect
   register_material_model<dim> (const std::string &, \
                                 const std::string &, \
                                 void ( *) (ParameterHandler &), \
-                                Interface<dim> *( *) ()); \
+                                std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template \
   std::string \
@@ -1141,7 +1139,7 @@ namespace aspect
   declare_parameters<dim> (ParameterHandler &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_material_model<dim> (const std::string &model_name); \
   \
   template \
@@ -1149,7 +1147,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_material_model<dim> (ParameterHandler &prm); \
   \
   template struct MaterialModelInputs<dim>; \

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -109,7 +109,7 @@ namespace aspect
           // create the base model and initialize its SimulatorAccess base
           // class; it will get a chance to read its parameters below after we
           // leave the current section
-          base_model.reset(create_material_model<dim>(prm.get("Base model")));
+          base_model = create_material_model<dim>(prm.get("Base model"));
           if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(base_model.get()))
             sim->initialize_simulator (this->get_simulator());
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -304,7 +304,7 @@ namespace aspect
     MeshDeformationHandler<dim>::register_mesh_deformation (const std::string &name,
                                                             const std::string &description,
                                                             void (*declare_parameters_function) (ParameterHandler &),
-                                                            Interface<dim> *(*factory_function) ())
+                                                            std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -493,7 +493,7 @@ namespace aspect
     Manager<dim>::register_mesh_refinement_criterion (const std::string &name,
                                                       const std::string &description,
                                                       void (*declare_parameters_function) (ParameterHandler &),
-                                                      Interface<dim> *(*factory_function) ())
+                                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -227,7 +227,7 @@ namespace aspect
       register_particle_generator (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   Interface<dim> *(*factory_function) ())
+                                   std::unique_ptr<Interface<dim>>(*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,
@@ -238,7 +238,7 @@ namespace aspect
 
 
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_generator (ParameterHandler &prm)
       {
         std::string name;
@@ -324,7 +324,7 @@ namespace aspect
   register_particle_generator<dim> (const std::string &, \
                                     const std::string &, \
                                     void ( *) (ParameterHandler &), \
-                                    Interface<dim> *( *) ()); \
+                                    std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -335,7 +335,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_particle_generator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -107,7 +107,7 @@ namespace aspect
       register_particle_integrator (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    Interface<dim> *(*factory_function) ())
+                                    std::unique_ptr<Interface<dim>>(*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,
@@ -118,7 +118,7 @@ namespace aspect
 
 
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_integrator (ParameterHandler &prm)
       {
         std::string name;
@@ -263,7 +263,7 @@ namespace aspect
   register_particle_integrator<dim> (const std::string &, \
                                      const std::string &, \
                                      void ( *) (ParameterHandler &), \
-                                     Interface<dim> *( *) ()); \
+                                     std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -274,7 +274,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_particle_integrator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -71,7 +71,7 @@ namespace aspect
       register_particle_interpolator (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      Interface<dim> *(*factory_function) ())
+                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,
@@ -82,7 +82,7 @@ namespace aspect
 
 
       template <int dim>
-      Interface<dim> *
+      std::unique_ptr<Interface<dim>>
       create_particle_interpolator (ParameterHandler &prm)
       {
         std::string name;
@@ -168,7 +168,7 @@ namespace aspect
   register_particle_interpolator<dim> (const std::string &, \
                                        const std::string &, \
                                        void ( *) (ParameterHandler &), \
-                                       Interface<dim> *( *) ()); \
+                                       std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -179,7 +179,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_particle_interpolator<dim> (ParameterHandler &prm);
 
       ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -762,15 +762,11 @@ namespace aspect
         // their own parameters
         for (auto &plugin_name : plugin_names)
           {
-            aspect::Particle::Property::Interface<dim> *
-            particle_property = std::get<dim>(registered_plugins)
-                                .create_plugin (plugin_name,
-                                                "Particle property plugins");
+            property_list.emplace_back (std::get<dim>(registered_plugins)
+                                        .create_plugin (plugin_name,
+                                                        "Particle property plugins"));
 
-            property_list.push_back (std::unique_ptr<Property::Interface<dim>>
-                                     (particle_property));
-
-            if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(&*property_list.back()))
+            if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_list.back().get()))
               sim->initialize_simulator (this->get_simulator());
 
             property_list.back()->parse_parameters (prm);
@@ -789,7 +785,7 @@ namespace aspect
       register_particle_property (const std::string &name,
                                   const std::string &description,
                                   void (*declare_parameters_function) (ParameterHandler &),
-                                  Property::Interface<dim> *(*factory_function) ())
+                                  std::unique_ptr<Property::Interface<dim>> (*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1616,7 +1616,7 @@ namespace aspect
       TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Initialization");
 
       // Create a generator object depending on what the parameters specify
-      generator.reset(Generator::create_particle_generator<dim> (prm));
+      generator = Generator::create_particle_generator<dim> (prm);
       if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(generator.get()))
         sim->initialize_simulator (this->get_simulator());
       generator->parse_parameters(prm);
@@ -1630,14 +1630,14 @@ namespace aspect
       property_manager->initialize();
 
       // Create an integrator object depending on the specified parameter
-      integrator.reset(Integrator::create_particle_integrator<dim> (prm));
+      integrator = Integrator::create_particle_integrator<dim> (prm);
       if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
         sim->initialize_simulator (this->get_simulator());
       integrator->parse_parameters(prm);
       integrator->initialize();
 
       // Create an interpolator object depending on the specified parameter
-      interpolator.reset(Interpolator::create_particle_interpolator<dim> (prm));
+      interpolator = Interpolator::create_particle_interpolator<dim> (prm);
       if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(interpolator.get()))
         sim->initialize_simulator (this->get_simulator());
       interpolator->parse_parameters(prm);

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -392,7 +392,7 @@ namespace aspect
     Manager<dim>::register_postprocessor (const std::string &name,
                                           const std::string &description,
                                           void (*declare_parameters_function) (ParameterHandler &),
-                                          Interface<dim> *(*factory_function) ())
+                                          std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -72,7 +72,7 @@ namespace aspect
     register_prescribed_stokes_solution_model (const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               Interface<dim> *(*factory_function) ())
+                                               std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,
@@ -82,7 +82,7 @@ namespace aspect
 
 
     template <int dim>
-    Interface<dim> *
+    std::unique_ptr<Interface<dim>>
     create_prescribed_stokes_solution (ParameterHandler &prm)
     {
       std::string model_name;
@@ -95,8 +95,8 @@ namespace aspect
       if (model_name == "unspecified")
         return nullptr;
 
-      Interface<dim> *plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
-                                                                                "Prescribed Stokes solution::Model name");
+      std::unique_ptr<Interface<dim>>plugin = std::get<dim>(registered_plugins).create_plugin (model_name,
+                                               "Prescribed Stokes solution::Model name");
       return plugin;
     }
 
@@ -160,7 +160,7 @@ namespace aspect
   register_prescribed_stokes_solution_model<dim> (const std::string &, \
                                                   const std::string &, \
                                                   void ( *) (ParameterHandler &), \
-                                                  Interface<dim> *( *) ()); \
+                                                  std::unique_ptr<Interface<dim>>( *) ()); \
   \
   template  \
   void \
@@ -171,7 +171,7 @@ namespace aspect
   write_plugin_graph<dim> (std::ostream &); \
   \
   template \
-  Interface<dim> * \
+  std::unique_ptr<Interface<dim>> \
   create_prescribed_stokes_solution<dim> (ParameterHandler &prm);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -910,17 +910,14 @@ namespace aspect
 
       const typename DoFHandler<dim>::face_iterator face = scratch.cell->face(scratch.face_number);
 
-      if (this->get_boundary_traction()
-          .find (face->boundary_id())
+      if (this->get_boundary_traction().find (face->boundary_id())
           !=
           this->get_boundary_traction().end())
         {
           for (unsigned int q=0; q<scratch.face_finite_element_values.n_quadrature_points; ++q)
             {
               const Tensor<1,dim> traction
-                = this->get_boundary_traction().find(
-                    face->boundary_id()
-                  )->second
+                = this->get_boundary_traction().find(face->boundary_id())->second
                   ->boundary_traction (face->boundary_id(),
                                        scratch.face_finite_element_values.quadrature_point(q),
                                        scratch.face_finite_element_values.normal_vector(q));

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -413,7 +413,7 @@ namespace aspect
 
     if (postprocess_manager.template has_matching_postprocessor<Postprocess::Particles<dim>>())
       {
-        particle_world.reset(new Particle::World<dim>());
+        particle_world = std::make_unique<Particle::World<dim>>();
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(particle_world.get()))
           sim->initialize_simulator (*this);
 
@@ -455,15 +455,15 @@ namespace aspect
                              "the use of a Cartesian geometry model."));
 
     for (const auto &p : parameters.prescribed_traction_boundary_indicators)
+      boundary_traction[p.first]
+        = BoundaryTraction::create_boundary_traction<dim> (p.second.second);
+
+    for (auto &bv : boundary_traction)
       {
-        BoundaryTraction::Interface<dim> *bv
-          = BoundaryTraction::create_boundary_traction<dim>
-            (p.second.second);
-        boundary_traction[p.first].reset (bv);
-        if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(bv))
+        if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(bv.second.get()))
           sim->initialize_simulator(*this);
-        bv->parse_parameters (prm);
-        bv->initialize ();
+        bv.second->parse_parameters (prm);
+        bv.second->initialize ();
       }
 
     std::set<types::boundary_id> open_velocity_boundary_indicators
@@ -544,7 +544,12 @@ namespace aspect
   template <int dim>
   Simulator<dim>::~Simulator ()
   {
-    particle_world.reset(nullptr);
+    // The particle_world object is declared before the triangulation, and so
+    // is destroyed after the latter. But it stores a pointer to the
+    // triangulation and uses it during destruction. This results in
+    // trouble. So destroy it first.
+    particle_world.reset();
+
     // wait if there is a thread that's still writing the statistics
     // object (set from the output_statistics() function)
     if (output_statistics_thread.joinable())

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -1065,6 +1065,8 @@ namespace aspect
       for (unsigned int i = 0; i < dim-1; i++)
         data_position[i] = internal_position[boundary_dimensions[i]];
 
+      Assert (lookups.find(boundary_indicator) != lookups.end(),
+              ExcInternalError());
       const double data = lookups.find(boundary_indicator)->second->get_data(data_position,component);
 
       if (!time_dependent)

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -248,7 +248,7 @@ namespace aspect
     Manager<dim>::register_termination_criterion (const std::string &name,
                                                   const std::string &description,
                                                   void (*declare_parameters_function) (ParameterHandler &),
-                                                  Interface<dim> *(*factory_function) ())
+                                                  std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -246,7 +246,7 @@ namespace aspect
     Manager<dim>::register_time_stepping_model(const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               Interface<dim> *(*factory_function) ())
+                                               std::unique_ptr<Interface<dim>>(*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,


### PR DESCRIPTION
A rabbit hole opened up right in front of me looking at just one small place. I fell right into it.

Long story short, it turns out that in our plugin systems, we had all of these factory functions that create objects. They all returned raw pointers; in many but not all places, these returned raw pointers were then converted to `std::unique_ptr`s. This is just not very modern any more. This patch addresses this by (hopefully) consistently letting factory functions return `std::unique_ptr`s right away, and then dealing with them at the receiving end.

Also not for the upcoming release.

/rebuild