### PR TITLE
remove obsolete comment

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -26,14 +26,7 @@
 #include <aspect/material_model/utilities.h>
 
 #include <deal.II/base/point.h>
-
-// Work around an incorrect instantiation in qprojector.h of deal.II 9.2.0,
-// which requires including qprojector.h before quadrature.h (and not
-// after). This file doesn't actually need qprojector.h, so the include can be
-// removed when we require 9.3.. For more info see
-// https://github.com/geodynamics/aspect/issues/3728
 #include <deal.II/base/quadrature.h>
-
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/dofs/dof_handler.h>


### PR DESCRIPTION
Only part of #3740 was removed when we required 9.3 but the comment was
left there. Remove it.
