### PR TITLE
Release the WorldBuilder object early.

### DIFF
--- a/include/aspect/initial_composition/world_builder.h
+++ b/include/aspect/initial_composition/world_builder.h
@@ -28,6 +28,12 @@
 #include <aspect/initial_composition/interface.h>
 #include <aspect/simulator_access.h>
 
+namespace WorldBuilder
+{
+  class World;
+}
+
+
 namespace aspect
 {
   namespace InitialComposition
@@ -86,6 +92,12 @@ namespace aspect
          * should be evaluated for this compositional field.
          */
         std::vector<bool> relevant_compositions;
+
+        /**
+         * A pointer to the WorldBuilder object. Keeping this pointer ensures
+         * that the object doesn't go away while we still need it.
+         */
+        std::shared_ptr<const ::WorldBuilder::World> world_builder;
     };
   }
 }

--- a/include/aspect/initial_temperature/world_builder.h
+++ b/include/aspect/initial_temperature/world_builder.h
@@ -28,6 +28,12 @@
 #include <aspect/initial_temperature/interface.h>
 #include <aspect/simulator_access.h>
 
+namespace WorldBuilder
+{
+  class World;
+}
+
+
 
 namespace aspect
 {
@@ -65,6 +71,12 @@ namespace aspect
          */
         double initial_temperature (const Point<dim> &position) const override;
 
+      private:
+        /**
+         * A pointer to the WorldBuilder object. Keeping this pointer ensures
+         * that the object doesn't go away while we still need it.
+         */
+        std::shared_ptr<const ::WorldBuilder::World> world_builder;
     };
   }
 }

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1907,7 +1907,18 @@ namespace aspect
 
       const std::unique_ptr<AdiabaticConditions::Interface<dim>>             adiabatic_conditions;
 #ifdef ASPECT_WITH_WORLD_BUILDER
-      const std::unique_ptr<WorldBuilder::World>                             world_builder;
+      /**
+       * A pointer to the WorldBuilder object. Like the
+       * `initial_temperature_manager` and
+       * `initial_composition_manager` objects above, the Simulator
+       * object itself releases this pointer at the end of the
+       * initialization process (right after releasing the
+       * two mentioned initial condition objects). If a part of
+       * the plugin system still needs the world builder object
+       * after this point, it needs to keep its own shared pointer
+       * to it.
+       */
+      std::shared_ptr<WorldBuilder::World>                                   world_builder;
 #endif
       BoundaryVelocity::Manager<dim>                                         boundary_velocity_manager;
       std::map<types::boundary_id,std::unique_ptr<BoundaryTraction::Interface<dim>>> boundary_traction;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -805,6 +805,7 @@ namespace aspect
        */
       const NewtonHandler<dim> &
       get_newton_handler () const;
+
 #ifdef ASPECT_WITH_WORLD_BUILDER
       /**
        * Return a reference to the world builder that controls the setup of
@@ -812,9 +813,30 @@ namespace aspect
        *
        * This call will only succeed if ASPECT was configured to use
        * the WorldBuilder.
+       *
+       * While the Simulator class creates a shared pointer to a
+       * WorldBuilder object before the first time step, it releases
+       * the pointer once it no longer needs access to the initial
+       * conditions. As a consequence, you can only call this function
+       * during the first time step. If a plugin needs access to the object
+       * so returned at a later time, it has to store its own shared
+       * pointer to that object, and that is what can be achieved using
+       * the get_world_builder_pointer() function below.
        */
       const WorldBuilder::World &
       get_world_builder () const;
