### PR TITLE
Add a default local.cfg for a candi installation

### DIFF
--- a/contrib/install/local.cfg
+++ b/contrib/install/local.cfg
@@ -1,0 +1,9 @@
+PACKAGES="load:dealii-prepare once:cmake once:astyle once:hdf5 once:sundials once:p4est once:trilinos dealii"
+
+DEAL_II_VERSION=v9.5.0
+NATIVE_OPTIMIZATIONS=ON
+BUILD_EXAMPLES=OFF
+MKL=OFF
+USE_DEAL_II_CMAKE_MPI_COMPILER=ON
+DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF"
+

--- a/doc/sphinx/user/install/local-installation/using-candi.md
+++ b/doc/sphinx/user/install/local-installation/using-candi.md
@@ -4,14 +4,7 @@
 In its default configuration `candi` downloads and compiles a <span
 class="smallcaps">deal.II</span> configuration that is able to run
 ASPECT, but it also contains a number of packages
-that are not required (and that can be safely disabled if problems occur
-during the installation). We require at least the packages <span
-class="smallcaps">p4est</span>, Trilinos, and
-finally deal.II.
-
-At the time of this writing (2022), `candi` will install
-p4est 2.3.2, Trilinos 12.18.1, and deal.II 9.3.3.
-We strive to keep
+that are not required. We strive to keep
 the development version of ASPECT compatible
 with the latest release of deal.II and the
 current deal.II development version at any
@@ -23,6 +16,22 @@ class="smallcaps">p4est</span> and Trilinos.
             git clone https://github.com/dealii/candi
 
     in a directory of your choice.
+
+2.  *Obtaining a suitable candi configuration file:* As
+    mentioned above the default configuration of candi includes
+    a number of packages that are not necessary for ASPECT.
+    We require at least the packages <span-class="smallcaps">p4est</span>,
+    Trilinos, and finally deal.II. We may require SUNDIALS
+    in future ASPECT versions. In addition there are some
+    configuration options that make ASPECT faster.
+    We provide a candi configuration file that is optimized for
+    ASPECT at
+
+            https://github.com/geodynamics/aspect/tree/main/contrib/install/local.cfg
+
+    While not mandatory, we recommend to download this file and
+    place it inside the `candi` directory (you should then have two
+    configuration files in that directory, named `candi.cfg` and `local.cfg`).
 
 2.  *Installing deal.II and its dependencies:*
     Execute `candi` by running


### PR DESCRIPTION
Our local installation instructions use the default candi.cfg configuration file, which always tries to install opencascade, petsc and other packages, requiring a lot of time and causing more compilation complications than necessary. In addition it does not enable native optimizations. This PR provides a local.cfg file that  is better suited for ASPECT use and speeds up the GMG solver significantly for most users (many are not aware of the impact of native optimizations). With this file we also have more control over which deal.II version to suggest for users, the default seems to be the development version of deal.II.