### PR TITLE
Come up with a better format to indicate that a test requires the WorldBuilder.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,14 +97,15 @@ ENDFUNCTION()
 
 # Analyze the .prm to decide if this test should be run or not. We are
 # checking for the following strings in the .prm:
-# 1. "WORLD BUILDER" - only run with World Builder.
+# 1. "Enable if: ASPECT_WITH_WORLD_BUILDER" - only run with World Builder.
 # 2. "QUICK_TEST" - enable the test even if RUN_ALL_TESTS is false
 FUNCTION(SHOULD_ENABLE_TEST _filename)
 
   FILE(STRINGS ${_filename} _input_lines
-  REGEX "WORLD BUILDER")
+       REGEX "Enable if: ASPECT_WITH_WORLD_BUILDER")
   IF(NOT "${_input_lines}" STREQUAL "")
-    IF (${_input_lines} MATCHES "WORLD BUILDER" AND NOT ASPECT_WITH_WORLD_BUILDER)
+    IF (${_input_lines} MATCHES "Enable if: ASPECT_WITH_WORLD_BUILDER" 
+        AND NOT ASPECT_WITH_WORLD_BUILDER)
       SET(_use_test OFF PARENT_SCOPE)
     ENDIF()
   ENDIF()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,20 +98,20 @@ ENDFUNCTION()
 # Analyze the .prm to decide if this test should be run or not. We are
 # checking for the following strings in the .prm:
 # 1. "Enable if: ASPECT_WITH_WORLD_BUILDER" - only run with World Builder.
-# 2. "QUICK_TEST" - enable the test even if RUN_ALL_TESTS is false
+# 2. "Enable if: QUICK_TEST" - enable the test even if RUN_ALL_TESTS is false
 FUNCTION(SHOULD_ENABLE_TEST _filename)
 
   FILE(STRINGS ${_filename} _input_lines
        REGEX "Enable if: ASPECT_WITH_WORLD_BUILDER")
   IF(NOT "${_input_lines}" STREQUAL "")
-    IF (${_input_lines} MATCHES "Enable if: ASPECT_WITH_WORLD_BUILDER" 
+    IF (${_input_lines} MATCHES "Enable if: ASPECT_WITH_WORLD_BUILDER"
         AND NOT ASPECT_WITH_WORLD_BUILDER)
       SET(_use_test OFF PARENT_SCOPE)
     ENDIF()
   ENDIF()
 
   FILE(STRINGS ${_filename} _input_lines
-       REGEX "QUICK_TEST")
+       REGEX "Enable if: QUICK_TEST")
   IF(NOT ASPECT_RUN_ALL_TESTS AND "${_input_lines}" STREQUAL "")
     SET(_use_test OFF PARENT_SCOPE)
   ENDIF()

--- a/tests/quick_mpi.prm
+++ b/tests/quick_mpi.prm
@@ -3,7 +3,7 @@
 # we do not include statistics with the hope that this makes the test work on
 # a wide range of machines
 
-# QUICK_TEST
+# Enable if: QUICK_TEST
 # MPI: 2
 
 

--- a/tests/world_builder_select_composition.prm
+++ b/tests/world_builder_select_composition.prm
@@ -1,4 +1,4 @@
-# WORLD BUILDER
+# Enable if: ASPECT_WITH_WORLD_BUILDER
 # This test is a copy of world_builder_simple.prm and checks that we can select
 # a subset of compositions for which to evaluate the world builder.
 

--- a/tests/world_builder_simple.prm
+++ b/tests/world_builder_simple.prm
@@ -1,4 +1,4 @@
-# WORLD BUILDER
+# Enable if: ASPECT_WITH_WORLD_BUILDER
 # This test uses the Geodynamic World Builder to create
 # initial temperatures and compositions
 

--- a/tests/world_builder_simple_2d_cartesian_sticky_air.prm
+++ b/tests/world_builder_simple_2d_cartesian_sticky_air.prm
@@ -1,4 +1,4 @@
-# WORLD BUILDER
+# Enable if: ASPECT_WITH_WORLD_BUILDER
 set Nonlinear solver scheme =no Advection, no Stokes
 set World builder file                     = $ASPECT_SOURCE_DIR/tests/world_builder_simple_2d_cartesian_sticky_air.wb
 set Use years in output instead of seconds = false


### PR DESCRIPTION
I verified that it enables the same number of tests as before (990 on my machine).

/rebuild