### PR TITLE
std::[io]fstream can take file names as std::string.

### DIFF
--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -314,7 +314,7 @@ namespace aspect
       data_OES.clear();
       if (name_OES.size()==0)
         return;
-      std::istringstream in(Utilities::read_and_distribute_file_content(name_OES.c_str(),
+      std::istringstream in(Utilities::read_and_distribute_file_content(name_OES,
                                                                         this->get_mpi_communicator()));
       if (in.good())
         {

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -154,7 +154,7 @@ namespace aspect
 
                   const std::string filename = (filename_prefix +
                                                 DataOutBase::default_suffix(output_format));
-                  std::ofstream f (filename.c_str());
+                  std::ofstream f (filename);
 
 
                   if (output_format == DataOutBase::gnuplot)
@@ -174,7 +174,7 @@ namespace aspect
               else
                 {
                   const std::string filename (this->get_output_directory() + "depth_average.txt");
-                  std::ofstream f(filename.c_str(), std::ofstream::out);
+                  std::ofstream f(filename, std::ofstream::out);
 
                   // Write the header
                   f << "#       time" << "        depth";

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -592,7 +592,7 @@ namespace aspect
           // On processor 0, collect all the data and put them into the output density anomaly contribution SH coefficients file.
           if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
             {
-              std::ofstream density_anomaly_contribution_SH_coes_file (density_anomaly_contribution_SH_coes_filename.c_str());
+              std::ofstream density_anomaly_contribution_SH_coes_file (density_anomaly_contribution_SH_coes_filename);
               density_anomaly_contribution_SH_coes_file << "# "
                                                         << "degree order cosine_coefficient sine_coefficient"
                                                         << std::endl;
@@ -636,7 +636,7 @@ namespace aspect
           // and put them into the output surface topography contribution SH coefficients file.
           if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
             {
-              std::ofstream surface_topo_contribution_SH_coes_file (surface_topo_contribution_SH_coes_filename.c_str());
+              std::ofstream surface_topo_contribution_SH_coes_file (surface_topo_contribution_SH_coes_filename);
               surface_topo_contribution_SH_coes_file << "# "
                                                      << "degree order cosine_coefficient sine_coefficient"
                                                      << std::endl;
@@ -683,7 +683,7 @@ namespace aspect
           // to get the data. On processor 0, collect all the data and put them into the output CMB topography contribution SH coefficients file.
           if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
             {
-              std::ofstream CMB_topo_contribution_SH_coes_file (CMB_topo_contribution_SH_coes_filename.c_str());
+              std::ofstream CMB_topo_contribution_SH_coes_file (CMB_topo_contribution_SH_coes_filename);
               CMB_topo_contribution_SH_coes_file << "# "
                                                  << "degree order cosine_coefficient sine_coefficient"
                                                  << std::endl;
@@ -730,7 +730,7 @@ namespace aspect
           // On processor 0, collect all the data and put them into the output geoid anomaly SH coefficients file.
           if (dealii::Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
             {
-              std::ofstream geoid_anomaly_SH_coes_file (geoid_anomaly_SH_coes_filename.c_str());
+              std::ofstream geoid_anomaly_SH_coes_file (geoid_anomaly_SH_coes_filename);
               geoid_anomaly_SH_coes_file << "# "
                                          << "degree order cosine_coefficient sine_coefficient"
                                          << std::endl;

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -233,7 +233,7 @@ namespace aspect
             close(tmp_file_desc);
         }
 
-      std::ofstream out(tmp_filename.c_str());
+      std::ofstream out(tmp_filename);
 
       AssertThrow (out, ExcMessage(std::string("Trying to write to file <") +
                                    filename +
@@ -268,8 +268,8 @@ namespace aspect
       const std::string
       pvtu_master_filename = (solution_file_prefix +
                               ".pvtu");
-      std::ofstream pvtu_master ((this->get_output_directory() + "particles/" +
-                                  pvtu_master_filename).c_str());
+      std::ofstream pvtu_master (this->get_output_directory() + "particles/" +
+                                 pvtu_master_filename);
       data_out.write_pvtu_record (pvtu_master, filenames);
 
       // now also generate a .pvd file that matches simulation
@@ -278,7 +278,7 @@ namespace aspect
 
       const std::string
       pvd_master_filename = (this->get_output_directory() + "particles.pvd");
-      std::ofstream pvd_master (pvd_master_filename.c_str());
+      std::ofstream pvd_master (pvd_master_filename);
 
       DataOutBase::write_pvd_record (pvd_master, times_and_pvtu_file_names);
 
@@ -289,7 +289,7 @@ namespace aspect
                                + "particles/"
                                + solution_file_prefix
                                + ".visit");
-      std::ofstream visit_master (visit_master_filename.c_str());
+      std::ofstream visit_master (visit_master_filename);
 
       DataOutBase::write_visit_record (visit_master, filenames);
 
@@ -306,8 +306,8 @@ namespace aspect
         output_file_names_by_timestep.push_back (filenames_with_path);
       }
 
-      std::ofstream global_visit_master ((this->get_output_directory() +
-                                          "particles.visit").c_str());
+      std::ofstream global_visit_master (this->get_output_directory() +
+                                         "particles.visit");
 
       std::vector<std::pair<double, std::vector<std::string>>> times_and_output_file_names;
       for (unsigned int timestep=0; timestep<times_and_pvtu_file_names.size(); ++timestep)
@@ -502,7 +502,7 @@ namespace aspect
                                            + DataOutBase::default_suffix
                                            (DataOutBase::parse_output_format(output_format));
 
-              std::ofstream out (filename.c_str());
+              std::ofstream out (filename);
 
               AssertThrow(out,
                           ExcMessage("Unable to open file for writing: " + filename +"."));

--- a/source/postprocess/point_values.cc
+++ b/source/postprocess/point_values.cc
@@ -122,7 +122,7 @@ namespace aspect
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
         {
 
-          std::ofstream f (filename.c_str());
+          std::ofstream f (filename);
           f << ("# <time> "
                 "<evaluation_point_x> "
                 "<evaluation_point_y> ")

--- a/source/postprocess/stokes_residual.cc
+++ b/source/postprocess/stokes_residual.cc
@@ -60,8 +60,8 @@ namespace aspect
       // On the root process, write out the file.
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
         {
-          std::ofstream f((this->get_output_directory() +
-                           "stokes_residuals.txt").c_str());
+          std::ofstream f(this->get_output_directory() +
+                          "stokes_residuals.txt");
           f << "# time solveidx residual\n";
           for (unsigned int i=0; i<entries.size(); ++i)
             {

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -377,8 +377,8 @@ namespace aspect
                                                this->get_time());
       const std::string pvtu_master_filename = (solution_file_prefix +
                                                 ".pvtu");
-      std::ofstream pvtu_master ((this->get_output_directory() + "solution/" +
-                                  pvtu_master_filename).c_str());
+      std::ofstream pvtu_master (this->get_output_directory() + "solution/" +
+                                 pvtu_master_filename);
       data_out.write_pvtu_record (pvtu_master, filenames);
 
       // now also generate a .pvd file that matches simulation
@@ -398,7 +398,7 @@ namespace aspect
 
       const std::string pvd_master_filename = (this->get_output_directory() +
                                                (is_cell_data_output ? "solution.pvd" : "solution_surface.pvd"));
-      std::ofstream pvd_master (pvd_master_filename.c_str());
+      std::ofstream pvd_master (pvd_master_filename);
 
       DataOutBase::write_pvd_record (pvd_master, output_history.times_and_pvtu_names);
 
@@ -408,7 +408,7 @@ namespace aspect
                                                  + "solution/"
                                                  + solution_file_prefix
                                                  + ".visit");
-      std::ofstream visit_master (visit_master_filename.c_str());
+      std::ofstream visit_master (visit_master_filename);
 
       DataOutBase::write_visit_record (visit_master, filenames);
 
@@ -435,8 +435,8 @@ namespace aspect
           output_history.output_file_names_by_timestep.push_back (filenames_with_path);
       }
 
-      std::ofstream global_visit_master ((this->get_output_directory() +
-                                          (is_cell_data_output ? "solution.visit" : "solution_surface.visit")).c_str());
+      std::ofstream global_visit_master (this->get_output_directory() +
+                                         (is_cell_data_output ? "solution.visit" : "solution_surface.visit"));
 
       std::vector<std::pair<double, std::vector<std::string>>> times_and_output_file_names;
       for (unsigned int timestep=0; timestep<output_history.times_and_pvtu_names.size(); ++timestep)
@@ -631,7 +631,7 @@ namespace aspect
                                        + solution_file_prefix + "." + Utilities::int_to_string(myid, 4)
                                        + DataOutBase::default_suffix(
                                          DataOutBase::parse_output_format(output_format));
-          std::ofstream out(filename.c_str());
+          std::ofstream out(filename);
           AssertThrow(out,
                       ExcMessage(
                         "Unable to open file for writing: " + filename + "."));
@@ -1064,7 +1064,7 @@ namespace aspect
             close(tmp_file_desc);
         }
 
-      std::ofstream out(tmp_filename.c_str());
+      std::ofstream out(tmp_filename);
 
       AssertThrow (out, ExcMessage(std::string("Trying to write to file <") +
                                    filename +

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -344,7 +344,7 @@ namespace aspect
                 static_cast<uint32_t>(compressed_data_length)
               }; /* list of compressed sizes of blocks */
 
-          std::ofstream f ((parameters.output_directory + "restart.resume.z.new").c_str());
+          std::ofstream f ((parameters.output_directory + "restart.resume.z.new"));
           f.write(reinterpret_cast<const char *>(compression_header), 4 * sizeof(compression_header[0]));
           f.write(reinterpret_cast<char *>(&compressed_data[0]), compressed_data_length);
           f.close();

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -250,7 +250,7 @@ namespace aspect
       {
         // only open the log file on processor 0, the other processors won't be
         // writing into the stream anyway
-        log_file_stream.open((parameters.output_directory + "log.txt").c_str(),
+        log_file_stream.open(parameters.output_directory + "log.txt",
                              parameters.resume_computation ? std::ios_base::app : std::ios_base::out);
 
         // we already printed the header to the screen, so here we just dump it
@@ -536,13 +536,13 @@ namespace aspect
     // Only write the parameter files on the root node to avoid file system conflicts
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
       {
-        std::ofstream prm_out ((parameters.output_directory + "parameters.prm").c_str());
+        std::ofstream prm_out ((parameters.output_directory + "parameters.prm"));
         AssertThrow (prm_out,
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.prm>."));
         prm.print_parameters(prm_out, ParameterHandler::Text);
 
-        std::ofstream json_out ((parameters.output_directory + "parameters.json").c_str());
+        std::ofstream json_out ((parameters.output_directory + "parameters.json"));
         AssertThrow (json_out,
                      ExcMessage (std::string("Could not open file <") +
                                  parameters.output_directory + "parameters.json>."));

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1321,7 +1321,7 @@ namespace aspect
     bool
     fexists(const std::string &filename)
     {
-      std::ifstream ifile(filename.c_str());
+      std::ifstream ifile(filename);
 
       // return whether construction of the input file has succeeded;
       // success requires the file to exist and to be readable
@@ -1337,7 +1337,7 @@ namespace aspect
       bool file_exists = false;
       if (Utilities::MPI::this_mpi_process(comm) == 0)
         {
-          std::ifstream ifile(filename.c_str());
+          std::ifstream ifile(filename);
 
           // return whether construction of the input file has succeeded;
           // success requires the file to exist and to be readable
@@ -1487,9 +1487,9 @@ namespace aspect
               std::ifstream filestream;
               const bool filename_ends_in_gz = std::regex_search(filename, std::regex("\\.gz$"));
               if (filename_ends_in_gz == true)
-                filestream.open(filename.c_str(), std::ios_base::in | std::ios_base::binary);
+                filestream.open(filename, std::ios_base::in | std::ios_base::binary);
               else
-                filestream.open(filename.c_str());
+                filestream.open(filename);
 
               if (!filestream)
                 {
@@ -1562,8 +1562,7 @@ namespace aspect
 
       if (Utilities::MPI::this_mpi_process(comm) == 0)
         {
-          std::ofstream filestream;
-          filestream.open(filename.c_str());
+          std::ofstream filestream(filename);
 
           AssertThrow (filestream.good(),
                        ExcMessage (std::string("Could not open file <") + filename + ">."));
@@ -2911,7 +2910,7 @@ namespace aspect
           if (output_filename != "")
             {
               // output solver history
-              std::ofstream f((output_filename).c_str());
+              std::ofstream f((output_filename));
 
               for (const auto &solver_control: solver_controls)
                 {


### PR DESCRIPTION
`std::[if]stream` used to only take C-style pointers to file names, but since C++11 they are also happy with `std::string` objects. We have the latter, there is no need to extract a C-style pointer.