### PR TITLE
Add matrix random volume weighting utilities function

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1073,8 +1073,19 @@ namespace aspect
      * @param vector vector to sort
      */
     template <typename T>
+    inline
     std::vector<std::size_t>
-    compute_sorting_permutation(const std::vector<T> &vector);
+    compute_sorting_permutation(const std::vector<T> &vector)
+    {
+      std::vector<std::size_t> p(vector.size());
+      std::iota(p.begin(), p.end(), 0);
+      std::sort(p.begin(), p.end(),
+                [&](std::size_t i, std::size_t j)
+      {
+        return vector[i] < vector[j];
+      });
+      return p;
+    }
 
     /**
      * Applies a permutation vector to another vector and retuns the resulting vector.
@@ -1084,10 +1095,20 @@ namespace aspect
      * @return std::vector<T>
      */
     template <typename T>
+    inline
     std::vector<T>
     apply_permutation(
-      const std::vector<T> &vec,
-      const std::vector<std::size_t> &permutation_vector);
+      const std::vector<T> &vector,
+      const std::vector<std::size_t> &permutation_vector)
+    {
+      std::vector<T> sorted_vec(vector.size());
+      std::transform(permutation_vector.begin(), permutation_vector.end(), sorted_vec.begin(),
+                     [&](std::size_t i)
+      {
+        return vector[i];
+      });
+      return sorted_vec;
+    }
 
     /**
      * Get volume weighted rotation matrices, using random draws to convert

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -25,6 +25,7 @@
 #include <aspect/global.h>
 
 #include <array>
+#include <random>
 #include <deal.II/base/point.h>
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/table_indices.h>
@@ -1064,6 +1065,41 @@ namespace aspect
          */
         const std::function<Tensor<1,dim> (const Point<dim> &)> function_object;
     };
+
+    /**
+     * Create a permutation vector which can be used by the apply_permutation function
+     * which shorts the vector in increasing order.
+     *
+     * @param vector vector to sort
+     */
+    template <typename T>
+    std::vector<std::size_t>
+    sort_permutation(const std::vector<T> &vector);
+
+    /**
+     * Applies a permutation vector to return a sorted verions of the vector.
+     *
+     * @param vector vector to sort
+     * @param permutation_vector The permutation vector used to sort the input vector.
+     * @return std::vector<T>
+     */
+    template <typename T>
+    std::vector<T>
+    apply_permutation(
+      const std::vector<T> &vec,
+      const std::vector<std::size_t> &permutation_vector);
+
+    /**
+     * Get volume weighted rotation matrices, using random draws to convert
+     * to a discrete number of orientations, weighted by volume.
+     * The input is a vector of volume fractions and a vector of rotation matrices.
+     * The vectors need to have the same length.
+     */
+    std::vector<Tensor<2,3>>
+    random_draw_volume_weighting_rotation_matrices(const std::vector<double> volume_fraction,
+                                                   const std::vector<Tensor<2,3>> rotation_matrices,
+                                                   const unsigned int n_output_grains,
+                                                   std::mt19937 random_number_generator);
   }
 }
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1068,16 +1068,16 @@ namespace aspect
 
     /**
      * Create a permutation vector which can be used by the apply_permutation function
-     * which shorts the vector in increasing order.
+     * to put the vector in sorted order.
      *
      * @param vector vector to sort
      */
     template <typename T>
     std::vector<std::size_t>
-    sort_permutation(const std::vector<T> &vector);
+    compute_sorting_permutation(const std::vector<T> &vector);
 
     /**
-     * Applies a permutation vector to return a sorted verions of the vector.
+     * Applies a permutation vector to another vector and retuns the resulting vector.
      *
      * @param vector vector to sort
      * @param permutation_vector The permutation vector used to sort the input vector.
@@ -1094,12 +1094,18 @@ namespace aspect
      * to a discrete number of orientations, weighted by volume.
      * The input is a vector of volume fractions and a vector of rotation matrices.
      * The vectors need to have the same length.
+     *
+     * @param volume_fraction a vector of doubles representing the volume fraction of each grain
+     * @param rotation_matrices a vector of 2nd order 3D tensors representing the rotation matrix of each grain
+     * @param n_output_matrices The number of rotation matrices which are output by this function. This can be
+     * different from the number of entries in the volume fraction and rotation matrices vectors.
+     * @param random_number_generator a reference to a mt19937 random number generator.
      */
     std::vector<Tensor<2,3>>
-    random_draw_volume_weighting_rotation_matrices(const std::vector<double> volume_fraction,
+    rotation_matrices_random_draw_volume_weighting(const std::vector<double> volume_fractions,
                                                    const std::vector<Tensor<2,3>> rotation_matrices,
-                                                   const unsigned int n_output_grains,
-                                                   std::mt19937 random_number_generator);
+                                                   const unsigned int n_output_matrices,
+                                                   std::mt19937 &random_number_generator);
   }
 }
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2869,36 +2869,6 @@ namespace aspect
         throw QuietException();
     }
 
