### PR TITLE
Increase GMRES restart for nsinker_spherical_shell

### DIFF
--- a/benchmarks/nsinker_spherical_shell/gmg.prm
+++ b/benchmarks/nsinker_spherical_shell/gmg.prm
@@ -17,7 +17,7 @@ subsection Solver parameters
     set Number of cheap Stokes solver steps             = 2000
     set Maximum number of expensive Stokes solver steps = 0
     set Linear solver tolerance                         = 1e-6
-    set GMRES solver restart length                     = 100
+    set GMRES solver restart length                     = 200
   end
 end
 

--- a/tests/spherical_nsinker/screen-output
+++ b/tests/spherical_nsinker/screen-output
@@ -11,9 +11,9 @@ Number of degrees of freedom: 28,690 (20,790+970+6,930)
     GMG n_levels: 2
     Viscosity range: 0.1 - 433.496
     GMG workload imbalance: 1
-    Stokes solver: 117+0 iterations.
-    Schur complement preconditioner: 119+0 iterations.
-    A block preconditioner: 119+0 iterations.
+    Stokes solver: 106+0 iterations.
+    Schur complement preconditioner: 107+0 iterations.
+    A block preconditioner: 107+0 iterations.
 
    Postprocessing:
      System matrix memory consumption:  0.34 MB

--- a/tests/spherical_nsinker/statistics
+++ b/tests/spherical_nsinker/statistics
@@ -17,4 +17,4 @@
 # 17: MGTransfer memory consumption (MB) 
 # 18: Matrix-free cell data memory consumption (MB) 
 # 19: Visualization file name
-0 0.000000000000e+00 0.000000000000e+00 768 21760 6930 1 116 119 119 0.3390 0.3989 0.0805 1.0749 0.6582 0.3291 0.7182 0.0081 output-spherical_nsinker/solution/solution-00000 
+0 0.000000000000e+00 0.000000000000e+00 768 21760 6930 1 105 107 107 0.3390 0.3989 0.0805 1.0749 0.6582 0.3291 0.7182 0.0081 output-spherical_nsinker/solution/solution-00000 


### PR DESCRIPTION
The nsinker spherical shell benchmark does not converge with the current setting on my machine (just barely, 1e-8 would be converged, it stagnates around 1.8e-8). Increasing the GMRES restart length fixes the issue. The test in a lower resolution converges fine.

Found while preparing for #5145.