### PR TITLE
Add cpo elastic tensor decomposition plugin

### DIFF
--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -101,21 +101,18 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The integrated strains needs the gradients of the velocity.
-           */
-          UpdateFlags
-          get_needed_update_flags () const  override;
-
-          /**
-           * Return a specific permutation based on an index
+           * Return an even permutation based on an index. This is an internal
+           * utility function, also used by the unit tester.
            */
           static
           std::array<unsigned short int, 3>
           indexed_even_permutation(const unsigned short int index);
 
           /**
-           * Computes the voigt stiffness tensor from the elastic tensor
+           * Computes the voigt stiffness tensor from the elastic tensor.
+          * the Voigt stiffness tensor (see Browaeys and chevrot, 2004)
+          * defines the stress needed to cause an isotropic strain in the
+          * material
            */
           static
           SymmetricTensor<2,3>
@@ -123,6 +120,8 @@ namespace aspect
 
           /**
            * Computes the dilatation stiffness tensor from the elastic tensor
+          * The dilatational stiffness tensor (see Browaeys and chevrot, 2004)
+          * defines the stress to cause isotropic dilatation in the material.
            */
           static
           SymmetricTensor<2,3>
@@ -130,9 +129,21 @@ namespace aspect
 
           /**
            * Computes the Symmetry Cartesian Coordinate System (SCCS).
+           *
+           * This is based on Browaeys and Chevrot (2004), GJI (doi: 10.1111/j.1365-246X.2004.024115.x),
+           * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
+           * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
+           * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
+           * coordinate system is chosen.". The other property they talk about is that "The space of elastic
+           * vectors has a finite dimension [...], i.e. using a different norm from eq. (2.3 will change distances
+           * but not the resulting decomposition.".
+           *
            * With the three SCCS directions, the elastic tensor can be decomposed into the different
            * symmetries in those three SCCS direction, that is, triclinic, monoclinic, orthorhombic,
            * tetragonal, hexagonal, and isotropic (Browaeys & Chevrot, 2004).
+           *
+           * The dilatation_stiffness_tensor defines the stress to cause isotropic dilatation in the material.
+           * The voigt_stiffness_tensor defines the stress needed to cause an isotropic strain in the material
            */
           static
           Tensor<2,3> compute_unpermutated_SCCS(const SymmetricTensor<2,3> &dilatation_stiffness_tensor,
@@ -179,6 +190,9 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
 
+          /**
+           * The tenors below can be used to project matrices to different symmetries.
+           */
           static SymmetricTensor<2,21> projection_matrix_tric_to_mono;
           static SymmetricTensor<2,9> projection_matrix_mono_to_ortho;
           static SymmetricTensor<2,9> projection_matrix_ortho_to_tetra;

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -14,8 +14,8 @@
  <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _aspect_particle_property_elastic_tensor_decomposion_h
-#define _aspect_particle_property_elastic_tensor_decomposion_h
+#ifndef _aspect_particle_property_elastic_tensor_decomposition_h
+#define _aspect_particle_property_elastic_tensor_decomposition_h
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/simulator_access.h>
@@ -30,7 +30,7 @@ namespace aspect
 
       /**
        * Computes several properties of a elastic tensor stored on a particle.
-       * These include the eigenvectors and several projectsion on symmetry axis.
+       * These include the eigenvectors and conversions between different forms of 4th order tensors.
        *
        * @ingroup ParticleProperties
        */
@@ -69,21 +69,21 @@ namespace aspect
            * Update function. This function is called every time an update is
            * request by need_update() for every particle for every property.
            *
-           * @param [in] data_position An unsigned integer that denotes which
+           * @param [in] data_position. An unsigned integer that denotes which
            * component of the particle property vector is associated with the
            * current property. For properties that own several components it
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
-           * @param [in] position The current particle position.
+           * @param [in] position. The current particle position.
            *
-           * @param [in] solution The values of the solution variables at the
+           * @param [in] solution. The values of the solution variables at the
            * current particle position.
            *
-           * @param [in] gradients The gradients of the solution variables at
+           * @param [in] gradients. The gradients of the solution variables at
            * the current particle position.
            *
-           * @param [in,out] particle_properties The properties of the particle
+           * @param [in,out] particle_properties. The properties of the particle
            * that is updated within the call of this function.
            */
           void
@@ -94,8 +94,8 @@ namespace aspect
                                         const ArrayView<double> &particle_properties) const  override;
 
           /**
-           * This implementation tells the particle manager that
-           * we need to update particle properties every time step.
+           * This function tells the particle manager that
+           * we need to update particle properties.
            */
           UpdateTimeFlags
           need_update () const override;
@@ -145,8 +145,8 @@ namespace aspect
            * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
            * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
            * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
