### PR TITLE
CI: switch to checkout v3 to avoid warning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [ubuntu-20.04]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup
       run: |
         sudo apt-get update
@@ -43,7 +43,7 @@ jobs:
     runs-on: [ubuntu-20.04]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup
       run: |
         sudo apt-get update
@@ -126,7 +126,7 @@ jobs:
       options: ${{ matrix.container-options }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: compile
       run: |
         mkdir build


### PR DESCRIPTION
see the warnings for example at the bottom of
https://github.com/geodynamics/aspect/actions/runs/4253790230

indent+documentation:
Node.js 12 actions are deprecated. Please update the following actions to use 