### PR TITLE
fix zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -39,6 +39,6 @@
 	    "name": "John Naliboff",
 	    "affiliation": "New Mexico Tech",
 	    "orcid": "0000-0002-5697-7203"
-	},
+	}
     ]
 }


### PR DESCRIPTION
This is the reason zenodo gave an 'internal server error' when we created the 2.4 release. Sigh.