### PR TITLE
Fix particle cpo function by making it const.

### DIFF
--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -214,13 +214,13 @@ namespace aspect
            * Return the number of grains per particle
            */
           unsigned int
-          get_number_of_grains();
+          get_number_of_grains() const;
 
           /**
            * Return the number of minerals per particle
            */
           unsigned int
-          get_number_of_minerals();
+          get_number_of_minerals() const;
 
           /**
            * @brief Returns the value in the data array representing the deformation type.

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -557,7 +557,7 @@ namespace aspect
 
       template<int dim>
       unsigned int
-      CrystalPreferredOrientation<dim>::get_number_of_grains()
+      CrystalPreferredOrientation<dim>::get_number_of_grains() const
       {
         return n_grains;
       }
@@ -566,7 +566,7 @@ namespace aspect
 
       template<int dim>
       unsigned int
-      CrystalPreferredOrientation<dim>::get_number_of_minerals()
+      CrystalPreferredOrientation<dim>::get_number_of_minerals() const
       {
         return n_minerals;
       }


### PR DESCRIPTION
small fix of cpo get_number_of_grains and get_number_of_minerals functions, making them constant member functions. Needed to get #4980 working.