### PR TITLE
[Urgent] Fix 'main' breakage.

### DIFF
--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -43,7 +43,7 @@ namespace aspect
                                                       const std::vector<Tensor<1,dim>> &gradients,
                                                       typename ParticleHandler<dim>::particle_iterator &particle) const
       {
-        auto &data = particle->get_properties();
+        const auto data = particle->get_properties();
 
         Tensor<2,dim> old_strain;
         for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -44,7 +44,7 @@ namespace aspect
                                                                typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         // Integrated strain invariant from prior time step
-        auto &data = particle->get_properties();
+        const auto data = particle->get_properties();
         double old_strain = data[data_position];
 
         // Current timestep

--- a/source/particle/property/strain_rate.cc
+++ b/source/particle/property/strain_rate.cc
@@ -46,7 +46,7 @@ namespace aspect
                                                 const std::vector<Tensor<1,dim>> &gradients,
                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
       {
-        auto &data = particle->get_properties();
+        const auto data = particle->get_properties();
         // Velocity gradients
         Tensor<2,dim> grad_u;
         for (unsigned int d=0; d<dim; ++d)

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -130,7 +130,7 @@ namespace aspect
         const bool plastic_yielding = viscoplastic.is_yielding(material_inputs);
 
         // Next take the integrated strain invariant from the prior time step.
-        auto &data = particle->get_properties();
+        const auto data = particle->get_properties();
 
         // Calculate strain rate second invariant
         const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(material_inputs.strain_rate[0])), 0.));


### PR DESCRIPTION
This fix breakage such as this that currently trips up #5207 and #5206:
```
/__w/aspect/aspect/source/particle/property/strain_rate.cc:49:15: error: cannot bind non-const lvalue reference of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>&' to an rvalue of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>'
   49 |         auto &data = particle->get_properties();
      |               ^~~~
/__w/aspect/aspect/source/particle/property/strain_rate.cc: In instantiation of 'void aspect::Particle::Property::StrainRate<dim>::update_particle_property(unsigned int, const dealii::Vector<double>&, const std::vector<dealii::Tensor<1, dim> >&, typename dealii::Particles::ParticleHandler<dim>::particle_iterator&) const [with int dim = 3; typename dealii::Particles::ParticleHandler<dim>::particle_iterator = dealii::Particles::ParticleIterator<3, 3>]':
/__w/aspect/aspect/source/particle/property/strain_rate.cc:96:7:   required from here
/__w/aspect/aspect/source/particle/property/strain_rate.cc:49:15: error: cannot bind non-const lvalue reference of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>&' to an rvalue of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>'
In file included from CMakeFiles/aspect.dir/Unity/unity_24_cxx.cxx:17:
/__w/aspect/aspect/source/particle/property/viscoplastic_strain_invariants.cc: In instantiation of 'void aspect::Particle::Property::ViscoPlasticStrainInvariant<dim>::update_particle_property(unsigned int, const dealii::Vector<double>&, const std::vector<dealii::Tensor<1, dim> >&, typename dealii::Particles::ParticleHandler<dim>::particle_iterator&) const [with int dim = 2; typename dealii::Particles::ParticleHandler<dim>::particle_iterator = dealii::Particles::ParticleIterator<2, 2>]':
/__w/aspect/aspect/source/particle/property/viscoplastic_strain_invariants.cc:232:7:   required from here
/__w/aspect/aspect/source/particle/property/viscoplastic_strain_invariants.cc:133:15: error: cannot bind non-const lvalue reference of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>&' to an rvalue of type 'dealii::ArrayView<double, dealii::MemorySpace::Host>'
  133 |         auto &data = particle->get_properties();
      |               ^~~~
```
This is caused by https://github.com/dealii/dealii/pull/15671.