### PR TITLE
Make a function pointer declaration easier to read.

### DIFF
--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -186,7 +186,7 @@ namespace aspect
     register_adiabatic_conditions (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                   std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -200,7 +200,7 @@ namespace aspect
         register_boundary_composition (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -132,7 +132,7 @@ namespace aspect
     register_boundary_fluid_pressure (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -138,7 +138,7 @@ namespace aspect
     register_boundary_heat_flux (const std::string &name,
                                  const std::string &description,
                                  void (*declare_parameters_function) (ParameterHandler &),
-                                 std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                 std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -233,7 +233,7 @@ namespace aspect
         register_boundary_temperature (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -153,7 +153,7 @@ namespace aspect
     register_boundary_traction (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -173,7 +173,7 @@ namespace aspect
         register_boundary_velocity (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                    std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -122,7 +122,7 @@ namespace aspect
     register_initial_topography_model (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                       std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -401,7 +401,7 @@ namespace aspect
     register_geometry_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             std::unique_ptr<Interface<dim>>(*factory_function) ());
+                             std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -120,7 +120,7 @@ namespace aspect
     register_gravity_model (const std::string &name,
                             const std::string &description,
                             void (*declare_parameters_function) (ParameterHandler &),
-                            std::unique_ptr<Interface<dim>>(*factory_function) ());
+                            std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -327,7 +327,7 @@ namespace aspect
         register_heating_model (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -165,7 +165,7 @@ namespace aspect
         register_initial_composition (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -162,7 +162,7 @@ namespace aspect
         register_initial_temperature (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ());
 
 
         /**

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1401,7 +1401,7 @@ namespace aspect
     register_material_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             std::unique_ptr<Interface<dim>>(*factory_function) ());
+                             std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -260,7 +260,7 @@ namespace aspect
         (const std::string &name,
          const std::string &description,
          void (*declare_parameters_function) (ParameterHandler &),
-         std::unique_ptr<Interface<dim>>(*factory_function) ());
+         std::unique_ptr<Interface<dim>> (*factory_function) ());
 
         /**
          * Return a map of boundary indicators to the names of all mesh deformation models currently

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -265,7 +265,7 @@ namespace aspect
         register_mesh_refinement_criterion (const std::string &name,
                                             const std::string &description,
                                             void (*declare_parameters_function) (ParameterHandler &),
-                                            std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                            std::unique_ptr<Interface<dim>> (*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -222,7 +222,7 @@ namespace aspect
       register_particle_generator (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                   std::unique_ptr<Interface<dim>> (*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -199,7 +199,7 @@ namespace aspect
       register_particle_integrator (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                    std::unique_ptr<Interface<dim>> (*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -162,7 +162,7 @@ namespace aspect
       register_particle_interpolator (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ());
 
       /**
        * A function that given the name of a model returns a pointer to an

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -322,7 +322,7 @@ namespace aspect
         register_postprocessor (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                std::unique_ptr<Interface<dim>> (*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -140,7 +140,7 @@ namespace aspect
     register_prescribed_stokes_solution_model (const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                               std::unique_ptr<Interface<dim>> (*factory_function) ());
 
     /**
      * A function that given the name of a model returns a pointer to an

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -225,7 +225,7 @@ namespace aspect
         register_termination_criterion (const std::string &name,
                                         const std::string &description,
                                         void (*declare_parameters_function) (ParameterHandler &),
-                                        std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                        std::unique_ptr<Interface<dim>> (*factory_function) ());
 
         /**
          * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -271,7 +271,7 @@ namespace aspect
         register_time_stepping_model (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ());
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ());
 
       private:
 

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -142,7 +142,7 @@ namespace aspect
     register_adiabatic_conditions (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                   std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -112,7 +112,7 @@ namespace aspect
     Manager<dim>::register_boundary_composition (const std::string &name,
                                                  const std::string &description,
                                                  void (*declare_parameters_function) (ParameterHandler &),
-                                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                 std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -70,7 +70,7 @@ namespace aspect
     register_boundary_fluid_pressure (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -75,7 +75,7 @@ namespace aspect
     register_boundary_heat_flux (const std::string &name,
                                  const std::string &description,
                                  void (*declare_parameters_function) (ParameterHandler &),
-                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                 std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -110,7 +110,7 @@ namespace aspect
     Manager<dim>::register_boundary_temperature (const std::string &name,
                                                  const std::string &description,
                                                  void (*declare_parameters_function) (ParameterHandler &),
-                                                 std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                 std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -112,7 +112,7 @@ namespace aspect
     register_boundary_traction (const std::string &name,
                                 const std::string &description,
                                 void (*declare_parameters_function) (ParameterHandler &),
-                                std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -97,7 +97,7 @@ namespace aspect
     Manager<dim>::register_boundary_velocity (const std::string &name,
                                               const std::string &description,
                                               void (*declare_parameters_function) (ParameterHandler &),
-                                              std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                              std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -68,7 +68,7 @@ namespace aspect
     register_initial_topography_model (const std::string &name,
                                        const std::string &description,
                                        void (*declare_parameters_function) (ParameterHandler &),
-                                       std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                       std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -268,7 +268,7 @@ namespace aspect
     register_geometry_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             std::unique_ptr<Interface<dim>>(*factory_function) ())
+                             std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -75,7 +75,7 @@ namespace aspect
     register_gravity_model (const std::string &name,
                             const std::string &description,
                             void (*declare_parameters_function) (ParameterHandler &),
-                            std::unique_ptr<Interface<dim>>(*factory_function) ())
+                            std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -153,7 +153,7 @@ namespace aspect
     Manager<dim>::register_heating_model (const std::string &name,
                                           const std::string &description,
                                           void (*declare_parameters_function) (ParameterHandler &),
-                                          std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                          std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -79,7 +79,7 @@ namespace aspect
     Manager<dim>::register_initial_composition (const std::string &name,
                                                 const std::string &description,
                                                 void (*declare_parameters_function) (ParameterHandler &),
-                                                std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -77,7 +77,7 @@ namespace aspect
     Manager<dim>::register_initial_temperature (const std::string &name,
                                                 const std::string &description,
                                                 void (*declare_parameters_function) (ParameterHandler &),
-                                                std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -119,7 +119,7 @@ namespace aspect
     register_material_model (const std::string &name,
                              const std::string &description,
                              void (*declare_parameters_function) (ParameterHandler &),
-                             std::unique_ptr<Interface<dim>>(*factory_function) ())
+                             std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -304,7 +304,7 @@ namespace aspect
     MeshDeformationHandler<dim>::register_mesh_deformation (const std::string &name,
                                                             const std::string &description,
                                                             void (*declare_parameters_function) (ParameterHandler &),
-                                                            std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                            std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -493,7 +493,7 @@ namespace aspect
     Manager<dim>::register_mesh_refinement_criterion (const std::string &name,
                                                       const std::string &description,
                                                       void (*declare_parameters_function) (ParameterHandler &),
-                                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                      std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -227,7 +227,7 @@ namespace aspect
       register_particle_generator (const std::string &name,
                                    const std::string &description,
                                    void (*declare_parameters_function) (ParameterHandler &),
-                                   std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                   std::unique_ptr<Interface<dim>> (*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -107,7 +107,7 @@ namespace aspect
       register_particle_integrator (const std::string &name,
                                     const std::string &description,
                                     void (*declare_parameters_function) (ParameterHandler &),
-                                    std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                    std::unique_ptr<Interface<dim>> (*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -71,7 +71,7 @@ namespace aspect
       register_particle_interpolator (const std::string &name,
                                       const std::string &description,
                                       void (*declare_parameters_function) (ParameterHandler &),
-                                      std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                      std::unique_ptr<Interface<dim>> (*factory_function) ())
       {
         std::get<dim>(registered_plugins).register_plugin (name,
                                                            description,

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -392,7 +392,7 @@ namespace aspect
     Manager<dim>::register_postprocessor (const std::string &name,
                                           const std::string &description,
                                           void (*declare_parameters_function) (ParameterHandler &),
-                                          std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                          std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -72,7 +72,7 @@ namespace aspect
     register_prescribed_stokes_solution_model (const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                               std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -248,7 +248,7 @@ namespace aspect
     Manager<dim>::register_termination_criterion (const std::string &name,
                                                   const std::string &description,
                                                   void (*declare_parameters_function) (ParameterHandler &),
-                                                  std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                                  std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -246,7 +246,7 @@ namespace aspect
     Manager<dim>::register_time_stepping_model(const std::string &name,
                                                const std::string &description,
                                                void (*declare_parameters_function) (ParameterHandler &),
-                                               std::unique_ptr<Interface<dim>>(*factory_function) ())
+                                               std::unique_ptr<Interface<dim>> (*factory_function) ())
     {
       std::get<dim>(registered_plugins).register_plugin (name,
                                                          description,


### PR DESCRIPTION
This slipped my mind with #4891. I think it is easier to read this way.

/rebuild