### PR TITLE
Do not use deprecated interface in initial_lithostatic_pressure

### DIFF
--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -58,8 +58,9 @@ namespace aspect
          * a second argument.
          */
         Tensor<1,dim>
-        traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const override;
+        boundary_traction (const types::boundary_id boundary_indicator,
+                           const Point<dim> &position,
+                           const Tensor<1,dim> &normal_vector) const override;
 
 
         /**

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -228,15 +228,16 @@ namespace aspect
     template <int dim>
     Tensor<1,dim>
     InitialLithostaticPressure<dim>::
-    traction (const Point<dim> &p,
-              const Tensor<1,dim> &normal) const
+    boundary_traction (const types::boundary_id /*boundary_indicator*/,
+                       const Point<dim> &position,
+                       const Tensor<1,dim> &normal_vector) const
     {
       // We want to set the normal component to the vertical boundary
       // to the lithostatic pressure, the rest of the traction
       // components are left set to zero. We get the lithostatic pressure
       // from a linear interpolation of the calculated profile.
       Tensor<1,dim> traction;
-      traction = -interpolate_pressure(p) * normal;
+      traction = -interpolate_pressure(position) * normal_vector;
 
       return traction;
     }


### PR DESCRIPTION
The initial lithostatic pressure boundary traction plugin used a deprecated interface function (deprecated 7 years ago) that does not hand over the boundary indicator of the point that is computed at the moment. Fix this to use the new interface.

@anne-glerum: This PR should simplify your PR #5089 significantly, because as far as I see you do not need the `point_on_bottom_boundary` function anymore. Can you check if that is the case? If so, we should merge this PR, and then rebase yours so that you can simplify.