-           * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
-           * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+           * coordinate system is chosen.". The other property they talk about is that "The space of elastic
+           * vectors has a finite dimension [...], i.e. using a different norm from eq. (2.3 will change distances
            * but not the resulting decomposition.".
            */
           static
@@ -166,7 +166,7 @@ namespace aspect
           get_property_information() const  override;
 
           /**
-           * Declare paramters
+           * Declare parameters
            */
           static
           void

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -1,0 +1,196 @@
+/*
+ Copyright (C) 2023 by the authors of the ASPECT code.
+ This file is part of ASPECT.
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_property_elastic_tensor_decomposion_h
+#define _aspect_particle_property_elastic_tensor_decomposion_h
+
+#include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
+#include <array>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      /**
+       * Computes several properties of a elastic tensor stored on a particle.
+       * These include the eigenvectors and several projectsion on symmetry axis.
+       *
+       * @ingroup ParticleProperties
+       */
+      template <int dim>
+      class ElasticTensorDecomposition : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * constructor
+           */
+          ElasticTensorDecomposition();
+
+          /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           */
+          void
+          initialize () override;
+
+          /**
+           * Initialization function. This function is called once at the
+           * creation of every particle for every property to initialize its
+           * value.
+           *
+           * @param [in] position The current particle position.
+           * @param [in,out] particle_properties The properties of the particle
+           * that is initialized within the call of this function. The purpose
+           * of this function should be to extend this vector by a number of
+           * properties.
+           */
+          void
+          initialize_one_particle_property (const Point<dim> &position,
+                                            std::vector<double> &particle_properties) const override;
+
+          /**
+           * Update function. This function is called every time an update is
+           * request by need_update() for every particle for every property.
+           *
+           * @param [in] data_position An unsigned integer that denotes which
+           * component of the particle property vector is associated with the
+           * current property. For properties that own several components it
+           * denotes the first component of this property, all other components
+           * fill consecutive entries in the @p particle_properties vector.
+           *
+           * @param [in] position The current particle position.
+           *
+           * @param [in] solution The values of the solution variables at the
+           * current particle position.
+           *
+           * @param [in] gradients The gradients of the solution variables at
+           * the current particle position.
+           *
+           * @param [in,out] particle_properties The properties of the particle
+           * that is updated within the call of this function.
+           */
+          void
+          update_one_particle_property (const unsigned int data_position,
+                                        const Point<dim> &position,
+                                        const Vector<double> &solution,
+                                        const std::vector<Tensor<1,dim>> &gradients,
+                                        const ArrayView<double> &particle_properties) const  override;
+
+          /**
+           * This implementation tells the particle manager that
+           * we need to update particle properties every time step.
+           */
+          UpdateTimeFlags
+          need_update () const override;
+
+          /**
+           * Return which data has to be provided to update the property.
+           * The integrated strains needs the gradients of the velocity.
+           */
+          UpdateFlags
+          get_needed_update_flags () const  override;
+
+          /**
+           * Return a specific permutation based on an index
+           */
+          static
+          std::array<unsigned short int, 3>
+          indexed_even_permutation(const unsigned short int index);
+
+          /**
+           * Computes the voigt stiffness tensor from the elastic tensor
+           */
+          static
+          SymmetricTensor<2,3>
+          compute_voigt_stiffness_tensor(const SymmetricTensor<2,6> &elastic_tensor);
+
+          /**
+           * Computes the dilatation stiffness tensor from the elastic tensor
+           */
+          static
+          SymmetricTensor<2,3>
+          compute_dilatation_stiffness_tensor(const SymmetricTensor<2,6> &elastic_tensor);
+
+          /**
+           * Computes the Symmetry Cartesian Coordinate System (SCCS).
+           * With the three SCCS directions, the elastic tensor can be decomposed into the different
+           * symmetries in those three SCCS direction, that is, triclinic, monoclinic, orthorhombic,
+           * tetragonal, hexagonal, and isotropic (Browaeys & Chevrot, 2004).
+           */
+          static
+          Tensor<2,3> compute_unpermutated_SCCS(const SymmetricTensor<2,3> &dilatation_stiffness_tensor,
+                                                const SymmetricTensor<2,3> &voigt_stiffness_tensor);
+
+          /**
+           * Uses the Symmetry Cartesian Coordinate System (SCCS) to try the different permutations to
+           * determine what is the best projections.
+           * This is based on Browaeys and Chevrot (2004), GJI (doi: 10.1111/j.1365-246X.2004.024115.x),
+           * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
+           * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
+           * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
+           * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
+           * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+           * but not the resulting decomposition.".
+           */
+          static
+          std::array<std::array<double,3>,7>
+          compute_elastic_tensor_SCCS_decompositions(
+            const Tensor<2,3> &unpermutated_SCCS,
+            const SymmetricTensor<2,6> &elastic_matrix);
+
+          /**
+           * Set up the information about the names and number of components
+           * this property requires.
+           *
+           * @return A vector that contains pairs of the property names and the
+           * number of components this property plugin defines.
+           */
+          std::vector<std::pair<std::string, unsigned int>>
+          get_property_information() const  override;
+
+          /**
+           * Declare paramters
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Parse parameters
+           */
+          void
+          parse_parameters (ParameterHandler &prm) override;
+
+
+          static SymmetricTensor<2,21> projection_matrix_tric_to_mono;
+          static SymmetricTensor<2,9> projection_matrix_mono_to_ortho;
+          static SymmetricTensor<2,9> projection_matrix_ortho_to_tetra;
+          static SymmetricTensor<2,9> projection_matrix_tetra_to_hexa;
+          static SymmetricTensor<2,9> projection_matrix_hexa_to_iso;
+
+        private:
+          unsigned int cpo_data_position;
+          unsigned int cpo_elastic_tensor_data_position;
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -39,7 +39,7 @@ namespace aspect
       {
         public:
           /**
-           * constructor
+           * Constructor
            */
           ElasticTensorDecomposition();
 
@@ -67,7 +67,7 @@ namespace aspect
 
           /**
            * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
+           * requested by need_update() for every particle for every property.
            *
            * @param [in] data_position. An unsigned integer that denotes which
            * component of the particle property vector is associated with the
@@ -120,7 +120,7 @@ namespace aspect
 
           /**
            * Computes the dilatation stiffness tensor from the elastic tensor
-          * The dilatational stiffness tensor (see Browaeys and chevrot, 2004)
+          * The dilatational stiffness tensor (see Browaeys and Chevrot, 2004)
           * defines the stress to cause isotropic dilatation in the material.
            */
           static
@@ -135,7 +135,7 @@ namespace aspect
            * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
            * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
            * coordinate system is chosen.". The other property they talk about is that "The space of elastic
-           * vectors has a finite dimension [...], i.e. using a different norm from eq. (2.3 will change distances
+           * vectors has a finite dimension [...], i.e. using a different norm from eq. 2.3 will change distances
            * but not the resulting decomposition.".
            *
            * With the three SCCS directions, the elastic tensor can be decomposed into the different
@@ -157,7 +157,7 @@ namespace aspect
            * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
            * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
            * coordinate system is chosen.". The other property they talk about is that "The space of elastic
-           * vectors has a finite dimension [...], i.e. using a different norm from eq. (2.3 will change distances
+           * vectors has a finite dimension [...], i.e. using a different norm from eq. 2.3 will change distances
            * but not the resulting decomposition.".
            */
           static
@@ -174,7 +174,7 @@ namespace aspect
            * number of components this property plugin defines.
            */
           std::vector<std::pair<std::string, unsigned int>>
-          get_property_information() const  override;
+          get_property_information() const override;
 
           /**
            * Declare parameters
@@ -191,7 +191,7 @@ namespace aspect
 
 
           /**
-           * The tenors below can be used to project matrices to different symmetries.
+           * The tensors below can be used to project matrices to different symmetries.
            */
           static SymmetricTensor<2,21> projection_matrix_tric_to_mono;
           static SymmetricTensor<2,9> projection_matrix_mono_to_ortho;

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -190,7 +190,7 @@ namespace aspect
 
         // get max hexagonal element index, which is the same as the permutation index
         const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-        std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
+        std::array<unsigned short int, 3> permutation = indexed_even_permutation(max_hexagonal_element_index);
         // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
         Tensor<2,3> hexa_permutated_SCCS;
         for (size_t index = 0; index < 3; index++)
@@ -253,7 +253,7 @@ namespace aspect
         // get max hexagonal element index, which is the same as the permutation index
         const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
         std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
-        // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
+        // reorder the SCCS by the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
         Tensor<2,3> hexa_permutated_SCCS;
         for (size_t index = 0; index < 3; index++)
           {
@@ -349,7 +349,7 @@ namespace aspect
       ElasticTensorDecomposition<dim>::compute_dilatation_stiffness_tensor(const SymmetricTensor<2,6> &elastic_matrix)
       {
         /**
-         * The dilatational stiffness tensor (see Browaeys and chevrot, 2004)
+         * The dilatational stiffness tensor (see Browaeys and Chevrot, 2004)
          * It defines the stress to cause isotropic dilatation in the material.
          */
         SymmetricTensor<2,3> dilatation_stiffness_tensor;
@@ -380,7 +380,7 @@ namespace aspect
         std::vector<Tensor<1,3,double>> unpermutated_SCCS(3);
         // averaging eigenvectors
         // the next function looks for the smallest angle
-        // and returns the corresponding vecvo index for that
+        // and returns the corresponding vector index for that
         // vector.
         size_t NDVC = 0;
         for (size_t i1 = 0; i1 < 3; i1++)
@@ -394,14 +394,14 @@ namespace aspect
                 // limit the dot product between 1 and -1 so we can use the arccos function safely.
                 if (std::abs(dv_dot_product) >= 1.0)
                   dv_dot_product = std::copysign(1.0,dv_dot_product);
-                // compute the angle bewteen the vectors and account for that vectors in the oposit
+                // compute the angle between the vectors and account for that vector in the opposite
                 // direction are the same. So limit them between 0 and 90 degrees such that it
                 // represents the minimum angle between the two lines.
-                double ADV = dv_dot_product < 0.0 ? std::acos(-1.0)-std::acos(dv_dot_product) : std::acos(dv_dot_product);
+                const double ADV = dv_dot_product < 0.0 ? std::acos(-1.0)-std::acos(dv_dot_product) : std::acos(dv_dot_product);
                 // store this if the angle is smaller
                 if (ADV < ADVC)
                   {
-                    NDVC=std::copysign(1.0, dv_dot_product)*i2;
+                    NDVC = std::copysign(1.0, dv_dot_product)*i2;
                     ADVC = ADV;
                   }
               }

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -162,14 +162,12 @@ namespace aspect
                     ExcMessage("No cpo property plugin found."));
         AssertThrow(manager.plugin_name_exists("cpo elastic tensor"),
                     ExcMessage("No cpo elastic tensor property plugin found."));
-        Assert(manager.plugin_name_exists("decompose elastic matrix"),
-               ExcMessage("No hexagonal axes property plugin found."));
 
-        AssertThrow(manager.check_plugin_order("crystal preferred orientation","decompose elastic matrix"),
-                    ExcMessage("To use the decompose elastic matrix plugin, the cpo plugin need to be defined before this plugin."));
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","elastic tensor decomposition"),
+                    ExcMessage("To use the elastic tensor decomposition plugin, the cpo plugin need to be defined before this plugin."));
 
-        AssertThrow(manager.check_plugin_order("cpo elastic tensor","decompose elastic matrix"),
-                    ExcMessage("To use the decompose elastic matrix plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
+        AssertThrow(manager.check_plugin_order("cpo elastic tensor","elastic tensor decomposition"),
+                    ExcMessage("To use the elastic tensor decomposition plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
 
         cpo_elastic_tensor_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo elastic tensor"));
       }
@@ -487,15 +485,15 @@ namespace aspect
             // replaced by the lines below.
             //auto ortho_and_higher_vector = projection_matrix_mono_to_ortho*mono_and_higher_vector;
             dealii::Tensor<1,9>  mono_and_higher_vector_cropped;
-            mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
-            mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
-            mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];
-            mono_and_higher_vector_croped[3] = mono_and_higher_vector[3];
-            mono_and_higher_vector_croped[4] = mono_and_higher_vector[4];
-            mono_and_higher_vector_croped[5] = mono_and_higher_vector[5];
-            mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
-            mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
-            mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
+            mono_and_higher_vector_cropped[0] = mono_and_higher_vector[0];
+            mono_and_higher_vector_cropped[1] = mono_and_higher_vector[1];
+            mono_and_higher_vector_cropped[2] = mono_and_higher_vector[2];
+            mono_and_higher_vector_cropped[3] = mono_and_higher_vector[3];
+            mono_and_higher_vector_cropped[4] = mono_and_higher_vector[4];
+            mono_and_higher_vector_cropped[5] = mono_and_higher_vector[5];
+            mono_and_higher_vector_cropped[6] = mono_and_higher_vector[6];
+            mono_and_higher_vector_cropped[7] = mono_and_higher_vector[7];
+            mono_and_higher_vector_cropped[8] = mono_and_higher_vector[8];
             dealii::Tensor<1,9> ortho_and_higher_vector;
             ortho_and_higher_vector[0] = mono_and_higher_vector[0];
             ortho_and_higher_vector[1] = mono_and_higher_vector[1];
@@ -506,7 +504,7 @@ namespace aspect
             ortho_and_higher_vector[6] = mono_and_higher_vector[6];
             ortho_and_higher_vector[7] = mono_and_higher_vector[7];
             ortho_and_higher_vector[8] = mono_and_higher_vector[8];
-            auto mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
+            auto mono_vector = mono_and_higher_vector_cropped-ortho_and_higher_vector;
             norms[1][permutation_i] = mono_vector.norm_square();
 
 
@@ -535,15 +533,6 @@ namespace aspect
       ElasticTensorDecomposition<dim>::need_update() const
       {
         return update_output_step;
-      }
-
-
-
-      template <int dim>
-      UpdateFlags
-      ElasticTensorDecomposition<dim>::get_needed_update_flags () const
-      {
-        return update_default;
       }
 
 

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -437,8 +437,8 @@ namespace aspect
          * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
          * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
          * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
-         * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
-         * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+         * coordinate system is chosen.". The other property they talk about is that "The space of elastic
+         * vectors has a finite dimension [...], i.e. using a different norm from eq. (2.3 will change distances
          * but not the resulting decomposition.".
          */
         Tensor<2,3> permutated[3];
@@ -486,7 +486,7 @@ namespace aspect
             // The following line would do the same as the lines below, but it is slow. It has therefore been
             // replaced by the lines below.
             //auto ortho_and_higher_vector = projection_matrix_mono_to_ortho*mono_and_higher_vector;
-            dealii::Tensor<1,9>  mono_and_higher_vector_croped;
+            dealii::Tensor<1,9>  mono_and_higher_vector_cropped;
             mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
             mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
             mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -1,0 +1,615 @@
+/*
+ Copyright (C) 2023 by the authors of the ASPECT code.
+ This file is part of ASPECT.
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+//#include <cstdlib>
+#include <aspect/particle/property/elastic_tensor_decomposition.h>
+#include <aspect/particle/property/cpo_elastic_tensor.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/particle/world.h>
+
+#include <aspect/utilities.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      template <int dim> SymmetricTensor<2,21> ElasticTensorDecomposition<dim>::projection_matrix_tric_to_mono;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_mono_to_ortho;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_ortho_to_tetra;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_tetra_to_hexa;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_hexa_to_iso;
+
+
+
+      template <int dim>
+      ElasticTensorDecomposition<dim>::ElasticTensorDecomposition ()
+      {
+        // setup projection matrices
+        // projection_matrix_tric_to_mono
+        projection_matrix_tric_to_mono[0][0] = 1.0;
+        projection_matrix_tric_to_mono[1][1] = 1.0;
+        projection_matrix_tric_to_mono[2][2] = 1.0;
+        projection_matrix_tric_to_mono[3][3] = 1.0;
+        projection_matrix_tric_to_mono[4][4] = 1.0;
+        projection_matrix_tric_to_mono[5][5] = 1.0;
+        projection_matrix_tric_to_mono[6][6] = 1.0;
+        projection_matrix_tric_to_mono[7][7] = 1.0;
+        projection_matrix_tric_to_mono[8][8] = 1.0;
+        projection_matrix_tric_to_mono[11][11] = 1.0;
+        projection_matrix_tric_to_mono[14][14] = 1.0;
+        projection_matrix_tric_to_mono[17][17] = 1.0;
+        projection_matrix_tric_to_mono[20][20] = 1.0;
+
+
+        // projection_matrix_mono_to_ortho;
+        projection_matrix_mono_to_ortho[0][0] = 1.0;
+        projection_matrix_mono_to_ortho[1][1] = 1.0;
+        projection_matrix_mono_to_ortho[2][2] = 1.0;
+        projection_matrix_mono_to_ortho[3][3] = 1.0;
+        projection_matrix_mono_to_ortho[4][4] = 1.0;
+        projection_matrix_mono_to_ortho[5][5] = 1.0;
+        projection_matrix_mono_to_ortho[6][6] = 1.0;
+        projection_matrix_mono_to_ortho[7][7] = 1.0;
+        projection_matrix_mono_to_ortho[8][8] = 1.0;
+
+        // projection_matrix_ortho_to_tetra;
+        projection_matrix_ortho_to_tetra[0][0] = 0.5;
+        projection_matrix_ortho_to_tetra[0][1] = 0.5;
+        projection_matrix_ortho_to_tetra[1][1] = 0.5;
+        projection_matrix_ortho_to_tetra[2][2] = 1.0;
+        projection_matrix_ortho_to_tetra[3][3] = 0.5;
+        projection_matrix_ortho_to_tetra[3][4] = 0.5;
+        projection_matrix_ortho_to_tetra[4][4] = 0.5;
+        projection_matrix_ortho_to_tetra[5][5] = 1.0;
+        projection_matrix_ortho_to_tetra[6][6] = 0.5;
+        projection_matrix_ortho_to_tetra[6][7] = 0.5;
+        projection_matrix_ortho_to_tetra[7][7] = 0.5;
+        projection_matrix_ortho_to_tetra[8][8] = 1.0;
+
+        // projection_matrix_tetra_to_hexa;
+        projection_matrix_tetra_to_hexa[0][0] = 3./8.;
+        projection_matrix_tetra_to_hexa[0][1] = 3./8.;
+        projection_matrix_tetra_to_hexa[1][1] = 3./8.;
+        projection_matrix_tetra_to_hexa[2][2] = 1.0;
+        projection_matrix_tetra_to_hexa[3][3] = 0.5;
+        projection_matrix_tetra_to_hexa[3][4] = 0.5;
+        projection_matrix_tetra_to_hexa[4][4] = 0.5;
+        projection_matrix_tetra_to_hexa[5][5] = 3./4.;
+        projection_matrix_tetra_to_hexa[6][6] = 0.5;
+        projection_matrix_tetra_to_hexa[6][7] = 0.5;
+        projection_matrix_tetra_to_hexa[7][7] = 0.5;
+        projection_matrix_tetra_to_hexa[8][8] = 0.5;
+        projection_matrix_tetra_to_hexa[5][0] = 1./(4.*std::sqrt(2.0));
+        projection_matrix_tetra_to_hexa[5][1] = 1./(4.*std::sqrt(2.0));
+        projection_matrix_tetra_to_hexa[8][0] = 0.25;
+        projection_matrix_tetra_to_hexa[8][1] = 0.25;
+        projection_matrix_tetra_to_hexa[8][5] = -1/(2*std::sqrt(2.0));
+
+
+        // projection_matrix_hexa_to_iso;
+        projection_matrix_hexa_to_iso[0][0] = 3./15.;
+        projection_matrix_hexa_to_iso[0][1] = 3./15.;
+        projection_matrix_hexa_to_iso[0][2] = 3./15.;
+        projection_matrix_hexa_to_iso[1][1] = 3./15.;
+        projection_matrix_hexa_to_iso[1][2] = 3./15.;
+        projection_matrix_hexa_to_iso[2][2] = 3./15.;
+        projection_matrix_hexa_to_iso[3][3] = 4./15.;
+        projection_matrix_hexa_to_iso[3][4] = 4./15.;
+        projection_matrix_hexa_to_iso[3][5] = 4./15.;
+        projection_matrix_hexa_to_iso[4][4] = 4./15.;
+        projection_matrix_hexa_to_iso[4][5] = 4./15.;
+        projection_matrix_hexa_to_iso[5][5] = 4./15.;
+        projection_matrix_hexa_to_iso[6][6] = 1./5.;
+        projection_matrix_hexa_to_iso[6][7] = 1./5.;
+        projection_matrix_hexa_to_iso[6][8] = 1./5.;
+        projection_matrix_hexa_to_iso[7][7] = 1./5.;
+        projection_matrix_hexa_to_iso[7][8] = 1./5.;
+        projection_matrix_hexa_to_iso[8][8] = 1./5.;
+
+        projection_matrix_hexa_to_iso[0][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][6] = 2./15.;
+        projection_matrix_hexa_to_iso[0][7] = 2./15.;
+        projection_matrix_hexa_to_iso[0][8] = 2./15.;
+        projection_matrix_hexa_to_iso[1][6] = 2./15.;
+        projection_matrix_hexa_to_iso[1][7] = 2./15.;
+        projection_matrix_hexa_to_iso[1][8] = 2./15.;
+        projection_matrix_hexa_to_iso[2][6] = 2./15.;
+        projection_matrix_hexa_to_iso[2][7] = 2./15.;
+        projection_matrix_hexa_to_iso[2][8] = 2./15.;
+        projection_matrix_hexa_to_iso[3][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[3][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[3][8] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][8] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][8] = -std::sqrt(2.0)/15.;
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::initialize ()
+      {
+        const Particle::Property::Manager<dim> &manager = this->get_particle_world().get_property_manager();
+        AssertThrow(manager.plugin_name_exists("crystal preferred orientation"),
+                    ExcMessage("No cpo property plugin found."));
+        AssertThrow(manager.plugin_name_exists("cpo elastic tensor"),
+                    ExcMessage("No cpo elastic tensor property plugin found."));
+        Assert(manager.plugin_name_exists("decompose elastic matrix"),
+               ExcMessage("No hexagonal axes property plugin found."));
+
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","decompose elastic matrix"),
+                    ExcMessage("To use the decompose elastic matrix plugin, the cpo plugin need to be defined before this plugin."));
+
+        AssertThrow(manager.check_plugin_order("cpo elastic tensor","decompose elastic matrix"),
+                    ExcMessage("To use the decompose elastic matrix plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
+
+        cpo_elastic_tensor_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo elastic tensor"));
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::initialize_one_particle_property(const Point<dim> &,
+                                                                        std::vector<double> &data) const
+      {
+        const SymmetricTensor<2,6> elastic_matrix = Particle::Property::CpoElasticTensor<dim>::get_elastic_tensor(cpo_elastic_tensor_data_position,
+                                                    data);
+
+        const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = compute_dilatation_stiffness_tensor(elastic_matrix);
+        const SymmetricTensor<2,3> voigt_stiffness_tensor_full = compute_voigt_stiffness_tensor(elastic_matrix);
+        Tensor<2,3> SCCS_full = compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+
+        std::array<std::array<double,3>,7 > norms = compute_elastic_tensor_SCCS_decompositions(SCCS_full, elastic_matrix);
+
+        // get max hexagonal element index, which is the same as the permutation index
+        const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+        std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
+        // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
+        Tensor<2,3> hexa_permutated_SCCS;
+        for (size_t index = 0; index < 3; index++)
+          {
+            hexa_permutated_SCCS[index] = SCCS_full[perumation[index]];
+          }
+
+        data.push_back(SCCS_full[0][0]);
+        data.push_back(SCCS_full[0][1]);
+        data.push_back(SCCS_full[0][2]);
+        data.push_back(SCCS_full[1][0]);
+        data.push_back(SCCS_full[1][1]);
+        data.push_back(SCCS_full[1][2]);
+        data.push_back(SCCS_full[2][0]);
+        data.push_back(SCCS_full[2][1]);
+        data.push_back(SCCS_full[2][2]);
+        data.push_back(hexa_permutated_SCCS[2][0]);
+        data.push_back(hexa_permutated_SCCS[2][1]);
+        data.push_back(hexa_permutated_SCCS[2][2]);
+        data.push_back(norms[6][0]);
+        data.push_back(norms[0][0]); // triclinic
+        data.push_back(norms[0][1]); // triclinic
+        data.push_back(norms[0][2]); // triclinic
+        data.push_back(norms[1][0]); // monoclinic
+        data.push_back(norms[1][1]); // monoclinic
+        data.push_back(norms[1][2]); // monoclinic
+        data.push_back(norms[2][0]); // orthorhomic
+        data.push_back(norms[2][1]); // orthorhomic
+        data.push_back(norms[2][2]); // orthorhomic
+        data.push_back(norms[3][0]); // tetragonal
+        data.push_back(norms[3][1]); // tetragonal
+        data.push_back(norms[3][2]); // tetragonal
+        data.push_back(norms[4][0]); // hexagonal
+        data.push_back(norms[4][1]); // hexagonal
+        data.push_back(norms[4][2]); // hexagonal
+        data.push_back(norms[5][0]); // isotropic
+
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::update_one_particle_property(const unsigned int data_position,
+                                                                    const Point<dim> &,
+                                                                    const Vector<double> &,
+                                                                    const std::vector<Tensor<1,dim>> &,
+                                                                    const ArrayView<double> &data) const
+      {
+        const SymmetricTensor<2,6> elastic_matrix = Particle::Property::CpoElasticTensor<dim>::get_elastic_tensor(cpo_elastic_tensor_data_position,
+                                                    data);
+
+
+        const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = compute_dilatation_stiffness_tensor(elastic_matrix);
+        const SymmetricTensor<2,3> voigt_stiffness_tensor_full = compute_voigt_stiffness_tensor(elastic_matrix);
+        Tensor<2,3> SCCS_full = compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+
+        std::array<std::array<double,3>,7 > norms = compute_elastic_tensor_SCCS_decompositions(SCCS_full, elastic_matrix);
+
+        // get max hexagonal element index, which is the same as the permutation index
+        const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+        std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
+        // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
+        Tensor<2,3> hexa_permutated_SCCS;
+        for (size_t index = 0; index < 3; index++)
+          {
+            hexa_permutated_SCCS[index] = SCCS_full[perumation[index]];
+          }
+
+        data[data_position]    = SCCS_full[0][0];
+        data[data_position+1]  = SCCS_full[0][1];
+        data[data_position+2]  = SCCS_full[0][2];
+        data[data_position+3]  = SCCS_full[1][0];
+        data[data_position+4]  = SCCS_full[1][1];
+        data[data_position+5]  = SCCS_full[1][2];
+        data[data_position+6]  = SCCS_full[2][0];
+        data[data_position+7]  = SCCS_full[2][1];
+        data[data_position+8]  = SCCS_full[2][2];
+        data[data_position+9]  = hexa_permutated_SCCS[2][0];
+        data[data_position+10] = hexa_permutated_SCCS[2][1];
+        data[data_position+11] = hexa_permutated_SCCS[2][2];
+        data[data_position+12] = norms[6][0];
+        data[data_position+13] = norms[0][0]; // triclinic
+        data[data_position+14] = norms[0][1]; // triclinic
+        data[data_position+15] = norms[0][2]; // triclinic
+        data[data_position+16] = norms[1][0]; // monoclinic
+        data[data_position+17] = norms[1][1]; // monoclinic
+        data[data_position+18] = norms[1][2]; // monoclinic
+        data[data_position+19] = norms[2][0]; // orthorhomic
+        data[data_position+20] = norms[2][1]; // orthorhomic
+        data[data_position+21] = norms[2][2]; // orthorhomic
+        data[data_position+22] = norms[3][0]; // tetragonal
+        data[data_position+23] = norms[3][1]; // tetragonal
+        data[data_position+24] = norms[3][2]; // tetragonal
+        data[data_position+25] = norms[4][0]; // hexagonal
+        data[data_position+26] = norms[4][1]; // hexagonal
+        data[data_position+27] = norms[4][2]; // hexagonal
+        data[data_position+28] = norms[5][0]; // isotropic
+      }
+
+
+
+      template<int dim>
+      std::array<unsigned short int, 3>
+      ElasticTensorDecomposition<dim>::indexed_even_permutation(const unsigned short int index)
+      {
+        // there are 6 permutations, but only the odd or even are needed. We use the even
+        // permutation here.
+        switch (index)
+          {
+            case 0 :
+              return {{0,1,2}};
+            case 1 :
+              return {{1,2,0}};
+            case 2:
+              return {{2,0,1}};
+            /*case 3:
+              return {0,2,1};
+            case 4 :
+              return {1,0,2};
+            case 5:
+              return {2,1,0};*/
+            default:
+              AssertThrow(false,ExcMessage("Provided index larger then 2 (" + std::to_string(index)+ ")."));
+              return {{0,0,0}};
+          }
+
+      }
+
+
+
+      template<int dim>
+      SymmetricTensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_voigt_stiffness_tensor(const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * the Voigt stiffness tensor (see Browaeys and chevrot, 2004)
+         * It defines the stress needed to cause an isotropic strain in the
+         * material
+         */
+        SymmetricTensor<2,3> voigt_stiffness_tensor;
+        voigt_stiffness_tensor[0][0]=elastic_matrix[0][0]+elastic_matrix[5][5]+elastic_matrix[4][4];
+        voigt_stiffness_tensor[1][1]=elastic_matrix[5][5]+elastic_matrix[1][1]+elastic_matrix[3][3];
+        voigt_stiffness_tensor[2][2]=elastic_matrix[4][4]+elastic_matrix[3][3]+elastic_matrix[2][2];
+        voigt_stiffness_tensor[1][0]=elastic_matrix[0][5]+elastic_matrix[1][5]+elastic_matrix[3][4];
+        voigt_stiffness_tensor[2][0]=elastic_matrix[0][4]+elastic_matrix[2][4]+elastic_matrix[3][5];
+        voigt_stiffness_tensor[2][1]=elastic_matrix[1][3]+elastic_matrix[2][3]+elastic_matrix[4][5];
+
+        return voigt_stiffness_tensor;
+      }
+
+
+
+      template<int dim>
+      SymmetricTensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_dilatation_stiffness_tensor(const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * The dilatational stiffness tensor (see Browaeys and chevrot, 2004)
+         * It defines the stress to cause isotropic dilatation in the material.
+         */
+        SymmetricTensor<2,3> dilatation_stiffness_tensor;
+        for (size_t i = 0; i < 3; i++)
+          {
+            dilatation_stiffness_tensor[0][0]=elastic_matrix[0][i]+dilatation_stiffness_tensor[0][0];
+            dilatation_stiffness_tensor[1][1]=elastic_matrix[1][i]+dilatation_stiffness_tensor[1][1];
+            dilatation_stiffness_tensor[2][2]=elastic_matrix[2][i]+dilatation_stiffness_tensor[2][2];
+            dilatation_stiffness_tensor[1][0]=elastic_matrix[5][i]+dilatation_stiffness_tensor[1][0];
+            dilatation_stiffness_tensor[2][0]=elastic_matrix[4][i]+dilatation_stiffness_tensor[2][0];
+            dilatation_stiffness_tensor[2][1]=elastic_matrix[3][i]+dilatation_stiffness_tensor[2][1];
+          }
+        return dilatation_stiffness_tensor;
+      }
+
+
+
+      template<int dim>
+      Tensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_unpermutated_SCCS(const SymmetricTensor<2,3> &dilatation_stiffness_tensor,
+                                                                 const SymmetricTensor<2,3> &voigt_stiffness_tensor)
+      {
+        // computing the eigenvector of the dilation and voigt stiffness matrices and then averaging them by bysection.
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> voigt_eigenvectors_a = eigenvectors(voigt_stiffness_tensor, SymmetricTensorEigenvectorMethod::jacobi);
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> dilatation_eigenvectors_a = eigenvectors(dilatation_stiffness_tensor, SymmetricTensorEigenvectorMethod::jacobi);
+
+
+        std::vector<Tensor<1,3,double>> unpermutated_SCCS(3);
+        // averaging eigenvectors
+        // the next function looks for the smallest angle
+        // and returns the corresponding vecvo index for that
+        // vector.
+        size_t NDVC = 0;
+        for (size_t i1 = 0; i1 < 3; i1++)
+          {
+            NDVC = 0;
+            double ADVC = 10.0;
+            //double SCN = 0.0;
+            for (size_t i2 = 0; i2 < 3; i2++)
+              {
+                double dv_dot_product = dilatation_eigenvectors_a[i1].second*voigt_eigenvectors_a[i2].second;
+                // limit the dot product between 1 and -1 so we can use the arccos function safely.
+                if (std::abs(dv_dot_product) >= 1.0)
+                  dv_dot_product = std::copysign(1.0,dv_dot_product);
+                // compute the angle bewteen the vectors and account for that vectors in the oposit
+                // direction are the same. So limit them between 0 and 90 degrees such that it
+                // represents the minimum angle between the two lines.
+                double ADV = dv_dot_product < 0.0 ? std::acos(-1.0)-std::acos(dv_dot_product) : std::acos(dv_dot_product);
+                // store this if the angle is smaller
+                if (ADV < ADVC)
+                  {
+                    NDVC=std::copysign(1.0, dv_dot_product)*i2;
+                    ADVC = ADV;
+                  }
+              }
+
+            // Adds/substracting to vecdi the vecvo with the smallest
+            // angle times the i2/j index with the sign of SVD to vecdi
+            // (effectively turning the eigenvector),and then nomalizing it.
+            unpermutated_SCCS[i1] = 0.5*(dilatation_eigenvectors_a[i1].second + (double)NDVC*voigt_eigenvectors_a[std::abs((int)NDVC)].second);
+            unpermutated_SCCS[i1] = unpermutated_SCCS[i1]/unpermutated_SCCS[i1].norm();
+          }
+
+        return Tensor<2,3>(
+        {
+          {unpermutated_SCCS[0][0],unpermutated_SCCS[0][1],unpermutated_SCCS[0][2]},
+          {unpermutated_SCCS[1][0],unpermutated_SCCS[1][1],unpermutated_SCCS[1][2]},
+          {unpermutated_SCCS[2][0],unpermutated_SCCS[2][1],unpermutated_SCCS[2][2]}
+        });
+      }
+
+
+
+      template<int dim>
+      std::array<std::array<double,3>,7>
+      ElasticTensorDecomposition<dim>::compute_elastic_tensor_SCCS_decompositions(
+        const Tensor<2,3> &unpermutated_SCCS,
+        const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * Try the different permutations to determine what is the best hexagonal projection.
+         * This is based on Browaeys and Chevrot (2004), GJI (doi: 10.1111/j.1365-246X.2004.024115.x),
+         * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
+         * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
+         * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
+         * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
+         * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+         * but not the resulting decomposition.".
+         */
+        Tensor<2,3> permutated[3];
+        SymmetricTensor<2,6> rotated_elastic_matrix[3];
+        std::array<std::array<double,3>,7> norms;
+
+        for (unsigned short int permutation_i = 0; permutation_i < 3; permutation_i++)
+          {
+            std::array<unsigned short int, 3> perumation = indexed_even_permutation(permutation_i);
+
+            for (size_t j = 0; j < 3; j++)
+              {
+                permutated[permutation_i][j] = unpermutated_SCCS[perumation[j]];
+              }
+
+            rotated_elastic_matrix[permutation_i] = Utilities::Tensors::rotate_voigt_stiffness_matrix((permutated[permutation_i]),elastic_matrix);
+
+            const Tensor<1,21> full_elastic_vector_rotated = Utilities::Tensors::to_voigt_stiffness_vector(rotated_elastic_matrix[permutation_i]);
+
+
+            const double full_norm_square = full_elastic_vector_rotated.norm_square();
+            norms[6][permutation_i] = full_norm_square;
+
+            // The following line would do the same as the lines below, but is is very slow. It has therefore been
+            // replaced by the lines below.
+            //auto mono_and_higher_vector = projection_matrix_tric_to_mono*full_elastic_vector_rotated;
+            dealii::Tensor<1,21> mono_and_higher_vector;
+            mono_and_higher_vector[0] = full_elastic_vector_rotated[0];
+            mono_and_higher_vector[1] = full_elastic_vector_rotated[1];
+            mono_and_higher_vector[2] = full_elastic_vector_rotated[2];
+            mono_and_higher_vector[3] = full_elastic_vector_rotated[3];
+            mono_and_higher_vector[4] = full_elastic_vector_rotated[4];
+            mono_and_higher_vector[5] = full_elastic_vector_rotated[5];
+            mono_and_higher_vector[6] = full_elastic_vector_rotated[6];
+            mono_and_higher_vector[7] = full_elastic_vector_rotated[7];
+            mono_and_higher_vector[8] = full_elastic_vector_rotated[8];
+            mono_and_higher_vector[11] = full_elastic_vector_rotated[11];
+            mono_and_higher_vector[14] = full_elastic_vector_rotated[14];
+            mono_and_higher_vector[17] = full_elastic_vector_rotated[17];
+            mono_and_higher_vector[20] = full_elastic_vector_rotated[20];
+
+            auto tric_vector = full_elastic_vector_rotated-mono_and_higher_vector;
+            norms[0][permutation_i] = tric_vector.norm_square();
+
+            // The following line would do the same as the lines below, but it is slow. It has therefore been
+            // replaced by the lines below.
+            //auto ortho_and_higher_vector = projection_matrix_mono_to_ortho*mono_and_higher_vector;
+            dealii::Tensor<1,9>  mono_and_higher_vector_croped;
+            mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
+            mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
+            mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];
+            mono_and_higher_vector_croped[3] = mono_and_higher_vector[3];
+            mono_and_higher_vector_croped[4] = mono_and_higher_vector[4];
+            mono_and_higher_vector_croped[5] = mono_and_higher_vector[5];
+            mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
+            mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
+            mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
+            dealii::Tensor<1,9> ortho_and_higher_vector;
+            ortho_and_higher_vector[0] = mono_and_higher_vector[0];
+            ortho_and_higher_vector[1] = mono_and_higher_vector[1];
+            ortho_and_higher_vector[2] = mono_and_higher_vector[2];
+            ortho_and_higher_vector[3] = mono_and_higher_vector[3];
+            ortho_and_higher_vector[4] = mono_and_higher_vector[4];
+            ortho_and_higher_vector[5] = mono_and_higher_vector[5];
+            ortho_and_higher_vector[6] = mono_and_higher_vector[6];
+            ortho_and_higher_vector[7] = mono_and_higher_vector[7];
+            ortho_and_higher_vector[8] = mono_and_higher_vector[8];
+            auto mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
+            norms[1][permutation_i] = mono_vector.norm_square();
+
+
+            auto tetra_and_higher_vector = projection_matrix_ortho_to_tetra*ortho_and_higher_vector;
+            auto ortho_vector = ortho_and_higher_vector-tetra_and_higher_vector;
+            norms[2][permutation_i] = ortho_vector.norm_square();
+
+            auto hexa_and_higher_vector = projection_matrix_tetra_to_hexa*tetra_and_higher_vector;
+            auto tetra_vector = tetra_and_higher_vector-hexa_and_higher_vector;
+            norms[3][permutation_i] = tetra_vector.norm_square();
+
+            auto iso_vector = projection_matrix_hexa_to_iso*hexa_and_higher_vector;
+            auto hexa_vector = hexa_and_higher_vector-iso_vector;
+            norms[4][permutation_i] = hexa_vector.norm_square();
+            norms[5][permutation_i] = iso_vector.norm_square();
+
+          }
+        return norms;
+
+      }
+
+
+
+      template <int dim>
+      UpdateTimeFlags
+      ElasticTensorDecomposition<dim>::need_update() const
+      {
+        return update_output_step;
+      }
+
+
+
+      template <int dim>
+      UpdateFlags
+      ElasticTensorDecomposition<dim>::get_needed_update_flags () const
+      {
+        return update_default;
+      }
+
+
+
+      template <int dim>
+      std::vector<std::pair<std::string, unsigned int>>
+      ElasticTensorDecomposition<dim>::get_property_information() const
+      {
+        std::vector<std::pair<std::string,unsigned int>> property_information;
+
+        property_information.push_back(std::make_pair("cpo elastic axis e1",3));
+        property_information.push_back(std::make_pair("cpo elastic axis e2",3));
+        property_information.push_back(std::make_pair("cpo elastic axis e3",3));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal axis",3));
+        property_information.push_back(std::make_pair("cpo elastic vector norm square",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic isotropic vector norm square",1));
+
+        return property_information;
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::declare_parameters (ParameterHandler &)
+      {}
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::parse_parameters (ParameterHandler &)
+      {}
+    }
+  }
+}
+
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+      ASPECT_REGISTER_PARTICLE_PROPERTY(ElasticTensorDecomposition,
+                                        "elastic tensor decomposition",
+                                        "A plugin in which decomposes the elastic tensor "
+                                        "into different approximations and provides the "
+                                        "eigenvectors of the tensor.")
+    }
+  }
+}

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -19,6 +19,7 @@
 */
 
 #include "common.h"
