### PR TITLE
Be safer and more correct when using strain rate

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -220,10 +220,12 @@ namespace aspect
           out.entropy_derivative_pressure[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.entropy_derivative_pressure, MaterialUtilities::arithmetic);
           out.entropy_derivative_temperature[i] = MaterialUtilities::average_value (volume_fractions, eos_outputs.entropy_derivative_temperature, MaterialUtilities::arithmetic);
 
-          // Compute the effective viscosity if requested and retrieve whether the material is plastically yielding
+          // Compute the effective viscosity if requested and retrieve whether the material is plastically yielding.
+          // Also always compute the viscosity if additional outputs are requested, because the viscosity is needed
+          // to compute the elastic force term.
           bool plastic_yielding = false;
           IsostrainViscosities isostrain_viscosities;
-          if (in.requests_property(MaterialProperties::viscosity))
+          if (in.requests_property(MaterialProperties::viscosity) || in.requests_property(MaterialProperties::additional_outputs))
             {
               // Currently, the viscosities for each of the compositional fields are calculated assuming
               // isostrain amongst all compositions, allowing calculation of the viscosity ratio.

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -555,6 +555,7 @@ namespace aspect
                                            cell,
                                            this->introspection,
                                            current_linearization_point);
+
     scratch.material_model_inputs.requested_properties
       =
         MaterialModel::MaterialProperties::equation_of_state_properties |

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1506,6 +1506,7 @@ namespace aspect
                                          cell,
                                          this->introspection(),
                                          this->get_current_linearization_point());
+
             // We only need access to the MeltOutputs in p_c_scale().
             material_model_inputs.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 

--- a/tests/continental_extension/screen-output
+++ b/tests/continental_extension/screen-output
@@ -31,11 +31,11 @@ Number of mesh deformation degrees of freedom: 462
    Solving upper_crust system ... 9 iterations.
    Solving lower_crust system ... 9 iterations.
    Solving lithospheric_mantle system ... 9 iterations.
-   Initial Newton Stokes residual = 8.14683e+16, v = 8.14683e+16, p = 1.18823e+13
+   Initial Newton Stokes residual = 1.832e+14, v = 1.82814e+14, p = 1.18823e+13
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+18 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000175212, norm of the rhs: 1.42743e+13
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0779163, norm of the rhs: 1.42743e+13
 
 
    Postprocessing:

--- a/tests/visco_plastic_derivatives_2d.prm
+++ b/tests/visco_plastic_derivatives_2d.prm
@@ -7,6 +7,7 @@ set Dimension                              = 2
 set End time                               = 0
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = no Advection, no Stokes
+set Adiabatic surface temperature          = 273
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model

--- a/tests/visco_plastic_derivatives_2d/screen-output
+++ b/tests/visco_plastic_derivatives_2d/screen-output
@@ -5,94 +5,94 @@ Loading shared library <./libvisco_plastic_derivatives_2d.debug.so>
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter harmonic
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
-pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 1.14846e+34, Analytical derivative = 1.14846e+34
-strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
-strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 8.83884e+32, Analytical derivative = 8.83884e+32
-strain-rate: point = 0, component = 1, Finite difference = -1.14846e+34, Analytical derivative = -1.14846e+34
-strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
-strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
-strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
-strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
-pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 1.14845e+34, Analytical derivative = 1.14846e+34
-strain-rate: point = 1, component = 0, Finite difference = 6.58587e+26, Analytical derivative = 6.58655e+26
-strain-rate: point = 2, component = 0, Finite difference = 1.23759e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 8.83884e+32, Analytical derivative = 8.83884e+32
-strain-rate: point = 0, component = 1, Finite difference = -1.14846e+34, Analytical derivative = -1.14846e+34
-strain-rate: point = 1, component = 1, Finite difference = -6.58596e+26, Analytical derivative = -6.58657e+26
-strain-rate: point = 2, component = 1, Finite difference = -1.23785e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -1.27607e+33, Analytical derivative = -1.27606e+33
-strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
-strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
-pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 1.14846e+34, Analytical derivative = 1.14846e+34
-strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
-strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 8.83884e+32, Analytical derivative = 8.83884e+32
-strain-rate: point = 0, component = 1, Finite difference = -1.14846e+34, Analytical derivative = -1.14846e+34
-strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
-strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
-strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
-strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 2.12594e+08, Analytical derivative = 2.12594e+08
-pressure: point = 2, Finite difference = 2.68615e+08, Analytical derivative = 2.68615e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 1.14846e+34, Analytical derivative = 1.14846e+34
-strain-rate: point = 1, component = 0, Finite difference = 6.58655e+26, Analytical derivative = 6.58655e+26
-strain-rate: point = 2, component = 0, Finite difference = 1.23761e+27, Analytical derivative = 1.23761e+27
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 8.83884e+32, Analytical derivative = 8.83884e+32
-strain-rate: point = 0, component = 1, Finite difference = -1.14846e+34, Analytical derivative = -1.14846e+34
-strain-rate: point = 1, component = 1, Finite difference = -6.58657e+26, Analytical derivative = -6.58657e+26
-strain-rate: point = 2, component = 1, Finite difference = -1.23761e+27, Analytical derivative = -1.23761e+27
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -8.83883e+32, Analytical derivative = -8.83883e+32
-strain-rate: point = 0, component = 2, Finite difference = -1.27606e+33, Analytical derivative = -1.27606e+33
-strain-rate: point = 1, component = 2, Finite difference = 1.79805e+28, Analytical derivative = 1.79805e+28
-strain-rate: point = 2, component = 2, Finite difference = -1.1251e+28, Analytical derivative = -1.1251e+28
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = -4.41942e+32, Analytical derivative = -4.41942e+32
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
 OK
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 2,767 (882+121+441+441+441+441)

