### PR TITLE
Apply strict cutoff to the Peierls stress

### DIFF
--- a/doc/modules/changes/20230708_lhy11009
+++ b/doc/modules/changes/20230708_lhy11009
@@ -1,0 +1,5 @@
+ New: The cutoff stress for the Peierls stress
+ could now be applied strictly as the lower
+ limit of the stress in the Peierls rheology
+ <br>
+ (Haoyuan Li, Bob Myhill, 2023/07/08)

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -251,6 +251,12 @@ namespace aspect
           std::vector<double> stress_cutoffs;
 
           /**
+           * A parameter determines whether a strict cutoff
+           * on the stress is applied to the Peierls creep
+          */
+          bool apply_strict_cutoff;
+
+          /**
            * Parameters governing the iteration for the exact
            * Peierls viscosity.
            */

--- a/tests/visco_plastic_peierls_strict_cutoff_test.prm
+++ b/tests/visco_plastic_peierls_strict_cutoff_test.prm
@@ -1,0 +1,95 @@
+# A test for the exact Peierls creep flow law
+# with the visco_plastic material model.
+# Following the general Peierls creep flow law of Idrissi
+# et al. 2016 and assuming a strain rate of 1e-15 s^-1. The stress
+# from the Peierls rheology is limited by the cutoff stress
+# of 1000 Pa, so a viscosity of 5e17 Pa*s is computed instead
+# from:
+#     1000 / 1e-15 / 2.0 = 5e17
+
+# Global parameters
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 0
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, iterated Stokes
+set Max nonlinear iterations               = 1
+set Surface pressure                       = 3.e2
+
+# Model geometry (100x100 km, 10 km spacing)
+subsection Geometry model
+  set Model name = box
+  subsection Box
+    set X repetitions = 10
+    set Y repetitions = 10
+    set X extent      = 100e3
+    set Y extent      = 100e3
+  end
+end
+
+# Mesh refinement specifications
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 0
+  set Time steps between mesh refinement = 0
+end
+
+# No boundary-driven deformation, but the strain-rate used by the material
+# model is set in the material model section through the parameters
+# "Reference strain rate" and "Minimum strain rate".
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, top, left, right
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Function expression = 1673
+  end
+end
+
+# Material model (values for background material)
+subsection Material model
+  set Model name = visco plastic
+  subsection Visco Plastic
+    set Reference strain rate                     = 1e-15
+    set Minimum strain rate                       = 1e-15
+    # dislocation creep parameters
+    # These values produce such a sufficiently high viscosity that the
+    # composite viscosity between the diffusion and dislocation creep
+    # is effectively equal to the Peierls creep viscosity.
+    set Viscous flow law = dislocation
+    set Prefactors for dislocation creep          = 1.e-50
+    set Stress exponents for dislocation creep    = 1.0
+    set Activation energies for dislocation creep = 0
+    set Activation volumes for dislocation creep  = 0
+    # Peierls creep parameters
+    set Include Peierls creep                     = true
+    set Peierls creep flow law                    = exact
+    set Prefactors for Peierls creep              = 1e6
+    set Activation energies for Peierls creep     = 566.e3
+    set Activation volumes for Peierls creep      = 0.
+    set Peierls stresses                          = 3.8e9
+    set Stress exponents for Peierls creep        = 0.0
+    set Peierls fitting parameters                = 0.15
+    set Peierls glide parameters p                = 0.5
+    set Peierls glide parameters q                = 2.0
+    set Peierls strain rate residual tolerance    = 1e-22
+    set Maximum Peierls strain rate iterations    = 40
+    set Cutoff stresses for Peierls creep         = 1000
+    set Apply strict stress cutoff for Peierls creep = true
+  end
+end
+
+# Gravity model
+subsection Gravity model
+  set Model name = vertical
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+# Post processing
+subsection Postprocess
+  set List of postprocessors = material statistics
+end

--- a/tests/visco_plastic_peierls_strict_cutoff_test/screen-output
+++ b/tests/visco_plastic_peierls_strict_cutoff_test/screen-output
@@ -1,0 +1,18 @@
+
+Number of active cells: 100 (on 1 levels)
+Number of degrees of freedom: 1,444 (882+121+441)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 14+0 iterations.
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
+
+
+   Postprocessing:
+     Average density / Average viscosity / Total mass:  3141 kg/m^3, 5e+17 Pa s, 3.141e+13 kg
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/visco_plastic_peierls_strict_cutoff_test/statistics
+++ b/tests/visco_plastic_peierls_strict_cutoff_test/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of nonlinear iterations
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Average density (kg/m^3)
+# 13: Average viscosity (Pa s)
+# 14: Total mass (kg)
+0 0.000000000000e+00 0.000000000000e+00 100 1003 441 1 0 13 15 14 3.14061000e+03 5.00000000e+17 3.14061000e+13 


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

In the Pull request, I add an option to use the "Cutoff stresses for Peierls creep" as strict cutoffs for the stress in the Peierls rheology. Previously, these values are used to ensure a gradual decreases of the Peierls strain rate towards 0 when the stress approaches 0. However, the values of the calculated Peierls creep viscosity could still be ultra small with the Idrissi 16 rheology at mantle conditions (T = 1673 K, strain rate = ${10}^{-15} s^{-1}$.  By adding this new option, the stress in the Peierls rheology cannot drop pass the cutoff stress anymore, thus reasonalely large values of Peierls viscosity could be achieved by adjusting the cutoff stress.

New test:

1. visco_plastic_peierls_strict_cutoff_test
The viscosity is computed at mantle condition from the Idrissi 16 rheology.  A strict cutoff is applied to rise the viscosity to a value of $5 \times {10}^{17} Pa s$ to demonstrate the usage of this option.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
