### PR TITLE
Some optimizations for the grain size material model

### DIFF
--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -282,18 +282,6 @@ namespace aspect
                                       const Point<dim> &position,
                                       const double viscosity_guess = 0) const;
 
-        /**
-         * This function calculates the dislocation viscosity for a given
-         * dislocation strain rate.
-         */
-        double dislocation_viscosity_fixed_strain_rate (const double      temperature,
-                                                        const double      pressure,
-                                                        const std::vector<double> &,
-                                                        const SymmetricTensor<2,dim> &dislocation_strain_rate,
-                                                        const Point<dim> &position,
-                                                        const double adiabatic_temperature,
-                                                        const double adiabatic_pressure) const;
-
         double density (const double temperature,
                         const double pressure,
                         const std::vector<double> &compositional_fields,

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -183,6 +183,11 @@ namespace aspect
         double k_value;
 
         /**
+         * The index of the compositional field that represents the grain size.
+        */
+        unsigned int grain_size_index;
+
+        /**
          * Parameters controlling the grain size evolution.
          */
         std::vector<double> grain_growth_activation_energy;
@@ -255,7 +260,9 @@ namespace aspect
                                     const double      pressure,
                                     const std::vector<double>    &compositional_fields,
                                     const SymmetricTensor<2,dim> &,
-                                    const Point<dim> &position) const;
+                                    const Point<dim> &position,
+                                    const double adiabatic_temperature,
+                                    const double adiabatic_pressure) const;
 
         /**
          * This function calculates the dislocation viscosity. For this purpose
@@ -283,7 +290,9 @@ namespace aspect
                                                         const double      pressure,
                                                         const std::vector<double> &,
                                                         const SymmetricTensor<2,dim> &dislocation_strain_rate,
-                                                        const Point<dim> &position) const;
+                                                        const Point<dim> &position,
+                                                        const double adiabatic_temperature,
+                                                        const double adiabatic_pressure) const;
 
         double density (const double temperature,
                         const double pressure,

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -249,20 +249,12 @@ namespace aspect
          */
         bool advect_log_grainsize;
 
-
-        double viscosity (const double                  temperature,
-                          const double                  pressure,
-                          const std::vector<double>    &compositional_fields,
-                          const SymmetricTensor<2,dim> &strain_rate,
-                          const Point<dim>             &position) const;
-
-        double diffusion_viscosity (const double      temperature,
-                                    const double      pressure,
-                                    const std::vector<double>    &compositional_fields,
-                                    const SymmetricTensor<2,dim> &,
-                                    const Point<dim> &position,
+        double diffusion_viscosity (const double temperature,
                                     const double adiabatic_temperature,
-                                    const double adiabatic_pressure) const;
+                                    const double adiabatic_pressure,
+                                    const double grain_size,
+                                    const double second_strain_rate_invariant,
+                                    const Point<dim> &position) const;
 
         /**
          * This function calculates the dislocation viscosity. For this purpose
@@ -275,11 +267,12 @@ namespace aspect
          * unless a guess for the viscosity is provided, which can reduce the
          * number of iterations significantly.
          */
