### PR TITLE
Install data and allow environment override to ASPECT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,21 +650,6 @@ CONFIGURE_FILE(
   ${CMAKE_BINARY_DIR}/include/aspect/config.h
   )
 
-# And finally generate the file
-CONFIGURE_FILE(
-  ${CMAKE_SOURCE_DIR}/cmake/config.prm.in
-  ${CMAKE_BINARY_DIR}/config.prm
-  )
-
-SET(ASPECT_SOURCE_DIR ${CMAKE_INSTALL_PREFIX})
-
-  # And finally generate the file
-CONFIGURE_FILE(
-  ${CMAKE_SOURCE_DIR}/cmake/config.prm.in
-  ${CMAKE_BINARY_DIR}/forinstall/config.prm
-  )
-
-SET(ASPECT_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
 # Check if we want to precompile header files. This speeds up compile time,
 # but can fail on some machines with old cmake, therefore it is disabled by
@@ -796,11 +781,6 @@ INSTALL(TARGETS ${TARGETS}
   RUNTIME DESTINATION bin
   COMPONENT runtime)
 
-# config files:
-INSTALL(FILES ${CMAKE_BINARY_DIR}/forinstall/config.prm
-  DESTINATION bin
-  COMPONENT config)
-
 # make sure we have the rpath to our dependencies set:
 
 FOREACH(_T ${TARGETS})
@@ -829,6 +809,11 @@ IF (ASPECT_INSTALL_EXAMPLES)
     COMPONENT examples
     FILES_MATCHING PATTERN "*")
 ENDIF()