-    template <typename T>
-    std::vector<std::size_t>
-    compute_sorting_permutation(
-      const std::vector<T> &vec)
-    {
-      std::vector<std::size_t> p(vec.size());
-      std::iota(p.begin(), p.end(), 0);
-      std::sort(p.begin(), p.end(),
-                [&](std::size_t i, std::size_t j)
-      {
-        return vec[i] < vec[j];
-      });
-      return p;
-    }
-
-    template <typename T>
-    std::vector<T>
-    apply_permutation(
-      const std::vector<T> &vec,
-      const std::vector<std::size_t> &p)
-    {
-      std::vector<T> sorted_vec(vec.size());
-      std::transform(p.begin(), p.end(), sorted_vec.begin(),
-                     [&](std::size_t i)
-      {
-        return vec[i];
-      });
-      return sorted_vec;
-    }
-
     std::vector<Tensor<2,3>>
     rotation_matrices_random_draw_volume_weighting(const std::vector<double> volume_fraction,
                                                    const std::vector<Tensor<2,3>> rotation_matrices,
@@ -3054,18 +3024,5 @@ namespace aspect
                                                const unsigned int n_rows,
                                                const unsigned int n_columns,
                                                const std::string &property_name);
-
-    template std::vector<std::size_t>
-    compute_sorting_permutation(const std::vector<double> &vector);
-
-    template std::vector<double>
-    apply_permutation(
-      const std::vector<double> &vec,
-      const std::vector<std::size_t> &permutation_vector);
-
-    template std::vector<Tensor<2,3>>
-    apply_permutation(
-      const std::vector<Tensor<2,3>> &vec,
-      const std::vector<std::size_t> &permutation_vector);
   }
 }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2871,7 +2871,7 @@ namespace aspect
 
     template <typename T>
     std::vector<std::size_t>
