### PR TITLE
Slab2 model

### DIFF
--- a/data/initial-composition/slab-model/create_slab2_database.py
+++ b/data/initial-composition/slab-model/create_slab2_database.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# This script uses the slab2 model data, available to download from
+# https://www.sciencebase.gov/catalog/item/5aa1b00ee4b0b1c392e86467
+# (Choose the file "Slab2Distribute_Mar2018.tar.gz" under the
+# "Attached files" heading and unpack it in this directory).
+# 
+# This script then formats the data in a way that it can be used by
+# the slab model plugin in ASPECT.
+# 
+# Input files: Each input file contains attributes representing either depth
+# "dep", dip ("dip"), strike ("str"), and thickness ("thk") information for
+# each of the 27 slabs in the slab2 model in a structured ascii grid. The files
+# contains columns corresponding to longitude, latitude, and attribute ("dep,
+# "dip" etc). More information on the model can be found in the paper: 
+# Hayes, G. P., Moore, G. L., Portner, D. E., Hearne, M., Flamme, H., Furtney,
+# M., & Smoczyk, G. M.  (2018). Slab2,a comprehensive subduction zone geometry
+# model. Science, 362(6410), 58-61.
+# 
+# Output: A structured file containing all the slabs for the Earth with columns
+# representing longitude, colatitude, slab depths, and slab thickness
+
+import numpy as np
+import os
+from glob import glob
+from scipy.interpolate import griddata
+
+# Save the current working directory
+cwd = os.getcwd()
+
+# Set the path to the downloaded slab2 model here. This path is correct if you
+# download the model from the address above and extract in the current folder.
+os.chdir('./Slab2Distribute_Mar2018/Slab2_TXT')
+
+
+def interpolate_data (name_key, type_key):
+    """
+    From initial data inspection, we found that most slabs have spacing of 0.05 degrees except for 5 slabs,   
+    which have 0.02 degree spacing. Therefore, this function interpolates those slabs to 0.05 spacing for 
+    consistency.
+    """
+
+    file_name = glob(name_key + '*' + type_key +'*.xyz')
+    data_in   = np.loadtxt (file_name[0], delimiter=",")
+    
+    # We convert latitudes to co-latitudes for all the slab files.
+    points_x  = data_in[:, 0] 
+    points_y  = 90 - data_in[:, 1]
+    field     = data_in[:, 2]
+    
+    x0 = np.min(points_x)
+    x1 = np.max(points_x)
+    y0 = np.min(points_y)
+    y1 = np.max(points_y)
+    
+    # create the desired mesh
+    x = np.arange (x0, x1 + 0.05, 0.05)
+    y = np.arange (y0, y1 + 0.05, 0.05)
+    
+    x_grid, y_grid = np.meshgrid (x, y)
+    
+    depth_interp = griddata ((points_x, points_y), field, (x_grid, y_grid), method = 'linear')
+    data_save    = np.column_stack ((x_grid.flatten(), 90 - y_grid.flatten(), depth_interp.flatten()))
+    
+    np.savetxt (file_name[0], data_save, fmt='%1.2f', delimiter=',')
+
+
+# Slabs with 0.02 degree spacing
+file_name_key = ['hin', 'man', 'mue', 'pam', 'puy']
+file_type_key = ['dep', 'thk', 'dip']
+
+for i in range(len(file_name_key)):
+    for j in range(len(file_type_key)):
+        interpolate_data (file_name_key[i], file_type_key[j])
+
+# Create the grid for aspect, with global longitudes and colatitudes and
+# resolution same as all the slabs (0.05 degrees)
+longitudes_target = np.arange (0 , 360.05, 0.05)
+latitudes_target  = np.arange (0,  180.05, 0.05)
+longitude_grid, latitude_grid = np.meshgrid (longitudes_target, latitudes_target)
+
+# We initialize the depth array with a very large number and the
+# thickness value with 0 to make it easy to determine regions
+# without slabs.
+depths_target       = np.finfo(np.float64).max / 1e4 * np.ones (len(longitude_grid.flatten()),)
+thickness_target    = np.zeros (len(longitude_grid.flatten()),)
+dips_target         = np.zeros (len(longitude_grid.flatten()),)
+
+nan_indx = 0 
+def slab2_into_asciiboundary (slab_filename):
+    """
+    This function uses the above target mesh and fills it with the input slab depths, thicknesses
+    and dip angles.
+    Since the input data grid for each slab is a subset of this target grid, we can simply replace 
+    the target grid at those locations with the input slab grid. 
+    We have checked that in the input files longitude increases first and then latitude, suggesting that the 
+    elements are ordered identically to the target mesh.
+    """
+    
+    # load the input slab depth files
+    slab_data = np.loadtxt (slab_filename, delimiter=",")
+    points_x  = slab_data[:, 0] 
+    points_y  = 90 - slab_data[:, 1]
+    depths    = slab_data[:, 2]    
+    
+    x0 = np.min(points_x)
+    x1 = np.max(points_x)
+    y0 = np.min(points_y)
+    y1 = np.max(points_y)
+    
+    # need this to compare two floats
+    numerical_error = 1e-6
+   
+    indx = np.where ( (longitude_grid.flatten() >= x0 - numerical_error) & 
+                      (longitude_grid.flatten() <= x1 + numerical_error) &
+                      (latitude_grid.flatten()  >= y0 - numerical_error) & 
+                      (latitude_grid.flatten()  <= y1 + numerical_error) )
+    
+    # We do not simply replace all the points with the slab grid. This is because there 
+    # are some slabs in the western US with overlapping grid points. However, locations 
+    # in the slab grid where depths and thickness are not defined are nan values, and we
+    # want to avoid replacing existing depth and thickness values with nan values 
+    # from another slab grid.
+    # Therefore, we create a dummy variable that stores all the grid points in the slab 
+    # and then copies only the non-nan values into the target array.
+    depths_temp       = np.empty (len(longitude_grid.flatten()),)  
+    depths_temp[:]    = np.nan
+    depths_temp[indx] = slab_data[:, 2]
+    
+    # replace the target mesh with the slab data
+    indx_not_a_nan                = np.where(~np.isnan (depths_temp))
+    depths_target[indx_not_a_nan] = depths_temp[indx_not_a_nan]
+    
+    # do the same for the thickness file
+    thk_file  = slab_filename.replace ('dep', 'thk')
+    thk_data  = np.loadtxt (thk_file, delimiter=",", usecols=2)
+    
+    # do the same for the dip file
+    dip_file  = slab_filename.replace ('dep', 'dip')
+    dip_data  = np.loadtxt (dip_file, delimiter=",", usecols=2)
+
+    # We checked that slab thickness and dips are defined at points where
+    # slab depths are defined.
+    target_indx_not_a_nan            = np.where(~np.isnan (depths))
+    thickness_target[indx_not_a_nan] = thk_data[target_indx_not_a_nan]
+    dips_target[indx_not_a_nan]      = dip_data[target_indx_not_a_nan]
+
+    return (depths_target, thickness_target, dips_target)
+
+
+input_filenames = glob('*_slab2*' + file_type_key[0]  + '*.xyz')
+
+for i in range(len(input_filenames)):
+    print (input_filenames[i])
+    slab_depths, slab_thickness, slab_dips = slab2_into_asciiboundary (input_filenames[i])
+
+# The thickness in the slab2 model is perpendicular to the slab surface, therefore, we need
+# to convert it into equivalent distance vertically from the slab surface.
+thickness_vertical = slab_thickness/np.cos(np.deg2rad(slab_dips))
+
+# Save the arrays in the format for aspect ascii boundary :
+# 1. use radians in longitudes and co-latitudes, 2. first longitudes increase then co-latitudes
+# 3. convert depth and thickness from km to meters 4. depth is negative in the downward
+# direction of the slab2 database, convert to positive values. 5. Add necessary header
+# information.
+
+km_to_m          = 1e3
+output_dir       = cwd
+output_filename  = '/slab2_depth_thickness_highres.txt'
+output_data      = np.column_stack ((np.deg2rad(longitude_grid.flatten()), np.deg2rad(latitude_grid.flatten()),
+                                     abs(depths_target.flatten())*km_to_m, thickness_vertical.flatten()*km_to_m))
+
+aspect_header    = 'Test data for ascii data initial conditions.\n' + \
+                   'Only next line is parsed in format: [nx] [ny] because of keyword "POINTS"\n' + \
+                   'POINTS: %d %d\n' %(np.size(longitudes_target), np.size(latitudes_target)) + \
+                   'Columns: phi theta depth(m) thickness(m)'
+
+np.savetxt (output_dir + output_filename, output_data, header=aspect_header, fmt='%.4e')

