### PR TITLE
Field types for multicomponent incompressible and derived modules

### DIFF
--- a/doc/modules/changes/20230708_bobmyhill
+++ b/doc/modules/changes/20230708_bobmyhill
@@ -1,0 +1,10 @@
+Changed: Default field types are now defined by ASPECT
+based on Field Names if the types are not defined by the user.
+The logic is as follows: if the name contains the substring stress, 
+it has type stress. If the name is equal to 
+s11, s12, s22, s13, s23, s33, it has type strain.
+If the name is equal to grain_size, porosity, density_field, 
+or entropy it has the types grain size, porosity, density or entropy
+respectively. Otherwise it has the type chemical composition.
+<br>
+(Bob Myhill, 2023/07/08)

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -477,6 +477,26 @@ namespace aspect
       const std::vector<CompositionalFieldDescription> &
       get_composition_descriptions () const;
 
+      /**
+       * A function that returns the names of
+       * compositional fields that correspond to chemical compositions.
+       */
+      const std::vector<std::string> &
+      chemical_composition_field_names () const;
+
+      /**
+       * A function that returns the indices of
+       * compositional fields that correspond to chemical compositions.
+       */
+      const std::vector<unsigned int> &
+      chemical_composition_field_indices () const;
+
+      /**
+       * A function that returns the number of
+       * compositional fields that correspond to chemical compositions.
+       */
+      unsigned int
+      n_chemical_composition_fields () const;
 
       /**
        * A function that gets the type of a compositional field as an input
@@ -529,6 +549,13 @@ namespace aspect
       get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const;
 
       /**
+       * Get the number of compositional fields which are of a
+       * particular type (chemical composition, porosity, etc.).
+       */
+      unsigned int
+      get_number_of_fields_of_type (const CompositionalFieldDescription::Type &type) const;
+
+      /**
        * A function that gets a component index as an input
        * parameter and returns if the component is one of the stokes system
        * (i.e. if it is the pressure or one of the velocity components).
@@ -551,6 +578,27 @@ namespace aspect
        * to chemical composition, porosity etc.).
        */
       std::vector<CompositionalFieldDescription> composition_descriptions;
+
+      /**
+       * A vector that stores the names of the compositional fields
+       * corresponding to chemical compositions that will
+       * be used in the simulation.
+       */
+      std::vector<std::string> chemical_composition_names;
+
+      /**
+       * A vector that stores the indices of the compositional fields
+       * corresponding to chemical compositions that will
+       * be used in the simulation.
+       */
+      std::vector<unsigned int> chemical_composition_indices;
+
+      /**
+       * The number of compositional fields
+       * that correspond to chemical compositions that will
+       * be used in the simulation.
+       */
+      const unsigned int n_chemical_compositions;
 
   };
 }

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -256,6 +256,16 @@ namespace aspect
         std::vector<double> thermal_conductivities;
 
         /**
+         * Number of phase transitions for each chemical composition (including the background field).
+         */
+        std::vector<unsigned int> n_phase_transitions_for_each_chemical_composition;
+
+        /**
+         * Total number of phases.
+         */
+        unsigned int n_phases;
+
+        /**
          * Object for computing the equation of state.
          */
         EquationOfState::MulticomponentIncompressible<dim> equation_of_state;

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -675,6 +675,8 @@ namespace aspect
     unsigned int                   n_compositional_fields;
     std::vector<std::string>       names_of_compositional_fields;
     std::vector<aspect::CompositionalFieldDescription>  composition_descriptions;
