### PR TITLE
Working Docker ARM64 image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -34,11 +37,12 @@ jobs:
 
       - name: Build and push Docker image for main
         if: contains(github.event_name, 'push')
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ./contrib/docker/docker/
-          cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
+          cache-from: type=registry,ref=ubuntu:22.04
           cache-to: type=inline
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: geodynamics/aspect:latest
 
@@ -47,8 +51,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./contrib/docker/docker/
-          cache-from: type=registry,ref=dealii/dealii:v9.4.0-focal
+          cache-from: type=registry,ref=ubuntu:22.04
           cache-to: type=inline
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: geodynamics/aspect:${{github.ref_name}}
 

--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -1,41 +1,52 @@
-FROM dealii/dealii:v9.4.0-focal
+FROM ubuntu:22.04
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
-# we need a newer version of cmake to support unity builds:
-RUN cd $HOME && wget https://github.com/Kitware/CMake/releases/download/v3.17.3/cmake-3.17.3-Linux-x86_64.tar.gz && tar xf cmake*.tar.gz && rm cmake*.tar.gz
-ENV PATH $HOME/cmake-3.17.3-Linux-x86_64/bin:$PATH
+ARG VERSION=9.4.0
+ARG REPO=ppa:ginggs/deal.ii-9.4.0-backports
 
