### PR TITLE
allow a different list of assemblers for each advection field

### DIFF
--- a/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
+++ b/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
@@ -269,11 +269,16 @@ namespace aspect
                  ExcMessage("The entropy advection assembler requires "
                             "that adiabatic heating is disabled."));
 
-    // Replace all existing assemblers by the one for the entropy equation.
-    assemblers.advection_system.resize(1);
-    assemblers.advection_system[0] = std::make_unique<Assemblers::EntropyAdvectionSystem<dim>>();
+    // Replace all existing assemblers for the temperature and entropy fields by the one for the entropy equation.
+    const unsigned int temperature_index = 0;
+    assemblers.advection_system[temperature_index].resize(1);
+    assemblers.advection_system[temperature_index][0] = std::make_unique<Assemblers::EntropyAdvectionSystem<dim>>();
+    assemblers.advection_system_assembler_properties[temperature_index].needed_update_flags = update_hessians;
 
-    assemblers.advection_system_assembler_properties[0].needed_update_flags = update_hessians;
+    const unsigned int entropy_index = 1 + simulator_access.introspection().compositional_index_for_name("entropy");
+    assemblers.advection_system[entropy_index].resize(1);
+    assemblers.advection_system[entropy_index][0] = std::make_unique<Assemblers::EntropyAdvectionSystem<dim>>();
+    assemblers.advection_system_assembler_properties[entropy_index].needed_update_flags = update_hessians;
   }
 } // namespace aspect
 

--- a/doc/modules/changes/20230709_dannberg
+++ b/doc/modules/changes/20230709_dannberg
@@ -1,0 +1,4 @@
+New: ASPECT now allows it to select a different list of
+assemblers for each advection field.
+<br>
+(Juliane Dannberg, 2023/07/09)

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -716,28 +716,29 @@ namespace aspect
         std::vector<std::unique_ptr<Assemblers::Interface<dim>>> stokes_system_on_boundary_face;
 
         /**
-         * A vector of pointers containing all assemblers for the advection systems.
+         * A vector of vectors of pointers containing a list of all assemblers
+         * for each individual advection system.
          * These assemblers are called once per cell.
          */
-        std::vector<std::unique_ptr<Assemblers::Interface<dim>>> advection_system;
+        std::vector<std::vector<std::unique_ptr<Assemblers::Interface<dim>>>> advection_system;
 
         /**
-         * A vector of pointers containing all assemblers for the Advection
-         * systems that compute face contributions at boundaries. These assemblers
-         * are called once per boundary face with the properly initialized inputs,
-         * therefore they allow terms that only exist on boundary faces (e.g.
-         * flux boundary conditions).
+         * A vector of vectors of pointers containing a list of all assemblers
+         * for the individual advection systems that compute face contributions
+         * at boundaries. These assemblers are called once per boundary face with
+         * the properly initialized inputs, therefore they allow terms that only
+         * exist on boundary faces (e.g. flux boundary conditions).
          */
-        std::vector<std::unique_ptr<Assemblers::Interface<dim>>> advection_system_on_boundary_face;
+        std::vector<std::vector<std::unique_ptr<Assemblers::Interface<dim>>>> advection_system_on_boundary_face;
 
         /**
-         * A vector of pointers containing all assemblers for the Advection
-         * systems that compute face contributions on faces between cells.
-         * These assemblers are called once per interior face with the properly
-         * initialized inputs, therefore they allow terms that only exist on
-         * interior faces (e.g. DG penalty terms).
+         * A vector of vectors of pointers containing a list of all assemblers
+         * for the individual advection systems that compute face contributions
+         * on faces between cells. These assemblers are called once per interior
+         * face with the properly initialized inputs, therefore they allow terms
+         * that only exist on interior faces (e.g. DG penalty terms).
          */
-        std::vector<std::unique_ptr<Assemblers::Interface<dim>>> advection_system_on_interior_face;
+        std::vector<std::vector<std::unique_ptr<Assemblers::Interface<dim>>>> advection_system_on_interior_face;
 
         /**
          * A structure that describes what information an assembler function

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -134,14 +134,14 @@ namespace aspect
 
     std::vector<double> residual (scratch.finite_element_values.n_quadrature_points,0.0);
 
-    for (unsigned int i=0; i<assemblers->advection_system.size(); ++i)
+    for (unsigned int i=0; i<assemblers->advection_system[advection_field.field_index()].size(); ++i)
       {
-        const std::vector<double> new_residual = assemblers->advection_system[i]->compute_residual(scratch);
+        const std::vector<double> new_residual = assemblers->advection_system[advection_field.field_index()][i]->compute_residual(scratch);
         for (unsigned int j=0; j<residual.size(); ++j)
           residual[j] += new_residual[j];
 
         if (auto *stabilization_assembler =
-              dynamic_cast<Assemblers::AdvectionStabilizationInterface<dim>*> ((assemblers->advection_system[i]).get()))
+              dynamic_cast<Assemblers::AdvectionStabilizationInterface<dim>*> ((assemblers->advection_system[advection_field.field_index()][i]).get()))
           {
             // Ensure no other assembler has set max_advection_prefactor or max_conductivity before,
             // otherwise we dont know which one to use.
@@ -549,8 +549,8 @@ namespace aspect
           }
         scratch.material_model_inputs.current_cell = cell;
 
-        for (unsigned int i=0; i<assemblers->advection_system.size(); ++i)
-          assemblers->advection_system[i]->create_additional_material_model_outputs(scratch.material_model_outputs);
+        for (unsigned int i=0; i<assemblers->advection_system[advection_field.field_index()].size(); ++i)
+          assemblers->advection_system[advection_field.field_index()][i]->create_additional_material_model_outputs(scratch.material_model_outputs);
         heating_model_manager.create_additional_material_model_inputs_and_outputs(scratch.material_model_inputs,
                                                                                   scratch.material_model_outputs);
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1691,15 +1691,18 @@ namespace aspect
           std::make_unique<Assemblers::MeltPressureRHSCompatibilityModification<dim>> ());
       }
 
-    assemblers.advection_system.push_back(
-      std::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());
-
-    if (this->get_parameters().fixed_heat_flux_boundary_indicators.size() != 0)
+    for (unsigned int i=0; i<1+this->introspection().n_compositional_fields; ++i)
       {
-        assemblers.advection_system_on_boundary_face.push_back(
-          std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
-        assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
-        assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
+        assemblers.advection_system[i].push_back(
+          std::make_unique<Assemblers::MeltAdvectionSystem<dim>> ());
+
+        if (this->get_parameters().fixed_heat_flux_boundary_indicators.size() != 0)
+          {
+            assemblers.advection_system_on_boundary_face[i].push_back(
+              std::make_unique<aspect::Assemblers::AdvectionSystemBoundaryHeatFlux<dim>>());
+            assemblers.advection_system_assembler_on_face_properties[0].need_face_material_model_data = true;
+            assemblers.advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
+          }
       }
   }
 


### PR DESCRIPTION
It is useful to allow different advection fields to have different assemblers (i.e., we have different advection methods like advection field, diffusion field etc.) and not all of them require all assemblers. In cases where a signal is used to replace assemblers, it may even be necessary to only do that for specific fields and not for all of them. 

This PR makes the advection system assembers a vector of vectors (with each compositional field having their individual vector of advection assemblers). At the moment, all fields still get the same assemblers, to test that this change does not break any functionality. The next step would be to only include the assemblers that are needed in each list (in a separate PR). 

The change in the entropy benchmark shows how this could look like.  

I also want to see which tests this breaks to see where I still have to fix the assemblers. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
