### PR TITLE
Adiabatic boundary layer age function

### DIFF
--- a/doc/modules/changes/20221206_douglas
+++ b/doc/modules/changes/20221206_douglas
@@ -1,0 +1,7 @@
+Added: The 'adiabatic' initial temperature plugin can now use a spatially
+variable top boundary layer thickness read from a data file or specified as a
+function in the input file. Additionally, the boundary layer temperature can
+now also be computed following the plate cooling model instead of the
+half-space cooling model.
+<br>
+(Daniel Douglas, John Naliboff, Juliane Dannberg, Rene Gassmoeller, 2022/12/06)

--- a/include/aspect/initial_temperature/adiabatic.h
+++ b/include/aspect/initial_temperature/adiabatic.h
@@ -129,6 +129,17 @@ namespace aspect
          * diffusivity. The function depends only on depth.
          */
         std::unique_ptr<Functions::ParsedFunction<1>> function;
+
+        /**
+         * A function object representing the age of the top boundary layer.
+         */
+        Functions::ParsedFunction<dim> age_function;
+
+        /**
+         * The coordinate representation to evaluate the function. Possible
+         * choices are depth, cartesian and spherical.
+         */
+        Utilities::Coordinates::CoordinateSystem coordinate_system;
     };
   }
 }

--- a/include/aspect/initial_temperature/adiabatic.h
+++ b/include/aspect/initial_temperature/adiabatic.h
@@ -35,6 +35,33 @@ namespace aspect
     using namespace dealii;
 
     /**
+     * A namespace for selecting how to determine the age of a
+     * boundary layer. Current options are:
+     *
+     *  'constant': A constant age independent of position.
+     *  'ascii_data': Age is specified in an ascii data file.
+     *  'function': Age is specified as a function in the input file.
+     */
+    namespace BoundaryLayerAgeModel
+    {
+      enum Kind
+      {
+        constant,
+        ascii_data,
+        function
+      };
+
+      /**
+       * Read the lithosphere age model from the parameter file,
+       * using the parameter name given in @p parameter_name, and return the
+       * enum that corresponds to this operation.
+       */
+      BoundaryLayerAgeModel::Kind
+      parse (const std::string &parameter_name,
+             const ParameterHandler &prm);
+    }
+
+    /**
      * A class that implements adiabatic initial conditions for the
      * temperature field and, optional, upper and lower thermal boundary
      * layers calculated using the half-space cooling model. The age of the
@@ -75,14 +102,19 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
-
+        /**
+         * The boundary identifier representing the 'surface' boundary as
+         * reported by the geometry model.
+         */
         types::boundary_id surface_boundary_id;
+
         /**
          * Age of the upper thermal boundary layer at the surface of the
          * model. If set to zero, no boundary layer will be present in the
          * model.
          */
         double age_top_boundary_layer;
+
         /* Age of the lower thermal boundary layer. */
         double age_bottom_boundary_layer;
 
@@ -108,16 +140,18 @@ namespace aspect
          * profile.
          */
         double subadiabaticity;
-        /*
-         * Whether seafloor ages should be read in from an ASCII file,
-         *  or input as a constant value
-         */
-        bool read_from_ascii_file;
+
+        /**
+         * Age model to use for the top boundary layer.
+        */
+        BoundaryLayerAgeModel::Kind top_boundary_layer_age_model;
+
         /*
          * Whether to use the half space cooling model, or the plate cooling
          * model
          */
         std::string cooling_model;
+
         /*
          * Depth to the base of the lithosphere for plate cooling model, in m
          */
@@ -140,6 +174,11 @@ namespace aspect
          * choices are depth, cartesian and spherical.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
+
+        /**
+         * Compute the top boundary layer age at the given position.
+        */
+        double top_boundary_layer_age(const Point<dim> &position) const;
     };
   }
 }

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -101,9 +101,9 @@ namespace aspect
         }
       else if (top_boundary_layer_age_model == BoundaryLayerAgeModel::constant)
         {
-          age_top =    (this->convert_output_to_years() 
-          ? 
-          age_top_boundary_layer * year_in_seconds
+          age_top =    (this->convert_output_to_years()
+                        ?
+                        age_top_boundary_layer * year_in_seconds
                         :
                         age_top_boundary_layer);
         }
@@ -111,7 +111,7 @@ namespace aspect
         {
           Utilities::NaturalCoordinate<dim> point =
             this->get_geometry_model().cartesian_to_other_coordinates(position,
-            coordinate_system);
+                                                                      coordinate_system);
 
           age_top = age_function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));
           if (this->convert_output_to_years())

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -62,7 +62,15 @@ namespace aspect
     Adiabatic<dim>::
     initial_temperature (const Point<dim> &position) const
     {
-      double age_top = 0;
+      // convert input ages to seconds
+      // TODO: make old parameter deprecated
+      Utilities::NaturalCoordinate<dim> point =
+        this->get_geometry_model().cartesian_to_other_coordinates(position, coordinate_system);
+
+      double age_top = age_function.value(Utilities::convert_array_to_point<dim>(point.get_coordinates()));
+      if (this->convert_output_to_years())
+    	age_top *= year_in_seconds;
+
       const double age_bottom = (this->convert_output_to_years() ? age_bottom_boundary_layer * year_in_seconds
                                  : age_bottom_boundary_layer);
       if (read_from_ascii_file)
@@ -363,6 +371,29 @@ namespace aspect
             Functions::ParsedFunction<1>::declare_parameters (prm, 1);
           }
           prm.leave_subsection();
