### PR TITLE
Always update apt package list before install in tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: setup
       run: |
+        sudo apt-get update
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository ppa:ginggs/deal.ii-9.3.2-backports
         sudo apt-get update
@@ -45,6 +46,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: setup
       run: |
+        sudo apt-get update
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository ppa:ginggs/deal.ii-9.3.2-backports
         sudo apt-get update


### PR DESCRIPTION
I have seen a few failures of the no-unity-build tester lately with errors related to installing apt packages (e.g. https://github.com/geodynamics/aspect/actions/runs/3887199332/jobs/6633184425). This may help.