### PR TITLE
[WIP] Update cig logo option for sphinx

### DIFF
--- a/doc/sphinx/_templates/navbar_end.html
+++ b/doc/sphinx/_templates/navbar_end.html
@@ -1,0 +1,1 @@
+<p><img src="/en/latest/_static/images/cig_logo_dots.png" alt="CIG Logo" height="80px"  style="padding: 5px;"/></p>

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -81,8 +81,11 @@ html_theme_options = {
     "use_repository_button": True,
     "use_edit_page_button": True,
     "use_issues_button": True,
-    "extra_navbar": "<p><img src=\"/en/latest/_static/images/cig_logo_dots.png\" alt=\"CIG Logo\" height=\"80px\"  style=\"padding: 5px;\"/></p>",
     "home_page_in_toc": True,
+}
+
+html_sidebars = {
+    "**": ["navbar-logo.html","search-field.html","sbt-sidebar-nav.html","navbar_end.html"]
 }
 
 bibtex_bibfiles = ["references.bib"]


### PR DESCRIPTION
The "extra_navbar" option has been removed in newer versions of the sphinx-book-theme and I get warnings about it when building the documentation on my system. Readthedocs seems to be fine for now, but if the new option works on readthedocs we may as well already update to avoid the warnings (which are treated as errors by our settings).

I marked this WIP because I first want to check how this PR looks like on readthedocs.