### PR TITLE
Remove references to manual.bib

### DIFF
--- a/contrib/release/release-tasklist.md
+++ b/contrib/release/release-tasklist.md
@@ -167,10 +167,10 @@ and the links are working
   - update zenodo badge in README.md to newest version (see badge button on the right of zenodo page)
   - add zenodo badge also to the release on github (on top, see 2.0.1 for an example)
   - readme / release notes: add zenodo DOI button
-  - manual/manual.bib: add new zenodo entry
+  - doc/sphinx/references.bib: add new zenodo entry
 . create figshare DOI for manual (just upload a new version as the same entry)
-  - update manual/manual.bib entry
-. update doc/manual/manual.bib with src and manual doi
+  - update doc/sphinx/references.bib entry
+. update doc/sphinx/references.bib with src and manual doi
 . update aspect.geodynamics.org/cite.html and citing.html in www repo:
   - add new version in citing.html, search for "<option"
   - doc/make_cite_html.py:

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -1,7 +1,7 @@
-# A python3 script to generate the database.js file from manual/manual.bib for citing.html online
+# A python3 script to generate the database.js file from sphinx/references.bib for citing.html online
 
 # What this does:
-# - read bibtex entries from "manual/manual.bib" that are specified below
+# - read bibtex entries from "sphinx/references.bib" that are specified below
 # - use the DOI and the online API to request a clean text form for citation for each entry
 # - write database.js (in the current directory) that contains a javascript object with all the information above
 #
@@ -11,7 +11,7 @@ import requests
 import re
 from html import escape
 
-bibfile = "manual/manual.bib"
+bibfile = "sphinx/references.bib"
 
 bibitems = {}
 biburls = {}

--- a/doc/options.dox
+++ b/doc/options.dox
@@ -577,7 +577,7 @@ LAYOUT_FILE            =
 # of the bibliography can be controlled using LATEX_BIB_STYLE. To use this
 # feature you need bibtex and perl available in the search path.
 
-CITE_BIB_FILES         = manual/manual.bib
+CITE_BIB_FILES         = sphinx/references.bib
 
 #---------------------------------------------------------------------------
 # configuration options related to warning and progress messages


### PR DESCRIPTION
Clean up some leftovers from #5200, in particular some uses of doc/manual/manual.bib, which is now replaced by doc/sphinx/references.bib.