### PR TITLE
Update initial lithostatic pressure plugin to account for initial topography and mesh deformation.

### DIFF
--- a/doc/modules/changes/20230713_glerum
+++ b/doc/modules/changes/20230713_glerum
@@ -1,0 +1,6 @@
+ Improved: The initial lithostatic pressure plugin for
+ boundary tractions now includes the initial topography
+ of the reference point into its pressure profile 
+ instead of the maximum topography within the domain.
+ <br>
+ (Anne Glerum, 2023/07/13)

--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -105,8 +105,6 @@ namespace aspect
          * based on depth interpolation between computed pressure values.
          */
         double interpolate_pressure (const Point<dim> &p) const;
-
-
     };
   }
 }

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -22,6 +22,8 @@
 #include <aspect/boundary_traction/initial_lithostatic_pressure.h>
 #include <aspect/initial_temperature/interface.h>
 #include <aspect/initial_composition/interface.h>
+#include <aspect/geometry_model/initial_topography_model/zero_topography.h>
+#include <aspect/geometry_model/initial_topography_model/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
@@ -59,9 +61,6 @@ namespace aspect
       // but we use the initial temperature and composition and only calculate
       // a pressure profile with depth.
 
-      // The spacing of the depth profile
-      delta_z = this->get_geometry_model().maximal_depth() / (n_points-1);
-
       // The number of compositional fields
       const unsigned int n_compositional_fields = this->n_compositional_fields();
 
@@ -89,12 +88,27 @@ namespace aspect
 
       // Set the radius of the representative point to the surface radius for spherical domains
       // or set the vertical coordinate to the surface value for box domains.
+      // Also get the depth extent without including initial topography, and the vertical coordinate
+      // of the bottom boundary (radius for spherical and z-coordinate for cartesian domains).
+      double depth_extent = 0.;
       if (Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model()))
-        spherical_representative_point[0] = Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>>(this->get_geometry_model()).outer_radius();
+        {
+          spherical_representative_point[0] = Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>>(this->get_geometry_model()).outer_radius();
+          // Spherical shell cannot include initial topography
+          depth_extent =  Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>>(this->get_geometry_model()).maximal_depth();
+        }
       else if (Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()))
-        spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::Chunk<dim>>(this->get_geometry_model()).outer_radius();
+        {
+          // Does not include initial topography
+          spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::Chunk<dim>>(this->get_geometry_model()).outer_radius();
+          depth_extent = Plugins::get_plugin_as_type<const GeometryModel::Chunk<dim>>(this->get_geometry_model()).maximal_depth();
+        }
       else if (Plugins::plugin_type_matches<const GeometryModel::TwoMergedChunks<dim>> (this->get_geometry_model()))
-        spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::TwoMergedChunks<dim>>(this->get_geometry_model()).outer_radius();
+        {
+          // Does not include initial topography
+          spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::TwoMergedChunks<dim>>(this->get_geometry_model()).outer_radius();
+          depth_extent = Plugins::get_plugin_as_type<const GeometryModel::TwoMergedChunks<dim>>(this->get_geometry_model()).maximal_depth();
+        }
       else if (Plugins::plugin_type_matches<const GeometryModel::EllipsoidalChunk<dim>> (this->get_geometry_model()))
         {
           const GeometryModel::EllipsoidalChunk<dim> &gm = Plugins::get_plugin_as_type<const GeometryModel::EllipsoidalChunk<dim>> (this->get_geometry_model());
@@ -108,15 +122,53 @@ namespace aspect
           AssertThrow(gm.get_eccentricity() == 0.0, ExcMessage("This initial lithospheric pressure plugin cannot be used with a non-zero eccentricity. "));
 
           spherical_representative_point[0] = gm.get_semi_major_axis_a();
+          // Does not include initial topography
+          depth_extent = gm.maximal_depth();
         }
       else if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>> (this->get_geometry_model()))
-        spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::Sphere<dim>>(this->get_geometry_model()).radius();
+        {
+          AssertThrow(false, ExcMessage("Using the initial lithospheric pressure plugin does not make sense for a Sphere geometry."));
+          spherical_representative_point[0] =  Plugins::get_plugin_as_type<const GeometryModel::Sphere<dim>>(this->get_geometry_model()).radius();
+          // Cannot include initial topography. Radius and maximum depth are the same.
+          depth_extent = spherical_representative_point[0];
+        }
       else if (Plugins::plugin_type_matches<const GeometryModel::Box<dim>> (this->get_geometry_model()))
