### PR TITLE
Clarified phase / phase transition arguments and docstrings

### DIFF
--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -117,7 +117,7 @@ namespace aspect
     void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
                                             const std::vector<double> &phase_function_values,
-                                            const std::vector<unsigned int> &n_phases_per_composition,
+                                            const std::vector<unsigned int> &n_phase_transitions_per_composition,
                                             EquationOfStateOutputs<dim> &eos_outputs);
   }
 }

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -87,7 +87,7 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -58,7 +58,7 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */
@@ -68,7 +68,7 @@ namespace aspect
 
           /**
            * Compute the viscosity based on the composite viscous creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -80,12 +80,12 @@ namespace aspect
                              const SymmetricTensor<2,dim> &strain_rate,
                              std::vector<double> &partial_strain_rates,
                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                             const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the compositional field viscosity
            * based on the composite viscous creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -97,15 +97,11 @@ namespace aspect
                                          const SymmetricTensor<2,dim> &strain_rate,
                                          std::vector<double> &partial_strain_rates,
                                          const std::vector<double> &phase_function_values = std::vector<double>(),
-                                         const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                         const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the strain rate and first stress derivative
            * as a function of stress based on the composite viscous creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
-           * for each compositional field and viscosity will be first computed on
-           * each phase and then averaged for each compositional field.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double creep_stress,

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -69,7 +69,7 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */
@@ -80,7 +80,7 @@ namespace aspect
 
           /**
            * Compute the creep parameters for the diffusion creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -88,11 +88,11 @@ namespace aspect
           const DiffusionCreepParameters
           compute_creep_parameters (const unsigned int composition,
                                     const std::vector<double> &phase_function_values = std::vector<double>(),
-                                    const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                    const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the viscosity based on the diffusion creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -102,15 +102,11 @@ namespace aspect
                              const double temperature,
                              const unsigned int composition,
                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                             const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the strain rate and first stress derivative as a function
-           * of stress based on the diffusion creep law. If @p
-           * expected_n_phases_per_composition points to a vector of unsigned
-           * integers this is considered the number of phase transitions for
-           * each compositional field and viscosity will be first computed on
-           * each phase and then averaged for each compositional field.
+           * of stress based on the diffusion creep law.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -66,7 +66,7 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */
@@ -76,7 +76,7 @@ namespace aspect
 
           /**
            * Compute the creep parameters for the dislocation creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -84,11 +84,11 @@ namespace aspect
           const DislocationCreepParameters
           compute_creep_parameters (const unsigned int composition,
                                     const std::vector<double> &phase_function_values = std::vector<double>(),
-                                    const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                    const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the viscosity based on the dislocation creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
+           * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
            * each phase and then averaged for each compositional field.
@@ -99,15 +99,11 @@ namespace aspect
                              const double temperature,
                              const unsigned int composition,
                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                             const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the strain rate and first stress derivative
            * as a function of stress based on the dislocation creep law.
-           * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
-           * for each compositional field and viscosity will be first computed on
-           * each phase and then averaged for each compositional field.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -82,10 +82,17 @@ namespace aspect
           parse_parameters (ParameterHandler &prm,
                             const std::unique_ptr<std::vector<unsigned int>> &expected_n_phases_per_composition = nullptr);
 
+          /**
+           * Compute the parameters for the Drucker Prager plasticity.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
+           */
           const DruckerPragerParameters
           compute_drucker_prager_parameters (const unsigned int composition,
                                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                                             const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the plastic yield stress based on the Drucker Prager yield criterion.

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -88,7 +88,7 @@ namespace aspect
           /**
            * Read the parameters from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */
@@ -98,6 +98,10 @@ namespace aspect
 
           /**
            * Compute the viscosity based on the approximate Peierls creep flow law.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           double
           compute_approximate_viscosity (const double strain_rate,
@@ -105,10 +109,14 @@ namespace aspect
                                          const double temperature,
                                          const unsigned int composition,
                                          const std::vector<double> &phase_function_values = std::vector<double>(),
-                                         const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                         const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the viscosity based on the exact Peierls creep flow law.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           double
           compute_exact_viscosity (const double strain_rate,
@@ -116,12 +124,16 @@ namespace aspect
                                    const double temperature,
                                    const unsigned int composition,
                                    const std::vector<double> &phase_function_values = std::vector<double>(),
-                                   const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                                   const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the viscosity based on the selected Peierls creep flow law.
            * This function uses either the compute_approximate_viscosity
            * or the compute_exact_viscosity function.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           double
           compute_viscosity (const double strain_rate,
@@ -129,7 +141,7 @@ namespace aspect
                              const double temperature,
                              const unsigned int composition,
                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                             const std::vector<unsigned int> &n_phases_per_composition = std::vector<unsigned int>()) const;
+                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
            * Compute the strain rate and first stress derivative

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -124,19 +124,27 @@ namespace aspect
           /**
            * This function calculates viscosities assuming that all the compositional fields
            * experience the same strain rate (isostrain).
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           IsostrainViscosities
           calculate_isostrain_viscosities ( const MaterialModel::MaterialModelInputs<dim> &in,
                                             const unsigned int i,
                                             const std::vector<double> &volume_fractions,
                                             const std::vector<double> &phase_function_values = std::vector<double>(),
-                                            const std::vector<unsigned int> &n_phases_per_composition =
+                                            const std::vector<unsigned int> &n_phase_transitions_per_composition =
                                               std::vector<unsigned int>()) const;
 
           /**
            * A function that fills the viscosity derivatives in the
            * MaterialModelOutputs object that is handed over, if they exist.
            * Does nothing otherwise.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
            */
           void compute_viscosity_derivatives(const unsigned int point_index,
                                              const std::vector<double> &volume_fractions,
@@ -144,7 +152,7 @@ namespace aspect
                                              const MaterialModel::MaterialModelInputs<dim> &in,
                                              MaterialModel::MaterialModelOutputs<dim> &out,
                                              const std::vector<double> &phase_function_values = std::vector<double>(),
-                                             const std::vector<unsigned int> &n_phases_per_composition =
+                                             const std::vector<unsigned int> &n_phase_transitions_per_composition =
                                                std::vector<unsigned int>()) const;
 
           /**
@@ -165,7 +173,7 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            * If @p expected_n_phases_per_composition points to a vector of
-           * unsigned integers this is considered the number of phase transitions
+           * unsigned integers this is considered the number of phases
            * for each compositional field and will be checked against the parsed
            * parameters.
            */

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -435,9 +435,9 @@ namespace aspect
        * between 0 and 1.
        */
       double phase_average_value (const std::vector<double> &phase_function_values,
-                                  const std::vector<unsigned int> &n_phases_per_composition,
+                                  const std::vector<unsigned int> &n_phase_transitions_per_composition,
                                   const std::vector<double> &parameter_values,
-                                  const unsigned int composition,
+                                  const unsigned int composition_index,
                                   const PhaseUtilities::PhaseAveragingOperation operation = PhaseUtilities::arithmetic);
 
 

--- a/source/material_model/equation_of_state/interface.cc
+++ b/source/material_model/equation_of_state/interface.cc
@@ -44,23 +44,23 @@ namespace aspect
     void
     phase_average_equation_of_state_outputs(const EquationOfStateOutputs<dim> &eos_outputs_all_phases,
                                             const std::vector<double> &phase_function_values,
-                                            const std::vector<unsigned int> &n_phases_per_composition,
+                                            const std::vector<unsigned int> &n_phase_transitions_per_composition,
                                             EquationOfStateOutputs<dim> &eos_outputs)
     {
       for (unsigned int c=0; c<eos_outputs.densities.size(); ++c)
         {
           eos_outputs.densities[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.densities, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.densities, c);
           eos_outputs.thermal_expansion_coefficients[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.thermal_expansion_coefficients, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.thermal_expansion_coefficients, c);
           eos_outputs.specific_heat_capacities[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.specific_heat_capacities, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.specific_heat_capacities, c);
           eos_outputs.compressibilities[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.compressibilities, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.compressibilities, c);
           eos_outputs.entropy_derivative_pressure[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.entropy_derivative_pressure, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.entropy_derivative_pressure, c);
           eos_outputs.entropy_derivative_temperature[c] =
-            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition, eos_outputs_all_phases.entropy_derivative_temperature, c);
+            MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition, eos_outputs_all_phases.entropy_derivative_temperature, c);
         }
     }
   }