-USER root
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && \
+  apt install -yq --install-recommends sudo software-properties-common \
+  build-essential ca-certificates cmake cmake-curses-gui file gcc g++ \
+  gfortran git libblas-dev liblapack-dev libopenmpi-dev \
+  lsb-release ninja-build numdiff openmpi-bin \
+  openmpi-common wget zlib1g-dev \
+  libboost-all-dev &&\
+  add-apt-repository $REPO && apt update && \
+  apt install -yq libdeal.ii-$VERSION libdeal.ii-dev && \
+  apt-get clean && rm -r /var/lib/apt/lists/*
+
+# add and enable the default user
+ARG USER=dealii
+ARG USER_ID=1000
+RUN adduser --disabled-password --gecos '' --uid $USER_ID $USER
+RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+#make sure everything is in place
+RUN chown -R $USER:$USER /home/$USER
+USER $USER
+ENV HOME /home/$USER
+ENV USER $USER
+ENV OMPI_MCA_btl "^vader"
+WORKDIR $HOME
+
 RUN wget https://github.com/tjhei/astyle/releases/download/v2.04/astyle_2.04_linux.tar.gz && \
         tar xf astyle_2.04_linux.tar.gz && \
         cd astyle/build/gcc && make && \
-        make install && \
+        sudo make install && \
         cd && \
         rm -rf astyle* && \
         astyle --version
 
-USER dealii
+ENV Aspect_DIR $HOME/aspect
+RUN git clone https://github.com/geodynamics/aspect.git $Aspect_DIR && \
+    mkdir ${Aspect_DIR}/build && \
+    cd ${Aspect_DIR}/build && \
+    cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
+    -DASPECT_INSTALL_EXAMPLES=ON .. && \
+    make -j2 && make install && make clean && \
+    ln -s $Aspect_DIR/bin/aspect $Aspect_DIR/aspect && \
+    ln -s $Aspect_DIR/bin/aspect-release $Aspect_DIR/aspect-release
 
-# Build aspect, replace git checkout command to create image for release
-RUN git clone https://github.com/geodynamics/aspect.git ./aspect && \ 
-    mkdir aspect/build-release && \
-    cd aspect/build-release && \
-    git checkout main && \
-    cmake -DCMAKE_BUILD_TYPE=Release \
-          .. && \
-    make -j2 && \
-    mv aspect ../aspect-release && \
-    make clean && \
-    cd .. && \
-    mkdir build-debug && \
-    cd build-debug && \
-    cmake -DCMAKE_BUILD_TYPE=Debug \
-          .. && \
-    make -j2 && \
-    mv aspect $HOME/aspect/aspect && \
-    make clean
-
-ENV ASPECT_DIR /home/dealii/aspect/build-debug
-
-WORKDIR /home/dealii/aspect
+WORKDIR $Aspect_DIR
+ENV PATH $Aspect_DIR/bin:$PATH

--- a/contrib/docker/docker/build.sh
+++ b/contrib/docker/docker/build.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-# This script generates a docker image from the latest aspect development version.
+# This script generates a docker image from the latest aspect development version
+# for the linux/amd64 and linux/arm64 architectures.
 # It requires a docker installation on the local machine, and the ability to
 # communicate with the docker daemon without root user privileges (see the docker
 # webpage for an explanation).
 # Note: This container is build from the developer version on Github, it does not use
 # the local ASPECT folder. Therefore local changes are not included in the container.
 
+# This builds the image for amd64 and arm64 platforms and pushed to dockerhub
+#docker buildx build --no-cache -o type=registry --platform linux/amd64,linux/arm64 -t geodynamics/aspect .
+
+# This builds the image locally for the current platform
 docker build --no-cache -t geodynamics/aspect .

--- a/doc/sphinx/user/install/docker-container/installing-docker.md
+++ b/doc/sphinx/user/install/docker-container/installing-docker.md
@@ -17,8 +17,8 @@ docker pull geodynamics/aspect
 ```
 
 Note that the transfer size of the compressed image containing
-ASPECT and all its dependencies is about 2&nbsp;GB.
-When extracted the image requires about 7.3&nbsp;GB of disk space.
+ASPECT and all its dependencies is a few GB.
+When extracted the image requires less than 10 GB of disk space.
 
 Running the image is as simple as typing
 ``` ksh

--- a/doc/sphinx/user/install/docker-container/running-models.md
+++ b/doc/sphinx/user/install/docker-container/running-models.md
@@ -6,7 +6,7 @@ ASPECT docker image in a number of different ways, we
 recommend the following workflow:
 
 1.  Create your ASPECT input file in a folder
-    of your choice (possibly also containing any input data that is required
+    of your choice (also containing any input data that is required
     by your model) and navigate in a terminal into that directory.
 
 2.  Run the docker image and mount the current directory as a read-only volume
@@ -18,9 +18,9 @@ recommend the following workflow:
     Make sure your parameter file specifies a model output directory *other*
     than the input directory, e.g., `/home/dealii/aspect/model_output`. When
     you have started the container run the aspect model inside the container.
-    Note that there are two ASPECT executables
-    in the work directory of the container: `aspect` and `aspect-release`. For
-    a discussion of the different versions see {ref}`sec:run-aspect:debug-mode`, in
+    Note that there are two ASPECT versions in the container:
+    `aspect` and `aspect-release`. For a discussion of the different
+    versions see {ref}`sec:run-aspect:debug-mode`, in
     essence: You should run `aspect` first to check your model for errors,
     then run `aspect-release` for a faster model run.
 
@@ -34,7 +34,7 @@ recommend the following workflow:
     Within the container, simply run your model by executing:
 
     ``` ksh
-    ./aspect model_input/your_input_file.prm
+    aspect model_input/your_input_file.prm
     ```
 
 3.  After the model has finished (or during the model run if you want to check
@@ -80,6 +80,7 @@ recommend the following workflow:
 You are all set. Repeat steps 1-4 of this process as necessary when updating
 your model parameters.
 
-[^footnote1]: Note that it is possible to mount a directory as writeable into the container. However, this is often associated with file
-permission conflicts between the host system and the container. Therefore, we recommend this slightly more cumbersome, but
-also more reliable workflow.
+[^footnote1]: Note that it is possible to mount a directory as writeable
+into the container. However, this often causes file permission conflicts
+between your host operating system and the container. Therefore, we
+recommend this slightly more cumbersome, but also more reliable workflow.


### PR DESCRIPTION
I have build and pushed an experimental docker image for Apple Silicon CPUs on an M1 macbook. The image is available on docker hub as `gassmoeller/aspect:latest-arm64`. I had to modify a few things compared to our regular docker image, because it cannot be based on the deal.II image (at the moment there is no arm64 image for deal.II). However, first tests seemed good, I get performance only about 30% slower than natively compiled. The remaining difference is likely the virtual machine, or the fact that the machine is compiled for linux/arm64 instead of the Mac specific architecture darwin/arm64. For comparison the old ASPECT docker image (geodynamics/aspect), compiled for amd64 and emulated on Mac M1, is about 20X slower compared to natively installed ASPECT on M1.

I would appreciate:
- Anyone interested with a new Mac can test the image (`docker run -it gassmoeller/aspect:latest-arm64`) and give me feedback.
- Do we want to move forward with this PR? There is a much better way to handle different architectures, which is to build the same image for multiple architectures using `docker buildx` and then use the same image name and tag. Docker will then automatically download whatever image fits for your platform. I didnt have the time to set it up right now, but we could look into it. For this it would also be neat to have a deal.II image for arm64. I could look into that if there is interest.

