### PR TITLE
Do not bind temporaries to references.

### DIFF
--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -115,7 +115,7 @@ namespace aspect
         for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
              particle != particle_range.end(); ++particle, ++particle_index)
           {
-            const auto &particle_property_value = particle->get_properties();
+            const ArrayView<double> particle_property_value = particle->get_properties();
             for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
               {
                 if (selected_properties[property_index] == true)

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -371,7 +371,7 @@ namespace aspect
         for (typename ParticleHandler<dim>::particle_iterator particle = particle_range.begin();
              particle != particle_range.end(); ++particle, ++particle_index)
           {
-            const auto &particle_property_value = particle->get_properties();
+            const ArrayView<double> particle_property_value = particle->get_properties();
             for (unsigned int property_index = 0; property_index < n_particle_properties; ++property_index)
               {
                 if (selected_properties[property_index] == true)


### PR DESCRIPTION
Like #5208, except that the compiler did allow binding temporaries to a const reference. But just because we can doesn't mean that we should.