-    sort_permutation(
+    compute_sorting_permutation(
       const std::vector<T> &vec)
     {
       std::vector<std::size_t> p(vec.size());
@@ -2900,17 +2900,17 @@ namespace aspect
     }
 
     std::vector<Tensor<2,3>>
-    random_draw_volume_weighting_rotation_matrices(const std::vector<double> volume_fraction,
+    rotation_matrices_random_draw_volume_weighting(const std::vector<double> volume_fraction,
                                                    const std::vector<Tensor<2,3>> rotation_matrices,
-                                                   const unsigned int n_output_grains,
-                                                   std::mt19937 random_number_generator)
+                                                   const unsigned int n_output_matrices,
+                                                   std::mt19937 &random_number_generator)
     {
-      unsigned int n_grains = volume_fraction.size();
+      const unsigned int n_grains = volume_fraction.size();
 
       // Get volume weighted euler angles, using random draws to convert odf
       // to a discrete number of orientations, weighted by volume
       // 1a. Sort the volume fractions and matrices based on the volume fractions size
-      const auto p = sort_permutation(volume_fraction);
+      const auto p = compute_sorting_permutation(volume_fraction);
 
       const std::vector<double> fv_sorted = apply_permutation(volume_fraction, p);
       const std::vector<Tensor<2,3>> matrices_sorted = apply_permutation(rotation_matrices, p);
@@ -2921,8 +2921,8 @@ namespace aspect
 
       // 3. Generate random indices
       std::uniform_real_distribution<> dist(0, cum_weight[n_grains-1]);
-      std::vector<double> idxgrain(n_output_grains);
-      for (unsigned int grain_i = 0; grain_i < n_output_grains; ++grain_i)
+      std::vector<double> idxgrain(n_output_matrices);
+      for (unsigned int grain_i = 0; grain_i < n_output_matrices; ++grain_i)
         {
           idxgrain[grain_i] = dist(random_number_generator);
         }
@@ -2930,8 +2930,8 @@ namespace aspect
       // 4. Find the maximum cum_weight that is less than the random value.
       // the euler angle index is +1. For example, if the idxGrain(g) < cumWeight(1),
       // the index should be 1 not zero)
-      std::vector<Tensor<2,3>> matrices_out(n_output_grains);
-      for (unsigned int grain_i = 0; grain_i < n_output_grains; ++grain_i)
+      std::vector<Tensor<2,3>> matrices_out(n_output_matrices);
+      for (unsigned int grain_i = 0; grain_i < n_output_matrices; ++grain_i)
         {
           const std::vector<double>::iterator selected_matrix =
             std::lower_bound(cum_weight.begin(),
@@ -3054,6 +3054,9 @@ namespace aspect
                                                const unsigned int n_rows,
                                                const unsigned int n_columns,
                                                const std::string &property_name);
+
+    template std::vector<std::size_t>
+    compute_sorting_permutation(const std::vector<double> &vector);
 
     template std::vector<double>
     apply_permutation(

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -150,3 +150,81 @@ TEST_CASE("Utilities::AsciiDataLookup manual dim=2 equid")
   REQUIRE(lookup.get_data(Point<2>(1.0,6.0),0) == Approx(5.0));
   REQUIRE(lookup.get_data(Point<2>(1.5,6.0),0) == Approx(5.5));
 }
+
+TEST_CASE("Random draw volume weighted average rotation matrix")
+{
+  std::vector<double> unsorted_volume_fractions = {2.,5.,1.,3.,6.,4.};
+  std::vector<double> sorted_volume_fractions_ref = {1.,2.,3.,4.,5.,6.};
+  const std::vector<std::size_t> permutation = aspect::Utilities::sort_permutation<double>(unsorted_volume_fractions);
+  const std::vector<double> sorted_volume_fractions = aspect::Utilities::apply_permutation<double>(unsorted_volume_fractions,permutation);
+
+  for (unsigned int i = 0; i < sorted_volume_fractions.size(); i++)
+    {
+      REQUIRE(sorted_volume_fractions[i] == Approx(sorted_volume_fractions_ref[i]));
+    }
+
+  const std::vector<dealii::Tensor<2,3>> unsorted_rotation_matrices =
+  {
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{1.,1.,1.},{1.,1.,1.},{1.,1.,1.}}),
+    dealii::Tensor<2,3>({{3.,3.,3.},{3.,3.,3.},{3.,3.,3.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{4.,4.,4.},{4.,4.,4.},{4.,4.,4.}})
+  };
+
+  const std::vector<dealii::Tensor<2,3>> sorted_rotation_matrices_ref =
+  {
+    dealii::Tensor<2,3>({{1.,1.,1.},{1.,1.,1.},{1.,1.,1.}}),
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{3.,3.,3.},{3.,3.,3.},{3.,3.,3.}}),
+    dealii::Tensor<2,3>({{4.,4.,4.},{4.,4.,4.},{4.,4.,4.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}})
+  };
+  const std::vector<dealii::Tensor<2,3>> sorted_rotation_matrices = aspect::Utilities::apply_permutation<dealii::Tensor<2,3>>(unsorted_rotation_matrices,permutation);
+  for (unsigned int i = 0; i < sorted_rotation_matrices.size(); i++)
+    {
+      REQUIRE(sorted_rotation_matrices[i][0][0] == Approx(sorted_rotation_matrices[i][0][0]));
+    }
+
+  std::mt19937 random_number_generator;
+  random_number_generator.seed(5);
+  const std::vector<dealii::Tensor<2,3>> result = aspect::Utilities::random_draw_volume_weighting_rotation_matrices(unsorted_volume_fractions,
+                                                   unsorted_rotation_matrices,
+                                                   25,
+                                                   random_number_generator);
+
+  const std::vector<dealii::Tensor<2,3>> result_ref =
+  {
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{4.,4.,4.},{4.,4.,4.},{4.,4.,4.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{4.,4.,4.},{4.,4.,4.},{4.,4.,4.}}),
+    dealii::Tensor<2,3>({{4.,4.,4.},{4.,4.,4.},{4.,4.,4.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{3.,3.,3.},{3.,3.,3.},{3.,3.,3.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{3.,3.,3.},{3.,3.,3.},{3.,3.,3.}}),
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{5.,5.,5.},{5.,5.,5.},{5.,5.,5.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{1.,1.,1.},{1.,1.,1.},{1.,1.,1.}}),
+    dealii::Tensor<2,3>({{2.,2.,2.},{2.,2.,2.},{2.,2.,2.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+    dealii::Tensor<2,3>({{6.,6.,6.},{6.,6.,6.},{6.,6.,6.}}),
+  };
+  for (unsigned int i = 0; i < result.size(); i++)
+    {
+      REQUIRE(result[i][0][0] == Approx(result_ref[i][0][0]));
+    }
+}

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -155,7 +155,7 @@ TEST_CASE("Random draw volume weighted average rotation matrix")
 {
   std::vector<double> unsorted_volume_fractions = {2.,5.,1.,3.,6.,4.};
   std::vector<double> sorted_volume_fractions_ref = {1.,2.,3.,4.,5.,6.};
-  const std::vector<std::size_t> permutation = aspect::Utilities::sort_permutation<double>(unsorted_volume_fractions);
+  const std::vector<std::size_t> permutation = aspect::Utilities::compute_sorting_permutation<double>(unsorted_volume_fractions);
   const std::vector<double> sorted_volume_fractions = aspect::Utilities::apply_permutation<double>(unsorted_volume_fractions,permutation);
 
   for (unsigned int i = 0; i < sorted_volume_fractions.size(); i++)
@@ -190,7 +190,7 @@ TEST_CASE("Random draw volume weighted average rotation matrix")
 
   std::mt19937 random_number_generator;
   random_number_generator.seed(5);
-  const std::vector<dealii::Tensor<2,3>> result = aspect::Utilities::random_draw_volume_weighting_rotation_matrices(unsorted_volume_fractions,
+  const std::vector<dealii::Tensor<2,3>> result = aspect::Utilities::rotation_matrices_random_draw_volume_weighting(unsorted_volume_fractions,
                                                    unsorted_rotation_matrices,
                                                    25,
                                                    random_number_generator);


### PR DESCRIPTION
This is part of #4979, #4980 and #3885. This pull request splits out a function used in both #4979 and #4980 and uses an optimized algorithm proposed by @gassmoeller in #4980. Once this is merged, both pull request can be simplified by just using this utilities function.