### PR TITLE
Check that material model supports elasticity when it is enabled

### DIFF
--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -138,9 +138,6 @@ namespace aspect
     void
     Viscoelastic<dim>::parse_parameters (ParameterHandler &prm)
     {
-      AssertThrow(this->get_parameters().enable_elasticity == true,
-                  ExcMessage ("Material model Viscoelastic only works if 'Enable elasticity' is set to true"));
-
       prm.enter_subsection("Material model");
       {
         prm.enter_subsection("Viscoelastic");


### PR DESCRIPTION
See #4985. When a material model does not support elasticity, but elasticity is enabled, Throw a helpful exception.

I left in the AssertThrow in elasticity.cc that checks that `Enable elasticity` is set to true (so it checks the reverse of the new AssertThrow).

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
