### PR TITLE
Adjust max depth for origin

### DIFF
--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -297,7 +297,7 @@ namespace aspect
     double
     Box<dim>::maximal_depth() const
     {
-      return extents[dim-1] + topo_model->max_topography();
+      return extents[dim-1] - box_origin[dim-1] + topo_model->max_topography();
     }
 
     template <int dim>

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -296,7 +296,7 @@ namespace aspect
     double
     TwoMergedBoxes<dim>::maximal_depth() const
     {
-      return extents[dim-1];
+      return extents[dim-1] - lower_box_origin[dim-1];
     }
 
     template <int dim>


### PR DESCRIPTION
The origin of a box geometry domain can be other than at 0. In this case the maximum depth is not necessary equal to the maximum y coordinate. 

EDIT: Never mind, my reasoning was wrong. 

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