--- a/data/initial-composition/slab-model/shell_3d.txt
+++ b/data/initial-composition/slab-model/shell_3d.txt
@@ -1,0 +1,13 @@
+# Test data for slab model initial composition.
+# Only next line is parsed in format: [ny] [nz] because of keyword "POINTS:"
+# POINTS: 3 3
+phi theta depth(m) thickness(m)
+0       0       1000000. 0.
+0.7854  0       1000000. 0.
+1.5  0       1000000. 0.
+0       0.7854  0. 1000000.
+0.7854  0.7854  0. 1000000.
+1.5  0.7854  0. 0.
+0       1.5708  0. 1000000.
+0.7854  1.5708  0. 1000000.
+1.5 1.5708  0. 0.

--- a/doc/modules/changes/20230303_saxena
+++ b/doc/modules/changes/20230303_saxena
@@ -1,0 +1,4 @@
+New: There is a new initial composition plugin that reads in
+a slab model (e.g. Slab2) and converts it to a compositional field.
+<br>
+(Arushi Saxena, Rene Gassmoeller, Juliane Dannberg, 2023/03/03)

--- a/include/aspect/initial_composition/slab_model.h
+++ b/include/aspect/initial_composition/slab_model.h
@@ -1,0 +1,103 @@
+/*
+  Copyright (C) 2023 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_initial_composition_slab_model_h
+#define _aspect_initial_composition_slab_model_h
+
+#include <aspect/initial_composition/interface.h>
+
+#include <aspect/simulator_access.h>
+#include <aspect/structured_data.h>
+
+
+namespace aspect
+{
+  namespace InitialComposition
+  {
+    using namespace dealii;
+
+    /**
+     * A class that implements subducted slab geometries as a compositional
+     * field determined from an input file. The file defines the depth to
+     * the top of the slab and the slab thickness.
+     *
+     * An example model that is included is Slab2 described in
+     * Hayes, G. P., Moore, G. L., Portner, D. E., Hearne, M., Flamme, H., Furtney, M.,
+     * & Smoczyk, G. M. (2018). Slab2, a comprehensive subduction zone geometry model.
+     * Science, 362(6410), 58-61.
+     *
+     * @ingroup InitialCompositionModels
+     */
+    template <int dim>
+    class SlabModel : public Interface<dim>, public aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Initialization function. This function is called once at the
+         * beginning of the program. Checks preconditions.
+         */
+        void
+        initialize () override;
+
+        /**
+         * Return the initial composition as a function of position. For the
+         * current class, this function returns 1.0 inside subducted slabs and 0.0 outside.
+         */
+        double
+        initial_composition (const Point<dim> &position,
+                             const unsigned int n_comp) const override;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        void
+        parse_parameters (ParameterHandler &prm) override;
+
+      protected:
+        /**
+         * An object of ascii data boundary to input subducted slab depths
+         * and thicknesses.
+         */
+        Utilities::AsciiDataBoundary<dim> slab_boundary;
+
+        /**
+         * Cache the surface boundary id to avoid unnecessary lookups.
+         */
+        types::boundary_id surface_boundary_id;
+
+        /**
+         * Cache the compositional field index that corresponds to
+         * the slab composition to avoid unnecessary lookups.
+         */
+        unsigned int slab_index;
+    };
+  }
+}
+
+
+#endif