-        double dislocation_viscosity (const double      temperature,
-                                      const double      pressure,
-                                      const std::vector<double>    &compositional_fields,
+        double dislocation_viscosity (const double temperature,
+                                      const double adiabatic_temperature,
+                                      const double adiabatic_pressure,
                                       const SymmetricTensor<2,dim> &strain_rate,
                                       const Point<dim> &position,
+                                      const double diffusion_viscosity,
                                       const double viscosity_guess = 0) const;
 
         double density (const double temperature,

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -244,8 +244,8 @@ namespace aspect
 
           // grain size growth due to Ostwald ripening
           const double m = grain_growth_exponent[phase_index];
-          const double grain_size_growth_rate = grain_growth_rate_constant[phase_index] / (m * pow(grain_size,m-1))
-                                                * exp(- (grain_growth_activation_energy[phase_index] + pressure * grain_growth_activation_volume[phase_index])
+          const double grain_size_growth_rate = grain_growth_rate_constant[phase_index] / (m * std::pow(grain_size,m-1))
+                                                * std::exp(- (grain_growth_activation_energy[phase_index] + pressure * grain_growth_activation_volume[phase_index])
                                                       / (constants::gas_constant * temperature));
           const double grain_size_growth = grain_size_growth_rate * grain_growth_timestep;
 
@@ -271,7 +271,7 @@ namespace aspect
             {
               // paleowattmeter: Austin and Evans (2007): Paleowattmeters: A scaling relation for dynamically recrystallized grain size. Geology 35, 343-346
               const double stress = 2.0 * second_strain_rate_invariant * current_viscosity;
-              const double grain_size_reduction_rate = 2.0 * stress * boundary_area_change_work_fraction[phase_index] * dislocation_strain_rate * pow(grain_size,2)
+              const double grain_size_reduction_rate = 2.0 * stress * boundary_area_change_work_fraction[phase_index] * dislocation_strain_rate * std::pow(grain_size,2)
                                                        / (geometric_constant[phase_index] * grain_boundary_energy[phase_index]);
               grain_size_reduction = grain_size_reduction_rate * grain_growth_timestep;
             }
@@ -355,7 +355,7 @@ namespace aspect
       // find out in which phase we are
       const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
 
-      double energy_term = exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
+      double energy_term = std::exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
                                / (diffusion_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
       // If the adiabatic profile is already calculated we can use it to limit
@@ -363,7 +363,7 @@ namespace aspect
       if (this->get_adiabatic_conditions().is_initialized())
         {
           const double adiabatic_energy_term
-            = exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
+            = std::exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
                   / (diffusion_creep_exponent[phase_index] * constants::gas_constant * this->get_adiabatic_conditions().temperature(position)));
 
           const double temperature_dependence = energy_term / adiabatic_energy_term;
@@ -375,9 +375,9 @@ namespace aspect
 
       const double strain_rate_dependence = (1.0 - diffusion_creep_exponent[phase_index]) / diffusion_creep_exponent[phase_index];
 
-      return pow(diffusion_creep_prefactor[phase_index],-1.0/diffusion_creep_exponent[phase_index])
+      return std::pow(diffusion_creep_prefactor[phase_index],-1.0/diffusion_creep_exponent[phase_index])
              * std::pow(second_strain_rate_invariant,strain_rate_dependence)
-             * pow(grain_size, diffusion_creep_grain_size_exponent[phase_index]/diffusion_creep_exponent[phase_index])
+             * std::pow(grain_size, diffusion_creep_grain_size_exponent[phase_index]/diffusion_creep_exponent[phase_index])
              * energy_term;
     }
 
@@ -447,7 +447,7 @@ namespace aspect
       // find out in which phase we are
       const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
 
-      double energy_term = exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
+      double energy_term = std::exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
                                / (dislocation_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
       // If we are past the initialization of the adiabatic profile, use it to
@@ -455,7 +455,7 @@ namespace aspect
       if (this->get_adiabatic_conditions().is_initialized())
         {
           const double adiabatic_energy_term
-            = exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
+            = std::exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
                   / (dislocation_creep_exponent[phase_index] * constants::gas_constant * this->get_adiabatic_conditions().temperature(position)));
 
           const double temperature_dependence = energy_term / adiabatic_energy_term;
@@ -1357,8 +1357,8 @@ namespace aspect
           pv_grain_size_scaling                 = prm.get_double ("Lower mantle grain size scaling");
 
           // scale recrystallized grain size, diffusion creep and grain growth prefactor accordingly
-          diffusion_creep_prefactor[diffusion_creep_prefactor.size()-1] *= pow(pv_grain_size_scaling,diffusion_creep_grain_size_exponent[diffusion_creep_grain_size_exponent.size()-1]);
-          grain_growth_rate_constant[grain_growth_rate_constant.size()-1] *= pow(pv_grain_size_scaling,grain_growth_exponent[grain_growth_exponent.size()-1]);
+          diffusion_creep_prefactor[diffusion_creep_prefactor.size()-1] *= std::pow(pv_grain_size_scaling,diffusion_creep_grain_size_exponent[diffusion_creep_grain_size_exponent.size()-1]);
+          grain_growth_rate_constant[grain_growth_rate_constant.size()-1] *= std::pow(pv_grain_size_scaling,grain_growth_exponent[grain_growth_exponent.size()-1]);
           if (recrystallized_grain_size.size()>0)
             recrystallized_grain_size[recrystallized_grain_size.size()-1] *= pv_grain_size_scaling;
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -380,7 +380,7 @@ namespace aspect
 
       const double strain_rate_dependence = (1.0 - diffusion_creep_exponent[phase_index]) / diffusion_creep_exponent[phase_index];
 
-      return std::pow(diffusion_creep_prefactor[phase_index],-1.0/diffusion_creep_exponent[phase_index])
+      return diffusion_creep_prefactor[phase_index]
              * std::pow(second_strain_rate_invariant,strain_rate_dependence)
              * std::pow(grain_size, diffusion_creep_grain_size_exponent[phase_index]/diffusion_creep_exponent[phase_index])
              * energy_term;
@@ -492,7 +492,7 @@ namespace aspect
 
       const double strain_rate_dependence = (1.0 - dislocation_creep_exponent[phase_index]) / dislocation_creep_exponent[phase_index];
 
-      return std::pow(dislocation_creep_prefactor[phase_index],-1.0/dislocation_creep_exponent[phase_index])
+      return dislocation_creep_prefactor[phase_index]
              * std::pow(second_strain_rate_invariant,strain_rate_dependence)
              * energy_term;
     }
@@ -1424,6 +1424,12 @@ namespace aspect
           grain_growth_rate_constant[grain_growth_rate_constant.size()-1] *= std::pow(pv_grain_size_scaling,grain_growth_exponent[grain_growth_exponent.size()-1]);
           if (recrystallized_grain_size.size()>0)
             recrystallized_grain_size[recrystallized_grain_size.size()-1] *= pv_grain_size_scaling;
+
+          // prefactors never appear without their exponents. perform some calculations here to save time later
+          for (unsigned int i=0; i<diffusion_creep_prefactor.size(); ++i)
+            diffusion_creep_prefactor[i] = std::pow(diffusion_creep_prefactor[i],-1.0/diffusion_creep_exponent[i]);
+          for (unsigned int i=0; i<dislocation_creep_prefactor.size(); ++i)
+            dislocation_creep_prefactor[i] = std::pow(dislocation_creep_prefactor[i],-1.0/dislocation_creep_exponent[i]);
 
           if (use_paleowattmeter)
             boundary_area_change_work_fraction[boundary_area_change_work_fraction.size()-1] /= pv_grain_size_scaling;

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -187,7 +187,6 @@ namespace aspect
     convert_log_grain_size (std::vector<double> &composition) const
     {
       // get grain size and limit it to a global minimum
-      const unsigned int grain_size_index = this->introspection().compositional_index_for_name("grain_size");
       double grain_size = composition[grain_size_index];
       grain_size = std::max(std::exp(-grain_size), min_grain_size);
 
@@ -232,6 +231,17 @@ namespace aspect
       // for the next one
       double current_dislocation_viscosity = 0.0;
 
+      const double adiabatic_temperature = this->get_adiabatic_conditions().is_initialized()
+                                           ?
+                                           this->get_adiabatic_conditions().temperature(position)
+                                           :
+                                           temperature;
+      const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                        ?
+                                        this->get_adiabatic_conditions().pressure(position)
+                                        :
+                                        pressure;
+
       do
         {
           time += grain_growth_timestep;
@@ -246,14 +256,14 @@ namespace aspect
           const double m = grain_growth_exponent[phase_index];
           const double grain_size_growth_rate = grain_growth_rate_constant[phase_index] / (m * std::pow(grain_size,m-1))
                                                 * std::exp(- (grain_growth_activation_energy[phase_index] + pressure * grain_growth_activation_volume[phase_index])
-                                                      / (constants::gas_constant * temperature));
+                                                           / (constants::gas_constant * temperature));
           const double grain_size_growth = grain_size_growth_rate * grain_growth_timestep;
 
           // grain size reduction in dislocation creep regime
           const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
           const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
-          const double current_diffusion_viscosity   = diffusion_viscosity(temperature, pressure, current_composition, strain_rate, position);
+          const double current_diffusion_viscosity   = diffusion_viscosity(temperature, pressure, current_composition, strain_rate, position, adiabatic_temperature,adiabatic_pressure);
           current_dislocation_viscosity              = dislocation_viscosity(temperature, pressure, current_composition, strain_rate, position, current_dislocation_viscosity);
 
           double current_viscosity;
@@ -335,28 +345,23 @@ namespace aspect
     double
     GrainSize<dim>::
     diffusion_viscosity (const double                  temperature,
-                         const double                  pressure,
+                         const double                  /*pressure*/,
                          const std::vector<double>    &composition,
                          const SymmetricTensor<2,dim> &strain_rate,
-                         const Point<dim>             &position) const
+                         const Point<dim>             &position,
+                         const double adiabatic_temperature,
+                         const double adiabatic_pressure) const
     {
       const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
       const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
-      const double grain_size = composition[this->introspection().compositional_index_for_name("grain_size")];
-
-      // Currently this will never be called without adiabatic_conditions initialized, but just in case
-      const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
-                                        ?
-                                        this->get_adiabatic_conditions().pressure(position)
-                                        :
-                                        pressure;
+      const double grain_size = composition[grain_size_index];
 
       // find out in which phase we are
       const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
 
       double energy_term = std::exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
-                               / (diffusion_creep_exponent[phase_index] * constants::gas_constant * temperature));
+                                    / (diffusion_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
       // If the adiabatic profile is already calculated we can use it to limit
       // variations in viscosity due to temperature.
@@ -364,7 +369,7 @@ namespace aspect
         {
           const double adiabatic_energy_term
             = std::exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
-                  / (diffusion_creep_exponent[phase_index] * constants::gas_constant * this->get_adiabatic_conditions().temperature(position)));
+                       / (diffusion_creep_exponent[phase_index] * constants::gas_constant * adiabatic_temperature));
 
           const double temperature_dependence = energy_term / adiabatic_energy_term;
           if (temperature_dependence > max_temperature_dependence_of_eta)
@@ -393,12 +398,35 @@ namespace aspect
                            const Point<dim> &position,
                            const double viscosity_guess) const
     {
-      const double diff_viscosity = diffusion_viscosity(temperature,pressure,composition,strain_rate,position) ;
+      const double adiabatic_temperature = this->get_adiabatic_conditions().is_initialized()
+                                           ?
+                                           this->get_adiabatic_conditions().temperature(position)
+                                           :
+                                           temperature;
+      const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                        ?
+                                        this->get_adiabatic_conditions().pressure(position)
+                                        :
+                                        pressure;
+
+      const double diff_viscosity = diffusion_viscosity(temperature,
+                                                        pressure,
+                                                        composition,
+                                                        strain_rate,
+                                                        position,
+                                                        adiabatic_temperature,
+                                                        adiabatic_pressure);
 
       // Start the iteration with the full strain rate
       double dis_viscosity;
       if (viscosity_guess == 0)
-        dis_viscosity = dislocation_viscosity_fixed_strain_rate(temperature,pressure,std::vector<double>(),strain_rate,position);
+        dis_viscosity = dislocation_viscosity_fixed_strain_rate(temperature,
+                                                                pressure,
+                                                                std::vector<double>(),
+                                                                strain_rate,
+                                                                position,
+                                                                adiabatic_temperature,
+                                                                adiabatic_pressure);
       else
         dis_viscosity = viscosity_guess;
 
@@ -414,7 +442,9 @@ namespace aspect
                                                                   pressure,
                                                                   std::vector<double>(),
                                                                   dislocation_strain_rate,
-                                                                  position);
+                                                                  position,
+                                                                  adiabatic_temperature,
+                                                                  adiabatic_pressure);
           ++i;
         }
 
