### PR TITLE
Add cpo property Bingham average

### DIFF
--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -1,0 +1,202 @@
+/*
+ Copyright (C) 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_property_cpo_s_wave_anisotropy_h
+#define _aspect_particle_property_cpo_s_wave_anisotropy_h
+
+#include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
+#include <array>
+#include <random>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      /**
+       * Computes the Bingham average of the CPO particle properties.
+       * See https://courses.eas.ualberta.ca/eas421/lecturepages/orientation.html for more info.
+       *
+       * The layout of the data vector per partcle is the following (note that for this plugin the following dim's are always 3):
+       * 1 averaged a axis of olivine -> 3 (dim) doubles, starts at:
+       *                                   data_position + 1,
+       * 2 averaged b axis of olivine -> 3 (dim) doubles, starts at:
+       *                                   data_position + 4
+       * 3 averaged c axis of olivine -> 3 (dim) doubles, starts at:
+       *                                   data_position + 7
+       * 4 averaged a axis of enstatite -> 3 (dim) doubles, starts at:
+       *                                    data_position + 10
+       * 5 averaged b axis of enstatite -> 3 (dim) doubles, starts at:
+       *                                    data_position + 13
+       * 6 averaged c axis of enstatite -> 3 (dim) doubles, starts at:
+       *                                    data_position + 16
+       *
+       * @ingroup ParticleProperties
+       */
+      template <int dim>
+      class CpoBinghamAverage : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * constructor
+           */
+          CpoBinghamAverage();
+
+          /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           */
+          virtual
+          void
+          initialize ();
+
+          /**
+           * Initialization function. This function is called once at the
+           * creation of every particle for every property to initialize its
+           * value.
+           *
+           * @param [in] position The current particle position.
+           * @param [in,out] particle_properties The properties of the particle
+           * that is initialized within the call of this function. The purpose
+           * of this function should be to extend this vector by a number of
+           * properties.
+           */
+          virtual
+          void
+          initialize_one_particle_property (const Point<dim> &position,
+                                            std::vector<double> &particle_properties) const;
+
+          /**
+           * Update function. This function is called every time an update is
+           * request by need_update() for every particle for every property.
+           *
+           * @param [in] data_position An unsigned integer that denotes which
+           * component of the particle property vector is associated with the
+           * current property. For properties that own several components it
+           * denotes the first component of this property, all other components
+           * fill consecutive entries in the @p particle_properties vector.
+           *
+           * @param [in] position The current particle position.
+           *
+           * @param [in] solution The values of the solution variables at the
+           * current particle position.
+           *
+           * @param [in] gradients The gradients of the solution variables at
+           * the current particle position.
+           *
+           * @param [in,out] particle_properties The properties of the particle
+           * that is updated within the call of this function.
+           */
+          virtual
+          void
+          update_one_particle_property (const unsigned int data_position,
+                                        const Point<dim> &position,
+                                        const Vector<double> &solution,
+                                        const std::vector<Tensor<1,dim>> &gradients,
+                                        const ArrayView<double> &particle_properties) const;
+
+          /**
+           * This implementation tells the particle manager that
+           * we need to update particle properties every time step.
+           */
+          UpdateTimeFlags
+          need_update () const;
+
+          /**
+           * Return which data has to be provided to update the property.
+           * The integrated strains needs the gradients of the velocity.
+           */
+          virtual
+          UpdateFlags
+          get_needed_update_flags () const;
+
+          /**
+           * Set up the information about the names and number of components
+           * this property requires.
+           *
+           * @return A vector that contains pairs of the property names and the
+           * number of components this property plugin defines.
+           */
+          virtual
+          std::vector<std::pair<std::string, unsigned int>>
+          get_property_information() const;
+
+          /**
+           * Computes the Bingham average
+           */
+          std::array<std::array<double,3>,3> compute_bingham_average(std::vector<Tensor<2,3>> matrices) const;
+
+          /**
+          * Get volume weighted euler angles, using random draws to convert
+          * to a discrete number of orientations, weighted by volume.
+           */
+          std::vector<Tensor<2,3>>
+          random_draw_volume_weighting(std::vector<double> fv,
+                                       std::vector<Tensor<2,3>> matrices,
+                                       unsigned int n_output_grains) const;
+
+
+          /**
+          * Declare the parameters this class takes through input files.
+          */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          unsigned int cpo_data_position;
+
+          double rad_to_degree = 180.0/M_PI;
+          double degree_to_rad = M_PI/180.0;
+          /**
+           * Random number generator. For reproducibility of tests it is
+           * initialized in the constructor with a constant plus the MPI rank.
+           */
+          mutable std::mt19937            random_number_generator;
+
+          unsigned int random_number_seed;
+
+          unsigned int n_grains;
+          unsigned int n_minerals;
+
+          // when doing the random draw volume weighting, this sets how many samples are taken.
+          unsigned int n_samples;
+
+          /**
+           * The tensor equivalent to the permutation symbol.
+           */
+          Tensor<3,3> permutation_operator_3d;
+
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -152,31 +152,6 @@ namespace aspect
           std::array<std::array<double,3>,3> compute_bingham_average(std::vector<Tensor<2,3>> matrices) const;
 
           /**
-           * Create a permutation vector which can be used by the apply_permutation function
-           * which shorts the vector in .. order.
-           *
-           * @param vector vector to sort
-           */
-          template <typename T>
-          std::vector<std::size_t>
-          sort_permutation(
-            const std::vector<T> &vector) const;
-
-          /**
-           * Applies a permutation vector to return a sorted verions of the vector.
-           *
-           * @param vector vector to sort
-           * @param permutation_vector The permutation vector used to sort the input vector.
-           * @return std::vector<T>
-           */
-          template <typename T>
-          std::vector<T>
-          apply_permutation(
-            const std::vector<T> &vec,
-            const std::vector<std::size_t> &permutation_vector) const;
-
-
-          /**
           * Declare the parameters this class takes through input files.
           */
           static
