### PR TITLE
Set default build type to DebugRelease

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         mkdir build-no-unity
         cd build-no-unity
-        cmake -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
+        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
         make -j 2
         ./aspect --test
 
@@ -82,7 +82,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
+        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
         -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_INSTALL_EXAMPLES=ON ..
         make -j 2
         ./aspect --test
@@ -128,6 +128,7 @@ jobs:
         mkdir build
         cd build
         cmake \
+        -D CMAKE_BUILD_TYPE=Debug \
         -G 'Ninja' \
         -D CMAKE_CXX_FLAGS='-Werror' \
         -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,27 @@ IF ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   "begin a build in a different directory.")
 ENDIF()
 
+#
+# Setup CMAKE_BUILD_TYPE:
+#
+
+SET(CMAKE_BUILD_TYPE
+  "DebugRelease"
+  CACHE STRING
+  "Choose the type of build, options are: Debug, Release and DebugRelease."
+  )
+
+# This is a strict check. But it is better to only have a known number of
+# options for CMAKE_BUILD_TYPE...
+IF( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND
+    NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND
+    NOT "${CMAKE_BUILD_TYPE}" STREQUAL "DebugRelease" )
+  MESSAGE(FATAL_ERROR
+    "CMAKE_BUILD_TYPE must either be 'Release', 'Debug', or 'DebugRelease', but is set to '${CMAKE_BUILD_TYPE}'.")
+ELSE()
+  MESSAGE(STATUS "Setting up ASPECT for ${CMAKE_BUILD_TYPE} mode.")
+ENDIF()
+
 # Set the name of the project and main target. If we are generating
 # ASPECT debug and release mode, we have the debug build as 'aspect'
 # and we populate a list of all targets (by default they are the same):

--- a/doc/modules/changes/20230707_gassmoeller
+++ b/doc/modules/changes/20230707_gassmoeller
@@ -1,0 +1,8 @@
+ Improved: ASPECT is now by default compiled in DebugRelease
+ mode which compiles both a debug and a release (optimized)
+ version of the executable. Individual build types can still
+ be selected using 'make debug' or 'make release' or by
+ setting the cmake variable CMAKE_BUILD_TYPE to Debug or
+ Release.
+ <br>
+ (Rene Gassmoeller, Timo Heister, 2023/07/07)


### PR DESCRIPTION
This sets the ASPECT default build type to DebugRelease (just like deal.II). This creates two executables in the build directory. The main reason I think this is more useful because most users will need both executables eventually (debug for testing, release for actually running models) and I keep encountering users that either:
- never run debug mode, because they dont want to recompile before running the actual model
- or dont know that they are running debug mode (because it is the default) and are unaware there is a faster option available.

I hope with this change we can reduce these confusions (at the cost of slower compile time).