-        representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model()).get_extents()[dim-1];
+        {
+          representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model()).get_extents()[dim-1];
+          // Maximal_depth includes the maximum topography, while we need the topography at the
+          // representative point. Therefore, we only get the undeformed (uniform) depth.
+          depth_extent = representative_point[dim-1] - Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model()).get_origin()[dim-1];
+        }
       else if (Plugins::plugin_type_matches<const GeometryModel::TwoMergedBoxes<dim>> (this->get_geometry_model()))
-        representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()).get_extents()[dim-1];
+        {
+          representative_point[dim-1]=  Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()).get_extents()[dim-1];
+          // Maximal_depth includes the maximum topography, while we need the topography at the
+          // representative point. Therefore, we only get the undeformed (uniform) depth.
+          depth_extent = representative_point[dim-1] - Plugins::get_plugin_as_type<const GeometryModel::TwoMergedBoxes<dim>>(this->get_geometry_model()).get_origin()[dim-1];
+        }
       else
         AssertThrow(false, ExcNotImplemented());
+
+      // If present, retrieve initial topography at the reference point.
+      double topo = 0.;
+      if (!Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()))
+        {
+          // Get the surface x (,y) point
+          Point<dim-1> surface_point;
+          for (unsigned int d=0; d<dim-1; d++)
+            {
+              if (this->get_geometry_model().natural_coordinate_system() == Utilities::Coordinates::CoordinateSystem::cartesian)
+                surface_point[d] = representative_point[d];
+              else
+                surface_point[d] = spherical_representative_point[d];
+
+            }
+          const InitialTopographyModel::Interface<dim> *topo_model = const_cast<InitialTopographyModel::Interface<dim>*>(&this->get_initial_topography_model());
+          topo = topo_model->value(surface_point);
+        }
+
+      // The spacing of the depth profile at the location of the representative point.
+      delta_z = (depth_extent + topo) / (n_points-1);
 
       // Set up the input for the density function of the material model.
       typename MaterialModel::Interface<dim>::MaterialModelInputs in(1, n_compositional_fields);
@@ -251,6 +303,9 @@ namespace aspect
         }
 
       const unsigned int i = static_cast<unsigned int>(z/delta_z);
+      // If mesh deformation is allowed, the depth can become
+      // negative. However, the returned depth is capped at 0
+      // by the geometry models and thus always positive.
       Assert ((z/delta_z) >= 0, ExcInternalError());
       Assert (i+1 < pressure.size(), ExcInternalError());
 
@@ -348,7 +403,17 @@ namespace aspect
                                             "the number of integration points. "
                                             "The lateral coordinates of the point are used to calculate "
                                             "the lithostatic pressure profile with depth. This means that "
-                                            "the depth coordinate is not used."
+                                            "the depth coordinate is not used. "
+                                            "Note that when initial topography is included, the initial "
+                                            "topography at the user-provided representative point is used "
+                                            "to compute the profile. If at other points the (initial) topography "
+                                            "is higher, the behavior of this plugin at later timesteps depends "
+                                            "on the domain geometry. The depth returned by the geometry model "
+                                            "does (box geometries) or does not (spherical "
+                                            "geometries) include the initial topography. This depth is used "
+                                            "to interpolate between the points of the reference pressure profile. "
+                                            "Depths outside the reference profile get returned the pressure value "
+                                            "of the closest profile depth. "
                                             "\n\n"
                                             "Gravity is expected to point along the depth direction. ")
   }

