### PR TITLE
Improve the documentation on how to build the manual

### DIFF
--- a/doc/sphinx/user/install/local-installation/compiling.md
+++ b/doc/sphinx/user/install/local-installation/compiling.md
@@ -1,5 +1,5 @@
 (sec:install:local-installation:compiling)=
-# Compiling ASPECT and generating documentation
+# Compiling ASPECT
 
 After downloading ASPECT and having built the
 libraries it builds on, you can compile it by typing
@@ -9,16 +9,6 @@ libraries it builds on, you can compile it by typing
 on the command line (or `make -jN` if you have multiple processors in your
 machine, where `N` is the number of processors). This builds the
 ASPECT executable which will reside in the `build`
-directory and will be named `aspect`. To run
-ASPECT from the main source directory, you would need
-to reference it as `./build/aspect`. If you intend to modify
-ASPECT for your own experiments, you may want to also
-generate documentation about the source code. This can be done using the
-command
-
-      cd doc; make
-
-which assumes that you have the `doxygen` documentation generation tool
-installed. Most Linux distributions have packages for `doxygen`. The result
-will be the file `doc/doxygen/index.html` that is the starting point for
-exploring the documentation.
+directory and will be named `aspect` or `aspect-release`.
+To run ASPECT from the main source directory, you would need
+to reference it as `./build/aspect`.

--- a/doc/sphinx/user/install/local-installation/documentation.md
+++ b/doc/sphinx/user/install/local-installation/documentation.md
@@ -1,0 +1,33 @@
+(sec:install:local-installation:documentation)=
+# Building the documentation
+
+If you intend to modify
+ASPECT for your own experiments, you may want to also
+generate documentation about the source code and the user manual.
+This step is optional and not necessary if you do not intend to
+modify the source code or contribute to the project.
+The source code documentation can be build using the command
+
+      cd doc; make aspect.tag
+
+which assumes that you have the `doxygen` documentation generation tool
+installed. Most Linux distributions have packages for `doxygen`. The result
+will be the file `doc/doxygen/index.html` that is the starting point for
+exploring the documentation. You can see an online version of the documentation
+at <https://aspect.geodynamics.org/doc/doxygen/index.html>.
+
+The user manual is created using the Sphinx documentation system and can be
+built using the command
+
+      cd doc/sphinx; make html
+
+This will create the file `doc/sphinx/_build/html/index.html` that is the
+starting point for exploring the user manual. The Sphinx documentation system
+requires Python and a number of packages that are documented in the file
+[environment.yml](https://github.com/geodynamics/aspect/blob/main/doc/sphinx/environment.yml).
+You can create a Python environment with all
+required packages using the command
+
+      conda env create -f doc/sphinx/environment.yml
+
+which assumes that you have the Anaconda python installer available.

--- a/doc/sphinx/user/install/local-installation/index.md
+++ b/doc/sphinx/user/install/local-installation/index.md
@@ -27,4 +27,5 @@ system-prereqs.md
 using-candi.md
 obtaining.md
 compiling.md
+documentation.md
 :::


### PR DESCRIPTION
We currently have no documentation on how to build the sphinx documentation locally. Add instructions and combine them with the instructions on how to build the doxygen documentation.