### PR TITLE
Interpolate all particle properties in one operation

### DIFF
--- a/doc/modules/changes/20221010_gassmoeller
+++ b/doc/modules/changes/20221010_gassmoeller
@@ -1,0 +1,3 @@
+Improved: The interpolation from particles to fields used to be done field-by-field, creating a lot of overhead in the interpolation algorithms. Now all particle properties are interpolated to fields at the same time, significantly reducing the time required for interpolation for models with many particle properties.
+<br>
+(Rene Gassmoeller, 2022/10/10)

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -840,7 +840,7 @@ namespace aspect
        * Interpolate the corresponding particle properties into the given
        * @p advection_fields solution fields.
        */
-      void interpolate_particle_property_vector (const std::vector<AdvectionField> &advection_fields);
+      void interpolate_particle_properties (const std::vector<AdvectionField> &advection_fields);
 
       /**
        * Solve the Stokes linear system.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -831,8 +831,16 @@ namespace aspect
 
       /**
        * Interpolate a particular particle property to the solution field.
+       *
+       * @deprecated: Use interpolate_particle_property_vector() instead.
        */
-      void interpolate_particle_properties (const AdvectionField &advection_field);
+      void interpolate_particle_properties (const AdvectionField &advection_field) DEAL_II_DEPRECATED;
+
+      /**
+       * Interpolate the corresponding particle properties into the given
+       * @p advection_fields solution fields.
+       */
+      void interpolate_particle_property_vector (const std::vector<AdvectionField> &advection_fields);
 
       /**
        * Solve the Stokes linear system.

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -192,8 +192,18 @@ namespace aspect
   }
 
 
+
   template <int dim>
   void Simulator<dim>::interpolate_particle_properties (const AdvectionField &advection_field)
+  {
+    std::vector<AdvectionField> advection_fields(1,advection_field);
+    interpolate_particle_property_vector(advection_fields);
+  }
+
+
+
+  template <int dim>
+  void Simulator<dim>::interpolate_particle_property_vector (const std::vector<AdvectionField> &advection_fields)
   {
     TimerOutput::Scope timer (computing_timer, "Particles: Interpolate");
 
@@ -223,34 +233,51 @@ namespace aspect
     const Particle::Interpolator::Interface<dim> *particle_interpolator = &particle_postprocessor.get_particle_world().get_interpolator();
     const Particle::Property::Manager<dim> *particle_property_manager = &particle_postprocessor.get_particle_world().get_property_manager();
 
-    unsigned int particle_property;
+    std::vector<unsigned int> particle_property_indices;
+    ComponentMask property_mask  (particle_property_manager->get_data_info().n_components(),false);
 
-    if (parameters.mapped_particle_properties.size() != 0)
+    for (const auto &advection_field: advection_fields)
       {
-        const std::pair<std::string,unsigned int> particle_property_and_component = parameters.mapped_particle_properties.find(advection_field.compositional_variable)->second;
+        if (parameters.mapped_particle_properties.size() != 0)
+          {
+            const std::pair<std::string,unsigned int> particle_property_and_component = parameters.mapped_particle_properties.find(advection_field.compositional_variable)->second;
 
-        particle_property = particle_property_manager->get_data_info().get_position_by_field_name(particle_property_and_component.first)
-                            + particle_property_and_component.second;
-      }
-    else
-      {
-        particle_property = std::count(introspection.compositional_field_methods.begin(),
-                                       introspection.compositional_field_methods.begin() + advection_field.compositional_variable,
-                                       Parameters<dim>::AdvectionFieldMethod::particles);
-        AssertThrow(particle_property <= particle_property_manager->get_data_info().n_components(),
-                    ExcMessage("Can not automatically match particle properties to fields, because there are"
-                               "more fields that are marked as particle advected than particle properties"));
+            const unsigned int particle_property_index = particle_property_manager->get_data_info().get_position_by_field_name(particle_property_and_component.first)
+                                                         + particle_property_and_component.second;
+
+            particle_property_indices.push_back(particle_property_index);
+
+            property_mask.set(particle_property_index,true);
+          }
+        else
+          {
+            const unsigned int particle_property_index = std::count(introspection.compositional_field_methods.begin(),
+                                                                    introspection.compositional_field_methods.begin() + advection_field.compositional_variable,
+                                                                    Parameters<dim>::AdvectionFieldMethod::particles);
+            AssertThrow(particle_property_index <= particle_property_manager->get_data_info().n_components(),
+                        ExcMessage("Can not automatically match particle properties to fields, because there are"
+                                   "more fields that are marked as particle advected than particle properties"));
+
+            particle_property_indices.push_back(particle_property_index);
+            property_mask.set(particle_property_index,true);
+          }
       }
 
     LinearAlgebra::BlockVector particle_solution;
 
     particle_solution.reinit(system_rhs, false);
 
-    const unsigned int base_element = advection_field.base_element(introspection);
+    const unsigned int base_element_index = advection_fields[0].base_element(introspection);
+
+    // We can only combine the interpolation of properties into fields
+    // that share the same base element. Otherwise the element support points
+    // are not guaranteed to be identical.
+    for (const auto &advection_field: advection_fields)
+      Assert (advection_field.base_element(introspection) == base_element_index, ExcInternalError());
 
     // get the temperature/composition support points
     const std::vector<Point<dim>> support_points
-      = finite_element.base_element(base_element).get_unit_support_points();
+      = finite_element.base_element(base_element_index).get_unit_support_points();
     Assert (support_points.size() != 0,
             ExcInternalError());
 
@@ -266,9 +293,6 @@ namespace aspect
         {
           fe_values.reinit (cell);
           const std::vector<Point<dim>> quadrature_points = fe_values.get_quadrature_points();
-
-          ComponentMask property_mask  (particle_property_manager->get_data_info().n_components(),false);
-          property_mask.set(particle_property,true);
 
           std::vector<std::vector<double>> particle_properties;
 
@@ -307,39 +331,47 @@ namespace aspect
           // go through the composition dofs and set their global values
           // to the particle field interpolated at these points
           cell->get_dof_indices (local_dof_indices);
-          for (unsigned int i=0; i<finite_element.base_element(base_element).dofs_per_cell; ++i)
-            {
-              const unsigned int system_local_dof
-                = finite_element.component_to_system_index(advection_field.component_index(introspection),
-                                                           /*dof index within component=*/i);
+          const unsigned int n_dofs_per_cell = finite_element.base_element(base_element_index).dofs_per_cell;
+          for (unsigned int j=0; j<advection_fields.size(); ++j)
+            for (unsigned int i=0; i<n_dofs_per_cell; ++i)
+              {
+                const unsigned int system_local_dof
+                  = finite_element.component_to_system_index(advection_fields[j].component_index(introspection),
+                                                             /*dof index within component=*/i);
 
-              particle_solution(local_dof_indices[system_local_dof]) = particle_properties[i][particle_property];
-            }
+                particle_solution(local_dof_indices[system_local_dof]) = particle_properties[i][particle_property_indices[j]];
+              }
         }
 
     particle_solution.compress(VectorOperation::insert);
 