@@ -75,7 +75,7 @@ namespace aspect
   template struct EquationOfStateOutputs<dim>; \
   template void phase_average_equation_of_state_outputs<dim> (const EquationOfStateOutputs<dim> &, \
                                                               const std::vector<double> &phase_function_values, \
-                                                              const std::vector<unsigned int> &n_phases_per_composition, \
+                                                              const std::vector<unsigned int> &n_phase_transitions_per_composition, \
                                                               EquationOfStateOutputs<dim> &);
 
     ASPECT_INSTANTIATE(INSTANTIATE)

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -76,7 +76,7 @@ namespace aspect
                                                      const SymmetricTensor<2,dim> &strain_rate,
                                                      std::vector<double> &partial_strain_rates,
                                                      const std::vector<double> &phase_function_values,
-                                                     const std::vector<unsigned int> &n_phases_per_composition) const
+                                                     const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         double viscosity = 0.;
         partial_strain_rates.resize(5, 0.);
@@ -98,7 +98,7 @@ namespace aspect
                                                                strain_rate,
                                                                partial_strain_rates_composition,
                                                                phase_function_values,
-                                                               n_phases_per_composition));
+                                                               n_phase_transitions_per_composition));
                 for (unsigned int j=0; j < 5; ++j)
                   partial_strain_rates[j] += volume_fractions[composition] * partial_strain_rates_composition[j];
               }