+#include <aspect/particle/property/elastic_tensor_decomposition.h>
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/particle/property/cpo_elastic_tensor.h>
 #include <deal.II/base/parameter_handler.h>
@@ -1446,4 +1447,856 @@ TEST_CASE("CPO elastic tensor")
     {
       CHECK(array_plus_100[cpo_data_position + i] == tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
     }
+}
+
+
+
+
+TEST_CASE("LPO elastic tensor decomposition")
+{
+  using namespace dealii;
+  using namespace aspect::Particle::Property;
+  {
+    auto elastic_composition_class = ElasticTensorDecomposition<3>();
+
+    // the matrix from Browaeys and Chevrot, 2004, Geophys. J. Int. (doi: 10.1111/j.1365-246X.2004.02415.x)
+    // Note that the computed norms are not in the papers, but are an extra check.
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192;
+    full_elastic_matrix[0][1] = 66;
+    full_elastic_matrix[0][2] = 60;
+    full_elastic_matrix[1][1] = 160;
+    full_elastic_matrix[1][2] = 56;
+    full_elastic_matrix[2][2] = 272;
+    full_elastic_matrix[3][3] = 60;
+    full_elastic_matrix[4][4] = 62;
+    full_elastic_matrix[5][5] = 49;
+
+    SymmetricTensor<2,6> reference_isotropic_matrix;
+    reference_isotropic_matrix[0][0] = 194.7;
+    reference_isotropic_matrix[0][1] = 67.3;
+    reference_isotropic_matrix[0][2] = 67.3;
+    reference_isotropic_matrix[1][1] = 194.7;
+    reference_isotropic_matrix[1][2] = 67.3;
+    reference_isotropic_matrix[2][2] = 194.7;
+    reference_isotropic_matrix[3][3] = 63.7;
+    reference_isotropic_matrix[4][4] = 63.7;
+    reference_isotropic_matrix[5][5] = 63.7;
+
+    SymmetricTensor<2,6> reference_hex_matrix;
+    reference_hex_matrix[0][0] = -21.7;
+    reference_hex_matrix[1][1] = -21.7;
+    reference_hex_matrix[2][2] = 77.3;
+    reference_hex_matrix[1][2] = -9.3;
+    reference_hex_matrix[0][2] = -9.3;
+    reference_hex_matrix[0][1] = 1.7;
+    reference_hex_matrix[3][3] = -2.7;
+    reference_hex_matrix[4][4] = -2.7;
+    reference_hex_matrix[5][5] = -11.7;
+
+    SymmetricTensor<2,6> reference_T_matrix;
+    reference_T_matrix[0][0] = 3;
+    reference_T_matrix[1][1] = 3;
+    reference_T_matrix[0][1] = -3;
+    reference_T_matrix[5][5] = -3;
+
+    SymmetricTensor<2,6> reference_O_matrix;
+    reference_O_matrix[0][0] = 16;
+    reference_O_matrix[1][1] = -16;
+    reference_O_matrix[1][2] = -2;
+    reference_O_matrix[0][2] = 2;
+    reference_O_matrix[3][3] = -1;
+    reference_O_matrix[4][4] = 1;
+
+    const Tensor<1,21> full_elastic_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(full_elastic_matrix);
+    const Tensor<1,21> reference_isotropic_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_isotropic_matrix);
+    const Tensor<1,21> reference_hex_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_hex_matrix);
+    const Tensor<1,21> reference_T_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_T_matrix);
+    const Tensor<1,21> reference_O_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_O_matrix);
+
+    // this matrix is alreay in the SCCSS, so no rotation needed, only the  projection.
+    CHECK(full_elastic_vector.norm_square() == Approx(198012.0));
+    const Tensor<1,21> mono_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tric_to_mono * full_elastic_vector;
+    const Tensor<1,21> tric_vector = full_elastic_vector-mono_and_higher_vector;
+    for (size_t iii = 0; iii < 21; iii++)
+      {
+        CHECK(std::abs(tric_vector[iii]) < 1e-15);
+      }
+    CHECK(tric_vector.norm_square() == Approx(0.0));
+
+    dealii::Tensor<1,9>  mono_and_higher_vector_croped;
+    mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
+    mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
+    mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];
+    mono_and_higher_vector_croped[3] = mono_and_higher_vector[3];
+    mono_and_higher_vector_croped[4] = mono_and_higher_vector[4];
+    mono_and_higher_vector_croped[5] = mono_and_higher_vector[5];
+    mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
+    mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
+    mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
+    const Tensor<1,9> ortho_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_mono_to_ortho*mono_and_higher_vector_croped;
+    const Tensor<1,9> mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(std::abs(mono_vector[iii]) < 1e-15);
+      }
+    CHECK(mono_vector.norm_square() == Approx(0.0));
+
+    const Tensor<1,9> tetra_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_ortho_to_tetra*ortho_and_higher_vector;
+    const Tensor<1,9> ortho_vector = ortho_and_higher_vector-tetra_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(ortho_vector[iii] == Approx(reference_O_vector[iii]));
+      }
+    CHECK(ortho_vector.norm_square() == Approx(536.0));
+
+    const Tensor<1,9> hexa_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tetra_to_hexa*tetra_and_higher_vector;
+    const Tensor<1,9> tetra_vector = tetra_and_higher_vector-hexa_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(tetra_vector[iii] == Approx(reference_T_vector[iii]));
+      }
+    CHECK(tetra_vector.norm_square() == Approx(72.0));
+
+    const Tensor<1,9> iso_vector = ElasticTensorDecomposition<3>::projection_matrix_hexa_to_iso*hexa_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        // something weird is going on with the approx, somehow without a very large
+        // epsilon it thinks for example that "194.6666666667 == Approx( 194.7 )" is false.
+        CHECK(iso_vector[iii] == Approx(reference_isotropic_vector[iii]).epsilon(1e-3));
+      }
+    CHECK(iso_vector.norm_square() == Approx(189529.3333333334));
+
+    const Tensor<1,9> hexa_vector = hexa_and_higher_vector-iso_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        // same as above.
+        CHECK(hexa_vector[iii] == Approx(reference_hex_vector[iii]).epsilon(2.5e-2));
+      }
+    CHECK(hexa_vector.norm_square() == Approx(7874.6666666667));
+
+  }
+
+  {
+    // now compute the distribution in a elastic tensor which is not in SCCS.
+    // We will use the result (with the results of the steps in between) from
+    // Cowin and Mehrabadi, 1985, Mech. appl. Math.
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 1769.50;
+    full_elastic_matrix[0][1] = 873.50;
+    full_elastic_matrix[0][2] = 838.22;
+    full_elastic_matrix[0][3] = -17.68;
+    full_elastic_matrix[0][4] = -110.32;
+    full_elastic_matrix[0][5] = 144.92;
+    full_elastic_matrix[1][0] = 873.50;
+    full_elastic_matrix[1][1] = 1846.64;
+    full_elastic_matrix[1][2] = 836.66;
+    full_elastic_matrix[1][3] = -37.60;
+    full_elastic_matrix[1][4] = -32.32;
+    full_elastic_matrix[1][5] = 153.80;
+    full_elastic_matrix[2][0] = 838.22;
+    full_elastic_matrix[2][1] = 836.66;
+    full_elastic_matrix[2][2] = 1603.28;
+    full_elastic_matrix[2][3] = -29.68;
+    full_elastic_matrix[2][4] = -93.52;
+    full_elastic_matrix[2][5] = 22.40;
+    full_elastic_matrix[3][0] = -17.68;
+    full_elastic_matrix[3][1] = -37.60;
+    full_elastic_matrix[3][2] = -29.68;
+    full_elastic_matrix[3][3] = 438.77;
+    full_elastic_matrix[3][4] = 57.68;
+    full_elastic_matrix[3][5] = -50.50;
+    full_elastic_matrix[4][0] = -110.32;
+    full_elastic_matrix[4][1] = -32.32;
+    full_elastic_matrix[4][2] = -93.52;
+    full_elastic_matrix[4][3] = 57.68;
+    full_elastic_matrix[4][4] = 439.79;
+    full_elastic_matrix[4][5] = -34.78;
+    full_elastic_matrix[5][0] = 144.92;
+    full_elastic_matrix[5][1] = 153.80;
+    full_elastic_matrix[5][2] = 22.40;
+    full_elastic_matrix[5][3] = -50.50;
+    full_elastic_matrix[5][4] = -34.78;
+    full_elastic_matrix[5][5] = 501.80;
+    full_elastic_matrix /= 81.;
+
+    SymmetricTensor<2,3> reference_dilatation_matrix;
+    reference_dilatation_matrix[0][0] = 386.80;
+    reference_dilatation_matrix[0][1] = 35.68;
+    reference_dilatation_matrix[0][2] = -26.24;
+    //reference_dilatation_matrix[1][0] = ;
+    reference_dilatation_matrix[1][1] = 395.20;
+    reference_dilatation_matrix[1][2] = -9.44;
+    //reference_dilatation_matrix[2][0] = ;
+    //reference_dilatation_matrix[2][1] = ;
+    reference_dilatation_matrix[2][2] = 364.24;
+    reference_dilatation_matrix /= 9.;
+
+    SymmetricTensor<2,3> reference_voigt_matrix;
+    reference_voigt_matrix[0][0] = 33.47;
+    reference_voigt_matrix[0][1] = 4.4;
+    reference_voigt_matrix[0][2] = -3.14;
+    //reference_voigt_matrix[1][0] = ;
+    reference_voigt_matrix[1][1] = 34.41;
+    reference_voigt_matrix[1][2] = -1.26;
+    //reference_voigt_matrix[2][0] = ;
+    //reference_voigt_matrix[2][1] = ;
+    reference_voigt_matrix[2][2] = 30.64;
+
+    // Q in equation 2.17, but reordered from
+    // largest to smallest eigenvalue.
+    Tensor<2,3> reference_SCCS;
+    reference_SCCS[2][0] = 2./3.;
+    reference_SCCS[2][1] = -1./3.;
+    reference_SCCS[2][2] = 2./3.;
+    reference_SCCS[1][0] = 1./3.;
+    reference_SCCS[1][1] = -2./3.;
+    reference_SCCS[1][2] = -2./3.;
+    reference_SCCS[0][0] = 2./3.;
+    reference_SCCS[0][1] = 2./3.;
+    reference_SCCS[0][2] = -1./3.;
+
+    SymmetricTensor<2,6> reference_rotated_elastic_matrix;
+    reference_rotated_elastic_matrix[0][0] = 18;
+    reference_rotated_elastic_matrix[0][1] = 9.98;
+    reference_rotated_elastic_matrix[0][2] = 10.1;
+    //reference_rotated_elastic_matrix[1][0] = ;
+    reference_rotated_elastic_matrix[1][1] = 20.2;
+    reference_rotated_elastic_matrix[1][2] = 10.07;
+    //reference_rotated_elastic_matrix[2][0] = ;
+    //reference_rotated_elastic_matrix[2][1] = ;
+    reference_rotated_elastic_matrix[2][2] = 27.6;
+    reference_rotated_elastic_matrix[3][3] = 6.23;
+    reference_rotated_elastic_matrix[4][4] = 5.61;
+    reference_rotated_elastic_matrix[5][5] = 4.52;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            CHECK(reference_dilatation_matrix[iii][jjj] == Approx(dilatation_stiffness_tensor_full[iii][jjj]));
+          }
+      }
+
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            CHECK(reference_voigt_matrix[iii][jjj] == Approx(voigt_stiffness_tensor_full[iii][jjj]));
+          }
+      }
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    // chose the permutation which fits the solution given in the paper.
+    // This is not a even permutation.
+    std::array<unsigned short int, 3> perumation = {{2,1,0}};
+    Tensor<2,3> permutated_SCCS;
+    for (size_t j = 0; j < 3; j++)
+      {
+        permutated_SCCS[j] = unpermutated_SCCS[perumation[j]];
+      }
+    SymmetricTensor<2,6> rotated_elastic_matrix = aspect::Utilities::Tensors::rotate_voigt_stiffness_matrix(permutated_SCCS,full_elastic_matrix);
+
+    for (size_t iii = 0; iii < 6; iii++)
+      {
+        for (size_t jjj = 0; jjj < 6; jjj++)
+          {
+            CHECK(reference_rotated_elastic_matrix[iii][jjj] == Approx(rotated_elastic_matrix[iii][jjj]).margin(1e-4).epsilon(7.5e-2));
+          }
+      }
+  }
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 1.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192;
+    full_elastic_matrix[0][1] = 66;
+    full_elastic_matrix[0][2] = 56;
+    full_elastic_matrix[1][1] = 192;
+    full_elastic_matrix[1][2] = 56;
+    full_elastic_matrix[2][2] = 272;
+    full_elastic_matrix[3][3] = 60;
+    full_elastic_matrix[4][4] = 60;
+    full_elastic_matrix[5][5] = 0.5*(full_elastic_matrix[0][0] + full_elastic_matrix[0][1]);
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{12822.0,0,12822.0}}; // orthorhomic depedent on direction (remember, this is basically just one grain)
+    reference_norms[3] = {{1568.0,8712.0,1568.0}}; // tetragonal could be present
+    reference_norms[4] = {{2759.3333333333,8437.3333333333,2759.3333333333}}; // hexagonal is expected
+    reference_norms[5] = {{247182.6666666667,247182.6666666667,247182.6666666667}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{264332.0,264332.0,264332.0}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 0;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 1;
+    reference_unpermutated_SCCS[1][0] = 1;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 2: a more complicated matrix.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 225;
+    full_elastic_matrix[0][1] = 54;
+    full_elastic_matrix[0][2] = 72;
+    full_elastic_matrix[1][1] = 214;
+    full_elastic_matrix[1][2] = 53;
+    full_elastic_matrix[2][2] = 178;
+    full_elastic_matrix[3][3] = 78;
+    full_elastic_matrix[4][4] = 82;
+    full_elastic_matrix[5][5] = 76;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{453.5,1044.0,1113.5}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{91.125,84.5,595.125}}; // tetragonal could be present
+    reference_norms[4] = {{1350.175,766.3,186.175}}; // hexagonal is expected
+    reference_norms[5] = {{222364.2,222364.2,222364.2}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{224259.0,224259.0,224259.0}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 1;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 0;
+    reference_unpermutated_SCCS[2][2] = 1;
+
+    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {0,1,2};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 3: olivine from experiments as used in D-Rex.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 320.71;
+    full_elastic_matrix[0][1] = 69.84;
+    full_elastic_matrix[0][2] = 71.22;
+    full_elastic_matrix[1][1] = 197.25;
+    full_elastic_matrix[1][2] = 74.8;
+    full_elastic_matrix[2][2] = 234.32;
+    full_elastic_matrix[3][3] = 63.77;
+    full_elastic_matrix[4][4] = 77.67;
+    full_elastic_matrix[5][5] = 78.36;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{4181.95385,689.94905,8020.4222}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{1298.2060125,90.3840125,525.5282}}; // tetragonal could be present
+    reference_norms[4] = {{4364.6051908333,9064.4319908333,1298.8146533333}}; // hexagonal is expected
+    reference_norms[5] = {{282871.5975466666,282871.5975466666,282871.5975466666}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{292716.3626,292716.3626,292716.3626}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 1;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 0;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 1;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 1;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 0;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 4: enstatite from experiments as used in D-Rex.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 236.9;
+    full_elastic_matrix[0][1] = 79.6;
+    full_elastic_matrix[0][2] = 63.2;
+    full_elastic_matrix[1][1] = 180.5;
+    full_elastic_matrix[1][2] = 56.8;
+    full_elastic_matrix[2][2] = 230.4;
+    full_elastic_matrix[3][3] = 84.3;
+    full_elastic_matrix[4][4] = 79.4;
+    full_elastic_matrix[5][5] = 80.1;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{576.245,1514.945,1679.46}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{67.86125,199.00125,483.605}}; // tetragonal could be present
+    reference_norms[4] = {{2076.64175,1006.80175,557.683}}; // hexagonal is expected
+    reference_norms[5] = {{245485.992,245485.992,245485.992}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{248206.74,248206.74,248206.74}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 1;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {0,1,2};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 0;
+    reference_hexa_permutated_SCCS[1][2] = 1;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 1;
+    reference_hexa_permutated_SCCS[2][2] = 0;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 4: from http://solidmechanics.org/Text/Chapter3_2/Chapter3_2.php (Be).
+    // This one should have at least in one direction almost all the the anistropy be
+    // hexagonal anisotropy.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192.3;
+    full_elastic_matrix[0][1] = 26.7;
+    full_elastic_matrix[0][2] = 14;
+    full_elastic_matrix[1][1] = full_elastic_matrix[0][0];
+    full_elastic_matrix[1][2] = full_elastic_matrix[0][2];
+    full_elastic_matrix[2][2] = 336.4;
+    full_elastic_matrix[3][3] = 162.5;
+    full_elastic_matrix[4][4] = full_elastic_matrix[3][3];
+    full_elastic_matrix[5][5] = 0.5*(full_elastic_matrix[0][0] + full_elastic_matrix[0][1]);
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{16161.695,0.0,16161.695}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{2786.31125,1425.78,2786.31125}}; // tetragonal could be present
+    reference_norms[4] = {{8079.22575,25601.452,8079.22575}}; // hexagonal is expected
+    reference_norms[5] = {{421517.088,421517.088,421517.088}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{448544.32,448544.32,448544.32}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 0;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 1;
+    reference_unpermutated_SCCS[1][0] = 1;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
 }

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -23,6 +23,7 @@
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/particle/property/cpo_elastic_tensor.h>
 #include <deal.II/base/parameter_handler.h>
