### PR TITLE
move CompositionalFieldDescription outside Parameters class

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -45,6 +45,58 @@ namespace aspect
   construct_default_variables (const Parameters<dim> &parameters);
 
 
+  /**
+   * A data structure containing a description of each compositional field.
+   * At present, this structure only includes the field type
+   * (i.e., whether it is of type chemical composition, porosity, etc.).
+   */
+  struct CompositionalFieldDescription
+  {
+    /**
+     * This enum lists available compositional field types.
+     */
+    enum Type
+    {
+      chemical_composition,
+      stress,
+      strain,
+      grain_size,
+      porosity,
+      density,
+      generic,
+      unspecified
+    } type;
+
+    /**
+     * This function translates an input string into the
+     * available enum options for the type of compositional field.
+     */
+    static
+    Type
+    parse_type(const std::string &input)
+    {
+      if (input == "chemical composition")
+        return CompositionalFieldDescription::chemical_composition;
+      else if (input == "stress")
+        return CompositionalFieldDescription::stress;
+      else if (input == "strain")
+        return CompositionalFieldDescription::strain;
+      else if (input == "grain size")
+        return CompositionalFieldDescription::grain_size;
+      else if (input == "porosity")
+        return CompositionalFieldDescription::porosity;
+      else if (input == "density")
+        return CompositionalFieldDescription::density;
+      else if (input == "generic")
+        return CompositionalFieldDescription::generic;
+      else if (input == "unspecified")
+        return CompositionalFieldDescription::unspecified;
+      else
+        AssertThrow(false, ExcNotImplemented());
+
+      return CompositionalFieldDescription::Type();
+    }
+  };
 
   /**
    * The introspection class provides information about the simulation as a
@@ -419,7 +471,7 @@ namespace aspect
        * A function that returns the full vector of compositional
        * field descriptions.
        */
-      const std::vector<typename Parameters<dim>::CompositionalFieldDescription> &
+      const std::vector<CompositionalFieldDescription> &
       get_composition_descriptions () const;
 
 
@@ -432,7 +484,7 @@ namespace aspect
        * input file)
        */
       bool
-      composition_type_exists (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
+      composition_type_exists (const CompositionalFieldDescription::Type &type) const;
 
 
       /**
@@ -445,7 +497,7 @@ namespace aspect
        * input file)
        */
       unsigned int
-      find_composition_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
+      find_composition_type (const CompositionalFieldDescription::Type &type) const;
 
 
       /**
@@ -464,14 +516,14 @@ namespace aspect
        * particular type (chemical composition, porosity, etc.).
        */
       const std::vector<unsigned int>
-      get_indices_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
+      get_indices_for_fields_of_type (const CompositionalFieldDescription::Type &type) const;
 
       /**
       * Get the names of the compositional fields which are of a
       * particular type (chemical composition, porosity, etc.).
        */
       const std::vector<std::string>
-      get_names_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const;
+      get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const;
 
       /**
        * A function that gets a component index as an input
@@ -495,7 +547,7 @@ namespace aspect
        * including its type (i.e. whether the compositional field corresponds
        * to chemical composition, porosity etc.).
        */
-      std::vector<typename Parameters<dim>::CompositionalFieldDescription> composition_descriptions;
+      std::vector<CompositionalFieldDescription> composition_descriptions;
 
   };
 }

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -674,7 +674,7 @@ namespace aspect
      */
     unsigned int                   n_compositional_fields;
     std::vector<std::string>       names_of_compositional_fields;