@@ -429,26 +459,21 @@ namespace aspect
     double
     GrainSize<dim>::
     dislocation_viscosity_fixed_strain_rate (const double      temperature,
-                                             const double      pressure,
+                                             const double      /*pressure*/,
                                              const std::vector<double> &,
                                              const SymmetricTensor<2,dim> &dislocation_strain_rate,
-                                             const Point<dim> &position) const
+                                             const Point<dim> &position,
+                                             const double adiabatic_temperature,
+                                             const double adiabatic_pressure) const
     {
       const SymmetricTensor<2,dim> shear_strain_rate = dislocation_strain_rate - 1./dim * trace(dislocation_strain_rate) * unit_symmetric_tensor<dim>();
       const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
-
-      // Currently this will never be called without adiabatic_conditions initialized, but just in case
-      const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
-                                        ?
-                                        this->get_adiabatic_conditions().pressure(position)
-                                        :
-                                        pressure;
 
       // find out in which phase we are
       const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
 
       double energy_term = std::exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
-                               / (dislocation_creep_exponent[phase_index] * constants::gas_constant * temperature));
+                                    / (dislocation_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
       // If we are past the initialization of the adiabatic profile, use it to
       // limit viscosity variations due to temperature.
@@ -456,7 +481,7 @@ namespace aspect
         {
           const double adiabatic_energy_term
             = std::exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
-                  / (dislocation_creep_exponent[phase_index] * constants::gas_constant * this->get_adiabatic_conditions().temperature(position)));
+                       / (dislocation_creep_exponent[phase_index] * constants::gas_constant * adiabatic_temperature));
 
           const double temperature_dependence = energy_term / adiabatic_energy_term;
           if (temperature_dependence > max_temperature_dependence_of_eta)
