### PR TITLE
Fix override warnings in benchmarks and cookbooks

### DIFF
--- a/benchmarks/advection_in_annulus/advection_in_annulus.cc
+++ b/benchmarks/advection_in_annulus/advection_in_annulus.cc
@@ -120,9 +120,7 @@ namespace aspect
     class AdvectionInAnnulus : public Interface<dim>, public SimulatorAccess<dim>
     {
       public:
-
-        virtual
-        void stokes_solution (const Point<dim> &p, Vector<double> &value) const;
+        void stokes_solution (const Point<dim> &p, Vector<double> &value) const override;
     };
   }
 }

--- a/benchmarks/annulus/plugin/annulus.cc
+++ b/benchmarks/annulus/plugin/annulus.cc
@@ -590,7 +590,7 @@ namespace aspect
 
 
         std::list<std::string>
-        required_other_postprocessors() const
+        required_other_postprocessors() const override
         {
           return std::list<std::string> (1, "dynamic topography");
         }

--- a/benchmarks/burstedde/burstedde.cc
+++ b/benchmarks/burstedde/burstedde.cc
@@ -96,8 +96,8 @@ namespace aspect
             beta_(beta)
           {}
 
-          virtual void vector_value (const Point<dim>   &pos,
-                                     Vector<double>   &values) const
+          void vector_value (const Point<dim>   &pos,
+                             Vector<double>   &values) const override
           {
             Assert (dim == 3, ExcNotImplemented());
             Assert (values.size() >= 4, ExcInternalError());
@@ -131,10 +131,9 @@ namespace aspect
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id boundary_indicator,
-                           const Point<dim> &position) const;
+                           const Point<dim> &position) const override;
 
       private:
         const double beta;
@@ -183,8 +182,8 @@ namespace aspect
     class BursteddeMaterial : public MaterialModel::Interface<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -238,7 +237,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -252,9 +251,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         /**
          * Returns the viscosity value in the inclusion
@@ -330,7 +328,7 @@ namespace aspect
     class BursteddeGravity : public aspect::GravityModel::Interface<dim>
     {
       public:
-        virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const;
+        Tensor<1,dim> gravity_vector (const Point<dim> &pos) const override;
 
         static
         void
@@ -339,9 +337,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
         */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         double beta;
     };
@@ -414,9 +411,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics);
+        execute (TableHandler &statistics) override;
     };
 
     template <int dim>

--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -42,29 +42,24 @@ namespace aspect
     class CompressibilityFormulations : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual
-        void initialize();
+        void initialize() override;
 
-        virtual
-        void update();
+        void update() override;
 
-        virtual
-        bool is_compressible () const;
+        bool is_compressible () const override;
 
-        virtual
         void
         evaluate (const MaterialModelInputs<dim> &in,
-                  MaterialModelOutputs<dim> &out) const;
+                  MaterialModelOutputs<dim> &out) const override;
 
-        virtual
         void
-        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         static void
         declare_parameters (ParameterHandler &prm);
 
-        virtual void
-        parse_parameters (ParameterHandler &prm);
+        void
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**

--- a/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.cc
+++ b/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.cc
@@ -48,8 +48,7 @@ namespace aspect
          * Makes perturbs the top boundary of the box with a function
          * of the form z' = amplitude * cos(order * x )
          */
-        virtual
-        void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const;
+        void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const override;
 
         /**
          * Declare the parameters this class takes through input files.
@@ -62,21 +61,18 @@ namespace aspect
          * Read the parameters this class declares from the parameter
          * file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         /**
          * Give the depth of a point.
          */
-        virtual
-        double depth( const Point<dim> &position) const;
+        double depth( const Point<dim> &position) const override;
 
         /**
          * Give the maximal depth of a point.
          */
-        virtual
-        double maximal_depth() const;
+        double maximal_depth() const override;
 
       private:
 

