### PR TITLE
Avoid opening world builder file on all MPI processes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ if(ASPECT_WITH_WORLD_BUILDER)
     FILE(GLOB_RECURSE wb_files "${WORLD_BUILDER_SOURCE_DIR}/source/world_builder/*.cc")
   ENDIF()
   LIST(APPEND TARGET_SRC ${wb_files})
+  ADD_DEFINITIONS(-DWB_WITH_MPI)
 
   # generate config.cc and include it:
   IF(WORLD_BUILDER_VERSION VERSION_LESS 0.5.0)

--- a/contrib/world_builder/include/world_builder/utilities.h
+++ b/contrib/world_builder/include/world_builder/utilities.h
@@ -321,6 +321,16 @@ namespace WorldBuilder
      */
     std::array<std::array<double,3>,3>
     euler_angles_to_rotation_matrix(double phi1, double theta, double phi2);
+
+    /**
+     * Read a file and distribute the content over all MPI processes.
+     * If WB_WITH_MPI is not defined, this function will just read the file.
+     *
+     * @param filename The name of the file to read.
+     * @return The content of the file.
+    */
+    std::string
+    read_and_distribute_file_content(const std::string &filename);
   }
 }
 

--- a/contrib/world_builder/source/parameters.cc
+++ b/contrib/world_builder/source/parameters.cc
@@ -107,14 +107,8 @@ namespace WorldBuilder
     path_level =0;
     // Now read in the world builder file into a file stream and
     // put it into a the rapidjason document
-    std::ifstream json_input_stream(filename.c_str());
 
-    // Get world builder file and check whether it exists
-    WBAssertThrow(json_input_stream.good(),
-                  "Could not find the world builder file at the specified location: " + filename);
-
-    WBAssert(json_input_stream, "Could not read the world builder file.");
-
+    std::stringstream json_input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(filename));
     rapidjson::IStreamWrapper isw(json_input_stream);
 
     // relaxing sytax by allowing comments () for now, maybe also allow trailing commas and (kParseTrailingCommasFlag) and nan's, inf etc (kParseNanAndInfFlag)?
@@ -145,8 +139,6 @@ namespace WorldBuilder
                                                                             ));
 
     WBAssertThrow(parameters.IsObject(), "World builder file is is not an object.");
-    json_input_stream.close();
-
 
     SchemaDocument schema(declarations);
     SchemaValidator validator(schema);

--- a/contrib/world_builder/source/utilities.cc
+++ b/contrib/world_builder/source/utilities.cc
@@ -20,6 +20,13 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
+#include <sstream>
+#include <fstream>
+
+#ifdef WB_WITH_MPI
+#define OMPI_SKIP_MPICXX 1
+#include <mpi.h>
+#endif
 
 #include <world_builder/assert.h>
 #include <world_builder/coordinate_systems/interface.h>
@@ -1346,6 +1353,88 @@ namespace WorldBuilder
       rot_matrix[2][1] = -sin(theta)*cos(phi1);
       rot_matrix[2][2] = cos(theta);
       return rot_matrix;
+    }
+
+    std::string
+    read_and_distribute_file_content(const std::string &filename)
+    {
+      std::string data_string;
+
+      const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
+
+      const MPI_Comm comm = MPI_COMM_WORLD;
+      int my_rank = invalid_unsigned_int;
+      MPI_Comm_rank(comm, &my_rank);
+      if (my_rank == 0)
+        {
+          std::size_t filesize;
+          std::ifstream filestream;
+          filestream.open(filename.c_str());
+
+          // Need to convert to unsigned int, because MPI_Bcast does not support
+          // size_t or const unsigned int
+          unsigned int invalid_file_size = invalid_unsigned_int;
+
+          if (!filestream)
+            {
+              // broadcast failure state, then throw
+              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+              WBAssertThrow (ierr,
+                             std::string("Could not open file <") + filename + ">.");
+            }
+
+          // Read data from disk
+          std::stringstream datastream;
+
+          try
+            {
+              datastream << filestream.rdbuf();
+            }
+          catch (const std::ios::failure &)
+            {
+              // broadcast failure state, then throw
+              const int ierr = MPI_Bcast(&invalid_file_size, 1, MPI_UNSIGNED, 0, comm);
+              WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+              WBAssertThrow (false,
+                             std::string("Could not read file content from <") + filename + ">.");
+            }
+
+          data_string = datastream.str();
+          filesize = data_string.size();
+
+          // Distribute data_size and data across processes
+          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+
+          // Receive and store data
+          ierr = MPI_Bcast(&data_string[0],
+                           filesize,
+                           MPI_CHAR,
+                           0,
+                           comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+        }
+      else
+        {
+          // Prepare for receiving data
+          unsigned int filesize = 0;
+          int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+          WBAssertThrow(filesize != invalid_unsigned_int,
+                        std::string("Could not open file <") + filename + ">.");
+
+          data_string.resize(filesize);
+
+          // Receive and store data
+          ierr = MPI_Bcast(&data_string[0],
+                           filesize,
+                           MPI_CHAR,
+                           0,
+                           comm);
+          WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
+        }
+
+      return data_string;
     }
 
     template std::array<double,2> convert_point_to_array<2>(const Point<2> &point_);


### PR DESCRIPTION
While preparing for some large-scale runs I noticed that WorldBuilder is opening and reading its input file on every MPI rank. On large clusters this can cause a lot of problems with the file systems. I essentially reimplemented ASPECT's `read_and_distribute_file_content` function for world builder. I know this only fixes the bundled version, I will create a separate PR for the main WorldBuilder repo.

In order to check if MPI is available inside WorldBuilder I used the same compile definition the main world builder app uses. When bundled with ASPECT MPI is always available.

@MFraters: Can you take a look?