@@ -124,7 +124,7 @@ namespace aspect
                                                                  const SymmetricTensor<2,dim> &strain_rate,
                                                                  std::vector<double> &partial_strain_rates,
                                                                  const std::vector<double> &phase_function_values,
-                                                                 const std::vector<unsigned int> &n_phases_per_composition) const
+                                                                 const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         // If strain rate is zero (like during the first time step) set it to some very small number
         // to prevent a division-by-zero, and a floating point exception.
@@ -143,14 +143,14 @@ namespace aspect
 
         if (use_diffusion_creep)
           {
-            diffusion_creep_parameters = diffusion_creep->compute_creep_parameters(composition, phase_function_values, n_phases_per_composition);
-            eta_diff = diffusion_creep->compute_viscosity(pressure, temperature, composition, phase_function_values, n_phases_per_composition);
+            diffusion_creep_parameters = diffusion_creep->compute_creep_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+            eta_diff = diffusion_creep->compute_viscosity(pressure, temperature, composition, phase_function_values, n_phase_transitions_per_composition);
           }
 
         if (use_dislocation_creep)
           {
-            dislocation_creep_parameters = dislocation_creep->compute_creep_parameters(composition, phase_function_values, n_phases_per_composition);
-            eta_disl = dislocation_creep->compute_viscosity(edot_ii, pressure, temperature, composition, phase_function_values, n_phases_per_composition);
+            dislocation_creep_parameters = dislocation_creep->compute_creep_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+            eta_disl = dislocation_creep->compute_viscosity(edot_ii, pressure, temperature, composition, phase_function_values, n_phase_transitions_per_composition);
           }
 
         if (use_peierls_creep)