--- a/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
+++ b/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
@@ -45,10 +45,10 @@ namespace aspect
     {
       public:
 
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const;
+        void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                      typename Interface<dim>::MaterialModelOutputs &out) const override;
 
 
         /**
@@ -65,9 +65,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */

--- a/benchmarks/diffusion_of_hill/analytical_topography.h
+++ b/benchmarks/diffusion_of_hill/analytical_topography.h
@@ -43,8 +43,7 @@ namespace aspect
         /**
          * Output predicted and analytical topography [m] to file.
          */
-        virtual
-        std::pair<std::string,std::string> execute (TableHandler &statistics);
+        std::pair<std::string,std::string> execute (TableHandler &statistics) override;
 
         /**
          * @name Functions used in dealing with run-time parameters
@@ -60,9 +59,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */

--- a/benchmarks/doneahuerta/doneahuerta.cc
+++ b/benchmarks/doneahuerta/doneahuerta.cc
@@ -67,8 +67,8 @@ namespace aspect
             Function<dim>(dim+2)
           {}
 
-          virtual void vector_value (const Point<dim>   &pos,
-                                     Vector<double>   &values) const
+          void vector_value (const Point<dim>   &pos,
+                             Vector<double>   &values) const override
           {
             Assert (dim == 2, ExcNotImplemented());
             Assert (values.size() >= 4, ExcInternalError());
@@ -97,10 +97,9 @@ namespace aspect
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id ,
-                           const Point<dim> &position) const;
+                           const Point<dim> &position) const override;
     };
 
 
@@ -119,8 +118,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -150,7 +149,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -164,9 +163,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
     };
 
 
@@ -231,7 +229,7 @@ namespace aspect
     class DoneaHuertaGravity : public aspect::GravityModel::Interface<dim>
     {
       public:
-        virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const;
+        Tensor<1,dim> gravity_vector (const Point<dim> &pos) const override;
     };
 
 
@@ -264,9 +262,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics);
+        execute (TableHandler &statistics) override;
     };
 
     template <int dim>

--- a/benchmarks/entropy_adiabat/plugins/compute_entropy_profile.h
+++ b/benchmarks/entropy_adiabat/plugins/compute_entropy_profile.h
@@ -57,7 +57,7 @@ namespace aspect
          * adiabatic conditions along a vertical transect of the geometry
          * based on the given material model and other quantities.
          */
-        virtual void initialize ();
+        void initialize () override;
 
         /**
          * Some plugins need to know whether the adiabatic conditions are
@@ -69,37 +69,35 @@ namespace aspect
          * profile. This way the plugin behaves differently at initialization
          * time of the adiabatic conditions and during the main model run.
          */
-        virtual bool is_initialized() const;
+        bool is_initialized() const override;
 
         /**
          * Return the adiabatic temperature at a given point of the domain.
          */
-        virtual double temperature (const Point<dim> &p) const;
+        double temperature (const Point<dim> &p) const override;
 
         /**
          * Return the adiabatic pressure at a given point of the domain.
          */
-        virtual double pressure (const Point<dim> &p) const;
+        double pressure (const Point<dim> &p) const override;
 
         /**
          * Return the reference density at a given point of the domain.
          */
-        virtual double density (const Point<dim> &p) const;
+        double density (const Point<dim> &p) const override;
 
         /**
          * Return the derivative of the density with respect to depth
          * at the given point @p p.
          */
-        virtual
-        double density_derivative (const Point<dim> &p) const;
+        double density_derivative (const Point<dim> &p) const override;
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**

--- a/benchmarks/entropy_adiabat/plugins/entropy_advection.h
+++ b/benchmarks/entropy_adiabat/plugins/entropy_advection.h
@@ -38,14 +38,12 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>  &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;
 
-        virtual
         std::vector<double>
