### PR TITLE
improved parameter description for replace_placeholders function

### DIFF
--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -1036,7 +1036,12 @@ namespace aspect
        * pages of the <code>printf()</code> family of functions),
        * return the expanded string where the <code>%s</code> code is
        * replaced by @p boundary_name, and <code>%d</code> is replaced
-       * by @p filenumber.
+       * by @p filenumber. Options: (1) specify both boundary_name and
+       * filenumber placeholders (%s and %d), (2) do not specify any
+       * boundary_name and filenumber placeholders, (3) only specify
+       * boundary_name placeholder (%s). Do not only specify filenumber
+       * placeholder (%d). Placeholders order is first boundary_name
+       * (%s), then filenumber (%d).
        */
       std::string replace_placeholders(const std::string &filename_and_path,
                                        const std::string &boundary_name,


### PR DESCRIPTION
It wasn't clear that you cannot only specify the time step placeholder, even when there is only one boundary used. Very clear overview in the short Issue #4999 . I improved the replace_placeholders function description.