@@ -226,10 +201,6 @@ namespace aspect
            * The tensor equivalent to the permutation symbol (Levi-Civita symbol).
            */
           Tensor<3,3> permutation_operator_3d;
-
-          // utility values
-          double rad_to_degree = 180.0/M_PI;
-          double degree_to_rad = M_PI/180.0;
 
       };
     }

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -175,17 +175,6 @@ namespace aspect
             const std::vector<T> &vec,
             const std::vector<std::size_t> &permutation_vector) const;
 
-          /**
-          * Get volume weighted euler angles, using random draws to convert
-          * to a discrete number of orientations, weighted by volume.
-          * The input is a vector of volume fractions and a vector of rotation matrices.
-          * The vectors need to have the same length.
-          */
-          std::vector<Tensor<2,3>>
-          random_draw_volume_weighting(const std::vector<double> volume_fraction,
-                                       const std::vector<Tensor<2,3>> rotation_matrices,
-                                       const unsigned int n_output_grains) const;
-
 
           /**
           * Declare the parameters this class takes through input files.

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -1,0 +1,369 @@
+/*
+  Copyright (C) 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+//#include <cstdlib>
+#include <aspect/particle/property/cpo_bingham_average.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/particle/world.h>
+
+#include <aspect/utilities.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+
+      template <int dim>
+      CpoBinghamAverage<dim>::CpoBinghamAverage ()
+      {
+        permutation_operator_3d[0][1][2]  = 1;
+        permutation_operator_3d[1][2][0]  = 1;
+        permutation_operator_3d[2][0][1]  = 1;
+        permutation_operator_3d[0][2][1]  = -1;
+        permutation_operator_3d[1][0][2]  = -1;
+        permutation_operator_3d[2][1][0]  = -1;
+      }
+
+      template <int dim>
+      void
+      CpoBinghamAverage<dim>::initialize ()
+      {
+        const unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+        this->random_number_generator.seed(random_number_seed+my_rank);
+        const auto &manager = this->get_particle_world().get_property_manager();
+        AssertThrow(manager.plugin_name_exists("crystal preferred orientation"),
+                    ExcMessage("No crystal preferred orientation property plugin found."));
+        Assert(manager.plugin_name_exists("cpo bingham average"),
+               ExcMessage("No bingham average property plugin found."));
+
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","cpo bingham average"),
+                    ExcMessage("To use the cpo bingham average plugin, the cpo plugin need to be defined before this plugin."));
+
+        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("crystal preferred orientation"));
+
+      }
+
+
+
+      template <int dim>
+      void
+      CpoBinghamAverage<dim>::initialize_one_particle_property(const Point<dim> &,
+                                                               std::vector<double> &data) const
+      {
+
+        const unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+        this->random_number_generator.seed(random_number_seed+my_rank);
+
+        // Get a reference to the CPO particle property.
+        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+        std::vector<double> volume_fractions_grains(n_grains);
+        std::vector<Tensor<2,3>> rotation_matrices_grains(n_grains);
+        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+          {
+            // create volume fractions and rotation matrix vectors in the order that it is stored in the data array
+            for (size_t grain_i = 0; grain_i < n_grains; grain_i++)
+              {
+                volume_fractions_grains[grain_i] = cpo_particle_property.get_volume_fractions_grains(cpo_data_position,data,mineral_i,grain_i);
+                rotation_matrices_grains[grain_i] = cpo_particle_property.get_rotation_matrix_grains(cpo_data_position,data,mineral_i,grain_i);
+              }
+
+            const std::vector<Tensor<2,3>> weighted_rotation_matrices = random_draw_volume_weighting(volume_fractions_grains, rotation_matrices_grains, n_samples);
+            std::array<std::array<double,3>,3> bingham_average = compute_bingham_average(weighted_rotation_matrices);
+
+            for (unsigned int i = 0; i < 3; i++)
+              for (unsigned int j = 0; j < 3; j++)
+                data.emplace_back(bingham_average[i][j]);
+          }
+      }
+
+      template <int dim>
+      void
+      CpoBinghamAverage<dim>::update_one_particle_property(const unsigned int data_position,
+                                                           const Point<dim> &,
+                                                           const Vector<double> &,
+                                                           const std::vector<Tensor<1,dim>> &,
+                                                           const ArrayView<double> &data) const
+      {
+        // Get a reference to the CPO particle property.
+        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+        std::vector<double> volume_fractions_grains(n_grains);
+        std::vector<Tensor<2,3>> rotation_matrices_grains(n_grains);
+        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+          {
+            // create volume fractions and rotation matrix vectors in the order that it is stored in the data array
+            for (size_t grain_i = 0; grain_i < n_grains; grain_i++)
+              {
+                volume_fractions_grains[grain_i] = cpo_particle_property.get_volume_fractions_grains(cpo_data_position,data,mineral_i,grain_i);
+                rotation_matrices_grains[grain_i] = cpo_particle_property.get_rotation_matrix_grains(cpo_data_position,data,mineral_i,grain_i);
+              }
+
+            const std::vector<Tensor<2,3>> weighted_rotation_matrices = random_draw_volume_weighting(volume_fractions_grains, rotation_matrices_grains, n_samples);
+            std::array<std::array<double,3>,3> bingham_average = compute_bingham_average(weighted_rotation_matrices);
+
+            unsigned int counter = 0;
+            for (unsigned int i = 0; i < 3; i++)
+              for (unsigned int j = 0; j < 3; j++)
+                {
+                  data[data_position + mineral_i*9 + counter] = bingham_average[i][j];
+                  counter++;
+                }
+          }
+      }
+
+
+      template<int dim>
+      std::array<std::array<double,3>,3>
+      CpoBinghamAverage<dim>::compute_bingham_average(std::vector<Tensor<2,3>> matrices) const
+      {
+        SymmetricTensor< 2, 3, double > sum_matrix_a;
+        SymmetricTensor< 2, 3, double > sum_matrix_b;
+        SymmetricTensor< 2, 3, double > sum_matrix_c;
+
+        // extracting the a, b and c orientations from the olivine a matrix
+        // see https://courses.eas.ualberta.ca/eas421/lecturepages/orientation.html
+        for (unsigned int i_grain = 0; i_grain < matrices.size(); i_grain++)
+          {
+            sum_matrix_a[0][0] += matrices[i_grain][0][0] * matrices[i_grain][0][0]; // SUM(l^2)
+            sum_matrix_a[1][1] += matrices[i_grain][0][1] * matrices[i_grain][0][1]; // SUM(m^2)
+            sum_matrix_a[2][2] += matrices[i_grain][0][2] * matrices[i_grain][0][2]; // SUM(n^2)
+            sum_matrix_a[0][1] += matrices[i_grain][0][0] * matrices[i_grain][0][1]; // SUM(l*m)
+            sum_matrix_a[0][2] += matrices[i_grain][0][0] * matrices[i_grain][0][2]; // SUM(l*n)
+            sum_matrix_a[1][2] += matrices[i_grain][0][1] * matrices[i_grain][0][2]; // SUM(m*n)
+
+
+            sum_matrix_b[0][0] += matrices[i_grain][1][0] * matrices[i_grain][1][0]; // SUM(l^2)
+            sum_matrix_b[1][1] += matrices[i_grain][1][1] * matrices[i_grain][1][1]; // SUM(m^2)
+            sum_matrix_b[2][2] += matrices[i_grain][1][2] * matrices[i_grain][1][2]; // SUM(n^2)
+            sum_matrix_b[0][1] += matrices[i_grain][1][0] * matrices[i_grain][1][1]; // SUM(l*m)
+            sum_matrix_b[0][2] += matrices[i_grain][1][0] * matrices[i_grain][1][2]; // SUM(l*n)
+            sum_matrix_b[1][2] += matrices[i_grain][1][1] * matrices[i_grain][1][2]; // SUM(m*n)
+
+
+            sum_matrix_c[0][0] += matrices[i_grain][2][0] * matrices[i_grain][2][0]; // SUM(l^2)
+            sum_matrix_c[1][1] += matrices[i_grain][2][1] * matrices[i_grain][2][1]; // SUM(m^2)
+            sum_matrix_c[2][2] += matrices[i_grain][2][2] * matrices[i_grain][2][2]; // SUM(n^2)
+            sum_matrix_c[0][1] += matrices[i_grain][2][0] * matrices[i_grain][2][1]; // SUM(l*m)
+            sum_matrix_c[0][2] += matrices[i_grain][2][0] * matrices[i_grain][2][2]; // SUM(l*n)
+            sum_matrix_c[1][2] += matrices[i_grain][2][1] * matrices[i_grain][2][2]; // SUM(m*n)
+
+          }
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> eigenvectors_a = eigenvectors(sum_matrix_a, SymmetricTensorEigenvectorMethod::jacobi);
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> eigenvectors_b = eigenvectors(sum_matrix_b, SymmetricTensorEigenvectorMethod::jacobi);
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> eigenvectors_c = eigenvectors(sum_matrix_c, SymmetricTensorEigenvectorMethod::jacobi);
+
+
+        const Tensor<1,3,double> averaged_a = eigenvectors_a[0].second * eigenvectors_a[0].first;
+        const Tensor<1,3,double> averaged_b = eigenvectors_b[0].second * eigenvectors_b[0].first;
+        const Tensor<1,3,double> averaged_c = eigenvectors_c[0].second * eigenvectors_a[0].first;
+
+        return
+        {
+          {
+            {{averaged_a[0],averaged_a[1],averaged_a[2]}},
+            {{averaged_b[0],averaged_b[1],averaged_b[2]}},
+            {{averaged_c[0],averaged_c[1],averaged_c[2]}}
+          }
+        };
+      }
+
+      template<int dim>
+      std::vector<Tensor<2,3>>
+      CpoBinghamAverage<dim>::random_draw_volume_weighting(std::vector<double> fv,
+                                                           std::vector<Tensor<2,3>> matrices,
+                                                           unsigned int n_output_grains) const
+      {
+        // Get volume weighted euler angles, using random draws to convert odf
+        // to a discrete number of orientations, weighted by volume
+        // 1a. Get index that would sort volume fractions AND
+        //ix = np.argsort(fv[q,:]);
+        // 1b. Get the sorted volume and angle arrays
+        std::vector<double> fv_to_sort = fv;
+        std::vector<double> fv_sorted = fv;
+        std::vector<Tensor<2,3>> matrices_sorted = matrices;
+
+        unsigned int n_grain = fv_to_sort.size();
+
+
+        /**
+         * ...
+         */
+        for (int i = n_grain-1; i >= 0; --i)
+          {
+            unsigned int index_max_fv = std::distance(fv_to_sort.begin(),max_element(fv_to_sort.begin(), fv_to_sort.end()));
+
+            fv_sorted[i] = fv_to_sort[index_max_fv];
+            matrices_sorted[i] = matrices[index_max_fv];
+            fv_to_sort[index_max_fv] = -1;
+          }
+
+        // 2. Get cumulative weight for volume fraction
+        std::vector<double> cum_weight(n_grains);
+        std::partial_sum(fv_sorted.begin(),fv_sorted.end(),cum_weight.begin());
+        // 3. Generate random indices
+        std::uniform_real_distribution<> dist(0, 1);
+        std::vector<double> idxgrain(n_output_grains);
+        for (unsigned int grain_i = 0; grain_i < n_output_grains; ++grain_i)
+          {
+            idxgrain[grain_i] = dist(this->random_number_generator);
+          }
+
+        // 4. Find the maximum cum_weight that is less than the random value.
+        // the euler angle index is +1. For example, if the idxGrain(g) < cumWeight(1),
+        // the index should be 1 not zero)
+        std::vector<Tensor<2,3>> matrices_out(n_output_grains);
+        for (unsigned int grain_i = 0; grain_i < n_output_grains; ++grain_i)
+          {
+            unsigned int counter = 0;
+            for (unsigned int grain_j = 0; grain_j < n_grains; ++grain_j)
+              {
+                // find the first cummulative weight which is larger than the random number
+                // todo: there may be algorithms to do this faster
+                if (cum_weight[grain_j] < idxgrain[grain_i])
+                  {
+                    counter++;
+                  }
+                else
+                  {
+                    break;
+                  }
+              }
+            matrices_out[grain_i] = matrices_sorted[counter];
+          }
+        return matrices_out;
+      }
+
+
+
+      template <int dim>
+      UpdateTimeFlags
+      CpoBinghamAverage<dim>::need_update() const
+      {
+        return update_output_step;
+      }
+
+      template <int dim>
+      UpdateFlags
+      CpoBinghamAverage<dim>::get_needed_update_flags () const
+      {
+        return update_default;
+      }
+
+      template <int dim>
+      std::vector<std::pair<std::string, unsigned int>>
+      CpoBinghamAverage<dim>::get_property_information() const
+      {
+        std::vector<std::pair<std::string,unsigned int>> property_information;
+        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+          {
+            property_information.push_back(std::make_pair("cpo mineral " + std::to_string(mineral_i) + " bingham average a axis",3));
+            property_information.push_back(std::make_pair("cpo mineral " + std::to_string(mineral_i) + " bingham average b axis",3));
+            property_information.push_back(std::make_pair("cpo mineral " + std::to_string(mineral_i) + " bingham average c axis",3));
+          }
+
+        return property_information;
+      }
+
+      template <int dim>
+      void
+      CpoBinghamAverage<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            prm.enter_subsection("CpoBinghamAverage");
+            {
+              prm.declare_entry ("Random number seed", "1",
+                                 Patterns::Integer (0),
+                                 "The seed used to generate random numbers. This will make sure that "
+                                 "results are reproducable as long as the problem is run with the "
+                                 "same amount of MPI processes. It is implemented as final seed = "
+                                 "user seed + MPI Rank. ");
+
+              prm.declare_entry ("Number of samples", "0",
+                                 Patterns::Double(0),
+                                 "This determines how many samples are taken when using the random "
+                                 "draw volume averaging. Setting it to zero means that the number of "
+                                 "samples is set to be equal to the number of grains.");
+            }
+            prm.leave_subsection ();
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+      }
+
+
+      template <int dim>
+      void
+      CpoBinghamAverage<dim>::parse_parameters (ParameterHandler &prm)
+      {
+
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            prm.enter_subsection("CpoBinghamAverage");
+            {
+              // Get a reference to the CPO particle property.
+              const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+                this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+              random_number_seed = prm.get_integer ("Random number seed");
+              n_grains = cpo_particle_property.get_number_of_grains();
+              n_minerals = cpo_particle_property.get_number_of_minerals();
+              n_samples = prm.get_integer("Number of samples");
+              if (n_samples == 0)
+                n_samples = n_grains;
+            }
+            prm.leave_subsection ();
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+
+
+      }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+      ASPECT_REGISTER_PARTICLE_PROPERTY(CpoBinghamAverage,
+                                        "cpo bingham average",
+                                        "This is a particle property plugin which computes the Bingham "
+                                        "average for the Crystal Preferred Orienation particle property "
+                                        "plugin so that it can be visualized.")
+    }
+  }
+}

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2022 by the authors of the ASPECT code.
+  Copyright (C) 2023 by the authors of the ASPECT code.
 
  This file is part of ASPECT.
 
