### PR TITLE
Make sure cells are consistently ordered.

### DIFF
--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -207,6 +207,7 @@ namespace aspect
                 }
 
               // Then create the actual mesh:
+              GridTools::consistently_order_cells (cells);
               coarse_grid.create_triangulation(points, cells, subcell_data);
             }
         }


### PR DESCRIPTION
See also https://github.com/dealii/dealii/issues/15685. I don't think it matters here, but we should simply *always* call that function before `create_triangulation()`.