+
+# data files:
+INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/data/
+  DESTINATION data
+  COMPONENT data)
 
 # cmake stuff:
 INSTALL(FILES ${CMAKE_BINARY_DIR}/forinstall/AspectConfig.cmake ${CMAKE_BINARY_DIR}/AspectConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,6 +650,21 @@ CONFIGURE_FILE(
   ${CMAKE_BINARY_DIR}/include/aspect/config.h
   )
 
+# And finally generate the file
+CONFIGURE_FILE(
+  ${CMAKE_SOURCE_DIR}/cmake/config.prm.in
+  ${CMAKE_BINARY_DIR}/config.prm
+  )
+
+SET(ASPECT_SOURCE_DIR ${CMAKE_INSTALL_PREFIX})
+
+  # And finally generate the file
+CONFIGURE_FILE(
+  ${CMAKE_SOURCE_DIR}/cmake/config.prm.in
+  ${CMAKE_BINARY_DIR}/forinstall/config.prm
+  )
+
+SET(ASPECT_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
 # Check if we want to precompile header files. This speeds up compile time,
 # but can fail on some machines with old cmake, therefore it is disabled by
@@ -780,6 +795,11 @@ ENDIF()
 INSTALL(TARGETS ${TARGETS}
   RUNTIME DESTINATION bin
   COMPONENT runtime)
+
+# config files:
+INSTALL(FILES ${CMAKE_BINARY_DIR}/forinstall/config.prm
+  DESTINATION bin
+  COMPONENT config)
 
 # make sure we have the rpath to our dependencies set:
 

--- a/include/aspect/config.h.in
+++ b/include/aspect/config.h.in
@@ -21,7 +21,6 @@
 #ifndef _aspect_config_h
 #define _aspect_config_h
 
-#cmakedefine ASPECT_SOURCE_DIR "@ASPECT_SOURCE_DIR@"
 #cmakedefine01 ASPECT_USE_SHARED_LIBS
 
 // optional features:

--- a/include/aspect/config.h.in
+++ b/include/aspect/config.h.in
@@ -21,6 +21,7 @@
 #ifndef _aspect_config_h
 #define _aspect_config_h
 
+#cmakedefine ASPECT_SOURCE_DIR "@ASPECT_SOURCE_DIR@"
 #cmakedefine01 ASPECT_USE_SHARED_LIBS
 
 // optional features:

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1374,14 +1374,7 @@ namespace aspect
 
           // parameters for reading in tables with material properties
           datadirectory        = prm.get ("Data directory");
-          {
-            const std::string subst_text = "$ASPECT_SOURCE_DIR";
-            std::string::size_type position;
-            while (position = datadirectory.find (subst_text),  position!=std::string::npos)
-              datadirectory.replace (datadirectory.begin()+position,
-                                     datadirectory.begin()+position+subst_text.size(),
-                                     ASPECT_SOURCE_DIR);
-          }
+          datadirectory = Utilities::expand_ASPECT_SOURCE_DIR(datadirectory);
           material_file_names  = Utilities::split_string_list
                                  (prm.get ("Material file names"));
           derivatives_file_names = Utilities::split_string_list

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2150,24 +2150,16 @@ namespace aspect
     std::string
     expand_ASPECT_SOURCE_DIR (const std::string &location)
     {
-      ParameterHandler prm;
-      prm.declare_entry("ASPECT_SOURCE_DIR",
-                        ".",
-                        Patterns::Anything(),
-                        "The directory where the ASPECT source code is located. "
-                        "This is used to expand the string $ASPECT_SOURCE_DIR in "
-                        "the input file. If this parameter is not set, then the "
-                        "string $ASPECT_SOURCE_DIR is not expanded.");
-      try
-    {
-      const std::string input_as_string = aspect::Utilities::read_and_distribute_file_content("config.prm", MPI_COMM_WORLD);
-      prm.parse_input_from_string(input_as_string);
-      }
-      catch (...)
-    {
-    }
-      const std::string ASPECT_SOURCE_DIR = prm.get("ASPECT_SOURCE_DIR");
+      // Check for environment variable override to ASPECT_SOURCE_DIR
+      char const *ASPECT_SOURCE_DIR_env = getenv("ASPECT_SOURCE_DIR");
+      if (ASPECT_SOURCE_DIR_env != NULL)
+        {
+          return Utilities::replace_in_string(location,
+                                              "$ASPECT_SOURCE_DIR",
+                                              ASPECT_SOURCE_DIR_env);
+        }
 
+      // Otherwise, use the default define from config.h
       return Utilities::replace_in_string(location,
                                           "$ASPECT_SOURCE_DIR",
                                           ASPECT_SOURCE_DIR);

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2150,6 +2150,24 @@ namespace aspect
     std::string
     expand_ASPECT_SOURCE_DIR (const std::string &location)
     {
+      ParameterHandler prm;
+      prm.declare_entry("ASPECT_SOURCE_DIR",
+                        ".",
+                        Patterns::Anything(),
+                        "The directory where the ASPECT source code is located. "
+                        "This is used to expand the string $ASPECT_SOURCE_DIR in "
+                        "the input file. If this parameter is not set, then the "
+                        "string $ASPECT_SOURCE_DIR is not expanded.");
+      try
+    {
+      const std::string input_as_string = aspect::Utilities::read_and_distribute_file_content("config.prm", MPI_COMM_WORLD);
+      prm.parse_input_from_string(input_as_string);
+      }
+      catch (...)
+    {
+    }
+      const std::string ASPECT_SOURCE_DIR = prm.get("ASPECT_SOURCE_DIR");
+
       return Utilities::replace_in_string(location,
                                           "$ASPECT_SOURCE_DIR",
                                           ASPECT_SOURCE_DIR);

--- a/unit_tests/first.cc
+++ b/unit_tests/first.cc
@@ -41,8 +41,9 @@ TEST_CASE("floating point std::vector checks")
 
 TEST_CASE("Utilities::read_and_distribute_file_content")
 {
+  const std::string file_name = aspect::Utilities::expand_ASPECT_SOURCE_DIR("$ASPECT_SOURCE_DIR/VERSION");
   const std::string content =
-    aspect::Utilities::read_and_distribute_file_content(ASPECT_SOURCE_DIR "/VERSION",
+    aspect::Utilities::read_and_distribute_file_content(file_name,
                                                         MPI_COMM_WORLD);
   REQUIRE(content.size()>0);
 

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -42,7 +42,8 @@ TEST_CASE("Utilities::AsciiDataLookup")
 
   //TODO: add support for setting data directly instead of relying on a file to load:
   aspect::Utilities::StructuredDataLookup<1> lookup(2 /*n_components*/, 1.0 /*scaling*/);
-  lookup.load_file(ASPECT_SOURCE_DIR "/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt", MPI_COMM_WORLD);
+  const std::string data_filename = aspect::Utilities::expand_ASPECT_SOURCE_DIR("$ASPECT_SOURCE_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt");
+  lookup.load_file(data_filename, MPI_COMM_WORLD);
 
   INFO(lookup.get_data(Point<1>(330000./2.0),0));
   INFO(lookup.get_data(Point<1>(330000./2.0),1));


### PR DESCRIPTION
This is a suggested solution to #1824 that installs the data directory and allows the user to override the path of ASPECT_SOURCE_DIR by setting an environment variable. I need this for an installation where the build and source paths are no longer available after installation.

I implemented a first version using a run-time configuration file instead (as suggested in #1824, see first commit in this PR), but that has the disadvantage that it is not always easy to find the configuration file, even if it is installed in the same folder as the executable (e.g. if ASPECT is called from a different directory and the aspect binary is a weak link). Setting an environment variable seems safer.

However, I am not 100% sure about the name the environment variable should have:
- ASPECT_SOURCE_DIR: This is most similar to the define we use inside ASPECT and the default value for our parameters, so I went with this one, even though it is now technically incorrect because it could point either to the install location or the source location.
- reusing ASPECT_DIR: This would be convenient, we already use this environment variable for plugins to find the aspect installation, however all our default data paths are defined as `$ASPECT_SOURCE_DIR/data`, and while that works for the install directory, it does not work if someone sets ASPECT_DIR to the build directory, because the data is never moved to the build directory
- introducing a new variable ASPECT_ROOT, ASPECT_DATA_DIR or similar: Seemed confusing with the overlap with ASPECT_DIR, also ASPECT_DATA_DIR sounds as if it should point to ASPECT_DIR/data, which it should not.

In summary, I went with ASPECT_SOURCE_DIR, because it is the same as the variable we use in the parameter files, but it seems the best of not perfect options.
For now, I expect this to be only relevant for very few use cases.