### PR TITLE
Refactor particle property CPO bingham average

### DIFF
--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -22,7 +22,9 @@
 #define _aspect_particle_property_cpo_bingham_average_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/simulator_access.h>
+
 #include <array>
 #include <random>
 
@@ -37,7 +39,7 @@ namespace aspect
        * Computes the Bingham average of the CPO particle properties.
        * See https://courses.eas.ualberta.ca/eas421/lecturepages/orientation.html for more info.
        *
-       * The layout of the data vector per partcle is the following (note that for this plugin the following dim's are always 3):
+       * The layout of the data vector per particle is the following (note that for this plugin the following dim's are always 3):
        * 1 averaged a axis of olivine -> 3 (dim) doubles, starts at:
        *                                   data_position + 1,
        * 2 averaged b axis of olivine -> 3 (dim) doubles, starts at:
@@ -66,7 +68,6 @@ namespace aspect
            * Initialization function. This function is called once at the
            * beginning of the program after parse_parameters is run.
            */
-          virtual
           void
           initialize () override;
 
@@ -81,7 +82,6 @@ namespace aspect
            * of this function should be to extend this vector by a number of
            * properties.
            */
-          virtual
           void
           initialize_one_particle_property (const Point<dim> &position,
                                             std::vector<double> &particle_properties) const override;
@@ -107,7 +107,6 @@ namespace aspect
            * @param [in,out] particle_properties The properties of the particle
            * that is updated within the call of this function.
            */
-          virtual
           void
           update_one_particle_property (const unsigned int data_position,
                                         const Point<dim> &position,
@@ -120,13 +119,12 @@ namespace aspect
            * we need to update particle properties every time step.
            */
           UpdateTimeFlags
-          need_update () const;
+          need_update () const override;
 
           /**
            * Return which data has to be provided to update the property.
            * The integrated strains needs the gradients of the velocity.
            */
-          virtual
           UpdateFlags
           get_needed_update_flags () const override;
 
@@ -137,7 +135,6 @@ namespace aspect
            * @return A vector that contains pairs of the property names and the
            * number of components this property plugin defines.
            */
-          virtual
           std::vector<std::pair<std::string, unsigned int>>
           get_property_information() const override;
 
@@ -149,7 +146,8 @@ namespace aspect
            * axis associated with the densest clustering of points for each axis. the a to c axis vectors
            * are stored in the first to last array respectively.
            */
-          std::array<std::array<double,3>,3> compute_bingham_average(std::vector<Tensor<2,3>> matrices) const;
+          std::array<std::array<double,3>,3>
+          compute_bingham_average(std::vector<Tensor<2,3>> matrices) const;
 
           /**
           * Declare the parameters this class takes through input files.
@@ -170,6 +168,12 @@ namespace aspect
            * stores the postition of the cpo data in the particle property vector
            */
           unsigned int cpo_data_position;
+
+          /**
+           * A pointer to the crystal preferred orientation particle property.
+           * Avoids repeated searches for that property.
+          */
+          std::unique_ptr<const Particle::Property::CrystalPreferredOrientation<dim>> cpo_particle_property;
 
           /**
            * Random number generator. For reproducibility of tests it is


### PR DESCRIPTION
A bit of minor cleanup for #4980.

- `virtual` and `override` are redundant. If `override` is used, `virtual` should not be used
- I stored the reference to the CPO property in a unique pointer instead. This allows to initialize it only once, instead of searching for the right property again for every particle
- some minor coding conventions

@MFraters: Could you do a review? Also I have no way to test this. I know it compiles, but can you test if it runs correctly?