@@ -167,7 +167,7 @@ namespace aspect
         // Drucker-Prager yield stress. Probably fine for a first guess.
         if (use_drucker_prager)
           {
-            drucker_prager_parameters = drucker_prager->compute_drucker_prager_parameters(composition, phase_function_values, n_phases_per_composition);
+            drucker_prager_parameters = drucker_prager->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
             const double yield_stress = drucker_prager->compute_yield_stress(drucker_prager_parameters.cohesion,
                                                                              drucker_prager_parameters.angle_internal_friction,
                                                                              pressure,

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -43,7 +43,7 @@ namespace aspect
       const DiffusionCreepParameters
       DiffusionCreep<dim>::compute_creep_parameters (const unsigned int composition,
                                                      const std::vector<double> &phase_function_values,
-                                                     const std::vector<unsigned int> &n_phases_per_composition) const
+                                                     const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         DiffusionCreepParameters creep_parameters;
         if (phase_function_values == std::vector<double>())
@@ -58,15 +58,15 @@ namespace aspect
         else
           {
             // Average among phases
-            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                          prefactors_diffusion, composition,  MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic);
-            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_energies_diffusion, composition);
-            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_volumes_diffusion, composition);
-            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                stress_exponents_diffusion, composition);
-            creep_parameters.grain_size_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.grain_size_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                    grain_size_exponents_diffusion, composition);
           }
         return creep_parameters;
@@ -80,11 +80,11 @@ namespace aspect
                                               const double temperature,
                                               const unsigned int composition,
                                               const std::vector<double> &phase_function_values,
-                                              const std::vector<unsigned int> &n_phases_per_composition) const
+                                              const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         const DiffusionCreepParameters p = compute_creep_parameters(composition,
                                                                     phase_function_values,
-                                                                    n_phases_per_composition);
+                                                                    n_phase_transitions_per_composition);
 
         // Power law creep equation
         //    viscosity = 0.5 * A^(-1) * d^(m) * exp((E + P*V)/(RT))

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -42,7 +42,7 @@ namespace aspect
       const DislocationCreepParameters
       DislocationCreep<dim>::compute_creep_parameters (const unsigned int composition,
                                                        const std::vector<double> &phase_function_values,
-                                                       const std::vector<unsigned int> &n_phases_per_composition) const
+                                                       const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         DislocationCreepParameters creep_parameters;
         if (phase_function_values == std::vector<double>())
@@ -56,14 +56,14 @@ namespace aspect
         else
           {
             // Average among phases
-            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                          prefactors_dislocation, composition,
                                          MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic);
-            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_energies_dislocation, composition);
-            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_volumes_dislocation , composition);
-            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                stress_exponents_dislocation, composition);
           }
 
@@ -79,11 +79,11 @@ namespace aspect
                                                 const double temperature,
                                                 const unsigned int composition,
                                                 const std::vector<double> &phase_function_values,
-                                                const std::vector<unsigned int> &n_phases_per_composition) const
+                                                const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         const DislocationCreepParameters p = compute_creep_parameters(composition,
                                                                       phase_function_values,
-                                                                      n_phases_per_composition);
+                                                                      n_phase_transitions_per_composition);
 
         // Power law creep equation:
         //    viscosity = 0.5 * A^(-1/n) * edot_ii^((1-n)/n) * exp((E + P*V)/(nRT))

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -40,7 +40,7 @@ namespace aspect
       const DruckerPragerParameters
       DruckerPrager<dim>::compute_drucker_prager_parameters (const unsigned int composition,
                                                              const std::vector<double> &phase_function_values,
-                                                             const std::vector<unsigned int> &n_phases_per_composition) const
+                                                             const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         DruckerPragerParameters drucker_prager_parameters;
 
@@ -55,9 +55,9 @@ namespace aspect
         else
           {
             // Average among phases
-            drucker_prager_parameters.angle_internal_friction = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            drucker_prager_parameters.angle_internal_friction = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                                 angles_internal_friction, composition);
-            drucker_prager_parameters.cohesion = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            drucker_prager_parameters.cohesion = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  cohesions, composition);
           }
         return drucker_prager_parameters;

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -45,7 +45,7 @@ namespace aspect
       const PeierlsCreepParameters
       PeierlsCreep<dim>::compute_creep_parameters (const unsigned int composition,
                                                    const std::vector<double> &phase_function_values,
-                                                   const std::vector<unsigned int> &n_phases_per_composition) const
+                                                   const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         PeierlsCreepParameters creep_parameters;
         if (phase_function_values == std::vector<double>())