@@ -18,7 +18,6 @@
  <http://www.gnu.org/licenses/>.
  */
 
-//#include <cstdlib>
 #include <aspect/particle/property/cpo_bingham_average.h>
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/particle/world.h>
@@ -53,8 +52,6 @@ namespace aspect
         const auto &manager = this->get_particle_world().get_property_manager();
         AssertThrow(manager.plugin_name_exists("crystal preferred orientation"),
                     ExcMessage("No crystal preferred orientation property plugin found."));
-        Assert(manager.plugin_name_exists("cpo bingham average"),
-               ExcMessage("No bingham average property plugin found."));
 
         AssertThrow(manager.check_plugin_order("crystal preferred orientation","cpo bingham average"),
                     ExcMessage("To use the cpo bingham average plugin, the cpo plugin need to be defined before this plugin."));
@@ -70,27 +67,23 @@ namespace aspect
       CpoBinghamAverage<dim>::initialize_one_particle_property(const Point<dim> &,
                                                                std::vector<double> &data) const
       {
-
-        const unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-        this->random_number_generator.seed(random_number_seed+my_rank);
-
         // Get a reference to the CPO particle property.
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
           this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
 
         std::vector<double> volume_fractions_grains(n_grains);
         std::vector<Tensor<2,3>> rotation_matrices_grains(n_grains);
-        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+        for (unsigned int mineral_i = 0; mineral_i < n_minerals; mineral_i++)
           {
             // create volume fractions and rotation matrix vectors in the order that it is stored in the data array
-            for (size_t grain_i = 0; grain_i < n_grains; grain_i++)
+            for (unsigned int grain_i = 0; grain_i < n_grains; grain_i++)
               {
                 volume_fractions_grains[grain_i] = cpo_particle_property.get_volume_fractions_grains(cpo_data_position,data,mineral_i,grain_i);
                 rotation_matrices_grains[grain_i] = cpo_particle_property.get_rotation_matrix_grains(cpo_data_position,data,mineral_i,grain_i);
               }
 
             const std::vector<Tensor<2,3>> weighted_rotation_matrices = random_draw_volume_weighting(volume_fractions_grains, rotation_matrices_grains, n_samples);
-            std::array<std::array<double,3>,3> bingham_average = compute_bingham_average(weighted_rotation_matrices);
+            const std::array<std::array<double,3>,3> bingham_average = compute_bingham_average(weighted_rotation_matrices);
 
             for (unsigned int i = 0; i < 3; i++)
               for (unsigned int j = 0; j < 3; j++)
@@ -112,10 +105,10 @@ namespace aspect
 
         std::vector<double> volume_fractions_grains(n_grains);
         std::vector<Tensor<2,3>> rotation_matrices_grains(n_grains);
-        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+        for (unsigned int mineral_i = 0; mineral_i < n_minerals; mineral_i++)
           {
             // create volume fractions and rotation matrix vectors in the order that it is stored in the data array
-            for (size_t grain_i = 0; grain_i < n_grains; grain_i++)
+            for (unsigned int grain_i = 0; grain_i < n_grains; grain_i++)
               {
                 volume_fractions_grains[grain_i] = cpo_particle_property.get_volume_fractions_grains(cpo_data_position,data,mineral_i,grain_i);
                 rotation_matrices_grains[grain_i] = cpo_particle_property.get_rotation_matrix_grains(cpo_data_position,data,mineral_i,grain_i);
@@ -129,7 +122,7 @@ namespace aspect
               for (unsigned int j = 0; j < 3; j++)
                 {
                   data[data_position + mineral_i*9 + counter] = bingham_average[i][j];
-                  counter++;
+                  ++counter;
                 }
           }
       }
@@ -139,13 +132,14 @@ namespace aspect
       std::array<std::array<double,3>,3>
       CpoBinghamAverage<dim>::compute_bingham_average(std::vector<Tensor<2,3>> matrices) const
       {
-        SymmetricTensor< 2, 3, double > sum_matrix_a;
-        SymmetricTensor< 2, 3, double > sum_matrix_b;
-        SymmetricTensor< 2, 3, double > sum_matrix_c;
+        SymmetricTensor<2,3> sum_matrix_a;
+        SymmetricTensor<2,3> sum_matrix_b;
+        SymmetricTensor<2,3> sum_matrix_c;
 
         // extracting the a, b and c orientations from the olivine a matrix
         // see https://courses.eas.ualberta.ca/eas421/lecturepages/orientation.html
-        for (unsigned int i_grain = 0; i_grain < matrices.size(); i_grain++)
+        const unsigned int n_matrices = matrices.size();
+        for (unsigned int i_grain = 0; i_grain < n_matrices; i_grain++)
           {
             sum_matrix_a[0][0] += matrices[i_grain][0][0] * matrices[i_grain][0][0]; // SUM(l^2)
             sum_matrix_a[1][1] += matrices[i_grain][0][1] * matrices[i_grain][0][1]; // SUM(m^2)
@@ -191,34 +185,53 @@ namespace aspect
       }
 
       template<int dim>
-      std::vector<Tensor<2,3>>
-      CpoBinghamAverage<dim>::random_draw_volume_weighting(std::vector<double> fv,
-                                                           std::vector<Tensor<2,3>> matrices,
-                                                           unsigned int n_output_grains) const
+      template <typename T>
+      std::vector<std::size_t>
+      CpoBinghamAverage<dim>::sort_permutation(
+        const std::vector<T> &vec) const
       {
+        std::vector<std::size_t> p(vec.size());
+        std::iota(p.begin(), p.end(), 0);
+        std::sort(p.begin(), p.end(),
+                  [&](std::size_t i, std::size_t j)
+        {
+          return vec[i] < vec[j];
+        });
+        return p;
+      }
+
+      template<int dim>
+      template <typename T>
+      std::vector<T>
+      CpoBinghamAverage<dim>::apply_permutation(
+        const std::vector<T> &vec,
+        const std::vector<std::size_t> &p) const
+      {
+        std::vector<T> sorted_vec(vec.size());
+        std::transform(p.begin(), p.end(), sorted_vec.begin(),
+                       [&](std::size_t i)
+        {
+          return vec[i];
+        });
+        return sorted_vec;
+      }
+
+      template<int dim>
+      std::vector<Tensor<2,3>>
+      CpoBinghamAverage<dim>::random_draw_volume_weighting(const std::vector<double> volume_fraction,
+                                                           const std::vector<Tensor<2,3>> rotation_matrices,
+                                                           const unsigned int n_output_grains) const
+      {
+
+        unsigned int n_grains = volume_fraction.size();
+
         // Get volume weighted euler angles, using random draws to convert odf
         // to a discrete number of orientations, weighted by volume
-        // 1a. Get index that would sort volume fractions AND
-        //ix = np.argsort(fv[q,:]);
-        // 1b. Get the sorted volume and angle arrays
-        std::vector<double> fv_to_sort = fv;
-        std::vector<double> fv_sorted = fv;
-        std::vector<Tensor<2,3>> matrices_sorted = matrices;
+        // 1a. Sort the volume fractions and matrices based on the volume fractions size
+        const auto p = sort_permutation(volume_fraction);
 
-        unsigned int n_grain = fv_to_sort.size();
-
-
-        /**
-         * ...
-         */
-        for (int i = n_grain-1; i >= 0; --i)
-          {
-            unsigned int index_max_fv = std::distance(fv_to_sort.begin(),max_element(fv_to_sort.begin(), fv_to_sort.end()));
-
-            fv_sorted[i] = fv_to_sort[index_max_fv];
-            matrices_sorted[i] = matrices[index_max_fv];
-            fv_to_sort[index_max_fv] = -1;
-          }
+        const std::vector<double> fv_sorted = apply_permutation(volume_fraction, p);
+        const std::vector<Tensor<2,3>> matrices_sorted = apply_permutation(rotation_matrices, p);
 
         // 2. Get cumulative weight for volume fraction
         std::vector<double> cum_weight(n_grains);
@@ -237,21 +250,15 @@ namespace aspect
         std::vector<Tensor<2,3>> matrices_out(n_output_grains);
         for (unsigned int grain_i = 0; grain_i < n_output_grains; ++grain_i)
           {
-            unsigned int counter = 0;
-            for (unsigned int grain_j = 0; grain_j < n_grains; ++grain_j)
-              {
-                // find the first cummulative weight which is larger than the random number
-                // todo: there may be algorithms to do this faster
-                if (cum_weight[grain_j] < idxgrain[grain_i])
-                  {
-                    counter++;
-                  }
-                else
-                  {
-                    break;
-                  }
-              }
-            matrices_out[grain_i] = matrices_sorted[counter];
+            const std::vector<double>::iterator selected_matrix =
+              std::lower_bound(cum_weight.begin(),
+                               cum_weight.end(),
+                               idxgrain[grain_i]);
+
+            const unsigned int matrix_index =
+              std::distance(cum_weight.begin(), selected_matrix);
+
+            matrices_out[grain_i] = matrices_sorted[matrix_index];
           }
         return matrices_out;
       }
@@ -277,7 +284,7 @@ namespace aspect
       CpoBinghamAverage<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information;
-        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+        for (unsigned int mineral_i = 0; mineral_i < n_minerals; mineral_i++)
           {
             property_information.push_back(std::make_pair("cpo mineral " + std::to_string(mineral_i) + " bingham average a axis",3));
             property_information.push_back(std::make_pair("cpo mineral " + std::to_string(mineral_i) + " bingham average b axis",3));
@@ -362,7 +369,7 @@ namespace aspect
       ASPECT_REGISTER_PARTICLE_PROPERTY(CpoBinghamAverage,
                                         "cpo bingham average",
                                         "This is a particle property plugin which computes the Bingham "
-                                        "average for the Crystal Preferred Orienation particle property "
+                                        "average for the Crystal Preferred Orientation particle property "
                                         "plugin so that it can be visualized.")
     }
   }

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -30,8 +30,6 @@ namespace aspect
   {
     namespace Property
     {
-
-
       template <int dim>
       CpoBinghamAverage<dim>::CpoBinghamAverage ()
       {
@@ -42,6 +40,8 @@ namespace aspect
         permutation_operator_3d[1][0][2]  = -1;
         permutation_operator_3d[2][1][0]  = -1;
       }
+
+
 
       template <int dim>
       void
@@ -91,6 +91,8 @@ namespace aspect
           }
       }
 
+
+
       template <int dim>
       void
       CpoBinghamAverage<dim>::update_one_particle_property(const unsigned int data_position,
@@ -126,6 +128,7 @@ namespace aspect
                 }
           }
       }
