### PR TITLE
Increase use of parse_map in material models

### DIFF
--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -1166,48 +1166,75 @@ namespace aspect
                 AssertThrow (false, ExcNotImplemented());
             }
 
-          molar_masses = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Molar masses"))),
-                                                                 n_endmembers,
-                                                                 "Molar masses");
-          number_of_atoms = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Number of atoms"))),
-                                                                    n_endmembers,
-                                                                    "Number of atoms");
-          reference_volumes = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference volumes"))),
-                                                                      n_endmembers,
-                                                                      "Reference volumes");
-          reference_thermal_expansivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference thermal expansivities"))),
-                                                                                    n_endmembers,
-                                                                                    "Reference thermal expansivities");
-          reference_bulk_moduli = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference bulk moduli"))),
-                                                                          n_endmembers,
-                                                                          "Reference bulk moduli");
-          bulk_modulus_pressure_derivatives = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("First derivatives of the bulk modulus"))),
-                                                                                      n_endmembers,
-                                                                                      "First derivatives of the bulk modulus");
-          bulk_modulus_second_pressure_derivatives = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Second derivatives of the bulk modulus"))),
-                                                     n_endmembers,
+          molar_masses = Utilities::parse_map_to_double_array (prm.get("Molar masses"),
+                                                               endmember_names,
+                                                               false,
+                                                               "Molar masses");
+
+          number_of_atoms = Utilities::parse_map_to_double_array (prm.get("Number of atoms"),
+                                                                  endmember_names,
+                                                                  false,
+                                                                  "Number of atoms");
+
+          reference_volumes = Utilities::parse_map_to_double_array (prm.get("Reference volumes"),
+                                                                    endmember_names,
+                                                                    false,
+                                                                    "Reference volumes");
+
+          reference_thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Reference thermal expansivities"),
+                                                                                  endmember_names,
+                                                                                  false,
+                                                                                  "Reference thermal expansivities");
+
+          reference_bulk_moduli = Utilities::parse_map_to_double_array (prm.get("Reference bulk moduli"),
+                                                                        endmember_names,
+                                                                        false,
+                                                                        "Reference bulk moduli");
+
+          bulk_modulus_pressure_derivatives = Utilities::parse_map_to_double_array (prm.get("First derivatives of the bulk modulus"),
+                                                                                    endmember_names,
+                                                                                    false,
+                                                                                    "First derivatives of the bulk modulus");
+
+          bulk_modulus_second_pressure_derivatives = Utilities::parse_map_to_double_array (prm.get("Second derivatives of the bulk modulus"),
+                                                     endmember_names,
+                                                     false,
                                                      "Second derivatives of the bulk modulus");
