### PR TITLE
Remove deprecated function from heating model interface

### DIFF
--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -163,26 +163,12 @@ namespace aspect
          * the temperature equation) at each quadrature point as defined in
          * @p material_model_inputs, setting them to zero if they are not to
          * be used in the computation.
-         *
-         * The default implementation calls specific_heating_rate to make
-         * this implementation backwards compatible.
          */
         virtual
         void
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
-
-        /**
-         * Return the specific heating rate as a function of position.
-         */
-        DEAL_II_DEPRECATED
-        virtual
-        double
-        specific_heating_rate (const double temperature,
-                               const double pressure,
-                               const std::vector<double> &compositional_fields,
-                               const Point<dim> &position) const;
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const = 0;
 
         /**
          * Declare the parameters this class takes through input files. The

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -50,46 +50,12 @@ namespace aspect
 
 
 
-    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-    template <int dim>
-    void
-    Interface<dim>::evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-                              const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                              HeatingModel::HeatingModelOutputs &heating_model_outputs) const
-    {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
-             ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
-      for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
-        {
-          heating_model_outputs.heating_source_terms[q] = specific_heating_rate(material_model_inputs.temperature[q],
-                                                                                material_model_inputs.pressure[q],
-                                                                                material_model_inputs.composition[q],
-                                                                                material_model_inputs.position[q])
-                                                          * material_model_outputs.densities[q];
-          heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
-        }
-    }
-    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-
-    template <int dim>
-    double
-    Interface<dim>::specific_heating_rate (const double,
-                                           const double,
-                                           const std::vector<double> &,
-                                           const Point<dim> &) const
-    {
-      Assert(false,
-             ExcMessage ("There is no `evaluate()' or `specific_heating_rate()' function implemented in the heating model!"));
-      return 0.0;
-    }
-
-
     template <int dim>
     void
     Interface<dim>::
     declare_parameters (dealii::ParameterHandler &)
     {}
+
 
 
     template <int dim>
@@ -98,11 +64,13 @@ namespace aspect
     {}
 
 
+
     template <int dim>
     void
     Interface<dim>::
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> & /*outputs*/) const
     {}
+
 
 
     template <int dim>


### PR DESCRIPTION
One more PR removing deprecated functionality in the style of #5092 and #5091 this time for a function in the heating model interface that was deprecated 8 years ago.