### PR TITLE
Make the protected object public to use its functions elsewhere.

### DIFF
--- a/include/aspect/initial_composition/slab_model.h
+++ b/include/aspect/initial_composition/slab_model.h
@@ -78,13 +78,13 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm) override;
 
-      protected:
         /**
          * An object of ascii data boundary to input subducted slab depths
          * and thicknesses.
          */
         Utilities::AsciiDataBoundary<dim> slab_boundary;
 
+      protected:
         /**
          * Cache the surface boundary id to avoid unnecessary lookups.
          */

--- a/include/aspect/initial_composition/slab_model.h
+++ b/include/aspect/initial_composition/slab_model.h
@@ -79,12 +79,18 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
         /**
+        * A function that returns the slab_boundary object to allow access
+        * in other places.
+        */
+        const Utilities::AsciiDataBoundary<dim> &get_slab_boundary() const;
+
+      private:
+        /**
          * An object of ascii data boundary to input subducted slab depths
          * and thicknesses.
          */
         Utilities::AsciiDataBoundary<dim> slab_boundary;
 
-      protected:
         /**
          * Cache the surface boundary id to avoid unnecessary lookups.
          */

--- a/source/initial_composition/slab_model.cc
+++ b/source/initial_composition/slab_model.cc
@@ -82,6 +82,14 @@ namespace aspect
 
 
     template <int dim>
+    const Utilities::AsciiDataBoundary<dim> &
+    SlabModel<dim>::get_slab_boundary () const
+    {
+      return slab_boundary;
+    }
+
+
+    template <int dim>
     void
     SlabModel<dim>::declare_parameters (ParameterHandler &prm)
     {


### PR DESCRIPTION
We use the object `slab_boundary` in our material model to access `slab_depths` and `slab_thickness`. In order to do this, this PR allows public access for the object. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