-    // we should not have written at all into any of the blocks with
-    // the exception of the current composition block
-    for (unsigned int b=0; b<particle_solution.n_blocks(); ++b)
-      if (b != advection_field.block_index(introspection))
+    // overwrite the relevant composition blocks only
+    std::vector<bool> particle_blocks (introspection.n_blocks,false);
+    for (const auto &advection_field: advection_fields)
+      {
+        const unsigned int blockidx = advection_field.block_index(introspection);
+        particle_blocks[blockidx] = true;
+        solution.block(blockidx) = particle_solution.block(blockidx);
+
+        // In the first timestep, and for iterative Advection schemes only
+        // in the first nonlinear iteration, initialize all solution vectors with the initial
+        // particle solution, identical to the end of the
+        // Simulator<dim>::set_initial_temperature_and_compositional_fields ()
+        // function.
+        if (timestep_number == 0 && nonlinear_iteration == 0)
+          {
+            old_solution.block(blockidx) = particle_solution.block(blockidx);
+            old_old_solution.block(blockidx) = particle_solution.block(blockidx);
+          }
+      }
+
+    // we should not have written at all into any of the blocks
+    // that are not interpolated from particles
+    for (unsigned int b=0; b<introspection.n_blocks; ++b)
+      if (particle_blocks[b] == false)
         Assert (particle_solution.block(b).l2_norm() == 0,
                 ExcInternalError());
 
