### PR TITLE
Improve code readability in small ways in two places.

### DIFF
--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -258,9 +258,9 @@ namespace aspect
                                                       0,
                                                       bottom_depth)
                                           };
-      const unsigned int  subdivisions[dim] = {EW_subdiv,NS_subdiv,depth_subdiv};
+      const unsigned int  subdivisions[dim] = {EW_subdiv, NS_subdiv, depth_subdiv};
 
-      GridGenerator::subdivided_parallelepiped (coarse_grid, subdivisions,corner_points, true);
+      GridGenerator::subdivided_parallelepiped (coarse_grid, subdivisions, corner_points, true);
 
       // Shift the grid point at (0,0,0) (and the rest of the
       // points with it) to the correct location at corner[0] at a

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -154,13 +154,12 @@ namespace aspect
 
                     // are we done searching?
                     if (n_left_to_find == 0)
-                      break; // exit inner loop
+                      goto after_cell_loop; // exit both nested loops at the same time
                   }
-
-                if (n_left_to_find == 0)
-                  break; // exit outer loop
               }
 
+        after_cell_loop:
+          ;
         }
 
 


### PR DESCRIPTION
Trigger warning: contains a `goto`.