### PR TITLE
Call MPI_Abort after handling exception

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -803,6 +803,8 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
+
+      MPI_Abort(MPI_COMM_WORLD, 1);
       return 1;
     }
   catch (std::exception &exc)
@@ -817,6 +819,8 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
+
+      MPI_Abort(MPI_COMM_WORLD, 1);
       return 1;
     }
   catch (aspect::QuietException &)
@@ -830,6 +834,8 @@ int main (int argc, char *argv[])
       // other ranks to be printed before the MPI implementation might kill
       // the computation.
       std::this_thread::sleep_for(std::chrono::seconds(5));
+
+      MPI_Abort(MPI_COMM_WORLD, 1);
       return 1;
     }
   catch (...)
@@ -841,6 +847,8 @@ int main (int argc, char *argv[])
                 << "Aborting!" << std::endl
                 << "----------------------------------------------------"
                 << std::endl;
+
+      MPI_Abort(MPI_COMM_WORLD, 1);
       return 1;
     }
 

--- a/tests/advection_solver_fail/screen-output
+++ b/tests/advection_solver_fail/screen-output
@@ -60,3 +60,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/ascii_data_fail_1/screen-output
+++ b/tests/ascii_data_fail_1/screen-output
@@ -23,3 +23,4 @@ Additional information:
     lines at the end of the data file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/ascii_data_fail_2/screen-output
+++ b/tests/ascii_data_fail_2/screen-output
@@ -25,3 +25,4 @@ Additional information:
     POINTS header in the file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/ascii_data_fail_3/screen-output
+++ b/tests/ascii_data_fail_3/screen-output
@@ -25,3 +25,4 @@ Additional information:
     POINTS header in the file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/ascii_data_fail_4/screen-output
+++ b/tests/ascii_data_fail_4/screen-output
@@ -21,3 +21,4 @@ Additional information:
     not found!
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/cmake/default
+++ b/tests/cmake/default
@@ -57,5 +57,12 @@ while ( <STDIN> )
     last;
   }
 
+  if ($_ =~ m/^Aborting!/)
+  {
+    print "$_";
+    print "(rest of the output replaced by default.sh script)\n";
+    last;
+  }
+
   print "$_";
 }

--- a/tests/composition_names_duplicates/screen-output
+++ b/tests/composition_names_duplicates/screen-output
@@ -25,9 +25,4 @@ Additional information:
     corrupted.
 
 Aborting!
-MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
-with errorcode 1.
-
-NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
-You may or may not see output from other processes, depending on
-exactly when Open MPI kills them.
+(rest of the output replaced by default.sh script)

--- a/tests/fail/screen-output
+++ b/tests/fail/screen-output
@@ -12,3 +12,4 @@ Additional information:
     given in the parameter file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/find_boundary_composition_model_fail_1/screen-output
+++ b/tests/find_boundary_composition_model_fail_1/screen-output
@@ -26,3 +26,4 @@ Additional information:
     file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/find_boundary_composition_model_fail_2/screen-output
+++ b/tests/find_boundary_composition_model_fail_2/screen-output
@@ -25,3 +25,4 @@ Additional information:
     performed.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/find_mesh_refinement_fail_1/screen-output
+++ b/tests/find_mesh_refinement_fail_1/screen-output
@@ -25,3 +25,4 @@ Additional information:
     refinement strategy in the input file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/find_postprocess_fail_1/screen-output
+++ b/tests/find_postprocess_fail_1/screen-output
@@ -24,3 +24,4 @@ Additional information:
     postprocessor in the input file.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/find_postprocess_fail_2/screen-output
+++ b/tests/find_postprocess_fail_2/screen-output
@@ -25,3 +25,4 @@ Additional information:
     performed.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/isosurfaces_simple_box_2D_custom_fieldnames_fail/screen-output
+++ b/tests/isosurfaces_simple_box_2D_custom_fieldnames_fail/screen-output
@@ -18,3 +18,4 @@ Additional information:
     Temperature, field1, FieldB, fIEld_C.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/steinberger_lateral_fail/screen-output
+++ b/tests/steinberger_lateral_fail/screen-output
@@ -28,3 +28,4 @@ Additional information:
     lateral average bands)
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/stokes_solver_fail/screen-output
+++ b/tests/stokes_solver_fail/screen-output
@@ -63,3 +63,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/stokes_solver_fail_A/screen-output
+++ b/tests/stokes_solver_fail_A/screen-output
@@ -64,3 +64,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/stokes_solver_fail_S/screen-output
+++ b/tests/stokes_solver_fail_S/screen-output
@@ -64,3 +64,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/stokes_solver_fail_cheap/screen-output
+++ b/tests/stokes_solver_fail_cheap/screen-output
@@ -63,3 +63,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/stokes_solver_fail_gmg/screen-output
+++ b/tests/stokes_solver_fail_gmg/screen-output
@@ -70,3 +70,4 @@ Additional information:
     
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/time_stepping_fail/screen-output
+++ b/tests/time_stepping_fail/screen-output
@@ -55,3 +55,4 @@ Additional information:
     the computed step length of the "function" plugin was: -1.000000.
 
 Aborting!
+(rest of the output replaced by default.sh script)

--- a/tests/visualization_unique_list/screen-output
+++ b/tests/visualization_unique_list/screen-output
@@ -18,3 +18,4 @@ Additional information:
     allowed. Please check your parameter file.
 
 Aborting!
+(rest of the output replaced by default.sh script)


### PR DESCRIPTION
If a subset of processes throw an exception during communication, we can end up in a deadlock when the destructor of `MPI_InitFinalize` is called. `MPI_InitFinalize` checks for uncaught exceptions, but the exception was already correctly caught by the catch block we have in ASPECT. We should call `MPI_Abort`, just like deal.II's step-50 already does (https://github.com/dealii/dealii/blob/aa053f40abf916e6b3acdb843b636b7cd577f0e7/examples/step-50/step-50.cc#L1588).