### PR TITLE
Add a new strain healing mechanism used for fracture (or fault) deactivation

### DIFF
--- a/doc/modules/changes/20220819_sibiaoliu
+++ b/doc/modules/changes/20220819_sibiaoliu
@@ -1,0 +1,3 @@
+New: A new strain healing mechanism is added for deactivation of slow creeping fractures. We use the same formulation as Poliakov & Buck (1998). This method is commonly used in the formation and evolution of faults at oceanic spreading margins.
+<br>
+(Sibiao Liu, 2022/08/19)

--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -67,7 +67,8 @@ namespace aspect
       enum HealingMechanism
       {
         no_healing,
-        temperature_dependent
+        temperature_dependent,
+        fracture_healing
       };
 
       template <int dim>
@@ -217,6 +218,11 @@ namespace aspect
            * A prefactor of viscosity used in the strain healing calculation.
            */
           double strain_healing_temperature_dependent_prefactor;
+
+          /**
+           * The fracture recovery rate used in the strain healing model for faulting.
+           */
+          double strain_healing_fracture_recovery_rate;
 
           /**
            * We cache the evaluator that is necessary to evaluate the velocity

--- a/tests/visco_plastic_yield_plastic_strain_healing_fault.prm
+++ b/tests/visco_plastic_yield_plastic_strain_healing_fault.prm
@@ -1,0 +1,138 @@
+# This test runs on 1 mpi process for 10 timesteps (50 million years).
+# eff_strain = current_strain / (1+strain_healing_fracture_recovery_rate * timestep)
+# strain_healing_fracture_recovery_rate = 1/fracture healing time.
+# Here the unreal fracture healing time is 5 million years.
+# The returned effective strain values due to fracture strain healing should be:
+# plastic_strain: initial ~0.05 then drop to zero through time
+
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 5e7
+set Use years in output instead of seconds = true
+set Maximum time step                      = 5e6
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Output directory                       = visco_plastic_yield_plastic_strain_healing_fault
+set Timing output frequency                = 1
+
+set Adiabatic surface temperature = 273.
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+
+# Boundary classifications (fixed T boundaries, prescribed velocity)
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = bottom, top, left, right
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+# Temperature boundary and initial conditions
+subsection Boundary temperature model
+  set List of model names = box
+  subsection Box
+    set Bottom temperature = 273
+    set Left temperature   = 273
+    set Right temperature  = 273
+    set Top temperature    = 273
+  end
+end
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 273
+  end
+end
+
+# Compositional fields used to track finite strain invariant
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = plastic_strain, total_strain
+end
+
+# We prescribe some initial strain at the center of the domain
+subsection Initial composition model
+  set Model name = function
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if(x>=45e3&x<=55e3&y>=45.3e3&y<=55.e3,0.2,0); if(x>=45e3&x<=55e3&y>=45.3e3&y<=55.e3,0.4,0)
+  end
+end
+
+# Boundary composition specification
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Reference strain rate = 1.e-16
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep = 5.e-23
+    set Stress exponents for dislocation creep = 1.0
+    set Activation energies for dislocation creep = 0.
+    set Activation volumes for dislocation creep = 0.
+    set Yield mechanism = drucker
+    set Angles of internal friction = 0.
+    set Cohesions = 1.e6
+    set Strain weakening mechanism = plastic weakening with plastic strain only
+    set Start plasticity strain weakening intervals = 0.
+    set End plasticity strain weakening intervals = 1.
+    set Cohesion strain weakening factors = 0.5
+    set Strain healing mechanism = fracture healing
+    set Strain healing fracture recovery rate = 6.4e-15
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+# Post processing
+# named additional outputs includes the weakened cohesions and friction angles
+subsection Postprocess
+  set List of postprocessors = velocity statistics, mass flux statistics, visualization
+  subsection Visualization
+    set Interpolate output = false
+    set List of output variables = viscosity, strain rate, named additional outputs
+    set Output format            = gnuplot
+    set Time between graphical output = 5e7
+  end
+end

--- a/tests/visco_plastic_yield_plastic_strain_healing_fault/screen-output
+++ b/tests/visco_plastic_yield_plastic_strain_healing_fault/screen-output
@@ -1,0 +1,228 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 2,326 (882+121+441+441+441)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 0 iterations.
+   Solving total_strain system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+     Writing graphical output:           output-visco_plastic_yield_plastic_strain_healing_fault/solution/solution-00000
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 1:  t=5e+06 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 11 iterations.
+   Solving total_strain system ... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00145174
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 2:  t=1e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 10 iterations.
+   Solving total_strain system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 9+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0012287
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 3:  t=1.5e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000403175
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 4:  t=2e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000341888
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.00069 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 5:  t=2.5e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000274419
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000689 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 6:  t=3e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000251439
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000689 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 7:  t=3.5e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000233188
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000408 m/year, 0.000688 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 8:  t=4e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 8+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000201661
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000409 m/year, 0.000687 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 9:  t=4.5e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000170918
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000409 m/year, 0.000686 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+*** Timestep 10:  t=5e+07 years, dt=5e+06 years
+   Solving temperature system... 0 iterations.
+   Solving plastic_strain system ... 12 iterations.
+   Solving total_strain system ... 11 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 7+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000151331
+
+
+   Postprocessing:
+     RMS, max velocity:                  0.000409 m/year, 0.000685 m/year
+     Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
+     Writing graphical output:           output-visco_plastic_yield_plastic_strain_healing_fault/solution/solution-00001
+
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/visco_plastic_yield_plastic_strain_healing_fault/statistics
+++ b/tests/visco_plastic_yield_plastic_strain_healing_fault/statistics
@@ -1,0 +1,32 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for composition solver 2
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+# 17: Outward mass flux through boundary with indicator 0 ("left") (kg/yr)
+# 18: Outward mass flux through boundary with indicator 1 ("right") (kg/yr)
+# 19: Outward mass flux through boundary with indicator 2 ("bottom") (kg/yr)
+# 20: Outward mass flux through boundary with indicator 3 ("top") (kg/yr)
+# 21: Visualization file name
+ 0 0.000000000000e+00 0.000000000000e+00 100 1003 441 882 1 0  0  0 9 11 22 4.08249673e-04 6.91118640e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05 output-visco_plastic_yield_plastic_strain_healing_fault/solution/solution-00000 
+ 1 5.000000000000e+06 5.000000000000e+06 100 1003 441 882 1 0 11  9 8 10 20 4.08253241e-04 6.91041818e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 2 1.000000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 10 11 8 10 20 4.08262433e-04 6.90855870e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 3 1.500000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 11 7  9 18 4.08279379e-04 6.90525524e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 4 2.000000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 11 7  9 18 4.08305955e-04 6.90035261e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 5 2.500000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 10 7  9 18 4.08343750e-04 6.89401089e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 6 3.000000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 10 7  9 18 4.08393680e-04 6.88662893e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 7 3.500000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 10 7  9 18 4.08456085e-04 6.87866893e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 8 4.000000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 10 7  9 18 4.08531049e-04 6.87052397e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+ 9 4.500000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 11 6  8 17 4.08618523e-04 6.86248323e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05                                                                              "" 
+10 5.000000000000e+07 5.000000000000e+06 100 1003 441 882 1 0 12 11 6  8 16 4.08718267e-04 6.85476009e-04 1.65115500e+05 1.65115500e+05 -1.65115500e+05 -1.65115500e+05 output-visco_plastic_yield_plastic_strain_healing_fault/solution/solution-00001 


### PR DESCRIPTION
Since the strain healing function of deactivated fractures (faults) during shallow crustal deformation is missing in the code, I added a new strain healing mechanism following the approach of Poliakov & Buck (1998). This mechanism is widely used for crustal deformation at divergent margins, such as the formation and evolution of faults at mid-ocean ridges.

So far, I have only tested it in the visco_plastic model with turning on the "plastic weakening with plastic strain only".

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
