### PR TITLE
Remove deprecated interface functions for boundary conditions

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -101,7 +101,7 @@ namespace aspect
         double
         boundary_composition (const types::boundary_id boundary_indicator,
                               const Point<dim> &position,
-                              const unsigned int compositional_field) const;
+                              const unsigned int compositional_field) const = 0;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -79,11 +79,12 @@ namespace aspect
          * are requesting the temperature.
          * @param position The position of the point at which we ask for the
          * temperature.
+         *
          * @return Boundary temperature at position @p position.
          */
         virtual
         double boundary_temperature (const types::boundary_id boundary_indicator,
-                                     const Point<dim> &position) const;
+                                     const Point<dim> &position) const = 0;
 
         /**
          * Return the minimal temperature on that part of the boundary on

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -80,27 +80,24 @@ namespace aspect
         update ();
 
         /**
-         * Return the boundary traction as a function of position.
+         * Return the traction that is to hold at a particular position on
+         * the boundary of the domain.
          *
-         * @deprecated Use boundary_traction(const types::boundary_id boundary_indicator,
-         * const Point<dim> &position, const Tensor<1,dim> &normal_vector) const instead.
-         */
-        DEAL_II_DEPRECATED
-        virtual
-        Tensor<1,dim>
-        traction (const Point<dim> &position,
-                  const Tensor<1,dim> &normal_vector) const;
-
-        /**
-         * Return the boundary traction as a function of position. The
-         * (outward) normal vector to the domain is also provided as
-         * a second argument.
+         * @param boundary_indicator The boundary indicator of the part of the
+         * boundary of the domain on which the point is located at which we
+         * are requesting the traction.
+         * @param position The position of the point at which we ask for the
+         * traction.
+         * @param normal_vector The (outward) normal vector to the boundary
+         * of the domain.
+         *
+         * @return Boundary traction at position @p position.
          */
         virtual
         Tensor<1,dim>
         boundary_traction (const types::boundary_id boundary_indicator,
                            const Point<dim> &position,
-                           const Tensor<1,dim> &normal_vector) const;
+                           const Tensor<1,dim> &normal_vector) const = 0;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -86,7 +86,16 @@ namespace aspect
         update ();
 
         /**
-         * Return the boundary velocity as a function of position.
+         * Return the velocity that is to hold at a particular position on
+         * the boundary of the domain.
+         *
+         * @param boundary_indicator The boundary indicator of the part of the
+         * boundary of the domain on which the point is located at which we
+         * are requesting the velocity.
+         * @param position The position of the point at which we ask for the
+         * velocity.
+         *
+         * @return Boundary velocity at position @p position.
          */
         virtual
         Tensor<1,dim>

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -41,30 +41,21 @@ namespace aspect
     Interface<dim>::update ()
     {}
 
+
+
     template <int dim>
     void
     Interface<dim>::initialize ()
     {}
 
-    template <int dim>
-    double
-    Interface<dim>::boundary_composition (const types::boundary_id /*boundary_indicator*/,
-                                          const Point<dim>        &/*position*/,
-                                          const unsigned int       /*compositional_field*/) const
-    {
-      AssertThrow(false,
-                  ExcMessage("The boundary composition plugin has to implement a function called `composition' "
-                             "with four arguments or a function `boundary_composition' with three arguments. "
-                             "The function with four arguments is deprecated and will "
-                             "be removed in a later version of ASPECT."));
-      return numbers::signaling_nan<double>();
-    }
+
 
     template <int dim>
     void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
+
 
 
     template <int dim>

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -41,23 +41,13 @@ namespace aspect
     Interface<dim>::update ()
     {}
 
+
+
     template <int dim>
     void
     Interface<dim>::initialize ()
     {}
 
-    template <int dim>
-    double
-    Interface<dim>::boundary_temperature (const types::boundary_id /*boundary_indicator*/,
-                                          const Point<dim>        &/*position*/) const
-    {
-      AssertThrow(false,
-                  ExcMessage("The boundary temperature plugin has to implement a function called `temperature' "
-                             "with three arguments or a function `boundary_temperature' with two arguments. "
-                             "The function with three arguments is deprecated and will "
-                             "be removed in a later version of ASPECT."));
-      return numbers::signaling_nan<double>();
-    }
 
 
     template <int dim>
@@ -65,6 +55,7 @@ namespace aspect
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
+
 
 
     template <int dim>

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -46,45 +46,13 @@ namespace aspect
     {}
 
 
-    template <int dim>
-    Tensor<1,dim>
-    Interface<dim>::traction (const Point<dim> &,
-                              const Tensor<1,dim> &) const
-    {
-      /**
-       * We can only get here if the new-style boundary_traction function (with
-       * two arguments) calls it. This means that the derived class did not override
-       * the new-style boundary_velocity function, and because we are here, it also
-       * did not override this old-style boundary_velocity function (with one argument).
-       */
-      Assert (false, ExcMessage ("A derived class needs to override either the "
-                                 "boundary_traction(position, normal_vector) "
-                                 "(deprecated) or boundary_traction(types::boundary_id, "
-                                 "position, normal_vector) function."));
-
-      return Tensor<1,dim>();
-    }
-
-
-    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-    template <int dim>
-    Tensor<1,dim>
-    Interface<dim>::boundary_traction (const types::boundary_id /*boundary_indicator*/,
-                                       const Point<dim> &position,
-                                       const Tensor<1,dim> &normal_vector) const
-    {
-      // Call the old-style function without the boundary id to maintain backwards
-      // compatibility. Normally the derived class should override this function.
-      return this->traction(position, normal_vector);
-    }
-    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
 
     template <int dim>
     void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
+
 
 
     template <int dim>


### PR DESCRIPTION
We had some left over code from a switch in boundary condition interfaces 5-7 years ago. Except for the boundary traction model all deprecated functions had already been removed from the header files, but the implementations often still included a default implementation of the new interface with an error message (to notify users about the change). All of this is not necessary anymore, so I removed the remaining code. Functionally, nothing should change, because user plugins that did not implement the new interface were already triggering asserts for the past 5 years. The only exception was the boundary traction interface that still worked with the old interface. However, we had only one plugin (incl cookbooks and benchmarks) that implemented the old interface, which I fixed in #5090.

I also unified some empty lines between functions and comments in the header files between the different boundary condition interfaces.