+#include <aspect/utilities.h>
 
 
 /**
@@ -1456,6 +1457,7 @@ TEST_CASE("LPO elastic tensor decomposition")
 {
   using namespace dealii;
   using namespace aspect::Particle::Property;
+  using namespace aspect::Particle::Property::Utilities;
   {
     auto elastic_composition_class = ElasticTensorDecomposition<3>();
 
@@ -1514,9 +1516,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     const Tensor<1,21> reference_T_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_T_matrix);
     const Tensor<1,21> reference_O_vector = aspect::Utilities::Tensors::to_voigt_stiffness_vector(reference_O_matrix);
 
-    // this matrix is alreay in the SCCSS, so no rotation needed, only the  projection.
+    // this matrix is already in the SCCSS, so no rotation needed, only the  projection.
     CHECK(full_elastic_vector.norm_square() == Approx(198012.0));
-    const Tensor<1,21> mono_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tric_to_mono * full_elastic_vector;
+    const Tensor<1,21> mono_and_higher_vector = aspect::Particle::Property::Utilities::projection_matrix_triclinic_to_monoclinic * full_elastic_vector;
     const Tensor<1,21> tric_vector = full_elastic_vector-mono_and_higher_vector;
     for (size_t iii = 0; iii < 21; iii++)
       {
@@ -1534,7 +1536,7 @@ TEST_CASE("LPO elastic tensor decomposition")
     mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
     mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
     mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
-    const Tensor<1,9> ortho_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_mono_to_ortho*mono_and_higher_vector_croped;
+    const Tensor<1,9> ortho_and_higher_vector = aspect::Particle::Property::Utilities::projection_matrix_monoclinic_to_orthorhombic*mono_and_higher_vector_croped;
     const Tensor<1,9> mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
     for (size_t iii = 0; iii < 9; iii++)
       {
@@ -1542,7 +1544,7 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
     CHECK(mono_vector.norm_square() == Approx(0.0));
 
-    const Tensor<1,9> tetra_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_ortho_to_tetra*ortho_and_higher_vector;
+    const Tensor<1,9> tetra_and_higher_vector = aspect::Particle::Property::Utilities::projection_matrix_orthorhombic_to_tetragonal*ortho_and_higher_vector;
     const Tensor<1,9> ortho_vector = ortho_and_higher_vector-tetra_and_higher_vector;
     for (size_t iii = 0; iii < 9; iii++)
       {
@@ -1550,7 +1552,7 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
     CHECK(ortho_vector.norm_square() == Approx(536.0));
 
-    const Tensor<1,9> hexa_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tetra_to_hexa*tetra_and_higher_vector;
+    const Tensor<1,9> hexa_and_higher_vector = aspect::Particle::Property::Utilities::projection_matrix_tetragonal_to_hexagonal*tetra_and_higher_vector;
     const Tensor<1,9> tetra_vector = tetra_and_higher_vector-hexa_and_higher_vector;
     for (size_t iii = 0; iii < 9; iii++)
       {
@@ -1558,7 +1560,7 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
     CHECK(tetra_vector.norm_square() == Approx(72.0));
 
-    const Tensor<1,9> iso_vector = ElasticTensorDecomposition<3>::projection_matrix_hexa_to_iso*hexa_and_higher_vector;
+    const Tensor<1,9> iso_vector = aspect::Particle::Property::Utilities::projection_matrix_hexagonal_to_isotropic*hexa_and_higher_vector;
     for (size_t iii = 0; iii < 9; iii++)
       {
         // something weird is going on with the approx, somehow without a very large
@@ -1670,7 +1672,7 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_rotated_elastic_matrix[4][4] = 5.61;
     reference_rotated_elastic_matrix[5][5] = 4.52;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
     for (size_t iii = 0; iii < 3; iii++)
       {
         for (size_t jjj = 0; jjj < 3; jjj++)
@@ -1679,7 +1681,7 @@ TEST_CASE("LPO elastic tensor decomposition")
           }
       }
 
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
     for (size_t iii = 0; iii < 3; iii++)
       {
         for (size_t jjj = 0; jjj < 3; jjj++)
@@ -1687,7 +1689,7 @@ TEST_CASE("LPO elastic tensor decomposition")
             CHECK(reference_voigt_matrix[iii][jjj] == Approx(voigt_stiffness_tensor_full[iii][jjj]));
           }
       }
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -1701,11 +1703,11 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
     // chose the permutation which fits the solution given in the paper.
     // This is not a even permutation.
-    std::array<unsigned short int, 3> perumation = {{2,1,0}};
+    std::array<unsigned int, 3> permutation = {{2,1,0}};
     Tensor<2,3> permutated_SCCS;
     for (size_t j = 0; j < 3; j++)
       {
-        permutated_SCCS[j] = unpermutated_SCCS[perumation[j]];
+        permutated_SCCS[j] = unpermutated_SCCS[permutation[j]];
       }
     SymmetricTensor<2,6> rotated_elastic_matrix = aspect::Utilities::Tensors::rotate_voigt_stiffness_matrix(permutated_SCCS,full_elastic_matrix);
 
@@ -1736,10 +1738,10 @@ TEST_CASE("LPO elastic tensor decomposition")
     std::array<std::array<double,3>,7 > reference_norms;
     reference_norms[0] = {{0,0,0}}; // no triclinic
     reference_norms[1] = {{0,0,0}}; // no monoclinic
-    reference_norms[2] = {{12822.0,0,12822.0}}; // orthorhomic depedent on direction (remember, this is basically just one grain)
+    reference_norms[2] = {{12822.0,0,12822.0}}; // orthorhomic dependent on direction (remember, this is basically just one grain)
     reference_norms[3] = {{1568.0,8712.0,1568.0}}; // tetragonal could be present
     reference_norms[4] = {{2759.3333333333,8437.3333333333,2759.3333333333}}; // hexagonal is expected
-    reference_norms[5] = {{247182.6666666667,247182.6666666667,247182.6666666667}}; // isotropic should be the same for every permuation
+    reference_norms[5] = {{247182.6666666667,247182.6666666667,247182.6666666667}}; // isotropic should be the same for every permutation
     reference_norms[6] = {{264332.0,264332.0,264332.0}}; // total should be the same for every direction
 
     // It is already in a SCCS frame, so they should be
@@ -1755,8 +1757,8 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_unpermutated_SCCS[2][1] = 1;
     reference_unpermutated_SCCS[2][2] = 0;
 
-    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
-    // is permuated by {1,2,0};
+    // Permutation 2 has the highest norm, so reference_unpermutated_SCCS
+    // is permutated by {1,2,0};
     Tensor<2,3> reference_hexa_permutated_SCCS;
     reference_hexa_permutated_SCCS[0][0] = 1;
     reference_hexa_permutated_SCCS[0][1] = 0;
@@ -1768,9 +1770,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_hexa_permutated_SCCS[2][1] = 0;
     reference_hexa_permutated_SCCS[2][2] = 1;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -1783,7 +1785,7 @@ TEST_CASE("LPO elastic tensor decomposition")
                    && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
                    && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
       }
-    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<std::array<double,3>,7 > norms = aspect::Particle::Property::Utilities::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
     std::array<double,3> totals = {{0,0,0}};
     for (size_t iii = 0; iii < 7; iii++)
       {
@@ -1813,11 +1815,11 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
 
     const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    std::array<unsigned int, 3> permutation = aspect::Particle::Property::Utilities::indexed_even_permutation(max_hexagonal_element_index);
     Tensor<2,3> hexa_permutated_SCCS;
     for (size_t index = 0; index < 3; index++)
       {
-        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[permutation[index]];
       }
     for (size_t iii = 0; iii < 3; iii++)
       {
@@ -1851,10 +1853,10 @@ TEST_CASE("LPO elastic tensor decomposition")
     std::array<std::array<double,3>,7 > reference_norms;
     reference_norms[0] = {{0,0,0}}; // no triclinic
     reference_norms[1] = {{0,0,0}}; // no monoclinic
-    reference_norms[2] = {{453.5,1044.0,1113.5}}; // orthorhomic depedent on direction
+    reference_norms[2] = {{453.5,1044.0,1113.5}}; // orthorhomic dependent on direction
     reference_norms[3] = {{91.125,84.5,595.125}}; // tetragonal could be present
     reference_norms[4] = {{1350.175,766.3,186.175}}; // hexagonal is expected
-    reference_norms[5] = {{222364.2,222364.2,222364.2}}; // isotropic should be the same for every permuation
+    reference_norms[5] = {{222364.2,222364.2,222364.2}}; // isotropic should be the same for every permutation
     reference_norms[6] = {{224259.0,224259.0,224259.0}}; // total should be the same for every direction
 
     // It is already in a SCCS frame, so they should be
@@ -1870,8 +1872,8 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_unpermutated_SCCS[2][1] = 0;
     reference_unpermutated_SCCS[2][2] = 1;
 
-    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
-    // is permuated by {0,1,2};
+    // Permutation 1 has the highest norm, so reference_unpermutated_SCCS
+    // is permutated by {0,1,2};
     Tensor<2,3> reference_hexa_permutated_SCCS;
     reference_hexa_permutated_SCCS[0][0] = 1;
     reference_hexa_permutated_SCCS[0][1] = 0;
@@ -1883,9 +1885,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_hexa_permutated_SCCS[2][1] = 0;
     reference_hexa_permutated_SCCS[2][2] = 1;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -1898,7 +1900,7 @@ TEST_CASE("LPO elastic tensor decomposition")
                    && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
                    && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
       }
-    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<std::array<double,3>,7 > norms = aspect::Particle::Property::Utilities::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
     std::array<double,3> totals = {{0,0,0}};
     for (size_t iii = 0; iii < 7; iii++)
       {
@@ -1928,11 +1930,11 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
 
     const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    std::array<unsigned int, 3> permutation = aspect::Particle::Property::Utilities::indexed_even_permutation(max_hexagonal_element_index);
     Tensor<2,3> hexa_permutated_SCCS;
     for (size_t index = 0; index < 3; index++)
       {
-        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[permutation[index]];
       }
     for (size_t iii = 0; iii < 3; iii++)
       {
@@ -1967,10 +1969,10 @@ TEST_CASE("LPO elastic tensor decomposition")
     std::array<std::array<double,3>,7 > reference_norms;
     reference_norms[0] = {{0,0,0}}; // no triclinic
     reference_norms[1] = {{0,0,0}}; // no monoclinic
-    reference_norms[2] = {{4181.95385,689.94905,8020.4222}}; // orthorhomic depedent on direction
+    reference_norms[2] = {{4181.95385,689.94905,8020.4222}}; // orthorhomic dependent on direction
     reference_norms[3] = {{1298.2060125,90.3840125,525.5282}}; // tetragonal could be present
     reference_norms[4] = {{4364.6051908333,9064.4319908333,1298.8146533333}}; // hexagonal is expected
-    reference_norms[5] = {{282871.5975466666,282871.5975466666,282871.5975466666}}; // isotropic should be the same for every permuation
+    reference_norms[5] = {{282871.5975466666,282871.5975466666,282871.5975466666}}; // isotropic should be the same for every permutation
     reference_norms[6] = {{292716.3626,292716.3626,292716.3626}}; // total should be the same for every direction
 
     // It is already in a SCCS frame, so they should be
@@ -1986,8 +1988,8 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_unpermutated_SCCS[2][1] = 1;
     reference_unpermutated_SCCS[2][2] = 0;
 
-    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
-    // is permuated by {1,2,0};
+    // Permutation 2 has the highest norm, so reference_unpermutated_SCCS
+    // is permutated by {1,2,0};
     Tensor<2,3> reference_hexa_permutated_SCCS;
     reference_hexa_permutated_SCCS[0][0] = 0;
     reference_hexa_permutated_SCCS[0][1] = 0;
@@ -1999,9 +2001,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_hexa_permutated_SCCS[2][1] = 0;
     reference_hexa_permutated_SCCS[2][2] = 0;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -2014,7 +2016,7 @@ TEST_CASE("LPO elastic tensor decomposition")
                    && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
                    && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
       }
-    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<std::array<double,3>,7 > norms = aspect::Particle::Property::Utilities::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
     std::array<double,3> totals = {{0,0,0}};
     for (size_t iii = 0; iii < 7; iii++)
       {
@@ -2044,11 +2046,11 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
 
     const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    std::array<unsigned int, 3> permutation = aspect::Particle::Property::Utilities::indexed_even_permutation(max_hexagonal_element_index);
     Tensor<2,3> hexa_permutated_SCCS;
     for (size_t index = 0; index < 3; index++)
       {
-        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[permutation[index]];
       }
     for (size_t iii = 0; iii < 3; iii++)
       {
@@ -2083,10 +2085,10 @@ TEST_CASE("LPO elastic tensor decomposition")
     std::array<std::array<double,3>,7 > reference_norms;
     reference_norms[0] = {{0,0,0}}; // no triclinic
     reference_norms[1] = {{0,0,0}}; // no monoclinic
-    reference_norms[2] = {{576.245,1514.945,1679.46}}; // orthorhomic depedent on direction
+    reference_norms[2] = {{576.245,1514.945,1679.46}}; // orthorhomic dependent on direction
     reference_norms[3] = {{67.86125,199.00125,483.605}}; // tetragonal could be present
     reference_norms[4] = {{2076.64175,1006.80175,557.683}}; // hexagonal is expected
-    reference_norms[5] = {{245485.992,245485.992,245485.992}}; // isotropic should be the same for every permuation
+    reference_norms[5] = {{245485.992,245485.992,245485.992}}; // isotropic should be the same for every permutation
     reference_norms[6] = {{248206.74,248206.74,248206.74}}; // total should be the same for every direction
 
     // It is already in a SCCS frame, so they should be
@@ -2102,8 +2104,8 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_unpermutated_SCCS[2][1] = 1;
     reference_unpermutated_SCCS[2][2] = 0;
 
-    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
-    // is permuated by {0,1,2};
+    // Permutation 1 has the highest norm, so reference_unpermutated_SCCS
+    // is permutated by {0,1,2};
     Tensor<2,3> reference_hexa_permutated_SCCS;
     reference_hexa_permutated_SCCS[0][0] = 1;
     reference_hexa_permutated_SCCS[0][1] = 0;
@@ -2115,9 +2117,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_hexa_permutated_SCCS[2][1] = 1;
     reference_hexa_permutated_SCCS[2][2] = 0;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -2130,7 +2132,7 @@ TEST_CASE("LPO elastic tensor decomposition")
                    && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
                    && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
       }
-    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<std::array<double,3>,7 > norms = aspect::Particle::Property::Utilities::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
     std::array<double,3> totals = {{0,0,0}};
     for (size_t iii = 0; iii < 7; iii++)
       {
@@ -2161,11 +2163,11 @@ TEST_CASE("LPO elastic tensor decomposition")
 
 
     const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    std::array<unsigned int, 3> permutation = aspect::Particle::Property::Utilities::indexed_even_permutation(max_hexagonal_element_index);
     Tensor<2,3> hexa_permutated_SCCS;
     for (size_t index = 0; index < 3; index++)
       {
-        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[permutation[index]];
       }
     for (size_t iii = 0; iii < 3; iii++)
       {
@@ -2202,10 +2204,10 @@ TEST_CASE("LPO elastic tensor decomposition")
     std::array<std::array<double,3>,7 > reference_norms;
     reference_norms[0] = {{0,0,0}}; // no triclinic
     reference_norms[1] = {{0,0,0}}; // no monoclinic
-    reference_norms[2] = {{16161.695,0.0,16161.695}}; // orthorhomic depedent on direction
+    reference_norms[2] = {{16161.695,0.0,16161.695}}; // orthorhomic dependent on direction
     reference_norms[3] = {{2786.31125,1425.78,2786.31125}}; // tetragonal could be present
     reference_norms[4] = {{8079.22575,25601.452,8079.22575}}; // hexagonal is expected
-    reference_norms[5] = {{421517.088,421517.088,421517.088}}; // isotropic should be the same for every permuation
+    reference_norms[5] = {{421517.088,421517.088,421517.088}}; // isotropic should be the same for every permutation
     reference_norms[6] = {{448544.32,448544.32,448544.32}}; // total should be the same for every direction
 
     // It is already in a SCCS frame, so they should be
@@ -2221,8 +2223,8 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_unpermutated_SCCS[2][1] = 1;
     reference_unpermutated_SCCS[2][2] = 0;
 
-    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
-    // is permuated by {1,2,0};
+    // Permutation 2 has the highest norm, so reference_unpermutated_SCCS
+    // is permutated by {1,2,0};
     Tensor<2,3> reference_hexa_permutated_SCCS;
     reference_hexa_permutated_SCCS[0][0] = 1;
     reference_hexa_permutated_SCCS[0][1] = 0;
@@ -2234,9 +2236,9 @@ TEST_CASE("LPO elastic tensor decomposition")
     reference_hexa_permutated_SCCS[2][1] = 0;
     reference_hexa_permutated_SCCS[2][2] = 1;
 
-    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
-    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
-    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = aspect::Particle::Property::Utilities::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = aspect::Particle::Property::Utilities::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
     for (size_t iii = 0; iii < 3; iii++)
       {
         const double epsilon = 1e-3;
@@ -2249,7 +2251,7 @@ TEST_CASE("LPO elastic tensor decomposition")
                    && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
                    && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
       }
-    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<std::array<double,3>,7 > norms = aspect::Particle::Property::Utilities::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
     std::array<double,3> totals = {{0,0,0}};
     for (size_t iii = 0; iii < 7; iii++)
       {
@@ -2280,11 +2282,11 @@ TEST_CASE("LPO elastic tensor decomposition")
 
 
     const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
-    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    std::array<unsigned int, 3> permutation = aspect::Particle::Property::Utilities::indexed_even_permutation(max_hexagonal_element_index);
     Tensor<2,3> hexa_permutated_SCCS;
     for (size_t index = 0; index < 3; index++)
       {
-        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[permutation[index]];
       }
     for (size_t iii = 0; iii < 3; iii++)
       {


### PR DESCRIPTION
Last major part of #3885. Adds a property plugin which can use the elastic tensor computed in #4987 to compute actual useful values from it. It requires that plugin to be present, so it is currently rebased on that. 

Since this is the last major component of the CPO plugin set, I am happy to include the integration tests within this pull request, or do that in a follow up pull request. I will include the changelog entry in the pull request where the integration tests are added, so if that is here, that will be here as well.

This pull request is ready for review, but can't be merged until #4987 is merged.