### PR TITLE
Push image to ghcr

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,8 +52,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ github.repository_owner }}/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
+            ghcr.io/geodynamics/${{ github.repository }}:latest
+            geodynamics/${{ github.repository }}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -65,8 +65,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}
+            ghcr.io/geodynamics/${{ github.repository }}:${{github.ref_name}}
+            geodynamics/${{ github.repository }}:${{github.ref_name}}
 
   build-docker-tacc:
     runs-on: ubuntu-latest
@@ -104,8 +104,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ github.repository_owner }}/${{ github.repository }}:latest-tacc
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest-tacc
+            ghcr.io/geodynamics/${{ github.repository }}:latest-tacc
+            geodynamics/${{ github.repository }}:latest-tacc
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -117,5 +117,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}-tacc
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}-tacc
+            ghcr.io/geodynamics/${{ github.repository }}:${{github.ref_name}}-tacc
+            geodynamics/${{ github.repository }}:${{github.ref_name}}-tacc

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -44,7 +51,9 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: geodynamics/aspect:latest
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -55,7 +64,9 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: geodynamics/aspect:${{github.ref_name}}
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}
 
   build-docker-tacc:
     runs-on: ubuntu-latest
@@ -92,7 +103,9 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64
           push: true
-          tags: geodynamics/aspect:latest-tacc
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:latest-tacc
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest-tacc
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -103,4 +116,6 @@ jobs:
           cache-to: type=inline
           platforms: linux/amd64
           push: true
-          tags: geodynamics/aspect:${{github.ref_name}}-tacc
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}-tacc
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}-tacc


### PR DESCRIPTION
#4039 added the TACC docker image, and also included a try to upload the image to ghcr.io instead of docker hub. While the login was successful, the job didnt actually label the image for upload to ghcr.io. This PR represents an extension of that PR in that it:
- actually builds and pushes the TACC docker image to ghcr.io, and
- also uses ghcr.io for the regular docker image

It still also builds the images for docker hub, so existing workflows work as before. I would like to test if the new workflow runs correctly, before discussing if we want to drop Docker hub, or just keep using both.