@@ -486,12 +511,33 @@ namespace aspect
       const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
       const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
-      const double diff_viscosity = diffusion_viscosity(temperature, pressure, composition, strain_rate, position);
+      const double adiabatic_temperature = this->get_adiabatic_conditions().is_initialized()
+                                           ?
+                                           this->get_adiabatic_conditions().temperature(position)
+                                           :
+                                           temperature;
+      const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                        ?
+                                        this->get_adiabatic_conditions().pressure(position)
+                                        :
+                                        pressure;
+
+      const double diff_viscosity = diffusion_viscosity(temperature,
+                                                        pressure,
+                                                        composition,
+                                                        strain_rate,
+                                                        position,
+                                                        adiabatic_temperature,
+                                                        adiabatic_pressure);
 
       double effective_viscosity;
       if (std::abs(second_strain_rate_invariant) > 1e-30)
         {
-          const double disl_viscosity = dislocation_viscosity(temperature, pressure, composition, strain_rate, position);
+          const double disl_viscosity = dislocation_viscosity(temperature,
+                                                              pressure,
+                                                              composition,
+                                                              strain_rate,
+                                                              position);
           effective_viscosity = disl_viscosity * diff_viscosity / (disl_viscosity + diff_viscosity);
         }
       else
@@ -783,7 +829,6 @@ namespace aspect
             convert_log_grain_size(composition);
           else
             {
-              const unsigned int grain_size_index = this->introspection().compositional_index_for_name("grain_size");
               composition[grain_size_index] = std::max(min_grain_size,composition[grain_size_index]);
             }
 
