### PR TITLE
Avoid use of taking .c_str() just to convert back to std::string.

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -450,7 +450,7 @@ parse_parameters (const std::string &input_as_string,
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) == 0)
     try
       {
-        prm.parse_input_from_string(input_as_string.c_str());
+        prm.parse_input_from_string(input_as_string);
       }
     catch (const dealii::ExceptionBase &e)
       {
@@ -486,7 +486,7 @@ parse_parameters (const std::string &input_as_string,
   // other processors will be ok as well
   if (dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD) != 0)
     {
-      prm.parse_input_from_string(input_as_string.c_str());
+      prm.parse_input_from_string(input_as_string);
     }
 }
 

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -269,7 +269,7 @@ namespace aspect
             "velocity magnitude|sinking velocity|rising velocity|Vs|Vp|log viscosity|"
             "viscosity|vertical heat flux|vertical mass flux|composition mass";
           prm.declare_entry("List of output variables", "all",
-                            Patterns::MultipleSelection(variables.c_str()),
+                            Patterns::MultipleSelection(variables),
                             "A comma separated list which specifies which quantities to "
                             "average in each depth slice. It defaults to averaging all "
                             "available quantities, but this can be an expensive operation, "

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -469,7 +469,7 @@ namespace aspect
               // Just write one data file in parallel
               else if (group_files == 1)
                 {
-                  data_out.write_vtu_in_parallel(filename.c_str(),
+                  data_out.write_vtu_in_parallel(filename,
                                                  this->get_mpi_communicator());
                 }
               // Write as many output files as 'group_files' groups
@@ -481,7 +481,7 @@ namespace aspect
                   int ierr = MPI_Comm_split(this->get_mpi_communicator(), color, my_id, &comm);
                   AssertThrowMPI(ierr);
 
-                  data_out.write_vtu_in_parallel(filename.c_str(), comm);
+                  data_out.write_vtu_in_parallel(filename, comm);
                   ierr = MPI_Comm_free(&comm);
                   AssertThrowMPI(ierr);
                 }

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -593,7 +593,7 @@ namespace aspect
             // Just write one data file in parallel
             if (group_files == 1)
               {
-                data_out.write_vtu_in_parallel(filename.c_str(),
+                data_out.write_vtu_in_parallel(filename,
                                                this->get_mpi_communicator());
               }
             else               // Write as many output files as 'group_files' groups
@@ -602,7 +602,7 @@ namespace aspect
                 MPI_Comm comm;
                 int ierr = MPI_Comm_split(this->get_mpi_communicator(), color, my_id, &comm);
                 AssertThrowMPI(ierr);
-                data_out.write_vtu_in_parallel(filename.c_str(), comm);
+                data_out.write_vtu_in_parallel(filename, comm);
                 ierr = MPI_Comm_free(&comm);
                 AssertThrowMPI(ierr);
               }

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -308,7 +308,7 @@ namespace aspect
 
       signals.pre_checkpoint_store_user_data(triangulation);
 
-      triangulation.save ((parameters.output_directory + "restart.mesh.new").c_str());
+      triangulation.save (parameters.output_directory + "restart.mesh.new");
     }
 
     // save general information This calls the serialization functions on all
@@ -523,7 +523,7 @@ namespace aspect
     // now that we have resumed from the snapshot load the mesh and solution vectors
     try
       {
-        triangulation.load ((parameters.output_directory + "restart.mesh").c_str());
+        triangulation.load (parameters.output_directory + "restart.mesh");
       }
     catch (...)
       {


### PR DESCRIPTION
This is all in places where a function wants a string, we have a string, we ask for its `.c_str()`, which is then converted back to a string. This is not necessary.