-        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const;
+        compute_residual(internal::Assembly::Scratch::ScratchBase<dim>  &scratch) const override;
 
         std::vector<double>
         advection_prefactors(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const override;

--- a/benchmarks/entropy_adiabat/plugins/entropy_model.h
+++ b/benchmarks/entropy_adiabat/plugins/entropy_model.h
@@ -52,9 +52,8 @@ namespace aspect
          * Initialization function. Loads the material data and sets up
          * pointers.
          */
-        virtual
         void
-        initialize ();
+        initialize () override;
 
         /**
          * @name Qualitative properties one can ask a material model
@@ -64,7 +63,7 @@ namespace aspect
         /**
          * Return whether the model is compressible or not.
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -73,10 +72,9 @@ namespace aspect
          * Function to compute the material properties in @p out given the
          * inputs in @p in.
          */
-        virtual
         void
         evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                 MaterialModel::MaterialModelOutputs<dim> &out) const;
+                 MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         /**
          * @name Functions used in dealing with run-time parameters
@@ -92,9 +90,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */
@@ -108,9 +105,8 @@ namespace aspect
          * the Stokes equation). Also creates SeismicAdditionalOutputs for
          * postprocessing purposes.
          */
-        virtual
         void
-        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+        create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
 
       private:

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -177,8 +177,8 @@ namespace aspect
             mmm_(mmm)
           {}
 
-          virtual void vector_value (const Point<dim>   &pos,
-                                     Vector<double>   &values) const
+          void vector_value (const Point<dim>   &pos,
+                             Vector<double>   &values) const override
           {
             Assert (dim == 3, ExcNotImplemented());
             Assert (values.size() >= 4, ExcInternalError());
@@ -214,7 +214,7 @@ namespace aspect
          */
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id ,
-                           const Point<dim> &position) const;
+                           const Point<dim> &position) const override;
 
 
         static
@@ -224,9 +224,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
         */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
 
 
@@ -281,8 +280,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -341,7 +340,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -355,9 +354,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
 
 
@@ -460,9 +458,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics);
+        execute (TableHandler &statistics) override;
 
         /**
          * List the other postprocessors required by this plugin.

--- a/benchmarks/inclusion/inclusion.h
+++ b/benchmarks/inclusion/inclusion.h
@@ -89,8 +89,9 @@ namespace aspect
           FunctionInclusion (double eta_B,
                              const unsigned int n_compositional_fields)
             : Function<dim>(dim+2+n_compositional_fields), eta_B_(eta_B) {}
-          virtual void vector_value (const Point<dim>   &p,
-                                     Vector<double>   &values) const
+
+          void vector_value (const Point<dim>   &p,
+                             Vector<double>   &values) const override
           {
             double pos[2]= {p(0),p(1)};
             AnalyticSolutions::_Inclusion
@@ -116,10 +117,9 @@ namespace aspect
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id ,
-                           const Point<dim> &position) const
+                           const Point<dim> &position) const override
         {
           Assert (dim == 2, ExcNotImplemented());
 
@@ -154,8 +154,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -192,7 +192,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
@@ -222,9 +222,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {
@@ -276,9 +275,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &/*statistics*/)
+        execute (TableHandler &/*statistics*/) override
         {
           std::unique_ptr<Function<dim>> ref_func;
 

--- a/benchmarks/king2dcompressible/code.cc
+++ b/benchmarks/king2dcompressible/code.cc
@@ -70,8 +70,8 @@ namespace aspect
         /**
         * Evaluate material properties.
         */
-        virtual void evaluate(const MaterialModelInputs<dim> &in,
-                              MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModelInputs<dim> &in,
+                      MaterialModelOutputs<dim> &out) const override
         {
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -106,7 +106,7 @@ namespace aspect
             }
         }
 
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return true;
         }
@@ -126,9 +126,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
 
 

--- a/benchmarks/layeredflow/layeredflow.cc
+++ b/benchmarks/layeredflow/layeredflow.cc
@@ -83,8 +83,8 @@ namespace aspect
             epsilon_(epsilon)
           {}
 