+          prm.enter_subsection("Age function");
+          {
+            /**
+             * Choose the coordinates to evaluate the age
+             * function. The function can be declared in dependence of depth,
+             * cartesian coordinates or spherical coordinates. Note that the order
+             * of spherical coordinates is r,phi,theta and not r,theta,phi, since
+             * this allows for dimension independent expressions.
+             */
+            prm.declare_entry ("Coordinate system", "cartesian",
+                               Patterns::Selection ("cartesian|spherical|depth"),
+                               "A selection that determines the assumed coordinate "
+                               "system for the function variables. Allowed values "
+                               "are `cartesian', `spherical', and `depth'. `spherical' coordinates "
+                               "are interpreted as r,phi or r,phi,theta in 2D/3D "
+                               "respectively with theta being the polar angle. `depth' "
+                               "will create a function, in which only the first "
+                               "parameter is non-zero, which is interpreted to "
+                               "be the depth of the point.");
+
+            Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
+          }
+          prm.leave_subsection();
         }
         prm.leave_subsection ();
       }
@@ -419,6 +450,26 @@ namespace aspect
 
               prm.leave_subsection();
             }
+          prm.enter_subsection("Age function");
+          {
+        	coordinate_system = Utilities::Coordinates::string_to_coordinate_system(prm.get("Coordinate system"));
+          }
+          try
+            {
+              age_function.parse_parameters (prm);
+            }
+          catch (...)
+            {
+              std::cerr << "ERROR: FunctionParser failed to parse\n"
+                        << "\t'Initial temperature model.Adiabatic.Age Function'\n"
+                        << "with expression\n"
+                        << "\t'" << prm.get("Function expression") << "'"
+                        << "More information about the cause of the parse error \n"
+                        << "is shown below.\n";
+              throw;
+            }
+
+          prm.leave_subsection();
         }
         prm.leave_subsection ();
       }

--- a/tests/adiabatic_plate_function.prm
+++ b/tests/adiabatic_plate_function.prm
@@ -1,5 +1,6 @@
-# This test is used to check if the plate cooling model with seafloor ages
-# defined in an ASCII data file is calculated correctly.
+# This test is used to check if the half-space cooling model with seafloor ages
+# defined in an analytic function is calculated correctly. It is similar to
+# the adiabatic_plate_cooling test.
 
 set Dimension                              = 2
 set Output directory                       = adiabatic_plate_cooling
@@ -15,17 +16,21 @@ subsection Geometry model
   subsection Box
     set X extent = 150e3
     set Y extent = 150e3
-    set X repetitions = 10
-    set Y repetitions = 10
+    set X repetitions = 20
+    set Y repetitions = 20
   end
 end
 
 subsection Initial temperature model
   set Model name = adiabatic
   subsection Adiabatic
-    set Top boundary layer age model = ascii data
-    set Cooling model = plate cooling
-    set Lithosphere thickness = 125e3
+    set Top boundary layer age model = function
+    set Cooling model = half-space cooling
+
+    subsection Age function
+      set Function constants = cm=0.01, year=1
+      set Function expression = x / (1 * cm / year)
+    end
   end
 end
 
@@ -68,7 +73,7 @@ subsection Mesh refinement
 end
 
 subsection Postprocess
-  set List of postprocessors = temperature statistics
+  set List of postprocessors = temperature statistics, heat flux statistics
 
   subsection Visualization
     set Interpolate output = false

--- a/tests/adiabatic_plate_function/screen-output
+++ b/tests/adiabatic_plate_function/screen-output
@@ -1,0 +1,25 @@
+
+Number of active cells: 400 (on 1 levels)
+Number of degrees of freedom: 5,484 (3,362+441+1,681)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:            293 K, 1450 K, 1623 K
+     Heat fluxes through boundary parts: 0 W, 0 W, -1.786 W, 3.905e+04 W
+
+*** Timestep 1:  t=1 years, dt=1 years
+   Solving temperature system... 5 iterations.
+   Solving Stokes system... 31+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:            293 K, 1450 K, 1623 K
+     Heat fluxes through boundary parts: 0 W, 0 W, -2.001 W, 3.964e+04 W
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/adiabatic_plate_function/statistics
+++ b/tests/adiabatic_plate_function/statistics
@@ -1,0 +1,20 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Minimal temperature (K)
+# 12: Average temperature (K)
+# 13: Maximal temperature (K)
+# 14: Average nondimensional temperature (K)
+# 15: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 16: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 17: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 18: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 400 3803 1681 0 33 35 34 2.93000000e+02 1.44980956e+03 1.62300000e+03 8.69781626e-01 0.00000000e+00 0.00000000e+00 -1.78580829e+00 3.90503105e+04 
+1 1.000000000000e+00 1.000000000000e+00 400 3803 1681 5 30 32 32 2.93000000e+02 1.44980955e+03 1.62300063e+03 8.69781613e-01 0.00000000e+00 0.00000000e+00 -2.00129960e+00 3.96378696e+04 


### PR DESCRIPTION
Some improvements to #4184. Also add the ability to define plate age as an input function in the parameter file. This is very helpful for simple models of mid-ocean ridges and oceanic plates in general. I am currently preparing a cookbook that makes use of this functionality.

I modified the input parameter introduced in #4184 to allow for the extension to additional age models (I could for example envision a gplates file model, like for the boundary velocity). @naliboff and @danieldouglas92 I know this requires you to rename parameters in your parameter files, do you agree that the new form is more useful and are you ok with the change?