+
+      /**
+       * This function is to get_world_builder() what
+       * get_initial_temperature_manager_pointer() is to
+       * the get_initial_temperature_manager() function: It returns a
+       * shared pointer so that objects that still need access to the
+       * WorldBuilder object after the Simulator class has released
+       * it, can extend the lifetime of the object pointed to by
+       * keeping a shared pointer to it.
+       */
+      std::shared_ptr<const WorldBuilder::World>
+      get_world_builder_pointer () const;
 #endif
       /**
        * Return a reference to the mesh deformation handler. This function will

--- a/source/initial_composition/world_builder.cc
+++ b/source/initial_composition/world_builder.cc
@@ -23,8 +23,9 @@
 #ifdef ASPECT_WITH_WORLD_BUILDER
 #include <aspect/initial_composition/world_builder.h>
 #include <aspect/geometry_model/interface.h>
-#include <world_builder/world.h>
 #include <aspect/citation_info.h>
+
+#include <world_builder/world.h>
 
 
 namespace aspect
@@ -37,6 +38,7 @@ namespace aspect
     initialize()
     {
       CitationInfo::add("GWB");
+      world_builder = this->get_world_builder_pointer();
     }
 
 
@@ -47,9 +49,9 @@ namespace aspect
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
       if (relevant_compositions[n_comp] == true)
-        return this->get_world_builder().composition(Utilities::convert_point_to_array(position),
-                                                     -this->get_geometry_model().height_above_reference_surface(position),
-                                                     n_comp);
+        return world_builder->composition(Utilities::convert_point_to_array(position),
+                                          -this->get_geometry_model().height_above_reference_surface(position),
+                                          n_comp);
 
       return 0.0;
     }

--- a/source/initial_temperature/world_builder.cc
+++ b/source/initial_temperature/world_builder.cc
@@ -23,10 +23,11 @@
 #ifdef ASPECT_WITH_WORLD_BUILDER
 #include <world_builder/config.h>
 #include <aspect/initial_temperature/world_builder.h>
-#include <world_builder/world.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/citation_info.h>
+
+#include <world_builder/world.h>
 
 
 namespace aspect
@@ -43,7 +44,9 @@ namespace aspect
     initialize()
     {
       CitationInfo::add("GWB");
+      world_builder = this->get_world_builder_pointer();
     }
+
 
     template <int dim>
     double
@@ -51,13 +54,13 @@ namespace aspect
     initial_temperature (const Point<dim> &position) const
     {
 #if WORLD_BUILDER_VERSION_MAJOR > 0 || WORLD_BUILDER_VERSION_MINOR >= 5
-      return this->get_world_builder().temperature(Utilities::convert_point_to_array(position),
-                                                   -this->get_geometry_model().height_above_reference_surface(position));
+      return world_builder->temperature(Utilities::convert_point_to_array(position),
+                                        -this->get_geometry_model().height_above_reference_surface(position));
 #else
 
-      return this->get_world_builder().temperature(Utilities::convert_point_to_array(position),
-                                                   -this->get_geometry_model().height_above_reference_surface(position),
-                                                   this->get_gravity_model().gravity_vector(position).norm());
+      return world_builder->temperature(Utilities::convert_point_to_array(position),
+                                        -this->get_geometry_model().height_above_reference_surface(position),
+                                        this->get_gravity_model().gravity_vector(position).norm());
 #endif
     }
 

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -448,6 +448,10 @@ namespace aspect
     // their own shared pointers.
     initial_temperature_manager.reset();
     initial_composition_manager.reset();
+#ifdef ASPECT_WITH_WORLD_BUILDER
+    // The same applies to the world builder object:
+    world_builder.reset();
+#endif
 
     // Then start with the actual deserialization.
     // First check existence of the two restart files

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -189,7 +189,7 @@ namespace aspect
     adiabatic_conditions (AdiabaticConditions::create_adiabatic_conditions<dim>(prm)),
 #ifdef ASPECT_WITH_WORLD_BUILDER
     world_builder (parameters.world_builder_file != "" ?
-                   std::make_unique<WorldBuilder::World>(parameters.world_builder_file) :
+                   std::make_shared<WorldBuilder::World>(parameters.world_builder_file) :
                    nullptr),
 #endif
     boundary_heat_flux (BoundaryHeatFlux::create_boundary_heat_flux<dim>(prm)),
@@ -2031,7 +2031,10 @@ namespace aspect
         // conditions, they will have created their own shared pointers.
         initial_temperature_manager.reset();
         initial_composition_manager.reset();
-
+#ifdef ASPECT_WITH_WORLD_BUILDER
+        // The same applies to the world builder object:
+        world_builder.reset();
+#endif
         // Prepare the next time step:
         time_stepping_manager.update();
 

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -588,12 +588,12 @@ namespace aspect
             ExcMessage ("You are trying to access the initial temperature manager "
                         "object, but the Simulator object is no longer keeping "
                         "track of it because the initial time has passed. If "
-                        "you need to access to this object after the first time "
+                        "you need to access this object after the first time "
                         "step, you need to copy the object returned by "
                         "this function before or during the first time step "
                         "into a std::shared_ptr that lives long enough to "
                         "extend the lifetime of the object pointed to "
-                        "beyond the timeframe that the Simulator object "
+                        "beyond the time frame that the Simulator object "
                         "keeps track of it."));
     return simulator->initial_temperature_manager;
   }
@@ -608,12 +608,12 @@ namespace aspect
             ExcMessage ("You are trying to access the initial temperature manager "
                         "object, but the Simulator object is no longer keeping "
                         "track of it because the initial time has passed. If "
-                        "you need to access to this object after the first time "
+                        "you need to access this object after the first time "
                         "step, you need to copy the object returned by "
                         "this function before or during the first time step "
                         "into a std::shared_ptr that lives long enough to "
                         "extend the lifetime of the object pointed to "
-                        "beyond the timeframe that the Simulator object "
+                        "beyond the time frame that the Simulator object "
                         "keeps track of it."));
     return *simulator->initial_temperature_manager;
   }
@@ -721,17 +721,16 @@ namespace aspect
     Assert (simulator->world_builder.get() != nullptr,
             ExcMessage ("You are trying to access the WorldBuilder "
                         "object, but the Simulator object is not currently storing "
-                        "a pointer to such an object. This may be because you have "
-                        "not enabled WorldBuilder support during configuration of "
-                        "ASPECT. Alternatively, the Simulator object may no "
-                        "longer be keeping "
-                        "track of it because the initial time has passed. If "
-                        "you need to access to this object after the first time "
+                        "a valid pointer to such an object. This is likely "
+                        "because the Simulator object is no longer keeping "
+                        "track of wht WorldBuilder object because "
+                        "the initial time has passed. If "
+                        "you need to access this object after the first time "
                         "step, you need to copy the object returned by "
                         "this function before or during the first time step "
                         "into a std::shared_ptr that lives long enough to "
                         "extend the lifetime of the object pointed to "
-                        "beyond the timeframe that the Simulator object "
+                        "beyond the time frame that the Simulator object "
                         "keeps track of it."));
     return *simulator->world_builder;
   }
@@ -744,17 +743,16 @@ namespace aspect
     Assert (simulator->world_builder.get() != nullptr,
             ExcMessage ("You are trying to access the WorldBuilder "
                         "object, but the Simulator object is not currently storing "
-                        "a pointer to such an object. This may be because you have "
-                        "not enabled WorldBuilder support during configuration of "
-                        "ASPECT. Alternatively, the Simulator object may no "
-                        "longer be keeping "
-                        "track of it because the initial time has passed. If "
-                        "you need to access to this object after the first time "
+                        "a valid pointer to such an object. This is likely "
+                        "because the Simulator object is no longer keeping "
+                        "track of wht WorldBuilder object because "
+                        "the initial time has passed. If "
+                        "you need to access this object after the first time "
                         "step, you need to copy the object returned by "
                         "this function before or during the first time step "
                         "into a std::shared_ptr that lives long enough to "
                         "extend the lifetime of the object pointed to "
-                        "beyond the timeframe that the Simulator object "
+                        "beyond the time frame that the Simulator object "
                         "keeps track of it."));
     return simulator->world_builder;
   }

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -719,9 +719,44 @@ namespace aspect
   SimulatorAccess<dim>::get_world_builder () const
   {
     Assert (simulator->world_builder.get() != nullptr,
-            ExcMessage("You can not call this function if the World Builder is not enabled. "
-                       "Enable it by providing a path to a world builder file."));
-    return *(simulator->world_builder);
+            ExcMessage ("You are trying to access the WorldBuilder "
+                        "object, but the Simulator object is not currently storing "
+                        "a pointer to such an object. This may be because you have "
+                        "not enabled WorldBuilder support during configuration of "
+                        "ASPECT. Alternatively, the Simulator object may no "
+                        "longer be keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return *simulator->world_builder;
+  }
+
+
+  template <int dim>
+  std::shared_ptr<const WorldBuilder::World>
+  SimulatorAccess<dim>::get_world_builder_pointer () const
+  {
+    Assert (simulator->world_builder.get() != nullptr,
+            ExcMessage ("You are trying to access the WorldBuilder "
+                        "object, but the Simulator object is not currently storing "
+                        "a pointer to such an object. This may be because you have "
+                        "not enabled WorldBuilder support during configuration of "
+                        "ASPECT. Alternatively, the Simulator object may no "
+                        "longer be keeping "
+                        "track of it because the initial time has passed. If "
+                        "you need to access to this object after the first time "
+                        "step, you need to copy the object returned by "
+                        "this function before or during the first time step "
+                        "into a std::shared_ptr that lives long enough to "
+                        "extend the lifetime of the object pointed to "
+                        "beyond the timeframe that the Simulator object "
+                        "keeps track of it."));
+    return simulator->world_builder;
   }
 #endif
 


### PR DESCRIPTION
This follows the same approach as taken for the initial conditions objects in #4889.

/rebuild