### PR TITLE
Install cookbooks and benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,16 @@ INSTALL(DIRECTORY include/ ${CMAKE_BINARY_DIR}/include/
   COMPONENT includes
   FILES_MATCHING PATTERN "*.h")
 
+# examples:
+INSTALL(DIRECTORY cookbooks/
+  DESTINATION cookbooks
+  COMPONENT examples
+  FILES_MATCHING PATTERN "*")
+INSTALL(DIRECTORY benchmarks/
+  DESTINATION benchmarks
+  COMPONENT examples
+  FILES_MATCHING PATTERN "*")
+
 # cmake stuff:
 INSTALL(FILES ${CMAKE_BINARY_DIR}/forinstall/AspectConfig.cmake ${CMAKE_BINARY_DIR}/AspectConfigVersion.cmake
         DESTINATION "lib/cmake/Aspect/")


### PR DESCRIPTION
I am working on setting up an executable ASPECT tool on geodynamics.org. In order to avoid duplicating our cookbooks and examples, I would like to make sure we can install them into the installation directory. I do not have access to the source and build folder after the installation, and I do not want to clone the repository again, just to get the cookbooks and benchmarks. Currently, this PR will just copy all the cookbooks and benchmarks into CMAKE_INSTALL_PREFIX/cookbooks and CMAKE_INSTALL_PREFIX/benchmarks. This would already work for me, but I wanted to ask:

1. Are these the right folder to use?
2. Would it be easy to set it up like deal.II where we can build all the examples during the build (i.e. find all CMakeLists and compile all shared libraries)? That would make running the examples even easier for users after the installation.



