### PR TITLE
Remove admonition from markdown script

### DIFF
--- a/contrib/utilities/jsontomarkdown.py
+++ b/contrib/utilities/jsontomarkdown.py
@@ -155,12 +155,6 @@ def handle_parameters(data):
     global_output_file = open("doc/sphinx/parameters/index.md", "w")
     global_output_file.write("(parameters)=\n"
                              "# Parameter Documentation\n"
-                             ":::{admonition} Under construction\n"
-                             ":class: warning\n"
-                             "\n"
-                             "Migrating the ASPECT manual from LaTeX to Sphinx/MyST is not complete.\n"
-                             "If what you are looking for is not here, please see the PDF version.\n"
-                             ":::\n"
                              "\n"
                              ":::{toctree}\n"
                              "---\n"


### PR DESCRIPTION
In an earlier PR I removed a warning box from the parameter documentation without realizing that it was automatically generated by the script `jsontomarkdown.py`. Remove the automatic message from the script as well.