@@ -845,7 +890,24 @@ namespace aspect
               const SymmetricTensor<2,dim> shear_strain_rate = in.strain_rate[i] - 1./dim * trace(in.strain_rate[i]) * unit_symmetric_tensor<dim>();
               const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
-              const double diff_viscosity = diffusion_viscosity(in.temperature[i], pressure, composition, in.strain_rate[i], in.position[i]);
+              const double adiabatic_temperature = this->get_adiabatic_conditions().is_initialized()
+                                                   ?
+                                                   this->get_adiabatic_conditions().temperature(in.position[i])
+                                                   :
+                                                   in.temperature[i];
+              const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                                ?
+                                                this->get_adiabatic_conditions().pressure(in.position[i])
+                                                :
+                                                in.pressure[i];
+
+              const double diff_viscosity = diffusion_viscosity(in.temperature[i],
+                                                                pressure,
+                                                                composition,
+                                                                in.strain_rate[i],
+                                                                in.position[i],
+                                                                adiabatic_temperature,
+                                                                adiabatic_pressure);
 
               if (std::abs(second_strain_rate_invariant) > 1e-30)
                 {
@@ -1266,6 +1328,7 @@ namespace aspect
                    ExcMessage("The 'grain size' material model only works if a compositional "
                               "field with name 'grain_size' is present. Please use another material "
                               "model or add such a field."));
