### PR TITLE
Added field type functions

### DIFF
--- a/doc/modules/changes/20230119_bobmyhill
+++ b/doc/modules/changes/20230119_bobmyhill
@@ -1,0 +1,13 @@
+New: ASPECT has new introspection functions 
+get_indices_for_fields_of_type and get_names_for_fields_of_type.
+There is also a new utilities function called
+compute_only_composition_fractions that takes a vector of
+compositional field values and a list of indices that designates
+which of those fields correspond to chemical compositions.
+It then calculates the missing fraction corresponding to the
+background field, and returns the full vector of fractions.
+
+New: The "Compositional fields / Types of fields" parameter in ASPECT 
+has a new type called "strain".
+<br>
+(Bob Myhill, 2023/01/19)

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -464,14 +464,14 @@ namespace aspect
        * particular type (chemical composition, porosity, etc.).
        */
       const std::vector<unsigned int>
-      get_indices_for_fields_of_type (const std::string &type_name) const;
+      get_indices_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
 
       /**
       * Get the names of the compositional fields which are of a
       * particular type (chemical composition, porosity, etc.).
        */
       const std::vector<std::string>
-      get_names_for_fields_of_type (const std::string &type_name) const;
+      get_names_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
 
       /**
        * A function that gets a component index as an input

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -460,6 +460,20 @@ namespace aspect
       compositional_name_exists (const std::string &name) const;
 
       /**
+       * Get the indices of the compositional fields which are of a
+       * particular type (chemical composition, porosity, etc.).
+       */
+      const std::vector<unsigned int>
+      get_indices_for_fields_of_type (const std::string &type_name) const;
+
+      /**
+      * Get the names of the compositional fields which are of a
+      * particular type (chemical composition, porosity, etc.).
+       */
+      const std::vector<std::string>
+      get_names_for_fields_of_type (const std::string &type_name) const;
+
+      /**
        * A function that gets a component index as an input
        * parameter and returns if the component is one of the stokes system
        * (i.e. if it is the pressure or one of the velocity components).

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -261,7 +261,24 @@ namespace aspect
         };
       }
 
-
+      /**
+       * For multicomponent material models: Given a vector of compositional
+       * field values of length N, of which M indices correspond to mass or
+       * volume fractions, this function returns a vector of fractions
+       * of length M+1, corresponding to the fraction of a ``background
+       * material'' as the first entry, and fractions for each of the input
+       * fields as the following entries. The returned vector will sum to one.
+       * If the sum of the compositional_fields is greater than
+       * one, we assume that there is no background field (i.e., that field value
+       * is zero). Otherwise, the difference between the sum of the compositional
+       * fields and 1.0 is assumed to be the amount of the background field.
+       * This function makes no assumptions about the units of the
+       * compositional field values; for example, they could correspond to
+       * mass or volume fractions.
+       */
+      std::vector<double>
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices);
 
       /**
        * For multicomponent material models: Given a vector of compositional

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -278,7 +278,7 @@ namespace aspect
        */
       std::vector<double>
       compute_only_composition_fractions(const std::vector<double> &compositional_fields,
-                                         const std::vector<unsigned int> &indices);
+                                         const std::vector<unsigned int> &indices_to_use);
 
       /**
        * For multicomponent material models: Given a vector of compositional

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -390,6 +390,7 @@ namespace aspect
       {
         chemical_composition,
         stress,
+        strain,
         grain_size,
         porosity,
         density,
@@ -409,6 +410,8 @@ namespace aspect
           return CompositionalFieldDescription::chemical_composition;
         else if (input == "stress")
           return CompositionalFieldDescription::stress;
+        else if (input == "strain")
+          return CompositionalFieldDescription::strain;
         else if (input == "grain size")
           return CompositionalFieldDescription::grain_size;
         else if (input == "porosity")

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -791,6 +791,43 @@ namespace aspect
 
 
       std::vector<double>
+      compute_only_composition_fractions(const std::vector<double> &compositional_fields,
+                                         const std::vector<unsigned int> &indices)
+      {
+        std::vector<double> composition_fractions(indices.size()+1);
+
+        // Clip the compositional fields so they are between zero and one,
+        // and sum the compositional fields for normalization purposes.
+        double sum_composition = 0.0;
+        std::vector<double> x_comp (indices.size());
+
+        for (unsigned int i=0; i < x_comp.size(); ++i)
+          {
+            x_comp[i] = std::min(std::max(compositional_fields[indices[i]], 0.0), 1.0);
+            sum_composition += x_comp[i];
+          }
+
+        // Compute background field fraction
+        if (sum_composition >= 1.0)
+          composition_fractions[0] = 0.0;
+        else
+          composition_fractions[0] = 1.0 - sum_composition;
+
+        // Compute and possibly normalize field fractions
+        for (unsigned int i=0; i < x_comp.size(); ++i)
+          {
+            if (sum_composition >= 1.0)
+              composition_fractions[i+1] = x_comp[i]/sum_composition;
+            else
+              composition_fractions[i+1] = x_comp[i];
+          }
+
+        return composition_fractions;
+      }
+
+
+
+      std::vector<double>
       compute_composition_fractions(const std::vector<double> &compositional_fields,
                                     const ComponentMask &field_mask)
       {

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -792,18 +792,18 @@ namespace aspect
 
       std::vector<double>
       compute_only_composition_fractions(const std::vector<double> &compositional_fields,
-                                         const std::vector<unsigned int> &indices)
+                                         const std::vector<unsigned int> &indices_to_use)
       {
-        std::vector<double> composition_fractions(indices.size()+1);
+        std::vector<double> composition_fractions(indices_to_use.size()+1);
 
         // Clip the compositional fields so they are between zero and one,
         // and sum the compositional fields for normalization purposes.
         double sum_composition = 0.0;
-        std::vector<double> x_comp (indices.size());
+        std::vector<double> x_comp (indices_to_use.size());
 
         for (unsigned int i=0; i < x_comp.size(); ++i)
           {
-            x_comp[i] = std::min(std::max(compositional_fields[indices[i]], 0.0), 1.0);
+            x_comp[i] = std::min(std::max(compositional_fields[indices_to_use[i]], 0.0), 1.0);
             sum_composition += x_comp[i];
           }
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -403,6 +403,38 @@ namespace aspect
 
 
   template <int dim>
+  const std::vector<unsigned int>
+  Introspection<dim>::get_indices_for_fields_of_type (const std::string &type_name) const
+  {
+    std::vector<unsigned int> indices;
+    typename Parameters<dim>::CompositionalFieldDescription::Type type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
+
+    for (unsigned int i=0; i<n_compositional_fields; ++i)
+      if (composition_descriptions[i].type == type)
+        indices.push_back(i);
+
+    return indices;
+  }
+
+
+
+  template <int dim>
+  const std::vector<std::string>
+  Introspection<dim>::get_names_for_fields_of_type (const std::string &type_name) const
+  {
+    std::vector<std::string> names;
+    typename Parameters<dim>::CompositionalFieldDescription::Type type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
+
+    for (unsigned int i=0; i<n_compositional_fields; ++i)
+      if (composition_descriptions[i].type == type)
+        names.push_back(composition_names[i]);
+
+    return names;
+  }
+
+
+
+  template <int dim>
   bool
   Introspection<dim>::is_stokes_component (const unsigned int component_index) const
   {

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -404,10 +404,9 @@ namespace aspect
 
   template <int dim>
   const std::vector<unsigned int>
-  Introspection<dim>::get_indices_for_fields_of_type (const std::string &type_name) const
+  Introspection<dim>::get_indices_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
   {
     std::vector<unsigned int> indices;
-    typename Parameters<dim>::CompositionalFieldDescription::Type type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
 
     for (unsigned int i=0; i<n_compositional_fields; ++i)
       if (composition_descriptions[i].type == type)
@@ -420,10 +419,9 @@ namespace aspect
 
   template <int dim>
   const std::vector<std::string>
-  Introspection<dim>::get_names_for_fields_of_type (const std::string &type_name) const
+  Introspection<dim>::get_names_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
   {
     std::vector<std::string> names;
-    typename Parameters<dim>::CompositionalFieldDescription::Type type = Parameters<dim>::CompositionalFieldDescription::parse_type(type_name);
 
     for (unsigned int i=0; i<n_compositional_fields; ++i)
       if (composition_descriptions[i].type == type)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1203,11 +1203,11 @@ namespace aspect
                          Patterns::List(Patterns::Anything()),
                          "A user-defined name for each of the compositional fields requested.");
       prm.declare_entry ("Types of fields", "unspecified",
-                         Patterns::List (Patterns::Selection("chemical composition|stress|grain size|porosity|density|generic|unspecified")),
+                         Patterns::List (Patterns::Selection("chemical composition|stress|strain|grain size|porosity|density|generic|unspecified")),
                          "A type for each of the compositional fields requested. "
                          "Each entry of the list must be "
                          "one of several recognized types: chemical composition, "
-                         "stress, grain size, porosity, general and unspecified. "
+                         "stress, strain, grain size, porosity, general and unspecified. "
                          "The generic type is intended to be a placeholder type "
                          "that has no effect on the running of any material model, "
                          "while the unspecified type is intended to tell ASPECT "

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -35,8 +35,8 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   // Fields 0 and 4 are chemical compositions
   // These are called Field 1 and Field 5
-  const std::vector<unsigned int> indices = simulator_access.introspection().get_indices_for_fields_of_type("chemical composition");
-  const std::vector<std::string> names = simulator_access.introspection().get_names_for_fields_of_type("chemical composition");
+  const std::vector<unsigned int> indices = simulator_access.introspection().get_indices_for_fields_of_type(aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition);
+  const std::vector<std::string> names = simulator_access.introspection().get_names_for_fields_of_type(aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition);
 
   const std::vector<double> field_values { 0.1, 0.3, 0.3, 0.3, 0.2, 0.3, 0.3};
   const std::vector<double> compositional_field_fractions = MaterialUtilities::compute_only_composition_fractions(field_values, indices);

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -1,0 +1,71 @@
+/*
+  Copyright (C) 2023 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/simulator.h>
+#include <aspect/parameters.h>
+#include <aspect/material_model/utilities.h>
+
+template <int dim>
+void f(const aspect::SimulatorAccess<dim> &simulator_access,
+       aspect::Assemblers::Manager<dim> &)
+{
+  // This function tests whether the compositional field types are correctly
+  // processed.
+
+  using namespace aspect::MaterialModel;
+
+  aspect::ParameterHandler prm;
+
+  // Fields 0 and 4 are chemical compositions
+  // These are called Field 1 and Field 5
+  const std::vector<unsigned int> indices = simulator_access.introspection().get_indices_for_fields_of_type("chemical composition");
+  const std::vector<std::string> names = simulator_access.introspection().get_names_for_fields_of_type("chemical composition");
+
+  const std::vector<double> field_values { 0.1, 0.3, 0.3, 0.3, 0.2, 0.3, 0.3};
+  const std::vector<double> compositional_field_fractions = MaterialUtilities::compute_only_composition_fractions(field_values, indices);
+
+  std::cout << "Chemical composition field #0 (the background field) has value " << compositional_field_fractions[0] << "." << std::endl;
+
+  for (unsigned int i=0; i<2; ++i)
+    std::cout << "Chemical composition field #" << i+1 << " is called " << names[i] << ", is in position "  << indices[i] << ", and has value " << compositional_field_fractions[i+1] << "." << std::endl;
+
+  exit(0);
+
+}
+
+template <>
+void f(const aspect::SimulatorAccess<2> &,
+       aspect::Assemblers::Manager<2> &)
+{
+  AssertThrow(false,dealii::ExcInternalError());
+}
+
+template <int dim>
+void signal_connector (aspect::SimulatorSignals<dim> &signals)
+{
+  using namespace dealii;
+  std::cout << "* Connecting signals" << std::endl;
+  signals.set_assemblers.connect (std::bind(&f<dim>,
+                                            std::placeholders::_1,
+                                            std::placeholders::_2));
+}
+
+ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                  signal_connector<3>)

--- a/tests/check_compositional_field_functions.prm
+++ b/tests/check_compositional_field_functions.prm
@@ -1,0 +1,11 @@
+# This test checks whether the compositional field functions are implemented correctly.
+
+set Dimension = 3
+include $ASPECT_SOURCE_DIR/tests/composite_viscous_outputs.prm
+set Additional shared libraries = tests/libcheck_compositional_field_functions.so
+
+subsection Compositional fields
+  set Number of fields = 7
+  set Names of fields =  Field_1, Field_2, Field_3, Field_4, Field_5, Field_6, Field_7
+  set Types of fields =  chemical composition, stress, grain size, porosity, chemical composition, generic, unspecified
+end

--- a/tests/check_compositional_field_functions/screen-output
+++ b/tests/check_compositional_field_functions/screen-output
@@ -1,0 +1,7 @@
+
+Loading shared library <./libcheck_compositional_field_functions.so>
+
+* Connecting signals
+Chemical composition field #0 (the background field) has value 0.7.
+Chemical composition field #1 is called Field_1, is in position 0, and has value 0.1.
+Chemical composition field #2 is called Field_5, is in position 4, and has value 0.2.


### PR DESCRIPTION
This PR pulls out the new field type introspection functions from #5023.
It also changes the Type "chemical composition" to "chemical component", to avoid confusion with the "Compositional field". 

@tjhei, @MFraters, @naliboff: at the moment the new functions aren't tested. If I incorporate these into Steinberger, is it good to go, or would you like more tests (and if so, where?).

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