-          virtual void vector_value (const Point<dim>   &pos,
-                                     Vector<double>   &values) const
+          void vector_value (const Point<dim>   &pos,
+                             Vector<double>   &values) const override
           {
             Assert (dim == 2, ExcNotImplemented());
             Assert (values.size() >= 4, ExcInternalError());
@@ -116,10 +116,9 @@ namespace aspect
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id ,
-                           const Point<dim> &position) const;
+                           const Point<dim> &position) const override;
 
       private:
         const double beta;
@@ -141,8 +140,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -176,7 +175,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -190,9 +189,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
 
 
@@ -323,9 +321,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics);
+        execute (TableHandler &statistics) override;
     };
 
     template <int dim>

--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
@@ -54,22 +54,21 @@ namespace aspect
     class SimpleNonlinear : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         /**
          * This material model is incompressible.
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**

--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -92,8 +92,8 @@ namespace aspect
 
         double compute_viscosity(const double edot_ii,const double pressure,const int comp, const double prefactor,const bool regularize, const double min_visc, const double max_visc) const;
 
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         /**
          * Return whether the model is compressible or not.  Incompressibility
@@ -105,17 +105,16 @@ namespace aspect
         *
         * This material model is incompressible.
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
-        virtual double reference_density () const;
+        double reference_density () const;
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
 

--- a/benchmarks/nsinker/nsinker.cc
+++ b/benchmarks/nsinker/nsinker.cc
@@ -60,8 +60,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           const double sqrt_dynamic_viscosity_ratio = std::sqrt(dynamic_viscosity_ratio);
 
@@ -95,7 +95,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
@@ -131,9 +131,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {

--- a/benchmarks/nsinker_spherical_shell/nsinker.cc
+++ b/benchmarks/nsinker_spherical_shell/nsinker.cc
@@ -54,8 +54,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           const double sqrt_dynamic_viscosity_ratio = std::sqrt(dynamic_viscosity_ratio);
 
@@ -91,7 +91,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
@@ -131,9 +131,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -39,14 +39,14 @@ namespace aspect
     class ExponentialDecay : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters(ParameterHandler &prm);
+        void parse_parameters(ParameterHandler &prm) override;
 
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
-        virtual void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
       private:
 
@@ -70,13 +70,14 @@ namespace aspect
     class ExponentialDecayHeating : public HeatingModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual
         void
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
+
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters (ParameterHandler &prm);
+
+        void parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**
@@ -278,8 +279,9 @@ namespace aspect
   {
     public:
       RefFunction () : Function<dim>(dim+3) {}
-      virtual void vector_value (const Point<dim>   &p,
-                                 Vector<double>   &values) const
+
+      void vector_value (const Point<dim>   &p,
+                         Vector<double>   &values) const override
       {
         double x = p(0);
         double z = p(1);

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -37,14 +37,16 @@ namespace aspect
     class ExponentialDecay : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
+
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters(ParameterHandler &prm);
 
-        virtual bool is_compressible () const;
+        void parse_parameters(ParameterHandler &prm) override;
 
-        virtual void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const;
+        bool is_compressible () const override;
+
+        void create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
       private:
 
@@ -68,13 +70,14 @@ namespace aspect
     class ExponentialDecayHeating : public HeatingModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual
         void
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
+
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters (ParameterHandler &prm);
+
+        void parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
@@ -53,8 +53,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -94,7 +94,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -136,9 +136,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {

--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -125,8 +125,8 @@ namespace aspect
     class RigidShearMaterial : public MaterialModel::Interface<dim>, public SimulatorAccess<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           const double t = (this->simulator_is_past_initialization()) ? this->get_time() : 0.0;
 
@@ -219,7 +219,7 @@ namespace aspect
     class RigidShearGravity : public aspect::GravityModel::Interface<dim>, public aspect::SimulatorAccess<dim>
     {
       public:
-        virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const
+        Tensor<1,dim> gravity_vector (const Point<dim> &pos) const override
         {
           const double pi = numbers::PI;
           const double t = (this->simulator_is_past_initialization()) ? this->get_time() : 0.0;
@@ -253,9 +253,8 @@ namespace aspect
         /**
          * Generate error output for velocity, pressure, and density.
          */
