### PR TITLE
Remove outdated and wrong option in signal_handler for program termination

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -511,16 +511,10 @@ void signal_handler(int signal)
     {
       std::cerr << "Unexpected signal " << signal << " received\n";
     }
-#if DEAL_II_USE_CXX11
-  // Kill the program without performing any other cleanup, which is likely to
-  // lead to a deadlock
+
+  // Kill the program without performing any other cleanup, which would likely
+  // lead to a deadlock.
   std::_Exit(EXIT_FAILURE);
-#else
-  // Kill the program, or at least try to. The problem when we get here is
-  // that calling std::exit invokes at_exit() functions that may still hang
-  // the MPI system
-  std::exit(1);
-#endif
 }
 
 


### PR DESCRIPTION
While looking more into a solution for #4984 I found this wrong code in ASPECT's signal handler. `DEAL_II_USE_CXX11` is no longer set in deal.II, meaning we consistently used the pre C++11 option in ASPECT since deal.II 9.3.0

I have not yet tested if this resolves #4984, but  so far I was unsuccessful to create a test purely in deal.II to create the same deadlock that seems to happen in the ASPECT model (so maybe us messing with the signal_handler is involved).