--- a/tests/airy_isostasy_initial_topo.prm
+++ b/tests/airy_isostasy_initial_topo.prm
@@ -1,0 +1,32 @@
+# We setup three columns, of which the middle column has a higher density
+# and viscosity. By choosing a free surface in combination with a
+# prescribed lithostatic pressure,
+# we see the middle column sink until isostasy is reached (if end time is increased)
+# Compared to airy_isostasy.prm, we start off with a nonzero initial topography.
+
+include $ASPECT_SOURCE_DIR/tests/airy_isostasy.prm
+set Dimension = 2
+set End time                               = 3.5e-9
+
+subsection Geometry model
+  subsection Initial topography model
+    set Model name = function
+    subsection Function
+      set Function constants = L=1, R=0.05, C=0.5
+      set Function expression = R * cos(pi*(x-C)/(L))
+      set Maximum topography value = 0.05
+    end
+  end
+end
+
+subsection Boundary traction model
+  set Prescribed traction boundary indicators = 2 y: function
+end
+
+# The lithostatic pressure at the bottom of the domain
+# is rho * g * h = 1 * 10 * 1 = 10.
+subsection Boundary traction model
+  subsection Function
+   set Function expression = 0;10
+  end
+end

--- a/tests/airy_isostasy_initial_topo/screen-output
+++ b/tests/airy_isostasy_initial_topo/screen-output
@@ -1,0 +1,72 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 17,989 (8,450+1,089+4,225+4,225)
+
+Number of mesh deformation degrees of freedom: 2178
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+7 iterations.
+
+Number of active cells: 1,204 (on 7 levels)
+Number of degrees of freedom: 21,360 (10,034+1,292+5,017+5,017)
+
+Number of mesh deformation degrees of freedom: 2584
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 166+0 iterations.
+
+Number of active cells: 1,948 (on 8 levels)
+Number of degrees of freedom: 34,621 (16,270+2,081+8,135+8,135)
+
+Number of mesh deformation degrees of freedom: 4162
+   Solving mesh displacement system... 0 iterations.
+   Added initial topography to grid
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+16 iterations.
+
+   Postprocessing:
+     RMS, max velocity:    1.76e+06 m/year, 2.3e+06 m/year
+     Pressure min/avg/max: -1.132 Pa, 5.012 Pa, 10 Pa
+     Topography min/max:   0 m, 0.05 m
+
+*** Timestep 1:  t=1.69957e-09 years, dt=1.69957e-09 years
+   Solving mesh displacement system... 8 iterations.
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 9 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:    1.62e+06 m/year, 2.11e+06 m/year
+     Pressure min/avg/max: -1.118 Pa, 5.004 Pa, 10 Pa
+     Topography min/max:   -4.848e-05 m, 0.04609 m
+
+*** Timestep 2:  t=3.5e-09 years, dt=1.80043e-09 years
+   Solving mesh displacement system... 8 iterations.
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+4 iterations.
+
+   Postprocessing:
+     RMS, max velocity:    1.53e+06 m/year, 1.99e+06 m/year
+     Pressure min/avg/max: -0.8444 Pa, 5.003 Pa, 10 Pa
+     Topography min/max:   -9.971e-05 m, 0.04229 m
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/airy_isostasy_initial_topo/statistics
+++ b/tests/airy_isostasy_initial_topo/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/year)
+# 14: Max. velocity (m/year)
+# 15: Minimal pressure (Pa)
+# 16: Average pressure (Pa)
+# 17: Maximal pressure (Pa)
+# 18: Minimum topography (m)
+# 19: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 1948 18351 8135 8135 0  0 216 798 880 1.76281656e+06 2.30007330e+06 -1.13211631e+00 5.01241125e+00 1.00000000e+01  0.00000000e+00 5.00000000e-02 
+1 1.699566636086e-09 1.699566636086e-09 1948 18351 8135 8135 0  9 209 520 860 1.62176894e+06 2.11334115e+06 -1.11840083e+00 5.00434491e+00 1.00000025e+01 -4.84780055e-05 4.60937648e-02 
+2 3.500000000000e-09 1.800433363914e-09 1948 18351 8135 8135 0 10 204 376 840 1.52731894e+06 1.98772184e+06 -8.44385424e-01 5.00258872e+00 1.00000042e+01 -9.97076582e-05 4.22912453e-02 


### PR DESCRIPTION
I've updated the plugin to hopefully deal more self-consistently with initial topography and mesh deformation. The lithostatic pressure profile that is computed at t0 now uses the actual initial topography at the reference point instead of the maximum initial topography. Also, when traction is prescribed on a bottom boundary, the last pressure in the profile is prescribed, instead of using what the geometry model returns as depth to interpolate the pressure profile.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