-        virtual
         std::pair<std::string, std::string>
-        execute(TableHandler &statistics)
+        execute(TableHandler &statistics) override
         {
           const RigidShearMaterial<dim> &
           material_model

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -74,17 +74,17 @@ namespace aspect
       public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
 
-        virtual double reference_viscosity () const
+        double reference_viscosity () const
         {
           return eta_0;
         }
 
-        virtual double reference_darcy_coefficient () const
+        double reference_darcy_coefficient () const override
         {
           return reference_permeability * pow(0.01, permeability_exponent) / eta_f;
         }
@@ -109,13 +109,11 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
-
-        virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
-                              typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
+        void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
+                      typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const override
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
           const double strain_rate_dependence = (1.0 - dislocation_creep_exponent) / dislocation_creep_exponent;
@@ -294,23 +292,21 @@ namespace aspect
         /**
          * Return the initial porosity as a function of position.
          */
-        virtual
         double
-        initial_composition (const Point<dim> &position, const unsigned int n_comp) const;
+        initial_composition (const Point<dim> &position, const unsigned int n_comp) const override;
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         /**
          * Initialization function.
          */
         void
-        initialize ();
+        initialize () override;
 
       private:
         double noise_amplitude;

--- a/benchmarks/sinking_block/sinking_block.cc
+++ b/benchmarks/sinking_block/sinking_block.cc
@@ -52,8 +52,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -129,7 +129,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -171,9 +171,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -2960,8 +2960,8 @@ namespace aspect
          * @{
          */
 
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -2996,7 +2996,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
@@ -3035,9 +3035,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {
@@ -3112,9 +3111,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &/*statistics*/)
+        execute (TableHandler &/*statistics*/) override
         {
           std::unique_ptr<Function<dim>> ref_func;
 

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -327,22 +327,20 @@ namespace aspect
          * compute the analytical solution for the shape of the solitary wave.
          */
         void
-        initialize ();
+        initialize () override;
 
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         double
-        initial_composition (const Point<dim> &position, const unsigned int n_comp) const;
+        initial_composition (const Point<dim> &position, const unsigned int n_comp) const override;
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         double
         get_amplitude () const;
@@ -374,12 +372,12 @@ namespace aspect
     class SolitaryWaveMaterial : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
 
-        virtual double reference_darcy_coefficient () const
+        double reference_darcy_coefficient () const override
         {
           // Make sure we keep track of the initial composition manager and
           // that it continues to live beyond the time when the simulator
@@ -420,12 +418,11 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
-        virtual void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
-                              typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
+        void evaluate(const typename MaterialModel::Interface<dim>::MaterialModelInputs &in,
+                      typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const override
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
@@ -16,8 +16,8 @@ namespace aspect
     class SolKzCompositionalMaterial : public SolKzMaterial<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           SolKzMaterial<dim>::evaluate(in, out);
 

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -629,8 +629,8 @@ namespace aspect
         public:
           FunctionSolKz(unsigned int n_components) : Function<dim>(n_components) {}
 
-          virtual void vector_value(const Point<dim> &p,
-                                    Vector<double> &values) const
+          void vector_value(const Point<dim> &p,
+                            Vector<double> &values) const override
           {
             double pos[2] = {p(0), p(1)};
             double total_stress[3], strain_rate[3];
@@ -656,8 +656,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -693,7 +693,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible() const
+        bool is_compressible() const override
         {
           return false;
         }
@@ -702,7 +702,7 @@ namespace aspect
          */
 
         void
-        parse_parameters(ParameterHandler &/*prm*/)
+        parse_parameters(ParameterHandler &/*prm*/) override
         {
           // Declare dependencies on solution variables
           this->model_dependence.viscosity = MaterialModel::NonlinearDependence::none;
@@ -728,9 +728,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string, std::string>
-        execute(TableHandler &/*statistics*/)
+        execute(TableHandler &/*statistics*/) override
         {
           AnalyticSolutions::FunctionSolKz<dim> ref_func(this->introspection().n_components);
 

--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -78,8 +78,8 @@ namespace aspect
          * @{
          */
 
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -114,7 +114,7 @@ namespace aspect
          * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
          * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -140,9 +140,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */

--- a/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
+++ b/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
@@ -121,8 +121,8 @@ namespace aspect
         std::shared_ptr<Functions::ParsedFunction<dim>> density_function, pressure_function, velocity_function;
 
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -139,7 +139,7 @@ namespace aspect
             }
         }
 
-        virtual bool is_compressible () const
+        bool is_compressible () const override
         {
           return false;
         }
@@ -196,9 +196,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm)
+        parse_parameters (ParameterHandler &prm) override
         {
           prm.enter_subsection("Material model");
           {
@@ -305,9 +304,8 @@ namespace aspect
         std::shared_ptr<Function<dim>> ref_func;
 
       public:
-        virtual
         void
-        initialize ()
+        initialize () override
         {
           const MaterialModel::TimeDependentAnnulus<dim> &material_model =
             Plugins::get_plugin_as_type<const MaterialModel::TimeDependentAnnulus<dim>>(this->get_material_model());
@@ -318,9 +316,8 @@ namespace aspect
                                                                          1 + dim + 1 + this->n_compositional_fields()));
         }
 
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics)
+        execute (TableHandler &statistics) override
         {
           const QGauss<dim> quadrature_formula (this->get_fe().base_element(this->introspection().base_elements.velocities).degree+2);
 

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -70,8 +70,8 @@ namespace aspect
     class TosiMaterial : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           /**
            * As described in Tosi et al (2015), the viscosity \eta is computed as the
@@ -203,7 +203,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -217,9 +217,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
 

--- a/benchmarks/viscosity_grooves/viscosity_grooves.cc
+++ b/benchmarks/viscosity_grooves/viscosity_grooves.cc
@@ -82,8 +82,8 @@ namespace aspect
             geometry_model (geometry_model)
           {}
 
-          virtual void vector_value (const Point<dim>   &pos,
-                                     Vector<double>   &values) const
+          void vector_value (const Point<dim>   &pos,
+                             Vector<double>   &values) const override
           {
             Assert (dim == 2, ExcNotImplemented());
             Assert (values.size() >= 4, ExcInternalError());
@@ -114,10 +114,9 @@ namespace aspect
         /**
          * Return the boundary velocity as a function of position.
          */
-        virtual
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id ,
-                           const Point<dim> &position) const;
+                           const Point<dim> &position) const override;
 
       private:
         const double epsilon;
@@ -140,8 +139,8 @@ namespace aspect
          * @name Physical parameters used in the basic equations
          * @{
          */
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -174,7 +173,7 @@ namespace aspect
          * (compressible Stokes) or as $\nabla \cdot \mathbf{u}=0$
          * (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
         /**
          * @}
          */
@@ -188,9 +187,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         double get_epsilon() const;
 
@@ -285,7 +283,7 @@ namespace aspect
     class ViscosityGroovesGravity : public aspect::GravityModel::Interface<dim>
     {
       public:
-        virtual Tensor<1,dim> gravity_vector (const Point<dim> &pos) const;
+        Tensor<1,dim> gravity_vector (const Point<dim> &pos) const override;
 
         static
         void
@@ -294,9 +292,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
         */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         double epsilon;
 
@@ -375,9 +372,8 @@ namespace aspect
         /**
          * Generate graphical output from the current solution.
          */
-        virtual
         std::pair<std::string,std::string>
-        execute (TableHandler &statistics);
+        execute (TableHandler &statistics) override;
     };
 
     template <int dim>

--- a/benchmarks/yamauchi_takei_2016_anelasticity/anelasticity_temperature.h
+++ b/benchmarks/yamauchi_takei_2016_anelasticity/anelasticity_temperature.h
@@ -65,7 +65,7 @@ namespace aspect
          * current class, this function returns value from the text files.
          */
         double
-        initial_temperature (const Point<dim> &position) const;
+        initial_temperature (const Point<dim> &position) const override;
 
         /**
          * Declare the parameters for the input files.
@@ -78,7 +78,7 @@ namespace aspect
          * Read the parameters from the parameter file.
          */
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
 

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -76,7 +76,7 @@ namespace aspect
       public:
         AnisotropicViscosity(const unsigned int n_points);
 
-        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
 
         /**
          * Stress-strain "director" tensors at the given positions. This
@@ -148,15 +148,14 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;
 
         /**
          * Create AnisotropicViscosities.
          */
-        virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
+        void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
     };
 
     /**
@@ -168,15 +167,14 @@ namespace aspect
       public SimulatorAccess<dim>
     {
       public:
-        virtual
         void
         execute(internal::Assembly::Scratch::ScratchBase<dim>   &scratch,
-                internal::Assembly::CopyData::CopyDataBase<dim> &data) const;
+                internal::Assembly::CopyData::CopyDataBase<dim> &data) const override;
 
         /**
          * Create AdditionalMaterialOutputsStokesRHS if we need to do so.
          */
-        virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const;
+        void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
     };
 
 
@@ -385,18 +383,16 @@ namespace aspect
         /**
          * Compute the heating model outputs for this class.
          */
-        virtual
         void
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const;
+                  HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
          * Allow the heating model to attach additional material model outputs.
          */
-        virtual
         void
-        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const;
+        create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const override;
     };
 
 
@@ -488,14 +484,21 @@ namespace aspect
     class AV : public MaterialModel::Simple<dim>
     {
       public:
-        virtual void initialize();
-        virtual void evaluate (const MaterialModel::MaterialModelInputs<dim> &in,
-                               MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void initialize() override;
+
+        void evaluate (const MaterialModel::MaterialModelInputs<dim> &in,
+                       MaterialModel::MaterialModelOutputs<dim> &out) const override;
+
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters (ParameterHandler &prm);
-        virtual bool is_compressible () const;
-        virtual double reference_density () const;
-        virtual void create_additional_named_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const;
+
+        void parse_parameters (ParameterHandler &prm) override;
+
+        bool is_compressible () const override;
+
+        double reference_density () const;
+
+        void create_additional_named_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const override;
+
       private:
         double eta_N, viscosity_ratio; //normal viscosity and ratio between the shear and the normal viscosities
         static int delta (const unsigned int i, const unsigned int j); //kronecker delta function

--- a/cookbooks/finite_strain/finite_strain.cc
+++ b/cookbooks/finite_strain/finite_strain.cc
@@ -34,9 +34,9 @@ namespace aspect
     class FiniteStrain : public MaterialModel::Simple<dim>
     {
       public:
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
-        virtual void parse_parameters(ParameterHandler &prm);
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
+        void parse_parameters(ParameterHandler &prm) override;
     };
 
   }

--- a/cookbooks/free_surface_with_crust/plugin/simpler_with_crust.cc
+++ b/cookbooks/free_surface_with_crust/plugin/simpler_with_crust.cc
@@ -47,14 +47,14 @@ namespace aspect
          * Return whether the model is compressible or not. This model is
          * incompressible.
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
         /**
          * Function to compute the material properties in @p out given the
          * inputs in @p in.
          */
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const;
+        void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                      typename Interface<dim>::MaterialModelOutputs &out) const override;
 
         /**
          * @name Functions used in dealing with run-time parameters
@@ -70,9 +70,8 @@ namespace aspect
         /**
          * Read the parameters this class declares from the parameter file.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */

--- a/cookbooks/inner_core_convection/inner_core_assembly.cc
+++ b/cookbooks/inner_core_convection/inner_core_assembly.cc
@@ -66,10 +66,9 @@ namespace aspect
 
     public:
 
-      virtual
       void
       execute (internal::Assembly::Scratch::ScratchBase<dim>   &scratch_base,
-               internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const
+               internal::Assembly::CopyData::CopyDataBase<dim> &data_base) const override
       {
         internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
         internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>&> (data_base);

--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -38,8 +38,8 @@ namespace aspect
          */
         InnerCore ();
 
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         /**
          * A function that is called at the beginning of each time step to
@@ -47,9 +47,8 @@ namespace aspect
          * next be evaluated. For the current class, the function passes to
          * the parsed function what the current time is.
          */
-        virtual
         void
-        update ();
+        update () override;
 
         /**
          * Declare the parameters this class takes through input files. The
@@ -67,9 +66,8 @@ namespace aspect
          * parameters. Consequently, derived classes do not have to overload
          * this function if they do not take any runtime parameters.
          */
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
         /**
          * A function object representing resistance to phase change at the
@@ -103,7 +101,6 @@ namespace aspect
          * Percentage of material that has already undergone the phase
          * transition to the higher-pressure material.
          */
-        virtual
         double
         phase_function (const Point<dim> &position,
                         const double temperature) const;
@@ -111,7 +108,6 @@ namespace aspect
         /**
          * Hydrostatic pressure profile.
          */
-        virtual
         double
         hydrostatic_pressure (const double radius) const;
     };

--- a/cookbooks/magnetic_stripes/magnetic_stripes.cc
+++ b/cookbooks/magnetic_stripes/magnetic_stripes.cc
@@ -34,11 +34,11 @@ namespace aspect
     {
       public:
 
-        virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
+                      MaterialModel::MaterialModelOutputs<dim> &out) const override;
 
         static void declare_parameters (ParameterHandler &prm);
-        virtual void parse_parameters (ParameterHandler &prm);
+        void parse_parameters (ParameterHandler &prm) override;
 
       private:
         std::vector<double> reversal_times;

--- a/cookbooks/morency_doin_2004/morency_doin.h
+++ b/cookbooks/morency_doin_2004/morency_doin.h
@@ -82,8 +82,8 @@ namespace aspect
         /**
          * Evaluate material properties.
          */
-        virtual void evaluate(const MaterialModelInputs<dim> &in,
-                              MaterialModelOutputs<dim> &out) const;
+        void evaluate(const MaterialModelInputs<dim> &in,
+                      MaterialModelOutputs<dim> &out) const override;
 
         /**
          * Return whether the model is compressible or not.  Incompressibility
@@ -93,15 +93,14 @@ namespace aspect
          * equation as $\nabla \cdot (\rho \mathbf u)=0$ (compressible Stokes)
          * or as $\nabla \cdot \mathbf{u}=0$ (incompressible Stokes).
          */
-        virtual bool is_compressible () const;
+        bool is_compressible () const override;
 
         static
         void
         declare_parameters (ParameterHandler &prm);
 
-        virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
 
       private:
         std::vector<double> densities;


### PR DESCRIPTION
This PR fixes a bunch of warnings about virtual functions that should be marked as override. This only started recently when compiling with deal.II master and on gcc 9.4.0.

Things I did here:
- mostly just replaced `virtual` with `override`
- in a few places add empty lines between declarations that were missing
- very few functions were marked as virtual even though they were clearly not intended to (as they were new functions in a child class that was not intended to act as a base class). I removed `virtual` from them. See e.g. [benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc](https://github.com/geodynamics/aspect/compare/main...gassmoeller:aspect:fix_warnings?expand=1#diff-eb0cac43df75032fe3a79c4f0f88ad126034965d4d3e31c2fb9a839cfdfa19cd)
