### PR TITLE
add explicit instantiation hint

### DIFF
--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -284,6 +284,19 @@ namespace aspect
     set_assemblers;
   };
 
+  template <>
+  boost::signals2::signal<void (const unsigned int aspect_dim,
+                                ParameterHandler &prm)>  SimulatorSignals<2>::declare_additional_parameters;
+  template <>
+  boost::signals2::signal<void (const unsigned int aspect_dim,
+                                ParameterHandler &prm)>  SimulatorSignals<3>::declare_additional_parameters;
+  template <>
+  boost::signals2::signal<void (const Parameters<2> &,
+                                ParameterHandler &)>  SimulatorSignals<2>::parse_additional_parameters;
+  template <>
+  boost::signals2::signal<void (const Parameters<3> &,
+                                ParameterHandler &)>  SimulatorSignals<3>::parse_additional_parameters;
+
 
   namespace internals
   {

--- a/source/simulator/simulator_signals.cc
+++ b/source/simulator/simulator_signals.cc
@@ -27,14 +27,20 @@
 namespace aspect
 {
   // provide locations for the static variables of this class
-  template <int dim>
+
+  template <>
   boost::signals2::signal<void (const unsigned int,
-                                ParameterHandler &)>  SimulatorSignals<dim>::declare_additional_parameters;
+                                ParameterHandler &)>  SimulatorSignals<2>::declare_additional_parameters {};
+  template <>
+  boost::signals2::signal<void (const unsigned int,
+                                ParameterHandler &)>  SimulatorSignals<3>::declare_additional_parameters {};
+  template <>
+  boost::signals2::signal<void (const Parameters<2> &,
+                                ParameterHandler &)>  SimulatorSignals<2>::parse_additional_parameters {};
 
-  template <int dim>
-  boost::signals2::signal<void (const Parameters<dim> &,
-                                ParameterHandler &)>  SimulatorSignals<dim>::parse_additional_parameters;
-
+  template <>
+  boost::signals2::signal<void (const Parameters<3> &,
+                                ParameterHandler &)>  SimulatorSignals<3>::parse_additional_parameters {};
 
   namespace internals
   {


### PR DESCRIPTION
I am not sure if this is the right way to do it, but this fixes the following clang 15 warning:

```
/ssd/aspect-git/source/simulator/parameters.cc:2091:28: warning:
instantiation of variable
'aspect::SimulatorSignals<2>::parse_additional_parameters' required
here, but no definition is available [-Wundefined-var-template]
    SimulatorSignals<dim>::parse_additional_parameters (*this, prm);
                           ^
/ssd/aspect-git/include/aspect/simulator_signals.h:232:64: note: forward
declaration of template entity is here
ParameterHandler &)>
parse_additional_parameters;
                                                               ^
/ssd/aspect-git/source/simulator/parameters.cc:2091:28: note: add an
explicit instantiation declaration to suppress this warning if
'aspect::SimulatorSignals<2>::parse_additional_parameters' is explicitly
instantiated in another translation unit
    SimulatorSignals<dim>::parse_additional_parameters (*this, prm);
                           ^
```