### PR TITLE
Introduce utility function for file writing.

### DIFF
--- a/benchmarks/blankenbach/plugin/code.cc
+++ b/benchmarks/blankenbach/plugin/code.cc
@@ -18,6 +18,7 @@
   <http://www.gnu.org/licenses/>.
 */
 #include <aspect/global.h>
+#include <aspect/utilities.h>
 
 #include <aspect/postprocess/interface.h>
 #include <aspect/simulator_access.h>
@@ -134,18 +135,23 @@ namespace aspect
       }
 
 
-      std::ofstream f(filename.c_str());
+      std::stringstream f;
 
       f << std::scientific << std::setprecision(15);
 
-      // Note: POINTS is only useful if our mesh is a structured grid
-      f << "# POINTS: " << n_x << ' ' << n_y << "\n";
-      f << "# x y T\n";
+      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+        {
+          // Note: POINTS is only useful if our mesh is a structured grid
+          f << "# POINTS: " << n_x << ' ' << n_y << "\n";
+          f << "# x y T\n";
+        }
 
       for (unsigned int idx = 0; idx< entries.size(); ++idx)
         f << entries[idx].p << ' ' << entries[idx].t << '\n';
 
-      f.close();
+      aspect::Utilities::collect_and_write_file_content(filename,
+                                                        f.str(),
+                                                        this->get_mpi_communicator());
 
       return std::make_pair (std::string ("Writing TemperatureAsciiOut:"),
                              filename);

--- a/benchmarks/diffusion_of_hill/analytical_topography.cc
+++ b/benchmarks/diffusion_of_hill/analytical_topography.cc
@@ -58,6 +58,14 @@ namespace aspect
       std::ostringstream output_stats;
       std::ostringstream output_file;
 
+      // on processor 0, write the file header
+      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+        {
+          output_file << "# "
+                      << ((dim==2)? "x y" : "x y z")
+                      << " topography" << ((analytical_solution_example != 0)? " analytical topography" : "") << std::endl;
+        }
+
       // Choose stupidly large values for initialization
       double local_max_height = -std::numeric_limits<double>::max();
       double local_min_height = std::numeric_limits<double>::max();
@@ -240,55 +248,7 @@ namespace aspect
       if (this->get_parameters().run_postprocessors_on_nonlinear_iterations)
         filename.append("." + Utilities::int_to_string (this->get_nonlinear_iteration(), 4));
 
