### PR TITLE
removed a deprecated option

### DIFF
--- a/source/particle/property/grain_size.cc
+++ b/source/particle/property/grain_size.cc
@@ -73,13 +73,9 @@ namespace aspect
       {
         material_inputs.position[0] = particle->get_location();
 
-#if DEAL_II_VERSION_GTE(9,4,0)
         material_inputs.current_cell = typename DoFHandler<dim>::active_cell_iterator(*particle->get_surrounding_cell(),
                                                                                       &(this->get_dof_handler()));
-#else
-        material_inputs.current_cell = typename DoFHandler<dim>::active_cell_iterator(*particle->get_surrounding_cell(this->get_triangulation()),
-                                                                                      &(this->get_dof_handler()));
-#endif
+
         material_inputs.temperature[0] = solution[this->introspection().component_indices.temperature];
 
         material_inputs.pressure[0] = solution[this->introspection().component_indices.pressure];


### PR DESCRIPTION
Removed a deprecated option for choosing deal-ii version, as aspect now require deal-ii > v9.4

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
