### PR TITLE
rework world builder config and fix deprecations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,11 +148,14 @@ if(ASPECT_WITH_WORLD_BUILDER)
 
   # generate config.cc and include it:
   IF(WORLD_BUILDER_VERSION VERSION_LESS 0.5.0)
-    CONFIGURE_FILE("${WORLD_BUILDER_SOURCE_DIR}/source/config.cc.in" "${CMAKE_BINARY_DIR}/world_builder_config.cc" @ONLY)
+    CONFIGURE_FILE("${WORLD_BUILDER_SOURCE_DIR}/source/config.cc.in" "${CMAKE_BINARY_DIR}/source/world_builder/config.cc" @ONLY)
+    LIST(INSERT TARGET_SRC 0 "${CMAKE_BINARY_DIR}/source/world_builder/config.cc")
+    FILE(REMOVE "${CMAKE_BINARY_DIR}/include/world_builder/config.h")
   ELSE()
-    CONFIGURE_FILE("${WORLD_BUILDER_SOURCE_DIR}/source/world_builder/config.cc.in" "${CMAKE_BINARY_DIR}/world_builder_config.cc" @ONLY)
+    CONFIGURE_FILE("${WORLD_BUILDER_SOURCE_DIR}/include/world_builder/config.h.in" "${CMAKE_BINARY_DIR}/include/world_builder/config.h" @ONLY)
+    INCLUDE_DIRECTORIES("${CMAKE_BINARY_DIR}/include/")
+    FILE(REMOVE "${CMAKE_BINARY_DIR}/source/world_builder/config.cc")
   ENDIF()
-  LIST(INSERT TARGET_SRC 0 "${CMAKE_BINARY_DIR}/world_builder_config.cc")
 
   # Move some file to the end for unity builds to make sure other file come
   # "before". Note: The current design keeps all ASPECT files (including

--- a/source/initial_temperature/world_builder.cc
+++ b/source/initial_temperature/world_builder.cc
@@ -21,6 +21,7 @@
 #include <aspect/global.h>
 
 #ifdef ASPECT_WITH_WORLD_BUILDER
+#include <world_builder/config.h>
 #include <aspect/initial_temperature/world_builder.h>
 #include <world_builder/world.h>
 #include <aspect/geometry_model/interface.h>
@@ -49,9 +50,15 @@ namespace aspect
     WorldBuilder<dim>::
     initial_temperature (const Point<dim> &position) const
     {
+#if WORLD_BUILDER_VERSION_MAJOR > 0 || WORLD_BUILDER_VERSION_MINOR >= 5
+      return this->get_world_builder().temperature(Utilities::convert_point_to_array(position),
+                                                   -this->get_geometry_model().height_above_reference_surface(position));
+#else
+
       return this->get_world_builder().temperature(Utilities::convert_point_to_array(position),
                                                    -this->get_geometry_model().height_above_reference_surface(position),
                                                    this->get_gravity_model().gravity_vector(position).norm());
+#endif
     }
 
   }


### PR DESCRIPTION
This reworks the world builder config file so that it can fix the deprecation warning and works with the version currently shiped with aspect (0.4.0) and with a reworked version of the config file (https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/444) for the development branch. This reworked version on the world builder development branch will actually define macro values like WORLD_BUILDER_VERSION_MAJOR. 

Because they where never defined as macros is 0.4.0 (they where defined as a struct), the macro to test is written such that if WORLD_BUILDER_VERSION_MAJOR is not defined, it uses the 0.4.0 branch.

As discussed at todays aspect meeting, this fix (or a fix like this) should become part the the release branch as well. I will wait with merging https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/444 until this pull request is approved. 