### PR TITLE
Use custom cmake version in tester to fix bug

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,11 +29,15 @@ jobs:
         sudo add-apt-repository ppa:ginggs/deal.ii-9.3.2-backports
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends libdeal.ii-dev
+        #TODO: Remove this when github actions ships cmake 3.26.1 or younger
+        cd /opt && wget https://github.com/Kitware/CMake/releases/download/v3.26.1/cmake-3.26.1-linux-x86_64.tar.gz
+        tar -xzf cmake-3.26.1-linux-x86_64.tar.gz
+
     - name: compile
       run: |
         mkdir build-no-unity
         cd build-no-unity
-        cmake -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
+        /opt/cmake-3.26.1-linux-x86_64/bin/cmake -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
         make -j 2
         ./aspect --test
 
@@ -60,6 +64,10 @@ jobs:
         cd
         rm -rf astyle*
         astyle --version
+
+        #TODO: Remove this when github actions ships cmake 3.26.1 or younger
+        cd /opt && wget https://github.com/Kitware/CMake/releases/download/v3.26.1/cmake-3.26.1-linux-x86_64.tar.gz
+        tar -xzf cmake-3.26.1-linux-x86_64.tar.gz
     - name: make indent
       run: |
         ./contrib/utilities/indent
@@ -82,7 +90,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
+        /opt/cmake-3.26.1-linux-x86_64/bin/cmake -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
         -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_INSTALL_EXAMPLES=ON ..
         make -j 2
         ./aspect --test


### PR DESCRIPTION
We have seen some test failures on  `linux/no-unity-build` and `linux/indent+documentation` recently (see e.g. #5121 and other recent PRs).
I think this is what happened: Github actions updated their ubuntu 20.04 base image to include cmake 3.26.0 instead of 3.25.3. However, 3.26.0 seems to contain a bug that breaks our CMake system. Kitware has already released 3.26.1 (just 10 days after 3.26.0, they probably found the bug as well), but Github actions has not yet updated their included cmake version (they will soon, see https://github.com/actions/runner-images/issues/7336). I have checked locally that cmake 3.26.0 produces the same error on my system and 3.26.1 works correctly. 
This PR should fix our test failures until the github actions runner is updated.