### PR TITLE
Fixup for 5139

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,8 +52,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/geodynamics/${{ github.repository }}:latest
-            geodynamics/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:latest
+            ${{ github.repository }}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -65,8 +65,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/geodynamics/${{ github.repository }}:${{github.ref_name}}
-            geodynamics/${{ github.repository }}:${{github.ref_name}}
+            ghcr.io/${{ github.repository }}:${{github.ref_name}}
+            ${{ github.repository }}:${{github.ref_name}}
 
   build-docker-tacc:
     runs-on: ubuntu-latest
@@ -104,8 +104,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/geodynamics/${{ github.repository }}:latest-tacc
-            geodynamics/${{ github.repository }}:latest-tacc
+            ghcr.io/${{ github.repository }}:latest-tacc
+            ${{ github.repository }}:latest-tacc
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
@@ -117,5 +117,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/geodynamics/${{ github.repository }}:${{github.ref_name}}-tacc
-            geodynamics/${{ github.repository }}:${{github.ref_name}}-tacc
+            ghcr.io/${{ github.repository }}:${{github.ref_name}}-tacc
+            ${{ github.repository }}:${{github.ref_name}}-tacc


### PR DESCRIPTION
Turns out the `github.repository` context already includes the owner of the repository (e.g. `geodynamics/aspect`). So #5139 needs to be fixed to push the image to the correct address. See e.g. https://github.com/geodynamics/aspect/actions/runs/4790499929/jobs/8519704883#step:7:12498 for the error that the workflow encounters at the moment. Sorry for that, I should have tested more carefully.

This should still not cause any pushes in forked repositories, because we check that `github.repository == 'geodynamics/aspect'` earlier in the workflow (I should have realized my mistake when I saw that line yesterday).