### PR TITLE
cookbooks/initial-condition-S20RTS

### DIFF
--- a/cookbooks/initial-condition-S20RTS/S20RTS.prm
+++ b/cookbooks/initial-condition-S20RTS/S20RTS.prm
@@ -109,6 +109,7 @@ end
 # is too low to fully resolve the mantle flow, however it does capture
 # the main features.
 subsection Mesh refinement
+  set Time steps between mesh refinement = 0
   set Initial global refinement          = 2
   set Initial adaptive refinement        = 0
 end


### PR DESCRIPTION
Turn off mesh refinement to avoid divergence in a time dependent problem as discussed in https://github.com/geodynamics/aspect/issues/4919