@@ -65,23 +65,23 @@ namespace aspect
           {
             // Average among phases. This averaging is not strictly correct, but
             // it will not matter much if the parameters are similar across transitions.
-            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.prefactor = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                          prefactors, composition,  MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic);
-            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.stress_exponent = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                stress_exponents, composition);
-            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_energy = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_energies, composition);
-            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.activation_volume = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  activation_volumes, composition);
-            creep_parameters.peierls_stress = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.peierls_stress = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                               peierls_stresses, composition);
-            creep_parameters.glide_parameter_p = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.glide_parameter_p = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  glide_parameters_p, composition);
-            creep_parameters.glide_parameter_q = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.glide_parameter_q = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  glide_parameters_q, composition);
-            creep_parameters.fitting_parameter = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.fitting_parameter = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  fitting_parameters, composition);
-            creep_parameters.stress_cutoff = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phases_per_composition,
+            creep_parameters.stress_cutoff = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                              stress_cutoffs, composition);
           }
         return creep_parameters;
@@ -96,7 +96,7 @@ namespace aspect
                                                         const double temperature,
                                                         const unsigned int composition,
                                                         const std::vector<double> &phase_function_values,
-                                                        const std::vector<unsigned int> &n_phases_per_composition) const
+                                                        const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         /**
          * An approximation of the Peierls creep formulation, where stress is replaced with strain rate
@@ -124,7 +124,7 @@ namespace aspect
          * R is the gas constant
          */
 
-        const PeierlsCreepParameters p = compute_creep_parameters(composition, phase_function_values, n_phases_per_composition);
+        const PeierlsCreepParameters p = compute_creep_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
         const double s = ( (p.activation_energy + pressure * p.activation_volume) / (constants::gas_constant * temperature)) *
                          p.glide_parameter_p * p.glide_parameter_q *
@@ -166,7 +166,7 @@ namespace aspect
                                                   const double temperature,
                                                   const unsigned int composition,
                                                   const std::vector<double> &phase_function_values,
-                                                  const std::vector<unsigned int> &n_phases_per_composition) const
+                                                  const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         /**
          * A generalised Peierls creep formulation. The Peierls creep expression
@@ -177,7 +177,7 @@ namespace aspect
          * The equation for the strain rate is given in
          * compute_exact_strain_rate_and_derivative.
          */
-        const PeierlsCreepParameters p = compute_creep_parameters(composition, phase_function_values, n_phases_per_composition);
+        const PeierlsCreepParameters p = compute_creep_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
         // The generalized Peierls creep flow law cannot be expressed as viscosity in
         // terms of strain rate, because there are two stress-dependent terms
@@ -241,7 +241,7 @@ namespace aspect
                                             const double temperature,
                                             const unsigned int composition,
                                             const std::vector<double> &phase_function_values,
-                                            const std::vector<unsigned int> &n_phases_per_composition) const
+                                            const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         double viscosity = 0.0;
 
@@ -249,12 +249,12 @@ namespace aspect
           {
             case viscosity_approximation:
             {
-              viscosity = compute_approximate_viscosity(strain_rate, pressure, temperature, composition, phase_function_values, n_phases_per_composition);
+              viscosity = compute_approximate_viscosity(strain_rate, pressure, temperature, composition, phase_function_values, n_phase_transitions_per_composition);
               break;
             }
             case exact:
             {
-              viscosity = compute_exact_viscosity(strain_rate, pressure, temperature, composition, phase_function_values, n_phases_per_composition);
+              viscosity = compute_exact_viscosity(strain_rate, pressure, temperature, composition, phase_function_values, n_phase_transitions_per_composition);
               break;
             }
             default:

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -100,7 +100,7 @@ namespace aspect
                                        const unsigned int i,
                                        const std::vector<double> &volume_fractions,
                                        const std::vector<double> &phase_function_values,
-                                       const std::vector<unsigned int> &n_phases_per_composition) const
+                                       const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         IsostrainViscosities output_parameters;
 