+
 
 
       template<int dim>
@@ -184,38 +187,6 @@ namespace aspect
         };
       }
 
-      template<int dim>
-      template <typename T>
-      std::vector<std::size_t>
-      CpoBinghamAverage<dim>::sort_permutation(
-        const std::vector<T> &vec) const
-      {
-        std::vector<std::size_t> p(vec.size());
-        std::iota(p.begin(), p.end(), 0);
-        std::sort(p.begin(), p.end(),
-                  [&](std::size_t i, std::size_t j)
-        {
-          return vec[i] < vec[j];
-        });
-        return p;
-      }
-
-      template<int dim>
-      template <typename T>
-      std::vector<T>
-      CpoBinghamAverage<dim>::apply_permutation(
-        const std::vector<T> &vec,
-        const std::vector<std::size_t> &p) const
-      {
-        std::vector<T> sorted_vec(vec.size());
-        std::transform(p.begin(), p.end(), sorted_vec.begin(),
-                       [&](std::size_t i)
-        {
-          return vec[i];
-        });
-        return sorted_vec;
-      }
-
 
 
       template <int dim>
@@ -225,12 +196,16 @@ namespace aspect
         return update_output_step;
       }
 
+
+
       template <int dim>
       UpdateFlags
       CpoBinghamAverage<dim>::get_needed_update_flags () const
       {
         return update_default;
       }