-          Einstein_temperatures = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Einstein temperatures"))),
-                                                                          n_endmembers,
-                                                                          "Einstein temperatures");
-          reference_enthalpies = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference enthalpies"))),
-                                                                         n_endmembers,
-                                                                         "Reference enthalpies");
-          reference_entropies = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference entropies"))),
-                                                                        n_endmembers,
-                                                                        "Reference entropies");
-          reference_specific_heats = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Reference specific heat capacities"))),
-                                                                             n_endmembers,
-                                                                             "Reference specific heat capacities");
-          specific_heat_linear_coefficients = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Linear coefficients for specific heat polynomial"))),
-                                                                                      n_endmembers,
-                                                                                      "Linear coefficients for specific heat polynomial");
-          specific_heat_second_coefficients = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Second coefficients for specific heat polynomial"))),
-                                                                                      n_endmembers,
-                                                                                      "Second coefficients for specific heat polynomial");
-          specific_heat_third_coefficients = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Third coefficients for specific heat polynomial"))),
-                                                                                     n_endmembers,
-                                                                                     "Third coefficients for specific heat polynomial");
+
+          Einstein_temperatures = Utilities::parse_map_to_double_array (prm.get("Einstein temperatures"),
+                                                                        endmember_names,
+                                                                        false,
+                                                                        "Einstein temperatures");
+
+          reference_enthalpies = Utilities::parse_map_to_double_array (prm.get("Reference enthalpies"),
+                                                                       endmember_names,
+                                                                       false,
+                                                                       "Reference enthalpies");
+
+          reference_entropies = Utilities::parse_map_to_double_array (prm.get("Reference entropies"),
+                                                                      endmember_names,
+                                                                      false,
+                                                                      "Reference entropies");
+
+          reference_specific_heats = Utilities::parse_map_to_double_array (prm.get("Reference specific heat capacities"),
+                                                                           endmember_names,
+                                                                           false,
+                                                                           "Reference specific heat capacities");
+
+          specific_heat_linear_coefficients = Utilities::parse_map_to_double_array (prm.get("Linear coefficients for specific heat polynomial"),
+                                                                                    endmember_names,
+                                                                                    false,
+                                                                                    "Linear coefficients for specific heat polynomial");
+
+          specific_heat_second_coefficients = Utilities::parse_map_to_double_array (prm.get("Second coefficients for specific heat polynomial"),
+                                                                                    endmember_names,
+                                                                                    false,
+                                                                                    "Second coefficients for specific heat polynomial");
+
+          specific_heat_third_coefficients = Utilities::parse_map_to_double_array (prm.get("Third coefficients for specific heat polynomial"),
+                                                                                   endmember_names,
+                                                                                   false,
+                                                                                   "Third coefficients for specific heat polynomial");
 
           // Check all lists have the correct length.
           AssertThrow(endmember_names.size() == endmember_states.size(),

--- a/source/material_model/rheology/constant_viscosity_prefactors.cc
+++ b/source/material_model/rheology/constant_viscosity_prefactors.cc
@@ -65,12 +65,16 @@ namespace aspect
       void
       ConstantViscosityPrefactors<dim>::parse_parameters (ParameterHandler &prm)
       {
-        // increment by one for background:
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
+        // Retrieve the list of composition names
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        constant_viscosity_prefactors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Constant viscosity prefactors"))),
-                                                                                n_fields,
-                                                                                "Constant viscosity prefactors");
+        // Establish that a background field is required here
+        const bool has_background_field = true;
+
+        constant_viscosity_prefactors = Utilities::parse_map_to_double_array (prm.get("Constant viscosity prefactors"),
+                                                                              list_of_composition_names,
+                                                                              has_background_field,
+                                                                              "Constant viscosity prefactors");
       }
     }
   }

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -113,12 +113,16 @@ namespace aspect
       void
       Elasticity<dim>::parse_parameters (ParameterHandler &prm)
       {
-        // Get the number of fields for composition-dependent material properties
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
+        // Retrieve the list of composition names
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        elastic_shear_moduli = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Elastic shear moduli"))),
-                                                                       n_fields,
-                                                                       "Elastic shear moduli");
+        // Establish that a background field is required here
+        const bool has_background_field = true;
+
+        elastic_shear_moduli = Utilities::parse_map_to_double_array (prm.get("Elastic shear moduli"),
+                                                                     list_of_composition_names,
+                                                                     has_background_field,
+                                                                     "Elastic shear moduli");
 
         // Stabilize elasticity through a viscous damper
         elastic_damper_viscosity = prm.get_double("Elastic damper viscosity");

--- a/source/material_model/rheology/frank_kamenetskii.cc
+++ b/source/material_model/rheology/frank_kamenetskii.cc
@@ -77,9 +77,6 @@ namespace aspect
       void
       FrankKamenetskii<dim>::parse_parameters (ParameterHandler &prm)
       {
-        // increment by one for background:
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
-
         AssertThrow (this->include_adiabatic_heating() == false,
                      ExcMessage("The Frank-Kamenetskii rheology is currently only implemented for "
                                 "models without adiabatic heating. Please implement the necessary "
@@ -90,12 +87,22 @@ namespace aspect
                                 "surface temperature (reference_temperature in equation for viscosity) "
                                 "is non-zero."));
 
-        viscosity_ratios_frank_kamenetskii = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Viscosity ratios for Frank Kamenetskii"))),
-                                                                                     n_fields,
-                                                                                     "Viscosity ratios for Frank Kamenetskii");
-        prefactors_frank_kamenetskii = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Prefactors for Frank Kamenetskii"))),
-                                                                               n_fields,
-                                                                               "Prefactors for Frank Kamenetskii");
+        // Retrieve the list of composition names
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+
+        // Establish that a background field is required here
+        const bool has_background_field = true;
+
+        viscosity_ratios_frank_kamenetskii = Utilities::parse_map_to_double_array (prm.get("Viscosity ratios for Frank Kamenetskii"),
+                                                                                   list_of_composition_names,
+                                                                                   has_background_field,
+                                                                                   "Viscosity ratios for Frank Kamenetskii");
+
+
+        prefactors_frank_kamenetskii = Utilities::parse_map_to_double_array (prm.get("Prefactors for Frank Kamenetskii"),
+                                                                             list_of_composition_names,
+                                                                             has_background_field,
+                                                                             "Prefactors for Frank Kamenetskii");
       }
     }
   }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -178,9 +178,6 @@ namespace aspect
       void
       StrainDependent<dim>::parse_parameters (ParameterHandler &prm)
       {
-        // Get the number of fields for composition-dependent material properties
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
-
         // number of required compositional fields for full finite strain tensor
         const unsigned int s = Tensor<2,dim>::n_independent_components;
 
@@ -289,34 +286,46 @@ namespace aspect
           }
 
 
