### PR TITLE
Add option for time constant ascii data boundary

### DIFF
--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -373,20 +373,45 @@ namespace aspect
 
         /**
          * Declare the parameters all derived classes take from input files.
+         *
+         * @param prm The parameter handler in which the parameters are declared.
+         * @param default_directory The default value for the data directory parameter.
+         * @param default_filename The default value for the filename parameter.
+         * @param subsection_name The name of the parameter file subsection all
+         * parameters will be declared in. The function will enter this subsection,
+         * declare all parameters, then leave this subsection, to return @p prm in
+         * the same subsection it was in before.
+         * @param declare_time_dependent_parameters Whether to declare the parameter
+         * that are only needed for time dependent AsciiDataBoundary objects. If
+         * the caller already knows time dependence is not supported for the current
+         * application, disabling this parameter avoids introducing these parameters
+         * to the parameter handler.
          */
         static
         void
         declare_parameters (ParameterHandler  &prm,
                             const std::string &default_directory,
                             const std::string &default_filename,
-                            const std::string &subsection_name = "Ascii data model");
+                            const std::string &subsection_name = "Ascii data model",
+                            const bool declare_time_dependent_parameters = true);
 
         /**
          * Read the parameters from the parameter file.
+         *
+         * @param prm The parameter handler from which the parameters are parsed.
+         * @param subsection_name The name of the parameter file subsection all
+         * parameters will be parsed from. The function will enter this subsection,
+         * parse all parameters, then leave this subsection, to return @p prm in
+         * the same subsection it was in before.
+         * @param parse_time_dependent_parameters Whether to parse the parameter
+         * that are only needed for time dependent AsciiDataBoundary objects. This
+         * parameter always needs to be set to the same value that was handed over
+         * to declare_parameters().
          */
         void
         parse_parameters (ParameterHandler &prm,
-                          const std::string &subsection_name = "Ascii data model");
+                          const std::string &subsection_name = "Ascii data model",
+                          const bool parse_time_dependent_parameters = true);
 
       protected:
 
@@ -470,7 +495,7 @@ namespace aspect
          * part of the boundary condition is over.
          */
         void
-        end_time_dependence ();
+        end_time_dependence (const bool issue_warning = true);
 
         /**
          * Create a filename out of the name template.

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -495,7 +495,7 @@ namespace aspect
          * part of the boundary condition is over.
          */
         void