+
+
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
@@ -247,6 +222,8 @@ namespace aspect
         return property_information;
       }
 
+
+
       template <int dim>
       void
       CpoBinghamAverage<dim>::declare_parameters (ParameterHandler &prm)
@@ -255,14 +232,14 @@ namespace aspect
         {
           prm.enter_subsection("Particles");
           {
-            prm.enter_subsection("CpoBinghamAverage");
+            prm.enter_subsection("CPO Bingham Average");
             {
               prm.declare_entry ("Random number seed", "1",
                                  Patterns::Integer (0),
                                  "The seed used to generate random numbers. This will make sure that "
                                  "results are reproducable as long as the problem is run with the "
                                  "same amount of MPI processes. It is implemented as final seed = "
-                                 "user seed + MPI Rank. ");
+                                 "Random number seed + MPI Rank. ");
 
               prm.declare_entry ("Number of samples", "0",
                                  Patterns::Double(0),
@@ -278,6 +255,7 @@ namespace aspect
       }
 
 
+
       template <int dim>
       void
       CpoBinghamAverage<dim>::parse_parameters (ParameterHandler &prm)
@@ -287,7 +265,7 @@ namespace aspect
         {
           prm.enter_subsection("Particles");
           {
-            prm.enter_subsection("CpoBinghamAverage");
+            prm.enter_subsection("CPO Bingham Average");
             {
               // Get a reference to the CPO particle property.
               const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
@@ -305,8 +283,6 @@ namespace aspect
           prm.leave_subsection ();
         }
         prm.leave_subsection ();
-
-
       }
     }
   }


### PR DESCRIPTION
Adds a particle property plugin to compute the Bingham average for the CPO particle properties.

This implementation is based on https://github.com/geodynamics/aspect/pull/4978, so this should not be merged until that one is. It is ready for review though.

(point 4 in https://github.com/geodynamics/aspect/issues/3885)