### PR TITLE
Improve ASPECT documentation headings and TOC

### DIFF
--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -3,7 +3,7 @@
 ```{admonition} Community Project
 :class: information
 
-ASPECT is a community project. Contributions to software or documentation by every user is welcomed and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
+ASPECT is a community project. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
 ```
 
 ```{image} _static/images/aspect_logo.png

--- a/doc/sphinx/user/extending/compatibility.md
+++ b/doc/sphinx/user/extending/compatibility.md
@@ -1,4 +1,4 @@
-# Compatibility of plugins with newer ASPECT versions
+# Compatibility of plugins
 
 We strive to maintain compatibility for user written plugins with new versions
 of ASPECT for as long as possible. However,

--- a/doc/sphinx/user/extending/contributing.md
+++ b/doc/sphinx/user/extending/contributing.md
@@ -1,5 +1,5 @@
 (sec:extending:contributing)=
-# Contributing to ASPECT's development
+# How to contribute
 
 To end this section, let us repeat something already stated in the
 introduction:

--- a/doc/sphinx/user/extending/index.md
+++ b/doc/sphinx/user/extending/index.md
@@ -152,6 +152,9 @@ section on how to debug deal.II programs.
 
 
 :::{toctree}
+---
+maxdepth: 1
+---
 idea-of-plugins.md
 write-a-plugin.md
 write-a-cookbook/index.md

--- a/doc/sphinx/user/extending/signals.md
+++ b/doc/sphinx/user/extending/signals.md
@@ -1,5 +1,5 @@
 (sec:extending-signals)=
-# Extending ASPECT through the signals mechanism
+# Extending ASPECT through signals
 
 Not all things you may want to do fit neatly into the list of plugins of the
 previous sections. Rather, there are cases where you may want to change things

--- a/doc/sphinx/user/extending/write-a-cookbook/index.md
+++ b/doc/sphinx/user/extending/write-a-cookbook/index.md
@@ -16,6 +16,9 @@ corresponding .cc file(s) located in a subdirectory of the cookbooks folder
 corresponding to the individual cookbook.
 
 :::{toctree}
+---
+maxdepth: 1
+---
 parameter-file.md
 plugins.md
 manual-section.md

--- a/doc/sphinx/user/extending/write-a-cookbook/plugins.md
+++ b/doc/sphinx/user/extending/write-a-cookbook/plugins.md
@@ -1,4 +1,4 @@
-# Plugins and other additional file
+# Plugins and additional files
 
 In case you need other files (like shared libraries) to run your cookbook, you
 have to create a new folder in the [cookbooks](https://github.com/geodynamics/aspect/tree/main/cookbooks) directory that is named after

--- a/doc/sphinx/user/extending/write-a-cookbook/quickref.md
+++ b/doc/sphinx/user/extending/write-a-cookbook/quickref.md
@@ -21,9 +21,8 @@ Put single asterisks around text you *want to italicize*, but double asterisks a
 ### Heading 3
 #### Heading 4
 ```
-becomes:
+becomes (note that the first heading is not rendered to avoid a duplicate heading in the table of contents):
 
-# Heading 1
 ## Heading 2
 ### Heading 3
 #### Heading 4

--- a/doc/sphinx/user/methods/choosing-a-formulation/index.md
+++ b/doc/sphinx/user/methods/choosing-a-formulation/index.md
@@ -1,5 +1,5 @@
 (sec:methods:choosing-a-formulation)=
-# Choosing a formulation in ASPECT
+# Choosing a formulation
 
 After discussing different reasonable approximations for modeling compressible or incompressible mantle convection, we will now describe the different steps one has to take to use one of these approximations in a computation.
 As noted towards the beginning of {ref}`sec:methods:approximate-equations`, one should choose a formulation that is adequate for the situation one wants to simulate, taking into account that other authors in previous studies may have used formulations not because they were suited to the situation but also because, possibly, they did not have software available that implemented the most suitable formulation.

--- a/doc/sphinx/user/methods/index.md
+++ b/doc/sphinx/user/methods/index.md
@@ -1,5 +1,5 @@
 (cha:methods)=
-# Model assumptions and numerical methods
+# Modeling assumptions and numerical methods
 
 :::{toctree}
 ---

--- a/doc/sphinx/user/methods/index.md
+++ b/doc/sphinx/user/methods/index.md
@@ -1,7 +1,10 @@
 (cha:methods)=
-# Geodynamic modeling assumptions and numerical methods in ASPECT
+# Model assumptions and numerical methods
 
 :::{toctree}
+---
+maxdepth: 1
+---
 basic-equations/index.md
 coefficients/index.md
 dimensionalize/index.md

--- a/doc/sphinx/user/run-aspect/2d-vs-3d.md
+++ b/doc/sphinx/user/run-aspect/2d-vs-3d.md
@@ -1,5 +1,5 @@
 (sec:run-aspect:2d-vs-3d)=
-# Selecting between 2d and 3d runs
+# Selecting between 2d and 3d
 
 ASPECT can solve both two- and
 three-dimensional problems.[^footnote1] You select which one you want by putting a

--- a/doc/sphinx/user/run-aspect/gui/index.md
+++ b/doc/sphinx/user/run-aspect/gui/index.md
@@ -1,4 +1,4 @@
-# A graphical user interface for editing ASPECT parameter files
+# A graphical user interface
 
 Preparing a parameter file in a text editor can be a tedious task, not only
 because the number of input parameters has grown considerably during the


### PR DESCRIPTION
This PR addresses two issues with documentation I noticed recently:
1. The introduction of the markdown quickref document has increased the size of some table of content lists considerably. This PR fixes that by removing the rendering of one top level heading, and by restricting some table of content lists to a smaller number of levels (they also look cleaner this way)
2. A lot of our headings in the manual are unnecessarily long, in particular many include the phrase "in ASPECT", which is quite redundant in a documentation about ASPECT. I reworded the worst offenders so that the new table of content side bar looks much cleaner (can be seen in the test build of the documentation of this PR).