### PR TITLE
Fix documentation layout

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+      python: "mambaforge-4.10"
+
 # Build documentation in the root directory with Sphinx
 sphinx:
   configuration: ./doc/sphinx/conf.py

--- a/doc/sphinx/_templates/navbar_end.html
+++ b/doc/sphinx/_templates/navbar_end.html
@@ -1,1 +1,1 @@
-<p><img src="/en/latest/_static/images/cig_logo_dots.png" alt="CIG Logo" height="80px"  style="padding: 5px;"/></p>
+<img src="/en/latest/_static/images/cig_logo_dots.png" alt="CIG Logo" height="80px"  style="padding: 5px;"/>

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -82,10 +82,10 @@ html_theme_options = {
     "use_edit_page_button": True,
     "use_issues_button": True,
     "home_page_in_toc": True,
-}
-
-html_sidebars = {
-    "**": ["navbar-logo.html","search-field.html","sbt-sidebar-nav.html","navbar_end.html"]
+    "logo": {
+        "text": "ASPECT " + release,
+    },
+    "primary_sidebar_end": "navbar_end.html"
 }
 
 bibtex_bibfiles = ["references.bib"]


### PR DESCRIPTION
Do not merge yet ;-)

#5216 accidentally removed the title text of the documentation. Reintroduce the title and remove an unnecessary paragraph in the CIG logo navbar.