### PR TITLE
New shear heating output

### DIFF
--- a/doc/modules/changes/20230112_dannberg
+++ b/doc/modules/changes/20230112_dannberg
@@ -1,0 +1,9 @@
+New: There is now a new additional material model output called
+ShearHeatingOutputs that contains the fraction of the deformation
+work that is released as shear heating rather than being
+converted into other forms of energy, to be filled by the
+material model. The boundary_area_change_work_fractions variable
+(which provides the same information) has been removed from the
+DislocationViscosityOutputs in the grain size material model.
+<br>
+(Juliane Dannberg, 2023/01/12)

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -61,6 +61,29 @@ namespace aspect
         void
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const override;
     };
+
+
+    /**
+     * Additional output fields for the shear heating computation
+     * to be added to the MaterialModel::MaterialModelOutputs structure
+     * and filled in the MaterialModel::evaluate() function.
+     */
+    template <int dim>
+    class ShearHeatingOutputs : public MaterialModel::NamedAdditionalMaterialOutputs<dim>
+    {
+      public:
+        ShearHeatingOutputs(const unsigned int n_points);
+
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
+
+        /**
+         * The fraction of the deformation work that is released as shear heating
+         * rather than being converted into other forms of energy (such as, for
+         * example, surface energy of grains). If it is set to 1, all deformation
+         * work will go into shear heating.
+         */
+        std::vector<double> shear_heating_work_fractions;
+    };
   }
 }
 

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -61,14 +61,6 @@ namespace aspect
          * the current object.
          */
         std::vector<double> diffusion_viscosities;
-
-        /**
-         * This contains the fraction of the deformation work that is
-         * converted to surface energy of grains instead of thermal energy.
-         * It is used to reduce the shear heating by this fraction. If it
-         * is set to 0.0 it will not change the shear heating.
-         */
-        std::vector<double> boundary_area_change_work_fractions;
     };
 
 

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/heating_model/shear_heating.h>
-#include <aspect/material_model/grain_size.h>
 
 
 namespace aspect
@@ -42,8 +41,8 @@ namespace aspect
 
       // Some material models provide dislocation viscosities and boundary area work fractions
       // as additional material outputs. If they are attached, use them.
-      const MaterialModel::DislocationViscosityOutputs<dim> *disl_viscosities_out =
-        material_model_outputs.template get_additional_output<MaterialModel::DislocationViscosityOutputs<dim>>();
+      const ShearHeatingOutputs<dim> *shear_heating_out =
+        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
@@ -61,17 +60,18 @@ namespace aspect
 
           heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
-          // If dislocation viscosities and boundary area work fractions are provided, reduce the
-          // overall heating by this amount (which is assumed to increase surface energy)
-          if (disl_viscosities_out != nullptr)
+          // If shear heating work fractions are provided, reduce the
+          // overall heating by this amount (which is assumed to be converted into other forms of energy)
+          if (shear_heating_out != nullptr)
             {
-              heating_model_outputs.heating_source_terms[q] *= 1 - disl_viscosities_out->boundary_area_change_work_fractions[q] *
-                                                               material_model_outputs.viscosities[q] / disl_viscosities_out->dislocation_viscosities[q];
+              heating_model_outputs.heating_source_terms[q] *= shear_heating_out->shear_heating_work_fractions[q];
             }
 
           heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
         }
     }
+
+
 
     template <int dim>
     void
@@ -79,6 +79,26 @@ namespace aspect
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const
     {
       this->get_material_model().create_additional_named_outputs(material_model_outputs);
+    }
+
+
+
+    template <int dim>
+    ShearHeatingOutputs<dim>::ShearHeatingOutputs (const unsigned int n_points)
+      :
+      MaterialModel::NamedAdditionalMaterialOutputs<dim>({"shear_heating_work_fraction"}),
+                  shear_heating_work_fractions(n_points, numbers::signaling_nan<double>())
+    {}
+
+
+
+    template <int dim>
+    std::vector<double>
+    ShearHeatingOutputs<dim>::get_nth_output(const unsigned int idx) const
+    {
+      AssertIndexRange (idx, 0);
+
+      return shear_heating_work_fractions;
     }
   }
 }
@@ -96,5 +116,12 @@ namespace aspect
                                   "\\varepsilon \\mathbf 1 \\right) : \\left( \\varepsilon - \\frac{1}{3} "
                                   "\\text{tr} \\varepsilon \\mathbf 1 \\right)$ to the "
                                   "right-hand side of the temperature equation.")
+
+#define INSTANTIATE(dim) \
+  template class ShearHeatingOutputs<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -56,8 +56,7 @@ namespace aspect
       :
       NamedAdditionalMaterialOutputs<dim>(make_dislocation_viscosity_outputs_names()),
       dislocation_viscosities(n_points, numbers::signaling_nan<double>()),
