### PR TITLE
fix bunge et al cookbook

### DIFF
--- a/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
+++ b/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
@@ -14,6 +14,7 @@ subsection Material model
     set Depth dependence method = File
     set Data directory = $ASPECT_SOURCE_DIR/cookbooks/bunge_et_al_mantle_convection/
     set Viscosity depth file = visc_depth_a.txt
+    set Reference viscosity = 1e22
   end
   subsection Simple model
     set Reference density             = 4500

--- a/tests/bunge_cookbook.prm
+++ b/tests/bunge_cookbook.prm
@@ -1,0 +1,18 @@
+# Test cookbooks/cookbooks/bunge_et_al_mantle_convection/
+
+
+include $ASPECT_SOURCE_DIR/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
+
+set End time                               = 1e2
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 1
+  set Time steps between mesh refinement = 0
+end
+
+
+# Post processing
+subsection Postprocess
+#  set List of postprocessors = temperature statistics
+end

--- a/tests/bunge_cookbook/screen-output
+++ b/tests/bunge_cookbook/screen-output
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 48 (on 2 levels)
+Number of degrees of freedom: 792 (480+72+240)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 21+0 iterations.
+
+   Postprocessing:
+
+**** Warning: When computing depth averages, there is at least one depth band
+     that does not have any quadrature points in it.
+     Consider reducing the number of depth layers for averaging.
+
+     Writing graphical output:           output-bunge_cookbook/solution/solution-00000
+     RMS, max velocity:                  0.000302 m/year, 0.000728 m/year
+     Temperature min/avg/max:            1060 K, 2139 K, 3450 K
+     Heat fluxes through boundary parts: -7.43e+04 W, 1.868e+05 W
+     Writing depth average:              output-bunge_cookbook/depth_average
+
+*** Timestep 1:  t=100 years, dt=100 years
+   Solving temperature system... 4 iterations.
+   Solving Stokes system... 8+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                  0.000302 m/year, 0.000728 m/year
+     Temperature min/avg/max:            1060 K, 2139 K, 3450 K
+     Heat fluxes through boundary parts: -6.129e+04 W, 1.681e+05 W
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------


### PR DESCRIPTION
fixes

```
An error occurred in line <261> of file
</home/heister/aspect-git/source/material_model/depth_dependent.cc> in
funct
ion
void
aspect::MaterialModel::DepthDependent<dim>::parse_parameters(dealii::ParameterHandler&)
[with int dim = 2]
The violated condition was:
reference_viscosity != std::numeric_limits<double>::max()
Additional information:
    You have to set a reference viscosity for the depth dependent model.
 ```
