### PR TITLE
Remove unnecessary lines of code

### DIFF
--- a/source/boundary_composition/ascii_data.cc
+++ b/source/boundary_composition/ascii_data.cc
@@ -37,9 +37,7 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::set<types::boundary_id> boundary_ids = this->get_fixed_composition_boundary_indicators();
-
-      Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
+      Utilities::AsciiDataBoundary<dim>::initialize(this->get_fixed_composition_boundary_indicators(),
                                                     this->n_compositional_fields());
     }
 

--- a/source/boundary_temperature/ascii_data.cc
+++ b/source/boundary_temperature/ascii_data.cc
@@ -39,8 +39,7 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      const std::set<types::boundary_id> boundary_ids = this->get_fixed_temperature_boundary_indicators();
-      Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
+      Utilities::AsciiDataBoundary<dim>::initialize(this->get_fixed_temperature_boundary_indicators(),
                                                     1);
     }
 

--- a/source/geometry_model/initial_topography_model/ascii_data.cc
+++ b/source/geometry_model/initial_topography_model/ascii_data.cc
@@ -49,10 +49,7 @@ namespace aspect
     {
       surface_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
 
-      std::set<types::boundary_id> surface_boundary_set;
-      surface_boundary_set.insert(surface_boundary_id);
-
-      Utilities::AsciiDataBoundary<dim>::initialize(surface_boundary_set,
+      Utilities::AsciiDataBoundary<dim>::initialize({surface_boundary_id},
                                                     1);
     }
 

--- a/source/mesh_deformation/ascii_data.cc
+++ b/source/mesh_deformation/ascii_data.cc
@@ -46,10 +46,7 @@ namespace aspect
     {
       surface_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
 
-      std::set<types::boundary_id> surface_boundary_set;
-      surface_boundary_set.insert(surface_boundary_id);
-
-      Utilities::AsciiDataBoundary<dim>::initialize(surface_boundary_set,
+      Utilities::AsciiDataBoundary<dim>::initialize({surface_boundary_id},
                                                     1);
     }
 


### PR DESCRIPTION
Something I saw while reviewing #5025. In a number of places we unnecessarily create a temporary `std::set` that is not really needed. This new version does not really change anything in the compiled code (it still needs the std::set internally), but I think the code is shorter and just as easy to read.