### PR TITLE
Fix override instead of virtual warnings

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1129,7 +1129,7 @@ namespace aspect
         /**
          * Function for NamedAdditionalMaterialOutputs interface
          */
-        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
 
         /**
          * A scalar value per evaluation point that specifies the prescribed dilation

--- a/include/aspect/material_model/melt_boukare.h
+++ b/include/aspect/material_model/melt_boukare.h
@@ -40,7 +40,7 @@ namespace aspect
       public:
         BoukareOutputs(const unsigned int n_points);
 
-        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
 
         /**
          * Bulk composition of the material.
@@ -71,18 +71,17 @@ namespace aspect
         /**
          * Initialization function. Computes endmember properties.
          */
-        virtual
         void
-        initialize ();
+        initialize () override;
 
         /**
          * Return whether the model is compressible or not. In this model,
          * both the melt and solid are compressible.
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const;
+        void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                      typename Interface<dim>::MaterialModelOutputs &out) const override;
 
         /**
          * Compute the equilibrium melt fractions for the given input conditions.
@@ -92,14 +91,14 @@ namespace aspect
          * @param melt_fractions Vector of doubles that is filled with the
          * equilibrium melt fraction for each given input conditions.
          */
-        virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                     std::vector<double> &melt_fractions) const;
+        void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
+                             std::vector<double> &melt_fractions) const override;
 
         /**
          * @name Reference quantities
          * @{
          */
-        virtual double reference_darcy_coefficient () const;
+        double reference_darcy_coefficient () const override;
 
         /**
          * @}
@@ -119,17 +118,15 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         /**
          * @}
          */
 
-        virtual
         void
-        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
 
       private:


### PR DESCRIPTION
Fix a few warnings that appear with the deal.II development tester (see https://github.com/geodynamics/aspect/actions/runs/4492088039/jobs/7901477861).