### PR TITLE
added n_phase functions to PhaseFunction

### DIFF
--- a/doc/modules/changes/20230122_myhill
+++ b/doc/modules/changes/20230122_myhill
@@ -1,0 +1,4 @@
+New: The PhaseFunction class now includes helper functions
+n_phases_for_each_composition() and n_phases().
+<br>
+(Bob Myhill, 2023/01/22)

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -492,6 +492,11 @@ namespace aspect
           unsigned int n_phase_transitions () const;
 
           /**
+           * Return the total number of phases.
+           */
+          unsigned int n_phases () const;
+
+          /**
            * Return the Clapeyron slope (dp/dT of the transition) for
            * phase transition number @p phase_index.
            */
@@ -502,6 +507,12 @@ namespace aspect
            */
           const std::vector<unsigned int> &
           n_phase_transitions_for_each_composition () const;
+
+          /**
+           * Return how many phases there are for each composition.
+           */
+          const std::vector<unsigned int> &
+          n_phases_for_each_composition () const;
 
           /**
            * Declare the parameters this class takes through input files.
@@ -547,6 +558,16 @@ namespace aspect
            * A vector that stores how many phase transitions there are for each compositional field.
            */
           std::unique_ptr<std::vector<unsigned int>> n_phase_transitions_per_composition;
+
+          /**
+           * A vector that stores how many phases there are for each compositional field.
+           */
+          std::vector<unsigned int> n_phases_per_composition;
+
+          /**
+           * Total number of phases over all compositional fields
+           */
+          unsigned int n_phases_total;
       };
     }
   }

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1133,6 +1133,13 @@ namespace aspect
           return transition_pressures.size();
       }
 
+      template <int dim>
+      unsigned int
+      PhaseFunction<dim>::
+      n_phases () const
+      {
+        return n_phases_total;
+      }
 
       template <int dim>
       const std::vector<unsigned int> &
@@ -1141,6 +1148,12 @@ namespace aspect
         return *n_phase_transitions_per_composition;
       }
 
+      template <int dim>
+      const std::vector<unsigned int> &
+      PhaseFunction<dim>::n_phases_for_each_composition () const
+      {
+        return n_phases_per_composition;
+      }
 
 
       template <int dim>
@@ -1279,6 +1292,14 @@ namespace aspect
                                                                   true,
                                                                   n_phase_transitions_per_composition,
                                                                   true);
+
+        n_phases_total = 0;
+        n_phases_per_composition.clear();
+        for (unsigned int n : *n_phase_transitions_per_composition)
+          {
+            n_phases_per_composition.push_back(n+1);
+            n_phases_total += n+1;
+          }
       }
     }
   }


### PR DESCRIPTION
This PR adds the functions `n_phases_for_each_composition()` and `n_phases()` to the PhaseFunction class. The `visco_plastic` material model is modified to use these functions.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.