--- a/source/initial_composition/slab_model.cc
+++ b/source/initial_composition/slab_model.cc
@@ -1,0 +1,139 @@
+/*
+  Copyright (C) 2023 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <aspect/global.h>
+#include <aspect/initial_composition/slab_model.h>
+#include <aspect/utilities.h>
+#include <aspect/geometry_model/interface.h>
+
+
+namespace aspect
+{
+  namespace InitialComposition
+  {
+    template <int dim>
+    void
+    SlabModel<dim>::initialize ()
+    {
+      AssertThrow(this->introspection().compositional_name_exists("slabs"),
+                  ExcMessage("The initial composition plugin `slab model' did not find a "
+                             "compositional field called `slabs' to initialize. Please add a "
+                             "compositional field with this name."));
+
+      slab_index = this->introspection().compositional_index_for_name("slabs");
+
+      // The input slabs are defined from the surface of the model
+      surface_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
+
+      // The two columns correspond to slabs depth and thickness
+      slab_boundary.initialize({surface_boundary_id}, 2);
+    }
+
+
+    template <int dim>
+    double
+    SlabModel<dim>::
+    initial_composition (const Point<dim> &position,
+                         const unsigned int compositional_index) const
+    {
+      if (compositional_index != slab_index)
+        return 0.0;
+
+      // The first data column corresponds to the slab depth and the second column to the slab thickness.
+      // 'Slab depth' stands for the depth of the upper surface of the slab, 'Slab thickness'
+      // for the vertical distance between upper and lower surface.
+      const double slab_depth     = slab_boundary.get_data_component(surface_boundary_id, position, 0);
+      const double slab_thickness = slab_boundary.get_data_component(surface_boundary_id, position, 1);
+
+      // Return 0.0 if there is no slab in this location in the data. No slab is encoded in
+      // the data file as a slab thickness of 0.0 and/or a depth larger than the depth of
+      // the domain.
+      if (slab_thickness == 0.0 ||
+          slab_depth > this->get_geometry_model().maximal_depth())
+        return 0.0;
+
+      // Return 1.0 if we are inside the depth range of the slab.
+      // We use a semi-closed interval so that a slab thickness of 0.0
+      // means no slab exists.
+      const double depth = this->get_geometry_model().depth(position);
+      if ((depth >= slab_depth) && (depth < slab_depth + slab_thickness))
+        return 1.0;
+
+      return 0.0;
+    }
+
+
+    template <int dim>
+    void
+    SlabModel<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Initial composition model");
+      {
+        Utilities::AsciiDataBoundary<dim>::declare_parameters(prm,
+                                                              "$ASPECT_SOURCE_DIR/data/initial-composition/slab-model/",
+                                                              "shell_3d.txt",
+                                                              "Slab model",
+                                                              /*time dependent = */ false);
+      }
+      prm.leave_subsection();
+    }
+
+
+    template <int dim>
+    void
+    SlabModel<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Initial composition model");
+      {
+        slab_boundary.initialize_simulator (this->get_simulator());
+        slab_boundary.parse_parameters(prm, "Slab model", /*time dependent = */ false);
+      }
+      prm.leave_subsection();
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace InitialComposition
+  {
+    ASPECT_REGISTER_INITIAL_COMPOSITION_MODEL(SlabModel,
+                                              "slab model",
+                                              "An initial composition model that implements subducted "
+                                              "slab geometries as a compositional field determined from "
+                                              "an input file. The file defines the depth to the top of "
+                                              "the slab and the slab thickness. "
+                                              "The computed compositional value is 1 within the slabs "
+                                              "and zero elsewhere. "
+                                              "An example model that is included is Slab2 described in "
+                                              "Hayes, G. P., Moore, G. L., Portner, D. E., Hearne, M., "
+                                              "Flamme, H., Furtney, M., \\& Smoczyk, G. M. (2018). Slab2, "
+                                              "a comprehensive subduction zone geometry model. Science, "
+                                              "362(6410), 58-61. The script to convert the Slab2 model "
+                                              "into an aspect input data file is available in the directory "
+                                              "data/initial-composition/slab-model/. Please note that "
+                                              "Slab2 and the example data file assume spherical geometry "
+                                              "(latitude, longitude coordinates), however, that is not "
+                                              "necessary for this plugin, data files in "
+                                              "cartesian coordinates will work with box geometries.")
+  }
+}