-    // overwrite the relevant composition block only
-    const unsigned int blockidx = advection_field.block_index(introspection);
-    solution.block(blockidx) = particle_solution.block(blockidx);
-
-    // In the first timestep, and for iterative Advection schemes only
-    // in the first nonlinear iteration, initialize all solution vectors with the initial
-    // particle solution, identical to the end of the
-    // Simulator<dim>::set_initial_temperature_and_compositional_fields ()
-    // function.
-    if (timestep_number == 0 && nonlinear_iteration == 0)
-      {
-        old_solution.block(blockidx) = particle_solution.block(blockidx);
-        old_old_solution.block(blockidx) = particle_solution.block(blockidx);
-      }
   }
 
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -197,13 +197,13 @@ namespace aspect
   void Simulator<dim>::interpolate_particle_properties (const AdvectionField &advection_field)
   {
     std::vector<AdvectionField> advection_fields(1,advection_field);
-    interpolate_particle_property_vector(advection_fields);
+    interpolate_particle_properties(advection_fields);
   }
 
 
 
   template <int dim>
-  void Simulator<dim>::interpolate_particle_property_vector (const std::vector<AdvectionField> &advection_fields)
+  void Simulator<dim>::interpolate_particle_properties (const std::vector<AdvectionField> &advection_fields)
   {
     TimerOutput::Scope timer (computing_timer, "Particles: Interpolate");
 
@@ -273,7 +273,10 @@ namespace aspect
     // that share the same base element. Otherwise the element support points
     // are not guaranteed to be identical.
     for (const auto &advection_field: advection_fields)
-      Assert (advection_field.base_element(introspection) == base_element_index, ExcInternalError());
+      {
+        (void) advection_field;
+        Assert (advection_field.base_element(introspection) == base_element_index, ExcInternalError());
+      }
 
     // get the temperature/composition support points
     const std::vector<Point<dim>> support_points

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -249,6 +249,8 @@ namespace aspect
         Assert(initial_residual->size() == introspection.n_compositional_fields, ExcInternalError());
       }
 
+    std::vector<AdvectionField> fields_advected_by_particles;
+
     for (unsigned int c=0; c < introspection.n_compositional_fields; ++c)
       {
         const AdvectionField adv_field (AdvectionField::composition(c));
@@ -294,7 +296,8 @@ namespace aspect
 
             case Parameters<dim>::AdvectionFieldMethod::particles:
             {
-              interpolate_particle_properties(adv_field);
+              // handle all particle fields together to increase efficiency
+              fields_advected_by_particles.push_back(adv_field);
               break;
             }
 
@@ -335,6 +338,10 @@ namespace aspect
               AssertThrow(false,ExcNotImplemented());
           }
       }
+
+    if (fields_advected_by_particles.size() > 0)
+      interpolate_particle_property_vector(fields_advected_by_particles);
+
 
     // for consistency we update the current linearization point only after we have solved
     // all fields, so that we use the same point in time for every field when solving

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -340,7 +340,7 @@ namespace aspect
       }
 
     if (fields_advected_by_particles.size() > 0)
-      interpolate_particle_property_vector(fields_advected_by_particles);
+      interpolate_particle_properties(fields_advected_by_particles);
 
 
     // for consistency we update the current linearization point only after we have solved


### PR DESCRIPTION
Our particle interpolators support interpolating more than one property per call, but the calling side in the Simulator class does not make use of this. Instead we call one interpolation at a time, because it is embedded in a loop over all compositional fields. This is not efficient, but often does not matter much, since interpolation is usually quick. However, @KiralyAgi recently sent me a model with 37(!) particle properties, and there interpolation made up a significant part of the runtime. This change interpolates all properties in one call, and should decrease that cost significantly. @KiralyAgi can you try to take these changes, incorporate them into your branch and maybe report back if it helped your runtime? The change itself should be pretty uncontroversial, the only extra condition it applies to the interpolation is that all interpolated fields need to have the same base element. We do not support different elements for different fields anyway at the moment, but this is something to keep in mind for the future.

I should mention that this does not affect the results, because the current_linearization_point is only updated after all compositional fields (particles or otherwise) have been solved. This is done to avoid solutions that depend on the order in which compositional fields are specified.