+        // Retrieve the list of composition names
+        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        start_plastic_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Start plasticity strain weakening intervals"))),
-                                                   n_fields,
+        // Establish that a background field is required here
+        const bool has_background_field = true;
+
+        start_plastic_strain_weakening_intervals = Utilities::parse_map_to_double_array (prm.get("Start plasticity strain weakening intervals"),
+                                                   list_of_composition_names,
+                                                   has_background_field,
                                                    "Start plasticity strain weakening intervals");
 
-        end_plastic_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("End plasticity strain weakening intervals"))),
-                                                 n_fields,
-                                                 "End plasticity strain weakening intervals");
+        end_plastic_strain_weakening_intervals = Utilities::parse_map_to_double_array (prm.get("End plasticity strain weakening intervals"),
+                                                                                       list_of_composition_names,
+                                                                                       has_background_field,
+                                                                                       "End plasticity strain weakening intervals");
 
-        start_viscous_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Start prefactor strain weakening intervals"))),
-                                                   n_fields,
+        start_viscous_strain_weakening_intervals = Utilities::parse_map_to_double_array (prm.get("Start prefactor strain weakening intervals"),
+                                                   list_of_composition_names,
+                                                   has_background_field,
                                                    "Start prefactor strain weakening intervals");
 
-        end_viscous_strain_weakening_intervals = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("End prefactor strain weakening intervals"))),
-                                                 n_fields,
-                                                 "End prefactor strain weakening intervals");
+        end_viscous_strain_weakening_intervals = Utilities::parse_map_to_double_array (prm.get("End prefactor strain weakening intervals"),
+                                                                                       list_of_composition_names,
+                                                                                       has_background_field,
+                                                                                       "End prefactor strain weakening intervals");
 
-        viscous_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Prefactor strain weakening factors"))),
-                                                                                   n_fields,
-                                                                                   "Prefactor strain weakening factors");
+        viscous_strain_weakening_factors = Utilities::parse_map_to_double_array (prm.get("Prefactor strain weakening factors"),
+                                                                                 list_of_composition_names,
+                                                                                 has_background_field,
+                                                                                 "Prefactor strain weakening factors");
 
-        cohesion_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Cohesion strain weakening factors"))),
-                                                                                    n_fields,
-                                                                                    "Cohesion strain weakening factors");
+        cohesion_strain_weakening_factors = Utilities::parse_map_to_double_array (prm.get("Cohesion strain weakening factors"),
+                                                                                  list_of_composition_names,
+                                                                                  has_background_field,
+                                                                                  "Cohesion strain weakening factors");
 
-        friction_strain_weakening_factors = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Friction strain weakening factors"))),
-                                                                                    n_fields,
-                                                                                    "Friction strain weakening factors");
+        friction_strain_weakening_factors = Utilities::parse_map_to_double_array (prm.get("Friction strain weakening factors"),
+                                                                                  list_of_composition_names,
+                                                                                  has_background_field,
+                                                                                  "Friction strain weakening factors");
 
         if (prm.get ("Strain healing mechanism") == "no healing")
           healing_mechanism = no_healing;

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -611,9 +611,6 @@ namespace aspect
         // Retrieve the list of composition names
         const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
 
