### PR TITLE
Add docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: github-docker
+
+on: 
+  push: 
+    branches:
+      - 'main'
+  release:
+    types: [created]
+
+concurrency:
+  group: docker-build
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    if: github.repository == 'geodynamics/aspect'
+    steps:    
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LOGIN }}
+
+      - name: Build and push Docker image for main
+        if: contains(github.event_name, 'push')
+        uses: docker/build-push-action@v3
+        with:
+          context: ./contrib/docker/docker/
+          cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
+          cache-to: type=inline
+          push: false
+          tags: geodynamics/aspect:latest
+
+      - name: Build and push Docker image for release
+        if: contains(github.event_name, 'release')
+        uses: docker/build-push-action@v3
+        with:
+          context: ./contrib/docker/docker/
+          cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
+          cache-to: type=inline
+          push: false
+          tags: geodynamics/aspect:${{github.ref_name}}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
           context: ./contrib/docker/docker/
           cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
           cache-to: type=inline
-          push: false
+          push: true
           tags: geodynamics/aspect:latest
 
       - name: Build and push Docker image for release
@@ -49,6 +49,6 @@ jobs:
           context: ./contrib/docker/docker/
           cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
           cache-to: type=inline
-          push: false
+          push: true
           tags: geodynamics/aspect:${{github.ref_name}}
 

--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -6,6 +6,17 @@ LABEL maintainer <rene.gassmoeller@mailbox.org>
 RUN cd $HOME && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
 ENV PATH $HOME/cmake-3.17.3-Linux-x86_64/bin:$PATH
 
+USER root
+RUN wget https://github.com/tjhei/astyle/releases/download/v2.04/astyle_2.04_linux.tar.gz && \
+        tar xf astyle_2.04_linux.tar.gz && \
+        cd astyle/build/gcc && make && \
+        make install && \
+        cd && \
+        rm -rf astyle* && \
+        astyle --version
+
+USER dealii
+
 # Build aspect, replace git checkout command to create image for release
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
     mkdir aspect/build-release && \

--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM tjhei/dealii:v9.2.0-full-v9.2.0-r2-gcc5
+FROM dealii/dealii:v9.4.0-focal
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
 # we need a newer version of cmake to support unity builds:
-RUN cd $HOME/libs && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
-ENV PATH $HOME/libs/cmake-3.17.3-Linux-x86_64/bin:$PATH
+RUN cd $HOME && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
+ENV PATH $HOME/cmake-3.17.3-Linux-x86_64/bin:$PATH
 
 # Build aspect, replace git checkout command to create image for release
 RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
@@ -12,18 +12,16 @@ RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \
     cd aspect/build-release && \
     git checkout main && \
     cmake -DCMAKE_BUILD_TYPE=Release \
-          -DASPECT_PRECOMPILE_HEADERS=ON \
           .. && \
-    make -j6 && \
+    make -j2 && \
     mv aspect ../aspect-release && \
     make clean && \
     cd .. && \
     mkdir build-debug && \
     cd build-debug && \
     cmake -DCMAKE_BUILD_TYPE=Debug \
-          -DASPECT_PRECOMPILE_HEADERS=ON \
           .. && \
-    make -j6 && \
+    make -j2 && \
     mv aspect $HOME/aspect/aspect && \
     make clean
 


### PR DESCRIPTION
This adds an automatic build of the docker image, both for 'main' (after every merged PR) and for new releases (after the publication of the release). I have already set up the secrets with docker hub to make this work, and have tested everything as far as possible in my personal account (see https://hub.docker.com/repository/docker/gassmoeller/aspect/tags?page=1&ordering=last_updated and https://github.com/gassmoeller/aspect/actions).

This contributes to #4841