-      const unsigned int max_data_length = Utilities::MPI::max (output_file.str().size()+1,
-                                                                this->get_mpi_communicator());
-
-      const unsigned int mpi_tag = 789;
-
-      // on processor 0, collect all of the data the individual processors send
-      // and concatenate them into one file
-      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
-        {
-          std::ofstream file (filename.c_str());
-
-          file << "# "
-               << ((dim==2)? "x y" : "x y z")
-               << " topography" << ((analytical_solution_example != 0)? " analytical topography" : "") << std::endl;
-
-          // first write out the data we have created locally
-          file << output_file.str();
-
-          std::string tmp;
-          tmp.resize (max_data_length, '\0');
-
-          // then loop through all of the other processors and collect
-          // data, then write it to the file
-          for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
-            {
-              MPI_Status status;
-              // get the data. note that MPI says that an MPI_Recv may receive
-              // less data than the length specified here. since we have already
-              // determined the maximal message length, we use this feature here
-              // rather than trying to find out the exact message length with
-              // a call to MPI_Probe.
-              MPI_Recv (&tmp[0], max_data_length, MPI_CHAR, p, mpi_tag,
-                        this->get_mpi_communicator(), &status);
-
-              // output the string. note that 'tmp' has length max_data_length,
-              // but we only wrote a certain piece of it in the MPI_Recv, ended
-              // by a \0 character. write only this part by outputting it as a
-              // C string object, rather than as a std::string
-              file << tmp.c_str();
-            }
-        }
-      else
-        // on other processors, send the data to processor zero. include the \0
-        // character at the end of the string
-        {
-          output_file << "\0";
-          MPI_Send (&output_file.str()[0], output_file.str().size()+1, MPI_CHAR, 0, mpi_tag,
-                    this->get_mpi_communicator());
-        }
+      Utilities::collect_and_write_file_content(filename, output_file.str(), this->get_mpi_communicator());
 
       // if output_interval is positive, then update the last supposed output
       // time

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -565,7 +565,9 @@ namespace aspect
     /**
      * Reads the content of the ascii file @p filename on process 0 and
      * distributes the content by MPI_Bcast to all processes. The function
-     * returns the content of the file on all processes.
+     * returns the content of the file on all processes. The purpose of this
+     * function is to reduce parallel file access to a single file access on
+     * process 0.
      *
      * @param [in] filename The name of the ascii file to load. If the
      *  file name ends in `.gz`, then the function assumes that the file
@@ -582,6 +584,23 @@ namespace aspect
     std::string
     read_and_distribute_file_content(const std::string &filename,
                                      const MPI_Comm &comm);
+
+    /**
+     * Collect the content of @p file_content using MPI_Gather to process 0.
+     * Then write the content to the file @p filename on process 0.
+     * The purpose of this function is to reduce parallel file access to
+     * process 0. Note that this function assumes that the content from
+     * all processes fits into the memory of process 0.
+     *
+     * @param [in] filename The name of the file to write.
+     * @param [in] file_content The content that should be written to file.
+     * @param [in] comm The MPI communicator from which the content is
+     * collected.
+     */
+    void
+    collect_and_write_file_content(const std::string &filename,
+                                   const std::string &file_content,
+                                   const MPI_Comm &comm);
 
     /**
      * Creates a path as if created by the shell command "mkdir -p", therefore

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -60,6 +60,14 @@ namespace aspect
       std::ostringstream output_stats;
       std::ostringstream output_file;
 
+      // On processor 0, write the file header
+      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+        {
+          output_file << "# "
+                      << ((dim==2)? "x y" : "x y z")
+                      << " topography" << std::endl;
+        }
+
       // Choose stupidly large values for initialization
       double local_max_height = std::numeric_limits<double>::lowest();
       double local_min_height = std::numeric_limits<double>::max();
@@ -132,21 +140,9 @@ namespace aspect
       if (this->get_parameters().run_postprocessors_on_nonlinear_iterations)
         filename.append("." + Utilities::int_to_string (this->get_nonlinear_iteration(), 4));
 
-      const std::vector<std::string> data = Utilities::MPI::gather(this->get_mpi_communicator(), output_file.str());
-
-      // On processor 0, collect all of the data the individual processors sent
-      // and concatenate them into one file:
-      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
-        {
-          std::ofstream file (filename.c_str());
-
-          file << "# "
-               << ((dim==2)? "x y" : "x y z")
-               << " topography" << std::endl;
-
-          for (const auto &str : data)
-            file << str;
-        }
+      Utilities::collect_and_write_file_content(filename,
+                                                output_file.str(),
+                                                this->get_mpi_communicator());
 
       // if output_interval is positive, then update the last supposed output
       // time


### PR DESCRIPTION
We have a number of places that deal with custom file output, besides the optimized output of visualization files and checkpoints. Many of these places copy the same code (some use outdated or simpler versions). This PR introduces one central function in the Utilities namespace that can deal with one common use case (every process writes some output, it needs to be collected and written to file by process 0).

The benefits of introducing this function are:
- unifies code -> less potential for copy-paste bugs
- we can make improvements and optimizations in one place instead of many (e.g. using MPI-IO or allowing to compress file output)
- the function is already better than many of the previous implementations, because it checks for success when writing and throws exceptions on all processes if something fails, not just the root process (preventing potential MPI deadlocks).

We have a number of cases that have a different use case (only rank 0 writes content), I have not modifed them so far (maybe a follow up PR some time).