### PR TITLE
Unify degrees to radians conversions

### DIFF
--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -589,8 +589,8 @@ namespace aspect
         cos_phi.resize(n_fields);
         for (unsigned int c = 0; c < n_fields; ++c)
           {
-            sin_phi[c] = std::sin(phi[c] * numbers::PI/180);
-            cos_phi[c] = std::cos(phi[c] * numbers::PI/180);
+            sin_phi[c] = std::sin(phi[c] * constants::degree_to_radians);
+            cos_phi[c] = std::cos(phi[c] * constants::degree_to_radians);
           }
 
         prefactor = get_vector_double("Viscous prefactors",n_fields,prm);

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -57,6 +57,16 @@ namespace aspect
     constexpr double celsius_to_kelvin = 273.15;
 
     /**
+     * Convert angles in degree to radians.
+     */
+    constexpr double degree_to_radians = dealii::numbers::PI / 180.;
+
+    /**
+     * Convert angles in radians to degrees.
+     */
+    constexpr double radians_to_degree = 180. / dealii::numbers::PI;
+
+    /**
      * Gas constant (also known as R) [J K^-1 mol^-1]
      */
     constexpr double gas_constant = 8.3144621;

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -70,16 +70,15 @@ namespace aspect
 
       // For spherical(-like) domains, modify the representative point:
       // go from degrees to radians...
-      const double degrees_to_radians = constants::degree_to_radians;
       std::array<double, dim> spherical_representative_point;
       for (unsigned int d=0; d<dim; d++)
         spherical_representative_point[d] = representative_point[d];
-      spherical_representative_point[1] *= degrees_to_radians;
+      spherical_representative_point[1] *= constants::degree_to_radians;
       // and go from latitude to colatitude.
       if (dim == 3)
         {
           spherical_representative_point[2] = 90.0 - spherical_representative_point[2];
-          spherical_representative_point[2] *= degrees_to_radians;
+          spherical_representative_point[2] *= constants::degree_to_radians;
         }
 
       // Check that the representative point lies in the domain.

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -70,7 +70,7 @@ namespace aspect
 
       // For spherical(-like) domains, modify the representative point:
       // go from degrees to radians...
-      const double degrees_to_radians = dealii::numbers::PI/180.0;
+      const double degrees_to_radians = constants::degree_to_radians;
       std::array<double, dim> spherical_representative_point;
       for (unsigned int d=0; d<dim; d++)
         spherical_representative_point[d] = representative_point[d];

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -81,7 +81,7 @@ namespace aspect
                    << "   Input point 2 normalized cartesian coordinates: " << point_two  << std::endl
                    << "   Input point 2 rotated model coordinates: " << transpose(rotation_matrix) * point_two << std::endl
                    << std::endl <<  std::setprecision(2)
-                   << "   Model will be rotated by " << -rotation_angle * 180.0 / numbers::PI
+                   << "   Model will be rotated by " << -rotation_angle * constants::radians_to_degree
                    << " degrees around axis " << rotation_axis << std::endl
                    << "   The ParaView rotation angles are: " << angles[0] << ' ' << angles [1] << ' ' << angles[2] << std::endl
                    << "   The inverse ParaView rotation angles are: " << back_angles[0] << ' ' << back_angles [1] << ' ' << back_angles[2]
@@ -396,7 +396,7 @@ namespace aspect
           }
 
         double theta = atan2(sinTheta, cosTheta);
-        orientation[1] = - theta * 180 / numbers::PI;
+        orientation[1] = - theta * constants::radians_to_degree;
 
         // now rotate about x axis
         double d = sqrt(x2*x2 + y2*y2 + z2*z2);
@@ -419,7 +419,7 @@ namespace aspect
           }
 
         double phi = atan2(sinPhi, cosPhi);
-        orientation[0] = phi * 180 / numbers::PI;
+        orientation[0] = phi * constants::radians_to_degree;
 
         // finally, rotate about z
         double x3p = x3*cosTheta - z3*sinTheta;
@@ -439,7 +439,7 @@ namespace aspect
           }
 
         double alpha = atan2(sinAlpha, cosAlpha);