--- a/tests/visco_plastic_derivatives_3d.prm
+++ b/tests/visco_plastic_derivatives_3d.prm
@@ -7,6 +7,7 @@ set Dimension                              = 3
 set End time                               = 0
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = no Advection, no Stokes
+set Adiabatic surface temperature          = 273
 
 # Model geometry (100x100 km, 10 km spacing)
 subsection Geometry model

--- a/tests/visco_plastic_derivatives_3d/screen-output
+++ b/tests/visco_plastic_derivatives_3d/screen-output
@@ -5,157 +5,154 @@ Loading shared library <./libvisco_plastic_derivatives_3d.debug.so>
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter harmonic
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
-pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 9.12871e+33, Analytical derivative = 9.12871e+33
-strain-rate: point = 1, component = 0, Finite difference = 2.48798e+26, Analytical derivative = 2.48801e+26
-strain-rate: point = 2, component = 0, Finite difference = 2.34886e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 1, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 1, Finite difference = -1.24397e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 2, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 2, Finite difference = -1.24397e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 2, Finite difference = 2.34886e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
-strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 3, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
-strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 4, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
-strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 5, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 4, component = 5, Finite difference = 0, Analytical derivative = 0
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter geometric
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
-pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 9.12871e+33, Analytical derivative = 9.12871e+33
-strain-rate: point = 1, component = 0, Finite difference = 2.48652e+26, Analytical derivative = 2.48801e+26
-strain-rate: point = 2, component = 0, Finite difference = 2.3492e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 1, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 1, Finite difference = -1.24701e+26, Analytical derivative = -1.24382e+26
-   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-strain-rate: point = 2, component = 1, Finite difference = -4.68813e+26, Analytical derivative = -4.69773e+26
-   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 2, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 2, Finite difference = -1.24701e+26, Analytical derivative = -1.24382e+26
-   Error: The derivative of the viscosity to the strain rate is too different from the analytical value.
-strain-rate: point = 2, component = 2, Finite difference = 2.3492e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
-strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 3, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 4, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
-strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 4, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 5, Finite difference = -7.60731e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
-strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 5, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-Some parts of the test were not successful.
+strain-rate: point = 4, component = 5, Finite difference = 0, Analytical derivative = 0
+OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter arithmetic
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
-pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 9.12871e+33, Analytical derivative = 9.12871e+33
-strain-rate: point = 1, component = 0, Finite difference = 2.48801e+26, Analytical derivative = 2.48801e+26
-strain-rate: point = 2, component = 0, Finite difference = 2.34884e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 1, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 1, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 2, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 2, Finite difference = 2.34884e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
-strain-rate: point = 2, component = 3, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 3, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
-strain-rate: point = 2, component = 4, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 4, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
-strain-rate: point = 2, component = 5, Finite difference = -3.20298e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 5, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 4, component = 5, Finite difference = 0, Analytical derivative = 0
 OK
 
 Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter maximum composition
 pressure: point = 0, Finite difference = 0, Analytical derivative = 0