+    unsigned int                   n_chemical_compositions;
+    std::vector<unsigned int>      chemical_composition_indices;
 
     /**
      * A vector that contains the advection field method for every compositional

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -107,33 +107,31 @@ namespace aspect
       {
         reference_T = prm.get_double ("Reference temperature");
 
-        // Establish that a background field is required here
-        const bool has_background_field = true;
+        // Make options file for parsing maps to double arrays
+        std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+        chemical_field_names.insert(chemical_field_names.begin(),"background");
 
-        // Retrieve the list of composition names
-        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+        std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
+        compositional_field_names.insert(compositional_field_names.begin(),"background");
+
+        Utilities::MapParsing::Options options(chemical_field_names, "Densities");
+        options.list_of_allowed_keys = compositional_field_names;
+        options.allow_multiple_values_per_key = true;
+        if (expected_n_phases_per_composition)
+          {
+            options.n_values_per_key = *expected_n_phases_per_composition;
+
+            // check_values_per_key is required to be true to duplicate single values
+            // if they are to be used for all phases associated with a given key.
+            options.check_values_per_key = true;
+          }
 
         // Parse multicomponent properties
-        densities = Utilities::parse_map_to_double_array (prm.get("Densities"),
-                                                          list_of_composition_names,
-                                                          has_background_field,
-                                                          "Densities",
-                                                          true,
-                                                          expected_n_phases_per_composition);
-
-        thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Thermal expansivities"),
-                                                                      list_of_composition_names,
-                                                                      has_background_field,
-                                                                      "Thermal expansivities",
-                                                                      true,
-                                                                      expected_n_phases_per_composition);
-
-        specific_heats = Utilities::parse_map_to_double_array (prm.get("Heat capacities"),
-                                                               list_of_composition_names,
-                                                               has_background_field,
-                                                               "Specific heats",
-                                                               true,
-                                                               expected_n_phases_per_composition);
+        densities = Utilities::MapParsing::parse_map_to_double_array(prm.get("Densities"), options);
+        options.property_name = "Thermal expansivities";
+        thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array(prm.get("Thermal expansivities"), options);
+        options.property_name = "Heat capacities";
+        specific_heats = Utilities::MapParsing::parse_map_to_double_array (prm.get("Heat capacities"), options);
       }
     }
   }

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -35,18 +35,17 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      EquationOfStateOutputs<dim> eos_outputs (this->n_compositional_fields()+1);
+      EquationOfStateOutputs<dim> eos_outputs (this->introspection().n_chemical_composition_fields()+1);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           // The (incompressible) Boussinesq approximation treats the
           // buoyancy term as Delta rho[i] * C[i], which implies that
           // compositional fields are given as volume fractions.
-          const std::vector<double> volume_fractions = MaterialUtilities::compute_composition_fractions(in.composition[i]);
+          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i], this->introspection().chemical_composition_field_indices());
 
           equation_of_state.evaluate(in, i, eos_outputs);
-
-          out.viscosities[i] = MaterialUtilities::average_value (volume_fractions, viscosities, viscosity_averaging);
+          out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, viscosities, viscosity_averaging);
           out.specific_heat[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.specific_heat_capacities, MaterialUtilities::arithmetic);
           out.thermal_expansion_coefficients[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.thermal_expansion_coefficients, MaterialUtilities::arithmetic);
           out.compressibilities[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.compressibilities, MaterialUtilities::arithmetic);
@@ -128,21 +127,21 @@ namespace aspect
           viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
                                 prm);
 
-          // Establish that a background field is required here
-          const bool has_background_field = true;
+          // Make options file for parsing maps to double arrays
+          std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+          chemical_field_names.insert(chemical_field_names.begin(),"background");
 
-          // Retrieve the list of composition names
-          const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+          std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
+          compositional_field_names.insert(compositional_field_names.begin(),"background");
 
-          viscosities = Utilities::parse_map_to_double_array (prm.get("Viscosities"),
-                                                              list_of_composition_names,
-                                                              has_background_field,
-                                                              "Viscosities");
+          Utilities::MapParsing::Options options(chemical_field_names, "Viscosities");
+          options.list_of_allowed_keys = compositional_field_names;
+          options.allow_multiple_values_per_key = true;
 
-          thermal_conductivities = Utilities::parse_map_to_double_array (prm.get("Thermal conductivities"),
-                                                                         list_of_composition_names,
-                                                                         has_background_field,
-                                                                         "Thermal conductivities");
+          // Parse multicomponent properties
+          viscosities = Utilities::MapParsing::parse_map_to_double_array (prm.get("Viscosities"), options);
+          options.property_name = "Thermal conductivities";
+          thermal_conductivities = Utilities::MapParsing::parse_map_to_double_array (prm.get("Thermal conductivities"), options);
         }
         prm.leave_subsection();
       }

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -255,7 +255,10 @@ namespace aspect
     temperature_method(parameters.temperature_method),
     compositional_field_methods(parameters.compositional_field_methods),
     composition_names(parameters.names_of_compositional_fields),
-    composition_descriptions(parameters.composition_descriptions)
+    composition_descriptions(parameters.composition_descriptions),
+    chemical_composition_names (get_names_for_fields_of_type(CompositionalFieldDescription::chemical_composition)),
+    chemical_composition_indices (get_indices_for_fields_of_type(CompositionalFieldDescription::chemical_composition)),
+    n_chemical_compositions (get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition))
   {}
 
 
@@ -366,6 +369,33 @@ namespace aspect
 
 
   template <int dim>
+  const std::vector<std::string> &
+  Introspection<dim>::chemical_composition_field_names () const
+  {
+    return chemical_composition_names;
+  }
+
+
+
+  template <int dim>
+  const std::vector<unsigned int> &
+  Introspection<dim>::chemical_composition_field_indices () const
+  {
+    return chemical_composition_indices;
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  Introspection<dim>::n_chemical_composition_fields () const
+  {
+    return n_chemical_compositions;
+  }
+
+
+
+  template <int dim>
   bool
   Introspection<dim>::composition_type_exists (const CompositionalFieldDescription::Type &type) const
   {
@@ -428,6 +458,21 @@ namespace aspect
         names.push_back(composition_names[i]);
 
     return names;
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  Introspection<dim>::get_number_of_fields_of_type (const CompositionalFieldDescription::Type &type) const
+  {
+    unsigned int n = 0;
+
+    for (unsigned int i=0; i<n_compositional_fields; ++i)
+      if (composition_descriptions[i].type == type)
+        n += 1;
+
+    return n;
   }
 
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -32,6 +32,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <cstdlib>
+#include <regex>
 #include <sys/stat.h>
 
 namespace aspect
@@ -1890,6 +1891,35 @@ namespace aspect
                                          - names_of_compositional_fields.begin();
       if (density_index != n_compositional_fields && x_compositional_field_types[density_index] == "unspecified")
         x_compositional_field_types[density_index] = "density";
+
+      // TODO ASPECT_4: Require all field types to be specified by the user
+      // Remove the following code block
+      for (unsigned int i=0; i<n_compositional_fields; ++i)
+        if (x_compositional_field_types[i] == "unspecified")
+          {
+            // Loop over various possibilities before
+            // choosing "chemical composition" as the standard field name
+            // stress, strain, grain_size, porosity, density
+            if (names_of_compositional_fields[i].find("stress") != std::string::npos)
+              x_compositional_field_types[i] = "stress";
+            else if ((names_of_compositional_fields[i].find("strain") != std::string::npos)
+                     || (std::regex_match(names_of_compositional_fields[i],std::regex("s[1-3][1-3]"))))
+              x_compositional_field_types[i] = "strain";
+            else if (names_of_compositional_fields[i].find("grain_size") != std::string::npos)
+              x_compositional_field_types[i] = "grain size";
+            else if (names_of_compositional_fields[i].find("entropy") != std::string::npos)
+              x_compositional_field_types[i] = "entropy";
+            else if (names_of_compositional_fields[i] == "porosity")
+              x_compositional_field_types[i] = "porosity";
+            else if (names_of_compositional_fields[i] == "density_field")
+              x_compositional_field_types[i] = "density";
+            else
+              x_compositional_field_types[i] = "chemical composition";
+          }
+
+      // If only one method is specified apply this to all fields
+      if (x_compositional_field_types.size() == 1)
+        x_compositional_field_types = std::vector<std::string> (n_compositional_fields, x_compositional_field_types[0]);
 
       AssertThrow (std::count(x_compositional_field_types.begin(), x_compositional_field_types.end(), "density") < 2,
                    ExcMessage("There can only be one field of type 'density' in a simulation!"));

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -272,7 +272,6 @@ namespace aspect
             {
               // Split the list by comma delimited components.
               const std::vector<std::string> field_entries = dealii::Utilities::split_string_list(input_string, ',');
-
               for (const auto &field_entry : field_entries)
                 {
                   // Split each entry into string and value ( <id> : <value>)
@@ -329,9 +328,9 @@ namespace aspect
           // 'value1, value2, value3' with as many entries as allowed keys.
           else if (Patterns::List(Patterns::Double(),options.list_of_allowed_keys.size(),options.list_of_allowed_keys.size()).match(input_string))
             {
-              const std::vector<double> values = possibly_extend_from_1_to_N (dealii::Utilities::string_to_double(dealii::Utilities::split_string_list(input_string)),
-                                                                              options.list_of_allowed_keys.size(),
-                                                                              options.property_name);
+              const std::vector<double> values = possibly_extend_from_1_to_N(dealii::Utilities::string_to_double(dealii::Utilities::split_string_list(input_string)),
+                                                                             options.list_of_allowed_keys.size(),
+                                                                             options.property_name);
 
               for (unsigned int i=0; i<values.size(); ++i)
                 {
@@ -510,18 +509,24 @@ namespace aspect
                                 Options &options)
       {
         // Check options for consistency
-        AssertThrow (options.list_of_required_keys.size() != 0,
-                     ExcMessage("parse_map_to_double_array needs at least one required key name."));
         AssertThrow (options.property_name != "",
                      ExcMessage("parse_map_to_double_array needs a property name to be able to properly report parsing errors."));
+        AssertThrow (options.list_of_required_keys.size() != 0,
+                     ExcMessage("parse_map_to_double_array needs at least one required key name for property "
+                                + options.property_name
+                                + "."));
         AssertThrow (options.check_values_per_key == false ||
                      options.store_values_per_key == false,
                      ExcMessage("parse_map_to_double_array can not simultaneously store the structure "
-                                "of the parsed map and check that structure against a given structure."));
+                                "of the parsed map for "
+                                + options.property_name
+                                + " and check that structure against a given structure."));
         AssertThrow (options.check_values_per_key == false ||
                      options.n_values_per_key.size() == options.list_of_required_keys.size(),
                      ExcMessage("parse_map_to_double_array can only check the structure "
-                                "of the parsed map if an expected number of values for each key is given."));
+                                "of the parsed map for "
+                                + options.property_name
+                                + " if an expected number of values for each key is given."));
 
         // First: parse the string into a map depending on what Pattern we are dealing with
         std::multimap<std::string, double> parsed_map = parse_string_to_map(input_string,

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -43,7 +43,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   std::cout << "Chemical composition field #0 (the background field) has value " << compositional_field_fractions[0] << "." << std::endl;
 
-  for (unsigned int i=0; i<2; ++i)
+  for (unsigned int i=0; i<3; ++i)
     std::cout << "Chemical composition field #" << i+1 << " is called " << names[i] << ", is in position "  << indices[i] << ", and has value " << compositional_field_fractions[i+1] << "." << std::endl;
 
   exit(0);

--- a/tests/check_compositional_field_functions/screen-output
+++ b/tests/check_compositional_field_functions/screen-output
@@ -2,6 +2,7 @@
 Loading shared library <./libcheck_compositional_field_functions.debug.so>
 
 * Connecting signals
-Chemical composition field #0 (the background field) has value 0.7.
+Chemical composition field #0 (the background field) has value 0.4.
 Chemical composition field #1 is called Field_1, is in position 0, and has value 0.1.
 Chemical composition field #2 is called Field_5, is in position 4, and has value 0.2.
+Chemical composition field #3 is called Field_7, is in position 6, and has value 0.3.

--- a/tests/check_compositional_field_names/screen-output
+++ b/tests/check_compositional_field_names/screen-output
@@ -8,4 +8,4 @@ Field_3 is of type grain size
 Field_4 is of type porosity
 Field_5 is of type chemical composition
 Field_6 is of type generic
-Field_7 is of type unspecified
+Field_7 is of type chemical composition

--- a/tests/viscoelastic_bending_beam.prm
+++ b/tests/viscoelastic_bending_beam.prm
@@ -26,3 +26,27 @@ subsection Postprocess
     set Output format = txt
   end
 end
+
+# Number and name of compositional fields
+subsection Compositional fields
+  set Number of fields = 4
+  set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, beam
+  set Types of fields  = stress, stress, stress, chemical composition
+end
+
+
+# Material model
+subsection Material model
+
+  set Model name = viscoelastic
+
+  subsection Viscoelastic
+    set Densities            =  2800,  3300
+    set Viscosities          = 1.e18, 1.e24
+    set Elastic shear moduli = 1.e11, 1.e11, 1.e11, 1.e11, 1.e10
+    set Fixed elastic time step     = 1e3
+    set Use fixed elastic time step = false
+    set Viscosity averaging scheme  = maximum composition
+  end
+
+end


### PR DESCRIPTION
This PR uses the new Field Types parameter in the multicomponent incompressible EoS and derived rheologies (multicomponent, viscoelastic, visco_plastic). The parameters defined by these models can take either:
- the old format - one value per compositional field, regardless of what that field represents, or 
- the new format - one value per compositional field that represents a chemical composition

This means that the changes are backwards compatible for now, although I've added `TODO ASPECT_3` notes in those places where code should (eventually) be removed.

The backwards compatibility does necessitate two additional things:
- a step during parameter parsing where default Field Types are defined in those cases where the user didn't specify them
- a function `prm_substring` that preprocesses parameter strings and if the string contains commas, selects only the values corresponding to compositional fields.

The changelog for this PR contains the information about the parameter parsing, as this could change behaviour if the user made unexpected choices in their field names. 

I'm trying to introduce these changes in review-friendly chunks, so I'll add a broader changelog entry when the changes are complete.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have modified a testcase for the new feature/benchmark in the tests directory.