-        end_time_dependence (const bool issue_warning = true);
+        end_time_dependence ();
 
         /**
          * Create a filename out of the name template.

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -778,7 +778,7 @@ namespace aspect
               else
                 {
                   // next file not found, issue warning and end looking for new files
-                  end_time_dependence (true);
+                  end_time_dependence ();
                 }
             }
         }
@@ -1013,30 +1013,27 @@ namespace aspect
 
       // If next file does not exist, end time dependent part with current_time_step and issue warning.
       else
-        end_time_dependence (true);
+        end_time_dependence ();
     }
 
 
 
     template <int dim>
     void
-    AsciiDataBoundary<dim>::end_time_dependence (const bool issue_warning)
+    AsciiDataBoundary<dim>::end_time_dependence ()
     {
       // no longer consider the problem time dependent from here on out
       // this cancels all attempts to read files at the next time steps
       time_dependent = false;
 
-      if (issue_warning == true)
-        {
-          // Give warning if first processor
-          this->get_pcout() << std::endl
-                            << "   From this timestep onwards, ASPECT will not attempt to load new Ascii data files." << std::endl
-                            << "   This is either because ASPECT has already read all the files necessary to impose" << std::endl
-                            << "   the requested boundary condition, or that the last available file has been read." << std::endl
-                            << "   If the Ascii data represented a time-dependent boundary condition," << std::endl
-                            << "   that time-dependence ends at this timestep  (i.e. the boundary condition" << std::endl
-                            << "   will continue unchanged from the last known state into the future)." << std::endl << std::endl;
-        }
+      // Give warning if first processor
+      this->get_pcout() << std::endl
+                        << "   From this timestep onwards, ASPECT will not attempt to load new Ascii data files." << std::endl
+                        << "   This is either because ASPECT has already read all the files necessary to impose" << std::endl
+                        << "   the requested boundary condition, or that the last available file has been read." << std::endl
+                        << "   If the Ascii data represented a time-dependent boundary condition," << std::endl
+                        << "   that time-dependence ends at this timestep  (i.e. the boundary condition" << std::endl
+                        << "   will continue unchanged from the last known state into the future)." << std::endl << std::endl;
     }
 
 
@@ -1223,13 +1220,13 @@ namespace aspect
             AssertThrow (create_filename (0, 0) == create_filename (1, 0),
                          ExcMessage("A boundary data file name was used that contained a placeholder for "
                                     "the current file number, but this AsciiDataBoundary object does not support "
-                                    "time dependent information. Please remove the timestep placeholder."));
+                                    "time dependent information. Please remove the file number placeholder."));
           }
 
         // if filename does not contain a placeholder for timestep, no time dependence
         // do not issue a warning, the parameter file is specifying exactly one file.
         if (create_filename (0, 0) == create_filename (1, 0))
-          end_time_dependence (false);
+          time_dependent = false;
         else
           time_dependent = true;
       }

--- a/tests/adiabatic_boundary/screen-output
+++ b/tests/adiabatic_boundary/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/initial-temperature/adiabatic-boundary/adiabatic_boundary.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 512 (on 4 levels)
 Number of degrees of freedom: 20,381 (14,739+729+4,913)
 
@@ -20,7 +12,7 @@ Number of degrees of freedom: 20,381 (14,739+729+4,913)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 6.69317e-08
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 6.6932e-08
 
 
    Postprocessing:

--- a/tests/adiabatic_plate_cooling/screen-output
+++ b/tests/adiabatic_plate_cooling/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/initial-temperature/adiabatic/adiabatic.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 1,444 (882+121+441)
 

--- a/tests/ascii_boundary_member/screen-output
+++ b/tests/ascii_boundary_member/screen-output
@@ -5,45 +5,13 @@ Loading shared library <./libascii_boundary_member.so>
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_composition_3d_box/screen-output
+++ b/tests/ascii_data_boundary_composition_3d_box/screen-output
@@ -3,56 +3,16 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_3d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_3d_front.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_3d_back.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_3d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-composition/ascii-data/test/box_3d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 652 (375+27+125+125)

--- a/tests/ascii_data_boundary_temperature_3d_box/screen-output
+++ b/tests/ascii_data_boundary_temperature_3d_box/screen-output
@@ -3,67 +3,19 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_front.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_back.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-temperature/ascii-data/test/box_3d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)

--- a/tests/ascii_data_boundary_velocity_2d_box/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box/screen-output
@@ -3,45 +3,13 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_list/screen-output
@@ -3,23 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_chunk/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_chunk/screen-output
@@ -3,45 +3,13 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_west.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_east.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 948 (578+81+289)

--- a/tests/ascii_data_boundary_velocity_2d_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_shell/screen-output
@@ -3,45 +3,13 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 2,724 (1,666+225+833)

--- a/tests/ascii_data_boundary_velocity_2d_shell_spherical/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_shell_spherical/screen-output
@@ -3,45 +3,13 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom_spherical.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top_spherical.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_left_spherical.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_right_spherical.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 2,724 (1,666+225+833)

--- a/tests/ascii_data_boundary_velocity_3d_box/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_box/screen-output
@@ -3,67 +3,19 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_front.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_back.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 200 (on 2 levels)
 Number of degrees of freedom: 9,183 (6,615+363+2,205)

--- a/tests/ascii_data_boundary_velocity_3d_chunk/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_chunk/screen-output
@@ -3,23 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_3d_west.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_3d_east.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)

--- a/tests/ascii_data_boundary_velocity_3d_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_shell/screen-output
@@ -3,56 +3,16 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)

--- a/tests/ascii_data_boundary_velocity_3d_shell_spherical/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_shell_spherical/screen-output
@@ -3,56 +3,16 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom_spherical.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top_spherical.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east_spherical.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west_spherical.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south_spherical.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)

--- a/tests/ascii_data_boundary_velocity_3d_sphere/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_sphere/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 56 (on 2 levels)
 Number of degrees of freedom: 2,147 (1,551+79+517)
 
@@ -20,7 +12,7 @@ Number of degrees of freedom: 2,147 (1,551+79+517)
 
    Postprocessing:
      RMS, max velocity:                  4.99 m/year, 14.8 m/year
-     Temperature min/avg/max:            -5.582e-14 K, 54.9 K, 273 K
+     Temperature min/avg/max:            -6.752e-14 K, 54.9 K, 273 K
      Heat fluxes through boundary parts: -4.562e+14 W
 
 *** Timestep 1:  t=1000 years, dt=1000 years

--- a/tests/ascii_data_boundary_velocity_residual_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_residual_shell/screen-output
@@ -3,56 +3,16 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)

--- a/tests/box_initial_mesh_deformation_ascii_data/screen-output
+++ b/tests/box_initial_mesh_deformation_ascii_data/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/box_3d_top.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)
 

--- a/tests/box_initial_topography_ascii_data/screen-output
+++ b/tests/box_initial_topography_ascii_data/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/box_3d_top.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)
 

--- a/tests/box_initial_topography_ascii_data_moved_origin/screen-output
+++ b/tests/box_initial_topography_ascii_data_moved_origin/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/box_3d_top.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)
 

--- a/tests/chunk_initial_topography_ascii_data/screen-output
+++ b/tests/chunk_initial_topography_ascii_data/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/shell_2d_outer.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 3,556 (2,178+289+1,089)
 

--- a/tests/chunk_initial_topography_ascii_data_3d/screen-output
+++ b/tests/chunk_initial_topography_ascii_data_3d/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/shell_3d_outer.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,041 (2,187+125+729)
 

--- a/tests/chunk_initial_topography_ascii_data_3d_colatitude/screen-output
+++ b/tests/chunk_initial_topography_ascii_data_3d_colatitude/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/shell_3d_outer_2.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Number of active cells: 64 (on 3 levels)
 Number of degrees of freedom: 3,041 (2,187+125+729)
 

--- a/tests/gmg_mesh_deform/screen-output
+++ b/tests/gmg_mesh_deform/screen-output
@@ -2,14 +2,6 @@
 
    Loading Ascii data boundary file ASPECT_DIR/data/geometry-model/initial-topography-model/ascii-data/test/box_3d_top.0.txt.
 
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
 Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
 Number of active cells: 8 (on 2 levels)
 Number of degrees of freedom: 527 (375+27+125)

--- a/tests/gmg_velocity_boundary_component/screen-output
+++ b/tests/gmg_velocity_boundary_component/screen-output
@@ -3,23 +3,7 @@
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   From this timestep onwards, ASPECT will not attempt to load new Ascii data files.
-   This is either because ASPECT has already read all the files necessary to impose
-   the requested boundary condition, or that the last available file has been read.
-   If the Ascii data represented a time-dependent boundary condition,
-   that time-dependence ends at this timestep  (i.e. the boundary condition
-   will continue unchanged from the last known state into the future).
 
 Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
 Number of active cells: 80 (on 3 levels)


### PR DESCRIPTION
The last step to make #5025 work. Add an option to AsciiDataBoundary to not support time dependent boundary conditions. This removes the irrelevant input parameters when a time-dependence of the dataset is not supported or allowed. Also make the class a bit safer to use without time dependence by initializing all time-dependent members to invalid values and reorder a few lines to only be executed when time-dependence is actually switched on.

This PR also fixes a long-standing property of AsciiDataBoundary, which is that even if we specify exactly one file without placeholder for timestep so far the class has issued a warning that it couldnt find the next file and therefore continues with a constant boundary condition. This has annoyed me for a long time, because if one specific file is given in the input file, it is obviously implied by the user that the boundary condition is not changing over time, and this warning was more confusing than helpful. In this new version we only issue the warning if we had found several files, and then reach the end of the file series.