### PR TITLE
Unify handling of repetitions between geometry models.

### DIFF
--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -228,12 +228,12 @@ namespace aspect
         /**
          * Flag whether the box is periodic in the x-, y-, and z-direction.
          */
-        bool periodic[dim];
+        std::array<bool, dim> periodic;
 
         /**
          * The number of cells in each coordinate direction.
          */
-        unsigned int repetitions[dim];
+        std::array<unsigned int, dim> repetitions;
 
         /**
          * A pointer to the initial topography model.

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -448,7 +448,7 @@ namespace aspect
         /**
          * The number of cells in each coordinate direction
          */
-        std::vector<unsigned int> repetitions;
+        std::array<unsigned int, dim> repetitions;
 
         /**
          * An object that describes the geometry.

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -238,12 +238,12 @@ namespace aspect
         /**
          * The number of cells in each coordinate direction for the lower box.
          */
-        unsigned int lower_repetitions[dim];
+        std::array<unsigned int, dim> lower_repetitions;
 
         /**
          * The number of cells in each coordinate direction for the upper box.
          */
-        unsigned int upper_repetitions[dim];
+        std::array<unsigned int, dim> upper_repetitions;
 
         /**
          * The height where the lithospheric part of the vertical boundary begins

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -313,8 +313,8 @@ namespace aspect
          * The number of cells in each coordinate direction
          * for the lower and upper chunk.
          */
-        std::vector<unsigned int> lower_repetitions;
-        std::vector<unsigned int> upper_repetitions;
+        std::array<unsigned int, dim> lower_repetitions;
+        std::array<unsigned int, dim> upper_repetitions;
 
         /**
          * An object that describes the geometry.

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -66,7 +66,7 @@ namespace aspect
     Box<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
     {
-      std::vector<unsigned int> rep_vec(repetitions, repetitions+dim);
+      const std::vector<unsigned int> rep_vec(repetitions.begin(), repetitions.end());
       GridGenerator::subdivided_hyper_rectangle (coarse_grid,
                                                  rep_vec,
                                                  box_origin,

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -502,8 +502,9 @@ namespace aspect
     Chunk<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
     {
+      const std::vector<unsigned int> rep_vec(repetitions.begin(), repetitions.end());
       GridGenerator::subdivided_hyper_rectangle (coarse_grid,
-                                                 repetitions,
+                                                 rep_vec,
                                                  point1,
                                                  point2,
                                                  true);
@@ -880,8 +881,6 @@ namespace aspect
       {
         prm.enter_subsection("Chunk");
         {
-          repetitions.resize(dim);
-
           point1[0] = prm.get_double ("Chunk inner radius");
           point2[0] = prm.get_double ("Chunk outer radius");
           repetitions[0] = prm.get_integer ("Radius repetitions");

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -77,10 +77,10 @@ namespace aspect
     TwoMergedBoxes<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &total_coarse_grid) const
     {
-      std::vector<unsigned int> lower_rep_vec(lower_repetitions, lower_repetitions+dim);
+      std::vector<unsigned int> lower_rep_vec(lower_repetitions.begin(), lower_repetitions.end());
       if (use_merged_grids)
         {
-          std::vector<unsigned int> upper_rep_vec(upper_repetitions, upper_repetitions+dim);
+          std::vector<unsigned int> upper_rep_vec(upper_repetitions.begin(), upper_repetitions.end());
 
           // the two triangulations that will be merged
           Triangulation<dim> lower_coarse_grid;

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -71,16 +71,19 @@ namespace aspect
           Triangulation<dim> lower_coarse_grid;
           Triangulation<dim> upper_coarse_grid;
 
+          const std::vector<unsigned int> lower_rep_vec(lower_repetitions.begin(), lower_repetitions.end());
+          const std::vector<unsigned int> upper_rep_vec(upper_repetitions.begin(), upper_repetitions.end());
+
           // Create the lower box.
           GridGenerator::subdivided_hyper_rectangle (lower_coarse_grid,
-                                                     lower_repetitions,
+                                                     lower_rep_vec,
                                                      point1,
                                                      point4,
                                                      false);
 
           // Create the upper box.
           GridGenerator::subdivided_hyper_rectangle (upper_coarse_grid,
-                                                     upper_repetitions,
+                                                     upper_rep_vec,
                                                      point3,
                                                      point2,
                                                      false);
@@ -93,8 +96,9 @@ namespace aspect
         }
       else
         {
+          const std::vector<unsigned int> lower_rep_vec(lower_repetitions.begin(), lower_repetitions.end());
           GridGenerator::subdivided_hyper_rectangle (coarse_grid,
-                                                     lower_repetitions,
+                                                     lower_rep_vec,
                                                      point1,
                                                      point2,
                                                      false);
@@ -558,12 +562,6 @@ namespace aspect
       {
         prm.enter_subsection("Chunk with lithosphere boundary indicators");
         {
-          Assert (dim >= 2, ExcInternalError());
-          Assert (dim <= 3, ExcInternalError());
-
-          upper_repetitions.resize(dim);
-          lower_repetitions.resize(dim);
-
           point1[0] = prm.get_double("Chunk inner radius");
           point2[0] = prm.get_double("Chunk outer radius");
           point3[0] = prm.get_double("Chunk middle boundary radius");


### PR DESCRIPTION
As seen in #4396 we handle repetition vectors differently in different geometry models. This PR simply unifies the data types and the way we call the deal.II routines. I wanted to get rid of the C-style arrays, but had the choice between std::array and std::vector. std::array in my opinion is the better (more specific) type for this variables, but std::vector is what the deal.II routines expect as input. I decided to go with std::array and convert before calling deal.II, but I am ok either way as long as its uniform across plugins.