-    std::vector<CompositionalFieldDescription>  composition_descriptions;
+    std::vector<aspect::CompositionalFieldDescription>  composition_descriptions;
 
     /**
      * A vector that contains the advection field method for every compositional

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -32,6 +32,8 @@ namespace aspect
 {
   using namespace dealii;
 
+  struct CompositionalFieldDescription;
+
   // forward declaration:
   namespace GeometryModel
   {
@@ -377,57 +379,9 @@ namespace aspect
     };
 
     /**
-     * A data structure containing a description of each compositional field.
-     * At present, this structure only includes the field type
-     * (i.e., whether it is of type chemical composition, porosity, etc.).
-     */
-    struct CompositionalFieldDescription
-    {
-      /**
-       * This enum lists available compositional field types.
-       */
-      enum Type
-      {
-        chemical_composition,
-        stress,
-        strain,
-        grain_size,
-        porosity,
-        density,
-        generic,
-        unspecified
-      } type;
-
-      /**
-       * This function translates an input string into the
-       * available enum options for the type of compositional field.
-       */
-      static
-      Type
-      parse_type(const std::string &input)
-      {
-        if (input == "chemical composition")
-          return CompositionalFieldDescription::chemical_composition;
-        else if (input == "stress")
-          return CompositionalFieldDescription::stress;
-        else if (input == "strain")
-          return CompositionalFieldDescription::strain;
-        else if (input == "grain size")
-          return CompositionalFieldDescription::grain_size;
-        else if (input == "porosity")
-          return CompositionalFieldDescription::porosity;
-        else if (input == "density")
-          return CompositionalFieldDescription::density;
-        else if (input == "generic")
-          return CompositionalFieldDescription::generic;
-        else if (input == "unspecified")
-          return CompositionalFieldDescription::unspecified;
-        else
-          AssertThrow(false, ExcNotImplemented());
-
-        return CompositionalFieldDescription::Type();
-      }
-    };
+    Use the struct aspect::CompositionalFieldDescription
+    */
+    using CompositionalFieldDescription DEAL_II_DEPRECATED = aspect::CompositionalFieldDescription;
 
     /**
      * Constructor. Fills the values of member functions from the given

--- a/source/initial_composition/adiabatic_density.cc
+++ b/source/initial_composition/adiabatic_density.cc
@@ -32,7 +32,7 @@ namespace aspect
     AdiabaticDensity<dim>::
     initial_composition (const Point<dim> &position, const unsigned int n_comp) const
     {
-      if (n_comp == this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density))
+      if (n_comp == this->introspection().find_composition_type(CompositionalFieldDescription::density))
         return this->get_adiabatic_conditions().density(position);
 
       return 0.0;

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -289,11 +289,11 @@ namespace aspect
             {
               // We only want to compute mass/volume fractions for fields that are chemical compositions.
               std::vector<double> chemical_compositions;
-              const std::vector<typename Parameters<dim>::CompositionalFieldDescription> composition_descriptions = this->introspection().get_composition_descriptions();
+              const std::vector<CompositionalFieldDescription> composition_descriptions = this->introspection().get_composition_descriptions();
 
               for (unsigned int c=0; c<in.composition[i].size(); ++c)
-                if (composition_descriptions[c].type == Parameters<dim>::CompositionalFieldDescription::chemical_composition
-                    || composition_descriptions[c].type == Parameters<dim>::CompositionalFieldDescription::unspecified)
+                if (composition_descriptions[c].type == CompositionalFieldDescription::chemical_composition
+                    || composition_descriptions[c].type == CompositionalFieldDescription::unspecified)
                   chemical_compositions.push_back(in.composition[i][c]);
 
               mass_fractions = MaterialUtilities::compute_composition_fractions(chemical_compositions, *composition_mask);
@@ -331,10 +331,10 @@ namespace aspect
       // set up variable to interpolate prescribed field outputs onto compositional field
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
 
-      if (this->introspection().composition_type_exists(Parameters<dim>::CompositionalFieldDescription::density)
+      if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
           && prescribed_field_out != nullptr)
         {
-          const unsigned int projected_density_index = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
+          const unsigned int projected_density_index = this->introspection().find_composition_type(CompositionalFieldDescription::density);
           prescribed_field_out->prescribed_field_outputs[q][projected_density_index] = out.densities[q];
         }
     }
@@ -523,7 +523,7 @@ namespace aspect
           equation_of_state.parse_parameters(prm);
 
           // Check if compositional fields represent a composition
-          const std::vector<typename Parameters<dim>::CompositionalFieldDescription> composition_descriptions = this->introspection().get_composition_descriptions();
+          const std::vector<CompositionalFieldDescription> composition_descriptions = this->introspection().get_composition_descriptions();
 
           // All chemical compositional fields are assumed to represent mass fractions.
           // If the field type is unspecified (has not been set in the input file),
@@ -531,8 +531,8 @@ namespace aspect
           // backwards compatibility.
           composition_mask = std::make_unique<ComponentMask> (this->n_compositional_fields(), false);
           for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
-            if (composition_descriptions[c].type == Parameters<dim>::CompositionalFieldDescription::chemical_composition
-                || composition_descriptions[c].type == Parameters<dim>::CompositionalFieldDescription::unspecified)
+            if (composition_descriptions[c].type == CompositionalFieldDescription::chemical_composition
+                || composition_descriptions[c].type == CompositionalFieldDescription::unspecified)
               composition_mask->set(c, true);
 
           const unsigned int n_chemical_fields = composition_mask->n_selected_components();
@@ -575,7 +575,7 @@ namespace aspect
     {
       equation_of_state.create_additional_named_outputs(out);
 
-      if (this->introspection().composition_type_exists(Parameters<dim>::CompositionalFieldDescription::density)
+      if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
           && out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -726,7 +726,7 @@ namespace aspect
       const unsigned int stokes_dofs_per_cell = data.local_dof_indices.size();
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
-      const unsigned int density_idx = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
+      const unsigned int density_idx = this->introspection().find_composition_type(CompositionalFieldDescription::density);
 
       const double time_step = this->get_timestep();
       const double old_time_step = this->get_old_timestep();

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1968,7 +1968,7 @@ namespace aspect
     distributed_vector.block(advection_block).compress(VectorOperation::insert);
 
     if (adv_field.is_temperature() ||
-        adv_field.compositional_variable != introspection.find_composition_type(Parameters<dim>::CompositionalFieldDescription::density))
+        adv_field.compositional_variable != introspection.find_composition_type(CompositionalFieldDescription::density))
       current_constraints.distribute (distributed_vector);
 
     solution.block(advection_block) = distributed_vector.block(advection_block);

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -357,7 +357,7 @@ namespace aspect
 
 
   template <int dim>
-  const std::vector<typename Parameters<dim>::CompositionalFieldDescription> &
+  const std::vector<CompositionalFieldDescription> &
   Introspection<dim>::get_composition_descriptions () const
   {
     return composition_descriptions;
@@ -367,7 +367,7 @@ namespace aspect
 
   template <int dim>
   bool
-  Introspection<dim>::composition_type_exists (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
+  Introspection<dim>::composition_type_exists (const CompositionalFieldDescription::Type &type) const
   {
     for (unsigned int c=0; c<composition_descriptions.size(); ++c)
       if (composition_descriptions[c].type == type)
@@ -379,7 +379,7 @@ namespace aspect
 
   template <int dim>
   unsigned int
-  Introspection<dim>::find_composition_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
+  Introspection<dim>::find_composition_type (const typename CompositionalFieldDescription::Type &type) const
   {
     for (unsigned int c=0; c<composition_descriptions.size(); ++c)
       if (composition_descriptions[c].type == type)
@@ -404,7 +404,7 @@ namespace aspect
 
   template <int dim>
   const std::vector<unsigned int>
-  Introspection<dim>::get_indices_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
+  Introspection<dim>::get_indices_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
     std::vector<unsigned int> indices;
 
@@ -419,7 +419,7 @@ namespace aspect
 
   template <int dim>
   const std::vector<std::string>
-  Introspection<dim>::get_names_for_fields_of_type (const typename Parameters<dim>::CompositionalFieldDescription::Type &type) const
+  Introspection<dim>::get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
     std::vector<std::string> names;
 


### PR DESCRIPTION
It doesn't seem logical to have this enum inside the Parameters class. It also makes the qualified name annoying to read.