-      diffusion_viscosities(n_points, numbers::signaling_nan<double>()),
-      boundary_area_change_work_fractions(n_points, numbers::signaling_nan<double>())
+      diffusion_viscosities(n_points, numbers::signaling_nan<double>())
     {}
 
 
@@ -66,7 +65,7 @@ namespace aspect
     std::vector<double>
     DislocationViscosityOutputs<dim>::get_nth_output(const unsigned int idx) const
     {
-      AssertIndexRange (idx, 2);
+      AssertIndexRange (idx, 1);
       switch (idx)
         {
           case 0:
@@ -74,9 +73,6 @@ namespace aspect
 
           case 1:
             return diffusion_viscosities;
-
-          case 2:
-            return boundary_area_change_work_fractions;
 
           default:
             AssertThrow(false, ExcInternalError());
@@ -874,10 +870,6 @@ namespace aspect
           out.densities[i] = density(in.temperature[i], pressure, in.composition[i], in.position[i]);
           out.thermal_conductivities[i] = k_value;
           out.compressibilities[i] = compressibility(in.temperature[i], pressure, composition, in.position[i]);
-
-          if (DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
-            disl_viscosities_out->boundary_area_change_work_fractions[i] =
-              boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
 
           if (in.requests_property(MaterialProperties::reaction_terms))
             for (unsigned int c=0; c<composition.size(); ++c)

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -22,6 +22,7 @@
 #include <aspect/material_model/grain_size.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/heating_model/shear_heating.h>
 #include <aspect/utilities.h>
 
 #include <deal.II/base/quadrature_lib.h>
@@ -862,6 +863,12 @@ namespace aspect
                   disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
                   disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
                 }
+
+              if (HeatingModel::ShearHeatingOutputs<dim> *shear_heating_out = out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>())
+                {
+                  const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
+                  shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / std::min(std::max(min_eta,disl_viscosity),1e300);
+                }
             }
 
           out.densities[i] = density(in.temperature[i], pressure, in.composition[i], in.position[i]);
@@ -1486,14 +1493,21 @@ namespace aspect
     void
     GrainSize<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      // These properties are useful as output, but will also be used by the
-      // heating model to reduce shear heating by the amount of work done to
-      // reduce grain size.
+      // These properties are useful as output.
       if (out.template get_additional_output<DislocationViscosityOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::DislocationViscosityOutputs<dim>> (n_points));
+        }
+
+      // These properties will be used by the heating model to reduce
+      // shear heating by the amount of work done to reduce grain size.
+      if (out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>() == nullptr)
+        {
+          const unsigned int n_points = out.n_evaluation_points();
+          out.additional_outputs.push_back(
+            std::make_unique<HeatingModel::ShearHeatingOutputs<dim>> (n_points));
         }
 
       // These properties are only output properties.

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -21,7 +21,7 @@
 #include <aspect/simulator_access.h>
 
 #include <aspect/material_model/simple.h>
-#include <aspect/material_model/grain_size.h>
+#include <aspect/heating_model/shear_heating.h>
 #include <aspect/heating_model/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/simulator/assemblers/stokes.h>
@@ -542,8 +542,8 @@ namespace aspect
 
       // Some material models provide dislocation viscosities and boundary area work fractions
       // as additional material outputs. If they are attached, use them.
-      const MaterialModel::DislocationViscosityOutputs<dim> *disl_viscosities_out =
-        material_model_outputs.template get_additional_output<MaterialModel::DislocationViscosityOutputs<dim>>();
+      const ShearHeatingOutputs<dim> *shear_heating_out =
+        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
 
       const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
         material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
@@ -576,13 +576,10 @@ namespace aspect
 
           heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
-          // If dislocation viscosities and boundary area work fractions are provided, reduce the
-          // overall heating by this amount (which is assumed to increase surface energy)
-          if (disl_viscosities_out != 0)
-            {
-              heating_model_outputs.heating_source_terms[q] *= 1 - disl_viscosities_out->boundary_area_change_work_fractions[q] *
-                                                               material_model_outputs.viscosities[q] / disl_viscosities_out->dislocation_viscosities[q];
-            }
+          // If shear heating work fractions are provided, reduce the
+          // overall heating by this amount (which is assumed to be converted into other forms of energy)
+          if (shear_heating_out != nullptr)
+            heating_model_outputs.heating_source_terms[q] *= shear_heating_out->shear_heating_work_fractions[q];
 
           heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
         }


### PR DESCRIPTION
This PR creates a new additional material model output that contains the fraction of work that goes into shear heating. This is useful because the same term is needed both in the material model and in the heating model, and with the new implementation, the shear heating does not have to know about the material model, but each material model could still implement its own model for this term. I have checked that the `DislocationViscosityOutputs`, which were used for that purpose before, are only used in the grain size material model. 

I want to make this change because there are different models for how this work fraction is being computed (some of them including dependencies on solution variables like the temperature), and as a next step I want to implement one of these more complex models. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
