### PR TITLE
automate citations/bibfile check

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,7 @@ jobs:
         sudo apt-get install -y software-properties-common
         sudo add-apt-repository ppa:ginggs/deal.ii-9.3.2-backports
         sudo apt-get update
-        sudo apt-get install -yq --no-install-recommends texlive-plain-generic texlive-base texlive-latex-recommended texlive-latex-base texlive-fonts-recommended texlive-bibtex-extra lmodern texlive-latex-extra texlive-science graphviz python3-pip python-setuptools libdeal.ii-dev doxygen inkscape
+        sudo apt-get install -yq --no-install-recommends texlive-plain-generic texlive-base texlive-latex-recommended texlive-latex-base texlive-fonts-recommended texlive-bibtex-extra lmodern texlive-latex-extra texlive-science graphviz python3-pip python-setuptools libdeal.ii-dev doxygen latexmk biber inkscape
         doxygen --version
 
         wget https://github.com/tjhei/astyle/releases/download/v2.04/astyle_2.04_linux.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -72,6 +72,10 @@ jobs:
     - name: check indentation
       run: |
         git diff --exit-code
+    - name: citation list
+      run: |
+        cd doc
+        latexmk -pdf -f citations-list.tex
     - name: compile
       run: |
         mkdir build

--- a/doc/citations-list.tex
+++ b/doc/citations-list.tex
@@ -1,0 +1,58 @@
+%
+% This file can be rendered by calling 
+% latexmk -pdf publication_list.tex
+%
+% NOTE: This file purposely does not allow UTF-8
+% and other unicode characters. This is to catch
+% character combinations (e.g. ``fi'', ``fl'') that
+% do not render as (likely) intended if their unicode
+% counterparts are used.
+%
+% This is based on
+% https://github.com/dealii/publication-list/blob/master/offline/publication_list.tex
+
+\documentclass[]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage[colorlinks,urlcolor=blue]{hyperref}
+\usepackage[
+  backend=biber,
+  sorting=ydnt,
+  defernumbers=true,
+  doi=true,
+  refsection=section,
+  style=numeric
+  ]{biblatex}
+\AtBeginBibliography{\small}
+
+%opening
+\title{ASPECT publication list}
+\author{The ASPECT authors and contributors}
+
+% If you get an error about invalid unicode characters, add them here and search
+% for the replacement string in the pdf output to fix it:
+%\DeclareUnicodeCharacter{0301}{*******************}
+
+% We don't ever use the output of this running pdflatex on this file
+% -- we only use it to find errors. As a consequence, the many
+% warnings on overfull hboxes are annoying and obscuring what really
+% constitutes a problem. Avoid this by just being totally relaxed
+% about overfull and underfull boxes:
+\hbadness=10000
+\vbadness=10000
+\hfuzz=10in
+\vfuzz=10in
+
+\begin{document}
+
+\maketitle
+
+\begin{refsection}[./manual/citing_aspect.bib]
+\nocite{*}
+\printbibliography[title={Publications citing ASPECT}]
+\end{refsection}
+\begin{refsection}[./sphinx/references.bib]
+  \nocite{*}
+  \printbibliography[title={Sphinx Manual References}]
+\end{refsection}
+\end{document}

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -3490,7 +3490,6 @@ source terms},
   author =       {Becker, R. and Braack, M. and Rannacher, R.},
   title =        {Adaptive finite elements for reactive flows},
   bootitle =     {ENUMATH 97},
-  crossref =     {enumath97},
   pages =        {206--213},
   year =         1999
 }
@@ -5120,7 +5119,6 @@ Linear and Nonlinear Solid and Structural Mechanics'' Udine, Oct. 4-8, 1999},
   author =       {Sch{\"a}fer, M. and Turek, S. and Rannacher, R.},
   title =        {Evaluation of a {CFD} Benchmark for Laminar Flows},
   booktitle =    {ENUMATH 97},
-  crossref =     {enumath97},
   OPTkey =       {},
   pages =        {549--563},
   OPTyear =      {},
@@ -7470,7 +7468,7 @@ tomography},
   journal =      {Control-Theory Adv. Tech.},
   year =         1991,
   volume =       1,
-  month =        {55--71}
+  pages =        {55--71}
 }
 
 @Article{KWGCFWSL03,
@@ -7482,7 +7480,7 @@ tomography},
 }
 
 @Article{KY02,
-  author =       {V. Komornik and M> Yamamoto},
+  author =       {V. Komornik and M. Yamamoto},
   title =        {Upper and lower estimates in determining point
                   sources in a wave equation},
   journal =      {Inverse Problems},
@@ -8004,7 +8002,7 @@ Transfer},
 }
 
 @Article{Mar93,
-  author =       {J. M. Mart{\' \i}nez},
+  author =       {J. M. Mart{\'i}nez},
   title =        {A theory of secant preconditioners},
   journal =      {Math. Comp.},
   year =         1993,
@@ -9819,7 +9817,7 @@ journal = {2007 SPEC Benchmark Workshop}
 
 
 @Article{ABEI99,
-  author =       {M. Aza\"\i{}ez and F. {Ben Belgacem} and H. {El Fekih}
+  author =       {M. Aza{\"i}ez and F. {Ben Belgacem} and H. {El Fekih}
                   and M. Ismail},
   title =        {Numerical simulation of the wave equation with
                   discontinuous coefficients by nonconforming finite elements},

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -9082,8 +9082,9 @@ Approximations},
                   of acousto-optical tomography and photo-acoustic
                   tomography},
   journal =      {Disease Markers},
-  year =         {2003/2004},
+  year =         {2004},
   volume =       19,
+  doi =          {10.1155/2004/478079},
   pages =        {123--138}
 }
 


### PR DESCRIPTION
It turns out that it is easy to add invalid bibtex to
- doc/sphinx/references.bib
- manual/citing_aspect.bib

I am adding a doc/citations-list.tex that generates a pdf with all of the citations above. Because we will soon delete the pdf manual, I am not adding and fixing doc/manual/manual.bib

Add a CI step that fails if invalid characters or any other problem is detected.