### PR TITLE
Fix deprication issue.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -834,7 +834,8 @@ namespace aspect
        *
        * @deprecated: Use interpolate_particle_property_vector() instead.
        */
-      void interpolate_particle_properties (const AdvectionField &advection_field) DEAL_II_DEPRECATED;
+      DEAL_II_DEPRECATED
+      void interpolate_particle_properties (const AdvectionField &advection_field);
 
       /**
        * Interpolate the corresponding particle properties into the given


### PR DESCRIPTION
A student in our group ran into the following error while compiling aspect on a Macbook Pro Intel Core i9 running Ventura 13.1:
```
[ 64%] Building CXX object CMakeFiles/aspect.dir/Unity/unity_42_cxx.cxx.o
In file included from /Users/,,,/aspect-src/aspect/build/CMakeFiles/aspect.dir/Unity/unity_42_cxx.cxx:3:
In file included from /Users/.../aspect-src/aspect/source/volume_of_fluid/handler.cc:23:
In file included from /Users/.../aspect-src/aspect/include/aspect/volume_of_fluid/handler.h:24:
/Users/.../aspect-src/aspect/include/aspect/simulator.h:837:84: error: 'deprecated' attribute cannot be applied to types
      void interpolate_particle_properties (const AdvectionField &advection_field) DEAL_II_DEPRECATED;
                                                                                   ^
/Applications/deal.II.app/Contents/Resources/Libraries/include/deal.II/base/config.h:164:30: note: expanded from macro 'DEAL_II_DEPRECATED'
#define DEAL_II_DEPRECATED [[deprecated]]
                             ^
1 error generated.
make[2]: *** [CMakeFiles/aspect.dir/Unity/unity_42_cxx.cxx.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/aspect.dir/all] Error 2
make: *** [all] Error 2
```

Looking at how at most places deprecation is handled we tried the solution in this pull request and that fixed the compilation. I am not sure why this is an issue on this particular mac, but I don't see any downsides to changing this since it is also more in line with the rest of the code.