@@ -166,7 +166,7 @@ namespace aspect
                    ?
                    diffusion_creep.compute_viscosity(pressure_for_creep, temperature_for_viscosity, j,
                                                      phase_function_values,
-                                                     n_phases_per_composition)
+                                                     n_phase_transitions_per_composition)
                    :
                    numbers::signaling_nan<double>());
 
@@ -176,7 +176,7 @@ namespace aspect
                    ?
                    dislocation_creep.compute_viscosity(edot_ii, pressure_for_creep, temperature_for_viscosity, j,
                                                        phase_function_values,
-                                                       n_phases_per_composition)
+                                                       n_phase_transitions_per_composition)
                    :
                    numbers::signaling_nan<double>());
 
@@ -216,7 +216,7 @@ namespace aspect
                 {
                   const double viscosity_peierls = peierls_creep->compute_viscosity(edot_ii, pressure_for_creep, temperature_for_viscosity, j,
                                                                                     phase_function_values,
-                                                                                    n_phases_per_composition);
+                                                                                    n_phase_transitions_per_composition);
                   viscosity_pre_yield = (viscosity_pre_yield * viscosity_peierls) / (viscosity_pre_yield + viscosity_peierls);
                 }
             }
@@ -266,7 +266,7 @@ namespace aspect
             // Step 4a: calculate strain-weakened friction and cohesion
             const DruckerPragerParameters drucker_prager_parameters = drucker_prager_plasticity.compute_drucker_prager_parameters(j,
                                                                       phase_function_values,
-                                                                      n_phases_per_composition);
+                                                                      n_phase_transitions_per_composition);
             const double current_cohesion = drucker_prager_parameters.cohesion * weakening_factors[0];
             double current_friction = drucker_prager_parameters.angle_internal_friction * weakening_factors[1];
 
@@ -337,14 +337,14 @@ namespace aspect
             // Step 6: limit the viscosity with specified minimum and maximum bounds
             const double maximum_viscosity_for_composition = MaterialModel::MaterialUtilities::phase_average_value(
                                                                phase_function_values,
-                                                               n_phases_per_composition,
+                                                               n_phase_transitions_per_composition,
                                                                maximum_viscosity,
                                                                j,
                                                                MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic
                                                              );
             const double minimum_viscosity_for_composition = MaterialModel::MaterialUtilities::phase_average_value(
                                                                phase_function_values,
-                                                               n_phases_per_composition,
+                                                               n_phase_transitions_per_composition,
                                                                minimum_viscosity,
                                                                j,
                                                                MaterialModel::MaterialUtilities::PhaseUtilities::logarithmic
@@ -365,7 +365,7 @@ namespace aspect
                                     const MaterialModel::MaterialModelInputs<dim> &in,
                                     MaterialModel::MaterialModelOutputs<dim> &out,
                                     const std::vector<double> &phase_function_values,
-                                    const std::vector<unsigned int> &n_phases_per_composition) const
+                                    const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         MaterialModel::MaterialModelDerivatives<dim> *derivatives =
           out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
@@ -403,7 +403,7 @@ namespace aspect
 
                 std::vector<double> eta_component =
                   calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                                  phase_function_values, n_phases_per_composition).composition_viscosities;
+                                                  phase_function_values, n_phase_transitions_per_composition).composition_viscosities;
 
                 // For each composition of the independent component, compute the derivative.
                 for (unsigned int composition_index = 0; composition_index < eta_component.size(); ++composition_index)