+      grain_size_index = this->introspection().compositional_index_for_name("grain_size");
 
       prm.enter_subsection("Material model");
       {
@@ -1426,7 +1489,7 @@ namespace aspect
           // wrong compositional fields.
           if (use_table_properties && material_file_names.size() > 1)
             {
-              AssertThrow(this->introspection().compositional_index_for_name("grain_size") >= material_file_names.size(),
+              AssertThrow(grain_size_index >= material_file_names.size(),
                           ExcMessage("The compositional fields indicating the major element composition need to be first in the "
                                      "list of compositional fields, but the grain size field seems to have a lower index than the number "
                                      "of provided data files. This is likely inconsistent. Please check the number of provided data "

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -173,11 +173,44 @@ namespace aspect
                       crossed_transition = k;
 
               if (in.requests_property(MaterialProperties::viscosity))
-                out.viscosities[i] = std::min(std::max(this->min_eta,this->viscosity(in.temperature[i],
-                                                                                     in.pressure[i],
-                                                                                     composition,
-                                                                                     in.strain_rate[i],
-                                                                                     in.position[i])),this->max_eta);
+                {
+                  double effective_viscosity;
+                  double disl_viscosity = std::numeric_limits<double>::max();
+                  Assert(std::isfinite(in.strain_rate[i].norm()),
+                         ExcMessage("Invalid strain_rate in the MaterialModelInputs. This is likely because it was "
+                                    "not filled by the caller."));
+                  const SymmetricTensor<2,dim> shear_strain_rate = in.strain_rate[i] - 1./dim * trace(in.strain_rate[i]) * unit_symmetric_tensor<dim>();
+                  const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
+
+                  const double adiabatic_temperature = this->get_adiabatic_conditions().is_initialized()
+                                                       ?
+                                                       this->get_adiabatic_conditions().temperature(in.position[i])
+                                                       :
+                                                       in.temperature[i];
+                  const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                                    ?
+                                                    this->get_adiabatic_conditions().pressure(in.position[i])
+                                                    :
+                                                    in.pressure[i];
+
+                  const unsigned int grain_size_index = this->introspection().compositional_index_for_name("grain_size");
+
+                  const double diff_viscosity = this->diffusion_viscosity(in.temperature[i],
+                                                                          adiabatic_temperature,
+                                                                          adiabatic_pressure,                                                                composition[grain_size_index],
+                                                                          second_strain_rate_invariant,
+                                                                          in.position[i]);
+
+                  if (std::abs(second_strain_rate_invariant) > 1e-30)
+                    {
+                      disl_viscosity = this->dislocation_viscosity(in.temperature[i], adiabatic_temperature, adiabatic_pressure, in.strain_rate[i], in.position[i],diff_viscosity);
+                      effective_viscosity = disl_viscosity * diff_viscosity / (disl_viscosity + diff_viscosity);
+                    }
+                  else
+                    effective_viscosity = diff_viscosity;
+
+                  out.viscosities[i] = std::min(std::max(this->min_eta,effective_viscosity),this->max_eta);
+                }
 
               out.densities[i] = this->density(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
 

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -197,7 +197,8 @@ namespace aspect
 
                   const double diff_viscosity = this->diffusion_viscosity(in.temperature[i],
                                                                           adiabatic_temperature,
-                                                                          adiabatic_pressure,                                                                composition[grain_size_index],
+                                                                          adiabatic_pressure,
+                                                                          composition[grain_size_index],
                                                                           second_strain_rate_invariant,
                                                                           in.position[i]);
 


### PR DESCRIPTION
The grain size material model always has been a very expensive material model due to the iterations for composite viscosity and the operator splitting for the grain size evolution (requiring many evaluations of the viscosity per time step of the operator splitting). The model is also pretty old and could use some improvements in code quality. These changes are only a first step in improving the quality of the code (I did not want to start a full rewrite), but they significantly speed up the evaluation of the model.

In a simple test model (with cheap solvers) this PR speeds up the evaluate function by about 3x, which results in an about 2x speedup for the total assembly. The material model can still make up several percent of total model runtime (in my worst case test the material model still makes up 25% of the total runtime), but at this point  further optimizations likely require larger changes than they are worth.

@jdannberg FYI