-        // increment by one for background:
-        const unsigned int n_fields = this->n_compositional_fields() + 1;
-
         strain_rheology.initialize_simulator (this->get_simulator());
         strain_rheology.parse_parameters(prm);
 
@@ -714,9 +711,10 @@ namespace aspect
         drucker_prager_plasticity.parse_parameters(prm, expected_n_phases_per_composition);
 
         // Stress limiter parameter
-        exponents_stress_limiter  = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Stress limiter exponents"))),
-                                                                            n_fields,
-                                                                            "Stress limiter exponents");
+        exponents_stress_limiter = Utilities::parse_map_to_double_array (prm.get("Stress limiter exponents"),
+                                                                         list_of_composition_names,
+                                                                         has_background_field,
+                                                                         "Stress limiter exponents");
 
         // Include an adiabat temperature gradient in flow laws
         adiabatic_temperature_gradient_for_viscosity = prm.get_double("Adiabat temperature gradient for viscosity");

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -353,9 +353,6 @@ namespace aspect
     void
     ViscoPlastic<dim>::parse_parameters (ParameterHandler &prm)
     {
-      // increment by one for background:
-      const unsigned int n_fields = this->n_compositional_fields() + 1;
-
       prm.enter_subsection("Material model");
       {
         prm.enter_subsection ("Visco Plastic");
@@ -378,15 +375,23 @@ namespace aspect
                                               std::make_unique<std::vector<unsigned int>>(n_phase_transitions_for_each_composition));
 
 
-          thermal_diffusivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal diffusivities"))),
-                                                                          n_fields,
-                                                                          "Thermal diffusivities");
+          // Retrieve the list of composition names
+          const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+
+          // Establish that a background field is required here
+          const bool has_background_field = true;
+
+          thermal_diffusivities = Utilities::parse_map_to_double_array (prm.get("Thermal diffusivities"),
+                                                                        list_of_composition_names,
+                                                                        has_background_field,
+                                                                        "Thermal diffusivities");
 
           define_conductivities = prm.get_bool ("Define thermal conductivities");
 
-          thermal_conductivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal conductivities"))),
-                                                                           n_fields,
-                                                                           "Thermal conductivities");
+          thermal_conductivities = Utilities::parse_map_to_double_array (prm.get("Thermal conductivities"),
+                                                                         list_of_composition_names,
+                                                                         has_background_field,
+                                                                         "Thermal conductivities");
 
           rheology = std::make_unique<Rheology::ViscoPlastic<dim>>();
           rheology->initialize_simulator (this->get_simulator());

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -138,10 +138,6 @@ namespace aspect
     void
     Viscoelastic<dim>::parse_parameters (ParameterHandler &prm)
     {
-
-      // Get the number of fields for composition-dependent material properties
-      const unsigned int n_fields = this->n_compositional_fields() + 1;
-
       AssertThrow(this->get_parameters().enable_elasticity == true,
                   ExcMessage ("Material model Viscoelastic only works if 'Enable elasticity' is set to true"));
 
@@ -159,13 +155,21 @@ namespace aspect
           viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
                                 prm);
 
-          // Parse viscoelastic properties
-          viscosities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Viscosities"))),
-                                                                n_fields,
-                                                                "Viscosities");
-          thermal_conductivities = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double(Utilities::split_string_list(prm.get("Thermal conductivities"))),
-                                                                           n_fields,
-                                                                           "Thermal conductivities");
+          // Retrieve the list of composition names
+          const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+
+          // Establish that a background field is required here
+          const bool has_background_field = true;
+
+          viscosities = Utilities::parse_map_to_double_array (prm.get("Viscosities"),
+                                                              list_of_composition_names,
+                                                              has_background_field,
+                                                              "Viscosities");
+
+          thermal_conductivities = Utilities::parse_map_to_double_array (prm.get("Thermal conductivities"),
+                                                                         list_of_composition_names,
+                                                                         has_background_field,
+                                                                         "Thermal conductivities");
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
This PR replaces use of the "possibly_extend_from_1_to_N" function with the more flexible "parse_map_to_double_array" in all material models apart from steinberger.

This is a small step towards unifying code functionality across material models.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.

