### PR TITLE
Reduce parallel file input operations

### DIFF
--- a/benchmarks/entropy_adiabat/plugins/entropy_model.cc
+++ b/benchmarks/entropy_adiabat/plugins/entropy_model.cc
@@ -24,8 +24,6 @@
 #include <aspect/utilities.h>
 
 #include <deal.II/base/table.h>
-#include <fstream>
-#include <iostream>
 
 
 namespace aspect

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -158,12 +158,11 @@ namespace aspect
        *
        * @param filename Name of the input file.
        */
-      void read_solitary_wave_solution (const std::string &filename)
+      void read_solitary_wave_solution (const std::string &filename,
+                                        MPI_Comm comm)
       {
         std::string temp;
-        std::ifstream in(filename.c_str(), std::ios::in);
-        AssertThrow (in,
-                     ExcMessage (std::string("Couldn't open file <") + filename + std::string(">")));
+        std::stringstream in(Utilities::read_and_distribute_file_content(filename, comm));
 
         while (!in.eof())
           {
@@ -195,13 +194,14 @@ namespace aspect
                              const double /*offset*/,
                              const double compaction_length,
                              const bool read_solution,
-                             const std::string file_name)
+                             const std::string file_name,
+                             MPI_Comm comm)
       {
         // non-dimensionalize the amplitude
         const double non_dim_amplitude = amplitude / background_porosity;
 
         if (read_solution)
-          read_solitary_wave_solution(file_name);
+          read_solitary_wave_solution(file_name, comm);
         else
           {
             porosity.resize(max_points);
@@ -582,7 +582,8 @@ namespace aspect
                                           offset,
                                           compaction_length,
                                           read_solution,
-                                          file_name);
+                                          file_name,
+                                          this->get_mpi_communicator());
     }
 
 

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -25,8 +25,6 @@
 
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/table.h>
-#include <fstream>
-#include <iostream>
 
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -25,8 +25,6 @@
 #include <aspect/simulator_access.h>
 #include <aspect/initial_composition/interface.h>
 #include <aspect/material_model/interface.h>
-#include <fstream>
-#include <iostream>
 #include <array>
 
 #include <boost/lexical_cast.hpp>

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -25,8 +25,6 @@
 #include <aspect/simulator_access.h>
 #include <aspect/initial_composition/interface.h>
 #include <aspect/material_model/interface.h>
-#include <fstream>
-#include <iostream>
 #include <array>
 
 #include <boost/lexical_cast.hpp>

--- a/source/initial_temperature/spherical_shell.cc
+++ b/source/initial_temperature/spherical_shell.cc
@@ -25,8 +25,6 @@
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/chunk.h>
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
-#include <fstream>
-#include <iostream>
 #include <cstring>
 
 

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -28,8 +28,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/base/table.h>
-#include <fstream>
-#include <iostream>
 #include <memory>
 
 

--- a/tests/original_prm/original.prm
+++ b/tests/original_prm/original.prm
@@ -10,4 +10,3 @@ include $ASPECT_SOURCE_DIR/tests/no_flow.prm
 
 set Output directory = output-original_prm
 
-


### PR DESCRIPTION
In a similar direction as #5132, but I looked for other instances of ifstream in ASPECT that were executed in parallel. I didnt find much, except for one benchmark and the reading of our main input file. However I found a bunch of header files that are leftovers from when `read_and_distribute_file_content` didnt exist.

Input files are typically small, so it might not matter much, but I think it is nice to always use the same function to read files, and who knows, maybe opening a small file on >100,000 cores will eventually be a problem ;-).