-pressure: point = 1, Finite difference = 1.52812e+08, Analytical derivative = 1.52812e+08
-pressure: point = 2, Finite difference = 1.96803e+08, Analytical derivative = 1.96803e+08
+pressure: point = 1, Finite difference = 0, Analytical derivative = 0
+pressure: point = 2, Finite difference = 0, Analytical derivative = 0
 pressure: point = 3, Finite difference = 0, Analytical derivative = 0
 pressure: point = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 0, component = 0, Finite difference = 9.12871e+33, Analytical derivative = 9.12871e+33
-strain-rate: point = 1, component = 0, Finite difference = 2.48801e+26, Analytical derivative = 2.48801e+26
-strain-rate: point = 2, component = 0, Finite difference = 2.34885e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 0, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 0, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 0, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 0, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 1, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 1, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 1, Finite difference = -4.69773e+26, Analytical derivative = -4.69773e+26
+strain-rate: point = 4, component = 0, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 1, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 1, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 1, Finite difference = -3.44265e+32, Analytical derivative = -3.44265e+32
-strain-rate: point = 0, component = 2, Finite difference = -4.56435e+33, Analytical derivative = -4.56435e+33
-strain-rate: point = 1, component = 2, Finite difference = -1.24382e+26, Analytical derivative = -1.24382e+26
-strain-rate: point = 2, component = 2, Finite difference = 2.34885e+26, Analytical derivative = 2.34885e+26
+strain-rate: point = 4, component = 1, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 2, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 2, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 2, Finite difference = 1.72133e+32, Analytical derivative = 1.72133e+32
-strain-rate: point = 0, component = 3, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 3, Finite difference = 5.09393e+27, Analytical derivative = 5.09393e+27
-strain-rate: point = 2, component = 3, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 2, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 3, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 3, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 3, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 4, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 4, Finite difference = 4.74422e+27, Analytical derivative = 4.74422e+27
-strain-rate: point = 2, component = 4, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 3, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 4, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 4, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 4, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
-strain-rate: point = 0, component = 5, Finite difference = -7.60726e+32, Analytical derivative = -7.60726e+32
-strain-rate: point = 1, component = 5, Finite difference = 4.56937e+27, Analytical derivative = 4.56937e+27
-strain-rate: point = 2, component = 5, Finite difference = -3.20297e+27, Analytical derivative = -3.20297e+27
+strain-rate: point = 4, component = 4, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 0, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 1, component = 5, Finite difference = 0, Analytical derivative = 0
+strain-rate: point = 2, component = 5, Finite difference = 0, Analytical derivative = 0
 strain-rate: point = 3, component = 5, Finite difference = 0, Analytical derivative = 0
-strain-rate: point = 4, component = 5, Finite difference = -1.72133e+32, Analytical derivative = -1.72133e+32
+strain-rate: point = 4, component = 5, Finite difference = 0, Analytical derivative = 0
 OK
 Number of active cells: 100 (on 1 levels)
 Number of degrees of freedom: 9,503 (3,969+242+1,323+1,323+1,323+1,323)

--- a/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
@@ -23,11 +23,11 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
 *** Timestep 1:  t=1 years, dt=1 years
    Solving temperature system... 0 iterations.
    Solving total_strain system ... 10 iterations.
-   Initial Newton Stokes residual = 1.85485e+13, v = 1.85069e+13, p = 1.24042e+12
+   Initial Newton Stokes residual = 1.8223e+13, v = 1.81808e+13, p = 1.24042e+12
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000108303, norm of the rhs: 2.00885e+09
+      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000110237, norm of the rhs: 2.00885e+09
 
 
    Postprocessing:


### PR DESCRIPTION
This PR contains three changes that make using the strain rate in material models safer. All of these changes were necessary for #5211.

1. The Stokes assembly currently only provides the strain rate to the material model if the viscosity is requested. However, with complex material models we dont know what other material properties the strain rate may be needed for. For example the visco_plastic and viscoelastic material models also need the viscosity to compute the elastic force terms. 
2. The visco-plastic rheology sometimes has to use a reference strain rate, but the condition for when to use the reference strain rate seems wrong. It needs to use the reference strain rate during the initialization (when timestep_number is undefined), during the first timestep (but only the first nonlinear iteration when we dont have the Stokes solution yet), and if the strain rate is very small (because we need to be able to divide through it).
3. The visco-plastic material model only computes the viscosity when it is requested, but it also uses the viscosity for the additional outputs (the elastic force terms). Make sure it computes the viscosity if the additional_outputs are requested.