-        orientation[2] = alpha * 180 / numbers::PI;
+        orientation[2] = alpha * constants::radians_to_degree;
         return orientation;
       }
 

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -81,7 +81,7 @@ namespace aspect
                    << "   Input point 2 normalized cartesian coordinates: " << point_two  << std::endl
                    << "   Input point 2 rotated model coordinates: " << transpose(rotation_matrix) * point_two << std::endl
                    << std::endl <<  std::setprecision(2)
-                   << "   Model will be rotated by " << -rotation_angle * constants::radians_to_degree
+                   << "   Model will be rotated by " << -rotation_angle *constants::radians_to_degree
                    << " degrees around axis " << rotation_axis << std::endl
                    << "   The ParaView rotation angles are: " << angles[0] << ' ' << angles [1] << ' ' << angles[2] << std::endl
                    << "   The inverse ParaView rotation angles are: " << back_angles[0] << ' ' << back_angles [1] << ' ' << back_angles[2]

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -905,8 +905,8 @@ namespace aspect
 
           if (dim == 3)
             {
-              point1[2] = prm.get_double ("Chunk minimum latitude") * degtorad;
-              point2[2] = prm.get_double ("Chunk maximum latitude") * degtorad;
+              point1[2] = prm.get_double ("Chunk minimum latitude") * constants::degree_to_radians;
+              point2[2] = prm.get_double ("Chunk maximum latitude") * constants::degree_to_radians;
               repetitions[2] = prm.get_integer ("Latitude repetitions");
 
               AssertThrow (point1[2] < point2[2],

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -880,16 +880,13 @@ namespace aspect
       {
         prm.enter_subsection("Chunk");
         {
-
-          const double degtorad = dealii::numbers::PI/180;
-
           repetitions.resize(dim);
 
           point1[0] = prm.get_double ("Chunk inner radius");
           point2[0] = prm.get_double ("Chunk outer radius");
           repetitions[0] = prm.get_integer ("Radius repetitions");
-          point1[1] = prm.get_double ("Chunk minimum longitude") * degtorad;
-          point2[1] = prm.get_double ("Chunk maximum longitude") * degtorad;
+          point1[1] = prm.get_double ("Chunk minimum longitude") * constants::degree_to_radians;
+          point2[1] = prm.get_double ("Chunk maximum longitude") * constants::degree_to_radians;
           repetitions[1] = prm.get_integer ("Longitude repetitions");
 
           AssertThrow (point1[0] < point2[0],

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -175,10 +175,10 @@ namespace aspect
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::pull_back_topography(const Point<3> &phi_theta_d) const
     {
       const double d = phi_theta_d[2];
-      const double rad_to_degree = constants::radians_to_degree;
       Point<dim-1> phi_theta;
       if (dim == 3)
-        phi_theta = Point<dim-1>(phi_theta_d[0] * rad_to_degree,phi_theta_d[1] * rad_to_degree);
+        phi_theta = Point<dim-1>(phi_theta_d[0] * constants::radians_to_degree,
+                                 phi_theta_d[1] * constants::radians_to_degree);
       const double h = topography != nullptr ? topography->value(phi_theta) : 0;
       const double d_hat = bottom_depth * (d-h)/(bottom_depth+h);
       const Point<3> phi_theta_d_hat (phi_theta_d[0],
@@ -265,9 +265,9 @@ namespace aspect
       // Shift the grid point at (0,0,0) (and the rest of the
       // points with it) to the correct location at corner[0] at a
       // negative depth.
-      const Point<3> base_point(corners[0][0] * constants::degree_to_radians, 
-      corners[0][1] * constants::degree_to_radians,
-      -bottom_depth);
+      const Point<3> base_point(corners[0][0] * constants::degree_to_radians,
+                                corners[0][1] * constants::degree_to_radians,
+                                -bottom_depth);
       GridTools::shift(base_point,coarse_grid);
 
       // Transform to the ellipsoid surface

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -248,11 +248,11 @@ namespace aspect
 
       // Generate parallelepiped grid with one point (point 0) at (0,0,0) and the
       // other corners (respectively corner 1,2 and 4) placed relative to that point.
-      const Point<3> corner_points[dim] = {Point<dim>((corners[1][0]-corners[0][0])*numbers::PI/180,
-                                                      (corners[1][1]-corners[0][1])*numbers::PI/180,
+      const Point<3> corner_points[dim] = {Point<dim>((corners[1][0]-corners[0][0])*constants::degree_to_radians,
+                                                      (corners[1][1]-corners[0][1])*constants::degree_to_radians,
                                                       0),
-                                           Point<dim>((corners[3][0]-corners[0][0])*numbers::PI/180,
-                                                      (corners[3][1]-corners[0][1])*numbers::PI/180,
+                                           Point<dim>((corners[3][0]-corners[0][0])*constants::degree_to_radians,
+                                                      (corners[3][1]-corners[0][1])*constants::degree_to_radians,
                                                       0),
                                            Point<dim>(0,
                                                       0,
@@ -265,7 +265,9 @@ namespace aspect
       // Shift the grid point at (0,0,0) (and the rest of the
       // points with it) to the correct location at corner[0] at a
       // negative depth.
-      const Point<3> base_point(corners[0][0] *numbers::PI/180,corners[0][1] *numbers::PI/180,-bottom_depth);
+      const Point<3> base_point(corners[0][0] * constants::degree_to_radians, 
+      corners[0][1] * constants::degree_to_radians,
+      -bottom_depth);
       GridTools::shift(base_point,coarse_grid);
 
       // Transform to the ellipsoid surface
@@ -724,8 +726,8 @@ namespace aspect
              ExcMessage("Given depth must be less than or equal to the maximal depth of this geometry."));
 
       // Choose a point on the center axis of the domain
-      Point<dim> p = Point<3>((eastLongitude + westLongitude) * 0.5 * numbers::PI/180,
-                              (southLatitude + northLatitude) * 0.5 * numbers::PI/180,
+      Point<dim> p = Point<3>((eastLongitude + westLongitude) * 0.5 * constants::degree_to_radians,
+                              (southLatitude + northLatitude) * 0.5 * constants::degree_to_radians,
                               -depth);
 
       return manifold.push_forward(p);

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -160,9 +160,8 @@ namespace aspect
     {
       const double d_hat = phi_theta_d_hat[2]; // long, lat, depth
       Point<dim-1> phi_theta;
-      const double rad_to_degree = 180/numbers::PI;
       if (dim == 3)
-        phi_theta = Point<dim-1>(phi_theta_d_hat[0] * rad_to_degree,phi_theta_d_hat[1] * rad_to_degree);
+        phi_theta = Point<dim-1>(phi_theta_d_hat[0] * constants::radians_to_degree,phi_theta_d_hat[1] * constants::radians_to_degree);
       const double h = topography != nullptr ? topography->value(phi_theta) : 0;
       const double d = d_hat + (d_hat + bottom_depth)/bottom_depth*h;
       const Point<3> phi_theta_d (phi_theta_d_hat[0],
@@ -176,7 +175,7 @@ namespace aspect
     EllipsoidalChunk<dim>::EllipsoidalChunkGeometry::pull_back_topography(const Point<3> &phi_theta_d) const
     {
       const double d = phi_theta_d[2];
-      const double rad_to_degree = 180/numbers::PI;
+      const double rad_to_degree = constants::radians_to_degree;
       Point<dim-1> phi_theta;
       if (dim == 3)
         phi_theta = Point<dim-1>(phi_theta_d[0] * rad_to_degree,phi_theta_d[1] * rad_to_degree);
@@ -743,7 +742,6 @@ namespace aspect
 
       // dim = 3
       const Point<dim> ellipsoidal_point = manifold.pull_back(point);
-      const double rad_to_degree = 180.0/numbers::PI;
 
       // compare deflection from the ellipsoid surface
       if (ellipsoidal_point[dim-1] > 0.0+std::numeric_limits<double>::epsilon()*bottom_depth ||
@@ -751,7 +749,7 @@ namespace aspect
         return false;
 
       // compare lon/lat
-      if (!Utilities::polygon_contains_point<dim>(corners, Point<2>(ellipsoidal_point[0]*rad_to_degree,ellipsoidal_point[1]*rad_to_degree)))
+      if (!Utilities::polygon_contains_point<dim>(corners, Point<2>(ellipsoidal_point[0]*constants::radians_to_degree,ellipsoidal_point[1]*constants::radians_to_degree)))
         return false;
 
       return true;

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -519,7 +519,7 @@ namespace aspect
       point1[0] = R0;
       point2[0] = R1;
       point1[1] = 0.0;
-      point2[1] = phi / 180.0 * numbers::PI;
+      point2[1] = phi * constants::degree_to_radians;
       if (dim == 3)
         {
           point1[2] = 0.0;

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -558,9 +558,6 @@ namespace aspect
       {
         prm.enter_subsection("Chunk with lithosphere boundary indicators");
         {
-
-          const double degtorad = dealii::numbers::PI/180;
-
           Assert (dim >= 2, ExcInternalError());
           Assert (dim <= 3, ExcInternalError());
 
@@ -573,8 +570,8 @@ namespace aspect
           point4[0] = point3[0];
           lower_repetitions[0] = prm.get_integer("Inner chunk radius repetitions");
           upper_repetitions[0] = prm.get_integer("Outer chunk radius repetitions");
-          point1[1] = prm.get_double("Chunk minimum longitude") * degtorad;
-          point2[1] = prm.get_double("Chunk maximum longitude") * degtorad;
+          point1[1] = prm.get_double("Chunk minimum longitude") * constants::degree_to_radians;
+          point2[1] = prm.get_double("Chunk maximum longitude") * constants::degree_to_radians;
           point3[1] = point1[1];
           point4[1] = point2[1];
           lower_repetitions[1] = prm.get_integer("Longitude repetitions");
@@ -598,8 +595,8 @@ namespace aspect
 
           if (dim == 3)
             {
-              point1[2] = prm.get_double ("Chunk minimum latitude") * degtorad;
-              point2[2] = prm.get_double ("Chunk maximum latitude") * degtorad;
+              point1[2] = prm.get_double ("Chunk minimum latitude") * constants::degree_to_radians;
+              point2[2] = prm.get_double ("Chunk maximum latitude") * constants::degree_to_radians;
               point3[2] = point1[2];
               point4[2] = point2[2];
               lower_repetitions[2] = prm.get_integer ("Latitude repetitions");

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -241,7 +241,7 @@ namespace aspect
                 Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model());
 
               const double inner_radius = shell_geometry_model.inner_radius();
-              const double half_opening_angle = numbers::PI/180.0 * 0.5 * shell_geometry_model.opening_angle();
+              const double half_opening_angle = constants::degree_to_radians * 0.5 * shell_geometry_model.opening_angle();
               if (dim==2)
                 {
                   // choose the center of the perturbation at half angle along the inner radius

--- a/source/initial_temperature/harmonic_perturbation.cc
+++ b/source/initial_temperature/harmonic_perturbation.cc
@@ -66,7 +66,7 @@ namespace aspect
             {
               // Use a sine as lateral perturbation that is scaled to the opening angle of the geometry.
               // This way the perturbation is always 0 at the model boundaries.
-              const double opening_angle = spherical_geometry_model.opening_angle()*numbers::PI/180.0;
+              const double opening_angle = spherical_geometry_model.opening_angle() * constants::degree_to_radians;
               lateral_perturbation = std::sin(lateral_wave_number_1*scoord[1]*numbers::PI/opening_angle);
             }
 

--- a/source/initial_temperature/spherical_shell.cc
+++ b/source/initial_temperature/spherical_shell.cc
@@ -61,7 +61,7 @@ namespace aspect
       const double phi   = std::atan2(position(0),position(1));
       const double s_mod = s
                            +
-                           0.2 * s * (1-s) * std::sin(angular_mode*phi +(90 + 2*rotation_offset)*numbers::PI/180 ) * scale;
+                           0.2 * s * (1-s) * std::sin(angular_mode*phi + (90 + 2*rotation_offset) * constants::degree_to_radians ) * scale;
 
       // Check that a boundary temperature is prescribed
       AssertThrow (this->has_boundary_temperature(),

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -245,7 +245,7 @@ namespace aspect
             maximum_viscosity          = prm.get_double ("Maximum viscosity");
             reference_strain_rate      = prm.get_double ("Reference strain rate");
             // Convert degrees to radians
-            angle_of_internal_friction = prm.get_double ("Angle of internal friction") * numbers::PI/180.0;
+            angle_of_internal_friction = prm.get_double ("Angle of internal friction") * constants::degree_to_radians;
             cohesion                   = prm.get_double ("Cohesion");
           }
           prm.leave_subsection();

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -218,7 +218,7 @@ namespace aspect
 
         // Convert angles from degrees to radians
         for (double &angle : angles_internal_friction)
-          angle *= numbers::PI/180.0;
+          angle *= constants::degree_to_radians;
 
         cohesions = Utilities::parse_map_to_double_array(prm.get("Cohesions"),
                                                          list_of_composition_names,

--- a/source/material_model/rheology/friction_models.cc
+++ b/source/material_model/rheology/friction_models.cc
@@ -94,7 +94,7 @@ namespace aspect
                 friction_function->value(Utilities::convert_array_to_point<dim>(point.get_coordinates()),volume_fraction_index);
 
               // Convert angles from degrees to radians
-              friction_from_function *= numbers::PI/180.0;
+              friction_from_function *= constants::degree_to_radians;
 
               return friction_from_function;
             }
@@ -235,7 +235,7 @@ namespace aspect
           {
             AssertThrow(angle <= 90,
                         ExcMessage("Dynamic angles of friction must be <= 90 degrees"));
-            angle *= numbers::PI/180.0;
+            angle *= constants::degree_to_radians;
           }
 
         dynamic_friction_smoothness_exponent = prm.get_double("Dynamic friction smoothness exponent");

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -777,7 +777,7 @@ namespace aspect
               {
                 plastic_out->cohesions[i]   += volume_fractions[j] * cohesions[j];
                 // Also convert radians to degrees
-                plastic_out->friction_angles[i] += 180.0/numbers::PI * volume_fractions[j] * friction_angles_RAD[j];
+                plastic_out->friction_angles[i] += constants::radians_to_degree * volume_fractions[j] * friction_angles_RAD[j];
                 plastic_out->yield_stresses[i] += volume_fractions[j] * drucker_prager_plasticity.compute_yield_stress(cohesions[j],
                                                   friction_angles_RAD[j],
                                                   pressure_for_plasticity,

--- a/source/particle/generator/uniform_radial.cc
+++ b/source/particle/generator/uniform_radial.cc
@@ -208,8 +208,8 @@ namespace aspect
 
                 P_min[0] = prm.get_double ("Minimum radius");
                 P_max[0] = prm.get_double ("Maximum radius");
-                P_min[1] = prm.get_double ("Minimum longitude") * numbers::PI / 180.0;
-                P_max[1] = prm.get_double ("Maximum longitude") * numbers::PI / 180.0;
+                P_min[1] = prm.get_double ("Minimum longitude") * constants::degree_to_radians;
+                P_max[1] = prm.get_double ("Maximum longitude") * constants::degree_to_radians;
 
                 AssertThrow(P_max[1] > P_min[1],
                             ExcMessage("The maximum longitude you prescribed in the uniform radial"
@@ -223,8 +223,8 @@ namespace aspect
                   {
                     P_center[2] = prm.get_double ("Center z");
 
-                    P_min[2]    = prm.get_double ("Minimum latitude") * numbers::PI / 180.0;
-                    P_max[2]    = prm.get_double ("Maximum latitude") * numbers::PI / 180.0;
+                    P_min[2]    = prm.get_double ("Minimum latitude") * constants::degree_to_radians;
+                    P_max[2]    = prm.get_double ("Maximum latitude") * constants::degree_to_radians;
 
                     AssertThrow(P_max[2] > P_min[2],
                                 ExcMessage("The maximum latitude you prescribed in the uniform radial"

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -751,12 +751,12 @@ namespace aspect
           for (unsigned int i=0; i<surface_cell_spherical_coordinates.size(); ++i)
             {
               // Transfer the spherical coordinates to geographical coordinates.
-              lat = 90. - surface_cell_spherical_coordinates.at(i).first*(180./numbers::PI);
+              lat = 90. - surface_cell_spherical_coordinates.at(i).first * constants::radians_to_degree;
               lon = (surface_cell_spherical_coordinates.at(i).second <= numbers::PI
                      ?
-                     surface_cell_spherical_coordinates.at(i).second*(180./numbers::PI)
+                     surface_cell_spherical_coordinates.at(i).second * constants::radians_to_degree
                      :
-                     surface_cell_spherical_coordinates.at(i).second*(180./numbers::PI) - 360.);
+                     surface_cell_spherical_coordinates.at(i).second * constants::radians_to_degree - 360.);
 
               // Write the solution to the stream output.
               output << lon
@@ -838,12 +838,12 @@ namespace aspect
               for (unsigned int i=0; i<surface_cell_spherical_coordinates.size(); ++i)
                 {
                   // Transfer the spherical coordinates to geographical coordinates.
-                  lat = 90. - surface_cell_spherical_coordinates.at(i).first*(180./numbers::PI);
+                  lat = 90. - surface_cell_spherical_coordinates.at(i).first * constants::radians_to_degree;
                   lon = (surface_cell_spherical_coordinates.at(i).second <= numbers::PI
                          ?
-                         surface_cell_spherical_coordinates.at(i).second*(180./numbers::PI)
+                         surface_cell_spherical_coordinates.at(i).second * constants::radians_to_degree
                          :
-                         surface_cell_spherical_coordinates.at(i).second*(180./numbers::PI) - 360.);
+                         surface_cell_spherical_coordinates.at(i).second * constants::radians_to_degree - 360.);
 
                   // Write the solution to the stream output.
                   output_gravity_anomaly << lon

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -114,13 +114,15 @@ namespace aspect
                       else
                         satellite_positions_spherical[p][0] = minimum_radius;
                       if (n_points_longitude > 1)
-                        satellite_positions_spherical[p][1] = (minimum_colongitude + ((maximum_colongitude - minimum_colongitude) / (n_points_longitude - 1)) * i) * numbers::PI / 180.;
+                        satellite_positions_spherical[p][1] = (minimum_colongitude + ((maximum_colongitude - minimum_colongitude) / 
+                        (n_points_longitude - 1)) * i) * constants::degree_to_radians;
                       else
-                        satellite_positions_spherical[p][1] = minimum_colongitude * numbers::PI / 180.;
+                        satellite_positions_spherical[p][1] = minimum_colongitude * constants::degree_to_radians;
                       if (n_points_latitude > 1)
-                        satellite_positions_spherical[p][2] = (minimum_colatitude + ((maximum_colatitude - minimum_colatitude) / (n_points_latitude - 1)) * j) * numbers::PI / 180.;
+                        satellite_positions_spherical[p][2] = (minimum_colatitude + ((maximum_colatitude - minimum_colatitude) / 
+                        (n_points_latitude - 1)) * j) * constants::degree_to_radians;
                       else
-                        satellite_positions_spherical[p][2] = minimum_colatitude * numbers::PI / 180.;
+                        satellite_positions_spherical[p][2] = minimum_colatitude * constants::degree_to_radians;
                       ++p;
                     }
                 }
@@ -154,10 +156,10 @@ namespace aspect
               else
                 satellite_positions_spherical[p][0] = radius_list[p];
               if (longitude_list[p] < 0)
-                satellite_positions_spherical[p][1] = (360 + longitude_list[p]) * numbers::PI / 180.;
+                satellite_positions_spherical[p][1] = (360 + longitude_list[p]) * constants::degree_to_radians;
               else
-                satellite_positions_spherical[p][1] = (longitude_list[p]) * numbers::PI / 180.;
-              satellite_positions_spherical[p][2] = (90 - latitude_list[p]) * numbers::PI / 180. ;
+                satellite_positions_spherical[p][1] = (longitude_list[p]) * constants::degree_to_radians;
+              satellite_positions_spherical[p][2] = (90 - latitude_list[p]) * constants::degree_to_radians;
             }
         }
 

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -114,13 +114,13 @@ namespace aspect
                       else
                         satellite_positions_spherical[p][0] = minimum_radius;
                       if (n_points_longitude > 1)
-                        satellite_positions_spherical[p][1] = (minimum_colongitude + ((maximum_colongitude - minimum_colongitude) / 
-                        (n_points_longitude - 1)) * i) * constants::degree_to_radians;
+                        satellite_positions_spherical[p][1] = (minimum_colongitude + ((maximum_colongitude - minimum_colongitude) /
+                                                                                      (n_points_longitude - 1)) * i) * constants::degree_to_radians;
                       else
                         satellite_positions_spherical[p][1] = minimum_colongitude * constants::degree_to_radians;
                       if (n_points_latitude > 1)
-                        satellite_positions_spherical[p][2] = (minimum_colatitude + ((maximum_colatitude - minimum_colatitude) / 
-                        (n_points_latitude - 1)) * j) * constants::degree_to_radians;
+                        satellite_positions_spherical[p][2] = (minimum_colatitude + ((maximum_colatitude - minimum_colatitude) /
+                                                                                     (n_points_latitude - 1)) * j) * constants::degree_to_radians;
                       else
                         satellite_positions_spherical[p][2] = minimum_colatitude * constants::degree_to_radians;
                       ++p;

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -495,8 +495,8 @@ namespace aspect
               // write output.
               // g_gradient is here given in eotvos E (1E = 1e-9 per square seconds):
               output << satellite_positions_spherical[p][0] << ' '
-                     << satellite_positions_spherical[p][1] *180. / numbers::PI << ' '
-                     << satellite_positions_spherical[p][2] *180. / numbers::PI << ' '
+                     << satellite_positions_spherical[p][1] * constants::radians_to_degree << ' '
+                     << satellite_positions_spherical[p][2] * constants::radians_to_degree << ' '
                      << satellite_position[0] << ' '
                      << satellite_position[1] << ' '
                      << satellite_position[2] << ' '

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -745,12 +745,12 @@ namespace aspect
                                 * std::sin(th) * std::sin(th)),
                                (p - (ellipticity * ellipticity * radius * (std::cos(th)
                                                                            * std::cos(th) * std::cos(th)))))
-                    * (180. / numbers::PI);
+                    * constants::radians_to_degree;
 
         if (dim == 3)
           {
             ecoord[1] = std::atan2(position(1), position(0))
-                        * (180. / numbers::PI);
+                        * constants::radians_to_degree;
 
             /* Set all longitudes between [0,360]. */
             if (ecoord[1] < 0.)

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -763,8 +763,8 @@ namespace aspect
 
 
         ecoord[0] = radius/std::sqrt(1- ellipticity * ellipticity
-                                     * std::sin(numbers::PI * ecoord[2]/180)
-                                     * std::sin(numbers::PI * ecoord[2]/180));
+                                     * std::sin(constants::degree_to_radians * ecoord[2])
+                                     * std::sin(constants::degree_to_radians * ecoord[2]));
         return ecoord;
       }
 

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -533,7 +533,7 @@ namespace aspect
                   const double tensile_strength_c = cohesions[c]/strength_reductions[c];
 
                   // Convert friction angle from degrees to radians
-                  double phi = angles_internal_friction[c] * numbers::PI/180.0;
+                  double phi = angles_internal_friction[c] * constants::degree_to_radians;
                   const double transition_pressure = (cohesions[c] * std::cos(phi) - tensile_strength_c) / (1.0 -  sin(phi));
 
                   double yield_strength_c = 0.0;

--- a/tests/solidus_initial_conditions.cc
+++ b/tests/solidus_initial_conditions.cc
@@ -275,7 +275,7 @@ namespace aspect
         {
           // Use a sine as lateral perturbation that is scaled to the opening angle of the geometry.
           // This way the perturbation is always 0 at the model boundaries.
-          const double opening_angle = spherical_geometry_model->opening_angle()*numbers::PI/180.0;
+          const double opening_angle = spherical_geometry_model->opening_angle() * constants::degree_to_radians;
           lateral_perturbation = std::sin(lateral_wave_number_1*scoord[1]*numbers::PI/opening_angle);
         }
       else if (dim==3)

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -612,8 +612,8 @@ namespace aspect
         cos_phi.resize(n_fields);
         for (unsigned int c = 0; c < n_fields; ++c)
           {
-            sin_phi[c] = std::sin(phi[c] * numbers::PI/180);
-            cos_phi[c] = std::cos(phi[c] * numbers::PI/180);
+            sin_phi[c] = std::sin(phi[c] * constants::degree_to_radians);
+            cos_phi[c] = std::cos(phi[c] * constants::degree_to_radians);
           }
 
         constant_viscosity = possibly_extend_from_1_to_N(string_to_double(split_string_list(prm.get("List of constant viscosities"))),


### PR DESCRIPTION
We have many places in the code that convert degrees to radians or vice versa. Instead of checking every time if we have used the right conversion, let's just make it a well named constant. This also saves a tiny amount of compute time.