--- a/tests/slab2_initial_composition_3d_shell.prm
+++ b/tests/slab2_initial_composition_3d_shell.prm
@@ -1,0 +1,86 @@
+##### simple test for slab2 model as initial composition
+
+set Dimension                              = 3
+
+set Use years in output instead of seconds = true
+set End time                               = 0
+
+set Adiabatic surface temperature          = 1613.0
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius = 3481000
+    set Outer radius = 6336000
+    set Opening angle = 90
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+  subsection Harmonic perturbation
+    set Magnitude = 30
+    set Reference temperature = 1613
+  end
+end
+
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+  set Fixed temperature boundary indicators   = bottom, top, west, east, south
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, top, west, east, south
+end
+
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields  = slabs
+  set Compositional field methods = static
+end
+
+
+subsection Initial composition model
+  set Model name = slab model
+  # The following lines point to the location of the slab2 model
+  # data file, generated using the jupyter notebook in the
+  # /data/initial-composition/slab-model/ folder.
+  subsection Slab model
+    set Data directory       = $ASPECT_SOURCE_DIR/data/initial-composition/slab-model/
+    set Data file name       = shell_3d.txt
+  end
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Viscosity = 1e21
+  end
+end
+
+
+subsection Mesh refinement
+  set Initial global refinement                = 2
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, composition statistics, visualization
+end

