### PR TITLE
GMG mesh displacement: clear user constraints

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1029,10 +1029,8 @@ namespace aspect
         }
       rhs.compress(VectorOperation::add);
 
-#if DEAL_II_VERSION_GTE(9,5,0)
       // clear the level constraints of the previous time step
       mg_constrained_dofs.clear_user_constraints();
-#endif
 
       // setup GMG, following deal.II step-37:
       const unsigned int n_levels = sim.triangulation.n_global_levels();

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1029,6 +1029,11 @@ namespace aspect
         }
       rhs.compress(VectorOperation::add);
 
+#if DEAL_II_VERSION_GTE(9,5,0)
+      // clear the level constraints of the previous time step
+      mg_constrained_dofs.clear_user_constraints();
+#endif
+
       // setup GMG, following deal.II step-37:
       const unsigned int n_levels = sim.triangulation.n_global_levels();
 


### PR DESCRIPTION
Clear the user constraints to avoid cycled constraints in certain cases. 