### PR TITLE
Fix late access to initial composition in cookbook

### DIFF
--- a/include/aspect/initial_composition/porosity.h
+++ b/include/aspect/initial_composition/porosity.h
@@ -23,6 +23,7 @@
 #define _aspect_initial_composition_porosity_h
 
 #include <aspect/initial_composition/interface.h>
+#include <aspect/initial_temperature/interface.h>
 #include <aspect/simulator_access.h>
 #include <aspect/utilities.h>
 
@@ -48,11 +49,33 @@ namespace aspect
     {
       public:
         /**
+         * Initialize the plugin.
+        */
+        void initialize () override;
+
+        /**
          * Return the initial composition as a function of position and number
          * of compositional field.
          */
         double initial_composition (const Point<dim> &position,
                                     const unsigned int compositional_index) const override;
+
+      private:
+        /**
+        * A shared pointer to the initial temperature object
+        * that ensures that the current object can continue
+        * to access the initial temperature object beyond the
+        * first time step.
+        */
+        std::shared_ptr<const aspect::InitialTemperature::Manager<dim>> initial_temperature_manager;
+
+        /**
+        * A shared pointer to the initial composition object
+        * that ensures that the current object can continue
+        * to access the initial composition object beyond the
+        * first time step.
+        */
+        std::shared_ptr<const aspect::InitialComposition::Manager<dim>> initial_composition_manager;
     };
   }
 }

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -31,6 +31,23 @@ namespace aspect
   namespace InitialComposition
   {
     template <int dim>
+    void
+    Porosity<dim>::initialize()
+    {
+      // Make sure we keep track of the initial temperature manager and
+      // that it continues to live beyond the time when the simulator
+      // class releases its pointer to it.
+      initial_temperature_manager = this->get_initial_temperature_manager_pointer();
+
+      // Make sure we keep track of the initial composition manager and
+      // that it continues to live beyond the time when the simulator
+      // class releases its pointer to it.
+      initial_composition_manager = this->get_initial_composition_manager_pointer();
+    }
+
+
+
+    template <int dim>
     double
     Porosity<dim>::
     initial_composition (const Point<dim> &position,
@@ -54,7 +71,7 @@ namespace aspect
           MaterialModel::MaterialModelInputs<dim> in(1, this->n_compositional_fields());
 
           in.position[0] = position;
-          in.temperature[0] = this->get_initial_temperature_manager().initial_temperature(position);
+          in.temperature[0] = initial_temperature_manager->initial_temperature(position);
           in.pressure[0] = this->get_adiabatic_conditions().pressure(position);
           in.pressure_gradient[0] = 0.0;
           in.velocity[0] = 0.0;
@@ -63,7 +80,7 @@ namespace aspect
           // infinite recursion
           for (unsigned int i = 0; i < this->n_compositional_fields(); ++i)
             if (i != porosity_index)
-              in.composition[0][i] = this->get_initial_composition_manager().initial_composition(position,i);
+              in.composition[0][i] = initial_composition_manager->initial_composition(position,i);
             else
               in.composition[0][i] = 0.0;
 


### PR DESCRIPTION
The cookbook `future/mantle_setup_start.prm` does not work at the moment, because it accesses the initial temperature manager after it has been discarded. This is because  it uses the boundary composition model `initial composition`, which calls the initial composition manager, however the `porosity` initial composition then accesses `initial temperature`, which has not been stored.

Related to #5145.