--- a/tests/slab2_initial_composition_3d_shell/screen-output
+++ b/tests/slab2_initial_composition_3d_shell/screen-output
@@ -1,0 +1,22 @@
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/initial-composition/slab-model/shell_3d.txt.
+
+Number of active cells: 192 (on 3 levels)
+Number of degrees of freedom: 10,070 (5,859+305+1,953+1,953)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 94+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:         0.0457 m/year, 0.39 m/year
+     Temperature min/avg/max:   1601 K, 1613 K, 1625 K
+     Compositions min/max/mass: 0/1/3.126e+19
+     Writing graphical output:  output-slab2_initial_composition_3d_shell/solution/solution-00000
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/slab2_initial_composition_3d_shell/statistics
+++ b/tests/slab2_initial_composition_3d_shell/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal temperature (K)
+# 16: Average temperature (K)
+# 17: Maximal temperature (K)
+# 18: Average nondimensional temperature (K)
+# 19: Minimal value for composition slabs
+# 20: Maximal value for composition slabs
+# 21: Global mass for composition slabs
+# 22: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 192 6164 1953 1953 0 4294967295 93 96 190 4.56902118e-02 3.89727519e-01 1.60122400e+03 1.61300000e+03 1.62477600e+03 3.12112279e-03 0.00000000e+00 1.00000000e+00 3.12584492e+19 output-slab2_initial_composition_3d_shell/solution/solution-00000 


### PR DESCRIPTION
This PR adds an initial composition model that outputs 1 at the locations of the slab2 model (https://www.science.org/doi/10.1126/science.aat4723) and 0 otherwise. 
The slab2 model is input as an ascii boundary datafile with columns representing depths and thickness at the lat/long points on the Earth spaced at 0.05 degrees. This results in an ascii file that is too big to be added with aspect, and therefore a jupyter notebook is added to format the input slab2 model for an aspect input file.
Below is the paraview output from aspect using higher resolution on the test file.  

![slab2](https://user-images.githubusercontent.com/19296817/213247557-9e426210-1a9a-453a-9113-2714056465d5.png)

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
