### PR TITLE
Update the default value of the Newton maximum Stokes sovler tolerance to a more conservative value.

### DIFF
--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -186,7 +186,7 @@ namespace aspect
                              "(1.0-(residual/switch\\_initial\\_residual)))$, where switch\\_initial\\_residual is the "
                              "residual at the time when the Newton solver is switched on.");
 
-          prm.declare_entry ("Maximum linear Stokes solver tolerance", "0.9",
+          prm.declare_entry ("Maximum linear Stokes solver tolerance", "1e-2",
                              Patterns::Double (0., 1.),
                              "The linear Stokes solver tolerance is dynamically chosen for the Newton solver, based "
                              "on the Eisenstat Walker (1994) paper (https://doi.org/10.1137/0917003), equation 2.2. "


### PR DESCRIPTION
Update the default value of the Newton maximum Stokes sovler tolerance to a more conservative value, as discussed during the user meeting. The current default value is too loose for most real world applications.