### PR TITLE
Fix compiler warnings gcc11

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -267,8 +267,8 @@ namespace aspect
         // measured by the minimum distance from any of the other vertices
         // to the first vertex), then we call this a horizontal face.
         constexpr unsigned int max_n_vertices_per_face = (dim==2 ? 2 : 4);
-        std::array<double, max_n_vertices_per_face>     distances_to_center;
-        std::array<double, max_n_vertices_per_face - 1> distances_to_first_vertex;
+        std::array<double, max_n_vertices_per_face>     distances_to_center {};
+        std::array<double, max_n_vertices_per_face - 1> distances_to_first_vertex {};
         distances_to_center[0] = face->vertex(0).norm_square();
         for (unsigned int i = 1; i < face->n_vertices(); ++i)
           {

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -96,6 +96,7 @@ namespace aspect
     std::vector<double>
     ShearHeatingOutputs<dim>::get_nth_output(const unsigned int idx) const
     {
+      (void) idx;
       AssertIndexRange (idx, 0);
 
       return shear_heating_work_fractions;

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -670,7 +670,7 @@ namespace aspect
             // these are variables we only need for olivine, but we need them for both
             // within this if block and the next ones
             // Ordered vector where the first entry is the max/weakest and the last entry is the inactive slip system.
-            std::array<unsigned int,4> indices;
+            std::array<unsigned int,4> indices {};
 
             // compute G and beta
             Tensor<1,4> bigI;


### PR DESCRIPTION
We have accumulated a few compiler warnings on the main branch (using gcc11), mostly over possibly non-initialized array entries and unused variables. This PR fixed all of them for me and should not change behavior.