### PR TITLE
Reduce duplication when checking for file existence

### DIFF
--- a/doc/modules/changes/20230414_gassmoeller
+++ b/doc/modules/changes/20230414_gassmoeller
@@ -1,0 +1,6 @@
+Improved: Significantly reduced the number of duplicated file system
+accesses across ASPECT. This should increase the stability and
+potentially the speed for models with large number of MPI ranks
+and systems with slow parallel file systems.
+<br>
+(Rene Gassmoeller, 2023/04/14)

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -551,11 +551,10 @@ namespace aspect
     /**
      * Checks whether a file named @p filename exists and is readable.
      *
-     * Warning: This function performs file access on all MPI ranks that
-     * call it. This can lead to overloading the file system if the
-     * function is called on many MPI ranks. Only use this function if
-     * you are sure that the file access is performed on all MPI ranks
-     * and on a fast file system (e.g. a local drive).
+     * Note: This function performs file access on all MPI ranks that
+     * call it. Only use this function if
+     * the file access is performed on all MPI ranks
+     * and on a reasonably fast file system.
      *
      * @return True if the file exists and is readable on all MPI ranks
      * that call this function.
@@ -564,12 +563,11 @@ namespace aspect
     bool fexists(const std::string &filename);
 
     /**
-     * Checks whether a file named @p filename exists and is readable
-     * on MPI rank 0. Afterwards, the result is broadcasted to all MPI
-     * ranks.
+     * Check whether a file named @p filename exists and is readable
+     * on MPI rank 0. Then, broadcast the result to all MPI ranks.
      *
-     * Note that in contrast to the other fexists function, this function
-     * uses MPI to check the existence of the file only on MPI rank 0.
+     * Note that in contrast to the other fexists() function, this function
+     * only checks for the existence of the file on a single process.
      * This is useful to avoid overloading the file system and is sufficient
      * if the subsequent file access is also only performed on MPI rank 0.
      *

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -551,9 +551,34 @@ namespace aspect
     /**
      * Checks whether a file named @p filename exists and is readable.
      *
+     * Warning: This function performs file access on all MPI ranks that
+     * call it. This can lead to overloading the file system if the
+     * function is called on many MPI ranks. Only use this function if
+     * you are sure that the file access is performed on all MPI ranks
+     * and on a fast file system (e.g. a local drive).
+     *
+     * @return True if the file exists and is readable on all MPI ranks
+     * that call this function.
      * @param filename File to check existence
      */
     bool fexists(const std::string &filename);