@@ -430,7 +430,7 @@ namespace aspect
 
             const std::vector<double> viscosity_difference =
               calculate_isostrain_viscosities(in_derivatives, i, volume_fractions,
-                                              phase_function_values, n_phases_per_composition).composition_viscosities;
+                                              phase_function_values, n_phase_transitions_per_composition).composition_viscosities;
 
             for (unsigned int composition_index = 0; composition_index < viscosity_difference.size(); ++composition_index)
               {

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1016,34 +1016,36 @@ namespace aspect
 
 
       double phase_average_value (const std::vector<double> &phase_function_values,
-                                  const std::vector<unsigned int> &n_phases_per_composition,
+                                  const std::vector<unsigned int> &n_phase_transitions_per_composition,
                                   const std::vector<double> &parameter_values,
-                                  const unsigned int composition,
+                                  const unsigned int composition_index,
                                   const PhaseUtilities::PhaseAveragingOperation operation)
       {
         // Calculate base index and assign base value
-        unsigned int base = 0;
-        for (unsigned int i=0; i<composition; ++i)
-          base += n_phases_per_composition[i] + 1;
+        unsigned int start_phase_index = 0;
+        for (unsigned int i=0; i<composition_index; ++i)
+          start_phase_index += n_phase_transitions_per_composition[i] + 1;
 
-        double averaged_parameter = parameter_values[base];
-        if (n_phases_per_composition[composition] > 0)
+        double averaged_parameter = parameter_values[start_phase_index];
+        if (n_phase_transitions_per_composition[composition_index] > 0)
           {
             // Do averaging when there are multiple phases
             if (operation == PhaseUtilities::logarithmic)
               averaged_parameter = log(averaged_parameter);
 
-            for (unsigned int i=0; i<n_phases_per_composition[composition]; ++i)
+            for (unsigned int i=0; i<n_phase_transitions_per_composition[composition_index]; ++i)
               {
-                Assert(base+i+1<parameter_values.size(), ExcInternalError());
+                const unsigned int phase_index = start_phase_index + i;
+
+                Assert(phase_index+1<parameter_values.size(), ExcInternalError());
                 if (operation == PhaseUtilities::logarithmic)
                   {
                     // First average by log values and then take the exponential.
                     // This is used for averaging prefactors in flow laws.
-                    averaged_parameter += phase_function_values[base-composition+i] * log(parameter_values[base+i+1] / parameter_values[base+i]);
+                    averaged_parameter += phase_function_values[phase_index-composition_index] * log(parameter_values[phase_index+1] / parameter_values[phase_index]);
                   }
                 else if (operation == PhaseUtilities::arithmetic)
-                  averaged_parameter += phase_function_values[base-composition+i] * (parameter_values[base+i+1] - parameter_values[base+i]);
+                  averaged_parameter += phase_function_values[phase_index-composition_index] * (parameter_values[phase_index+1] - parameter_values[phase_index]);
 
                 else
                   AssertThrow(false, ExcInternalError());

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -39,7 +39,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   const unsigned int composition = 0;
   const std::vector<double> volume_fractions = {1.};
   const std::vector<double> phase_function_values = std::vector<double>();
-  const std::vector<unsigned int> n_phases_per_composition = std::vector<unsigned int>(1);
+  const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
 
   // Next, we initialise instances of the composite rheology and
   // individual creep mechanisms.
@@ -78,7 +78,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   prm.set("Plastic damper viscosity", "1.e17");
   prm.set("Maximum yield stress", "5e8");
   drucker_prager->parse_parameters(prm, n_phases);
-  Rheology::DruckerPragerParameters p = drucker_prager->compute_drucker_prager_parameters(composition, phase_function_values, n_phases_per_composition);
+  Rheology::DruckerPragerParameters p = drucker_prager->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
   // The creep components are arranged in series with each other.
   // This package of components is then arranged in parallel with


### PR DESCRIPTION
The utilities function `phase_average_value` takes a vector of [numbers of *phase transitions* per compositional field] as an input argument, but this argument is currently called `n_phases_per_composition`.

The current PR renames the argument to `n_phase_transitions_per_composition`, and also renames all the arguments of functions that make use this function. As far as I can tell, there's only one place in the code where a mistake is currently made based on the name (in `tests/composite_viscous_outputs.cc`). 

This PR also improves the docstrings of several `parse_parameters` functions, which *do* require the number of phases per compositional field rather than the number of phase transitions.

The PR shouldn't change any tests or functionality.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
