### PR TITLE
make assert throw consistent between geometry models for whether a po…

### DIFF
--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -755,10 +755,8 @@ namespace aspect
     Chunk<dim>::point_is_in_domain(const Point<dim> &point) const
     {
       AssertThrow(!this->get_parameters().mesh_deformation_enabled ||
-                  // we are still before the first time step has started
-                  this->get_timestep_number() == 0 ||
-                  this->get_timestep_number() == numbers::invalid_unsigned_int,
-                  ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
+                  this->simulator_is_past_initialization() == false,
+                  ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -507,8 +507,8 @@ namespace aspect
     SphericalShell<dim>::point_is_in_domain(const Point<dim> &point) const
     {
       AssertThrow(!this->get_parameters().mesh_deformation_enabled ||
-                  this->get_timestep_number() == 0,
-                  ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
+                  this->simulator_is_past_initialization() == false,
+                  ExcMessage("After displacement of the free surface, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));


### PR DESCRIPTION
When using a spherical shell with 90 degrees opening angle and with initial lithostatic pressure on the lateral boundaries, initially the error is "After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not.", from the point_is_in_domain function. Does message does not appear for a box and chunk geometry, and it should be able to assess whether this given point (for the initial lithostatic pressure), is in the domain or not because this assessment happens before any mesh/free surface deformation. 

I now changed the AssertThrow in the spherical shell to the same conditions as in the box geometry, and also made the chunk assertthrow consistent with that of the box geometry. (also see issue #4715 )