+
+    /**
+     * Checks whether a file named @p filename exists and is readable
+     * on MPI rank 0. Afterwards, the result is broadcasted to all MPI
+     * ranks.
+     *
+     * Note that in contrast to the other fexists function, this function
+     * uses MPI to check the existence of the file only on MPI rank 0.
+     * This is useful to avoid overloading the file system and is sufficient
+     * if the subsequent file access is also only performed on MPI rank 0.
+     *
+     * @return True if the file exists and is readable on MPI rank 0.
+     * @param filename File to check existence
+     * @param comm MPI communicator to use.
+     */
+    bool fexists(const std::string &filename,
+                 MPI_Comm comm);
 
     /**
      * Checks to see if the user is trying to use data from a url.

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -545,7 +545,7 @@ namespace aspect
                         << create_filename (current_file_number) << '.' << std::endl << std::endl;
 
       const std::string filename (create_filename (current_file_number));
-      if (Utilities::fexists(filename))
+      if (Utilities::fexists(filename, this->get_mpi_communicator()))
         lookup->load_file(filename,this->get_mpi_communicator());
       else
         AssertThrow(false,
@@ -568,7 +568,7 @@ namespace aspect
           const std::string filename (create_filename (next_file_number));
           this->get_pcout() << std::endl << "   Loading GPlates data boundary file "
                             << filename << '.' << std::endl << std::endl;
-          if (Utilities::fexists(filename))
+          if (Utilities::fexists(filename, this->get_mpi_communicator()))
             {
               lookup.swap(old_lookup);
               lookup->load_file(filename,this->get_mpi_communicator());
@@ -658,7 +658,7 @@ namespace aspect
           const std::string filename (create_filename (current_file_number));
           this->get_pcout() << std::endl << "   Loading GPlates data boundary file "
                             << filename << '.' << std::endl << std::endl;
-          if (Utilities::fexists(filename))
+          if (Utilities::fexists(filename, this->get_mpi_communicator()))
             {
               lookup.swap(old_lookup);
               lookup->load_file(filename,this->get_mpi_communicator());
@@ -679,7 +679,7 @@ namespace aspect
       const std::string filename (create_filename (next_file_number));
       this->get_pcout() << std::endl << "   Loading GPlates data boundary file "
                         << filename << '.' << std::endl << std::endl;
-      if (Utilities::fexists(filename))
+      if (Utilities::fexists(filename, this->get_mpi_communicator()))
         {
           lookup.swap(old_lookup);
           lookup->load_file(filename,this->get_mpi_communicator());

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -455,7 +455,7 @@ namespace aspect
 
     // Then start with the actual deserialization.
     // First check existence of the two restart files
-    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh", mpi_communicator),
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh"),
                  ExcMessage ("You are trying to restart a previous computation, "
                              "but the restart file <"
                              +

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -455,7 +455,7 @@ namespace aspect
 
     // Then start with the actual deserialization.
     // First check existence of the two restart files
-    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh"),
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh", mpi_communicator),
                  ExcMessage ("You are trying to restart a previous computation, "
                              "but the restart file <"
                              +
@@ -463,7 +463,7 @@ namespace aspect
                              +
                              "> does not appear to exist!"));
 
-    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.resume.z"),
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.resume.z", mpi_communicator),
                  ExcMessage ("You are trying to restart a previous computation, "
                              "but the restart file <"
                              +

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -455,7 +455,7 @@ namespace aspect
 
     // Then start with the actual deserialization.
     // First check existence of the two restart files
-    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh"),
+    AssertThrow (Utilities::fexists(parameters.output_directory + "restart.mesh", mpi_communicator),
                  ExcMessage ("You are trying to restart a previous computation, "
                              "but the restart file <"
                              +

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1502,7 +1502,7 @@ namespace aspect
       resume_computation = false;
     else if (prm.get ("Resume computation") == "auto")
       {
-        resume_computation = Utilities::fexists(output_directory+"restart.mesh");
+        resume_computation = Utilities::fexists(output_directory+"restart.mesh", mpi_communicator);
       }
     else
       AssertThrow (false, ExcMessage ("Resume computation parameter must be either `true', `false', or `auto'."));

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -1023,7 +1023,7 @@ namespace aspect
                             << filename << '.' << std::endl << std::endl;
 
 
-          AssertThrow(Utilities::fexists(filename) || filename_is_url(filename),
+          AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                       ExcMessage (std::string("Ascii data file <")
                                   +
                                   filename
@@ -1045,7 +1045,7 @@ namespace aspect
                 current_file_number + 1;
 
               const std::string filename (create_filename (next_file_number, boundary_id));
-              if (Utilities::fexists(filename))
+              if (Utilities::fexists(filename, this->get_mpi_communicator()))
                 {
                   this->get_pcout() << std::endl << "   Also loading next Ascii data boundary file "
                                     << filename << '.' << std::endl << std::endl;
@@ -1105,7 +1105,7 @@ namespace aspect
       const std::string boundary_name = this->get_geometry_model().translate_id_to_symbol_name(boundary_id);
 
       const std::string result = replace_placeholders(templ, boundary_name, filenumber);
-      if (fexists(result))
+      if (fexists(result, this->get_mpi_communicator()))
         return result;
 
       // Backwards compatibility check: people might still be using the old
@@ -1115,13 +1115,13 @@ namespace aspect
       if (boundary_name == "top")
         {
           compatible_result = replace_placeholders(templ, "surface", filenumber);
-          if (!fexists(compatible_result))
+          if (!fexists(compatible_result, this->get_mpi_communicator()))
             compatible_result = replace_placeholders(templ, "outer", filenumber);
         }
       else if (boundary_name == "bottom")
         compatible_result = replace_placeholders(templ, "inner", filenumber);
 
-      if (!fexists(result) && fexists(compatible_result))
+      if (!fexists(result, this->get_mpi_communicator()) && fexists(compatible_result, this->get_mpi_communicator()))
         {
           this->get_pcout() << "WARNING: Filename convention concerning geometry boundary "
                             "names changed. Please rename '" << compatible_result << "'"
@@ -1204,7 +1204,7 @@ namespace aspect
           const std::string filename (create_filename (current_file_number,boundary_id));
           this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
                             << filename << '.' << std::endl << std::endl;
-          if (Utilities::fexists(filename))
+          if (Utilities::fexists(filename, this->get_mpi_communicator()))
             {
               lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
               lookups.find(boundary_id)->second->load_file(filename,this->get_mpi_communicator());
@@ -1225,7 +1225,7 @@ namespace aspect
       const std::string filename (create_filename (next_file_number,boundary_id));
       this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
                         << filename << '.' << std::endl << std::endl;
-      if (Utilities::fexists(filename))
+      if (Utilities::fexists(filename, this->get_mpi_communicator()))
         {
           lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
           lookups.find(boundary_id)->second->load_file(filename,this->get_mpi_communicator());
@@ -1566,7 +1566,7 @@ namespace aspect
       for (unsigned int i=0; i<number_of_layer_boundaries; ++i)
         {
           const std::string filename = data_directory + data_file_names[i];
-          AssertThrow(Utilities::fexists(filename) || filename_is_url(filename),
+          AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                       ExcMessage (std::string("Ascii data file <")
                                   +
                                   filename
@@ -1719,7 +1719,7 @@ namespace aspect
                         << filename << '.' << std::endl << std::endl;
 
 
-      AssertThrow(Utilities::fexists(filename) || filename_is_url(filename),
+      AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                   ExcMessage (std::string("Ascii data file <")
                               +
                               filename
@@ -1873,7 +1873,7 @@ namespace aspect
 
       const std::string filename = this->data_directory + this->data_file_name;
 
-      AssertThrow(Utilities::fexists(filename) || filename_is_url(filename),
+      AssertThrow(Utilities::fexists(filename, communicator) || filename_is_url(filename),
                   ExcMessage (std::string("Ascii data file <")
                               +
                               filename

--- a/source/termination_criteria/user_request.cc
+++ b/source/termination_criteria/user_request.cc
@@ -30,14 +30,7 @@ namespace aspect
     bool
     UserRequest<dim>::execute()
     {
-      // Only check for the file on the root process to avoid overloading the filesystem.
-      // The plugin manager later does an OR operation over all
-      // processors
-      if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
-        {
-          return Utilities::fexists(this->get_output_directory()+filename_to_test);
-        }
-      return false;
+      return Utilities::fexists(this->get_output_directory()+filename_to_test, this->get_mpi_communicator());
     }
 
     template <int dim>

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1331,6 +1331,24 @@ namespace aspect
 
 
     bool
+    fexists(const std::string &filename,
+            MPI_Comm comm)
+    {
+      bool file_exists = false;
+      if (Utilities::MPI::this_mpi_process(comm) == 0)
+        {
+          std::ifstream ifile(filename.c_str());
+
+          // return whether construction of the input file has succeeded;
+          // success requires the file to exist and to be readable
+          file_exists = static_cast<bool>(ifile);
+        }
+      return Utilities::MPI::broadcast(comm, file_exists);
+    }
+
+
+
+    bool
     filename_is_url(const std::string &filename)
     {
       if (filename.find("http://") == 0 || filename.find("https://") == 0 || filename.find("file://") == 0)

--- a/tests/ascii_data_fail_4/screen-output
+++ b/tests/ascii_data_fail_4/screen-output
@@ -14,7 +14,7 @@ Exception 'ExcMessage (std::string("Ascii data file <") + filename + "> not foun
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    Utilities::fexists(filename) || filename_is_url(filename)
+    Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename)
 Additional information: 
     Ascii data file
     <ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_4.txt>


### PR DESCRIPTION
One more PR in the same line as #5132, #5133, and #5134. In many places in the code we check for the existence of a file (on all MPI ranks) only to read it on rank 0 and distribute it via MPI. This makes no sense, as it increases the load on the file system and may even be wrong in case the file is on a local file system that is only accessible for rank 0.

I introduced a new function `Utilities::fexists` that takes the MPI communicator as second argument and only checks for the file existence on rank 0 and distributes the result to all ranks. The distribution is important, because the subsequent file access operation has to be started on all ranks (even if only rank 0 actually reads the file). I left the old version in, because we have a few functions that are only executed on rank 0 anyway, and in those functions I cannot easily use the new function without introducing additional arguments (like do_not_distribute_result).

Note that there is one instance of fexists where we likely want to check on all ranks. This is inside checkpoint_restart.cc, because the restart.mesh file is read by MPI-IO inside the triangulation class (so it needs to be available on all ranks). This line is just above the one I changed. Opinions welcome.

I also added a changelog entry for this series of patches.