### PR TITLE
Remove virtual when there is an override keyword from more functions.

### DIFF
--- a/include/aspect/initial_composition/world_builder.h
+++ b/include/aspect/initial_composition/world_builder.h
@@ -57,7 +57,6 @@ namespace aspect
          * beginning of the program after parse_parameters is run and after
          * the SimulatorAccess (if applicable) is initialized.
          */
-        virtual
         void
         initialize () override;
 

--- a/include/aspect/initial_temperature/world_builder.h
+++ b/include/aspect/initial_temperature/world_builder.h
@@ -62,7 +62,6 @@ namespace aspect
          * beginning of the program after parse_parameters is run and after
          * the SimulatorAccess (if applicable) is initialized.
          */
-        virtual
         void
         initialize () override;
 

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -48,7 +48,6 @@ namespace aspect
            * Look up where the RK2 data is stored. Done once and cached to
            * avoid repeated lookups.
            */
-          virtual
           void
           initialize () override;
 
@@ -98,7 +97,6 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            */
-          virtual
           void
           parse_parameters (ParameterHandler &prm) override;
 

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -46,7 +46,6 @@ namespace aspect
            * Look up where the RK4 data is stored. Done once and cached to
            * avoid repeated lookups.
            */
-          virtual
           void
           initialize () override;
 

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -159,7 +159,6 @@ namespace aspect
           /**
            * Read the parameters this class declares from the parameter file.
            */
-          virtual
           void
           parse_parameters (ParameterHandler &prm) override;
 

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -536,7 +536,6 @@ namespace aspect
            * Read the parameters this class needs to determine which integrator is used,
            * and therefore how many properties to reserve.
            */
-          virtual
           void
           parse_parameters (ParameterHandler &prm) override;
 

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -545,7 +545,7 @@ namespace aspect
        * model and storing the information necessary for a later call
        * to solve().
        */
-      virtual void assemble() override;
+      void assemble() override;
 
       /**
        * Computes and sets the diagonal for both the mass matrix operator and the A-block

--- a/include/aspect/time_stepping/conduction_time_step.h
+++ b/include/aspect/time_stepping/conduction_time_step.h
@@ -50,7 +50,6 @@ namespace aspect
         /**
          * @copydoc aspect::TimeStepping::Interface<dim>::execute()
          */
-        virtual
         double
         execute() override;
 

--- a/include/aspect/time_stepping/convection_time_step.h
+++ b/include/aspect/time_stepping/convection_time_step.h
@@ -50,7 +50,6 @@ namespace aspect
         /**
          * @copydoc aspect::TimeStepping::Interface<dim>::execute()
          */
-        virtual
         double
         execute() override;
 

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -179,7 +179,7 @@ namespace aspect
          * Override initialize_simulator() so that we can also initialize the contained
          * termination_manager.
          */
-        virtual void initialize_simulator (const Simulator<dim> &simulator_object) override;
+        void initialize_simulator (const Simulator<dim> &simulator_object) override;
 
 
         /**

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -102,16 +102,16 @@ namespace aspect
          * in the model is accounted for by changes in melt fraction."
          * Thus, this function will always return false.
          */
-        virtual bool is_compressible () const override;
+        bool is_compressible () const override;
 
         /**
          * @name Reference quantities
          * @{
          */
-        virtual double reference_darcy_coefficient () const override;
+        double reference_darcy_coefficient () const override;
 
-        virtual void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
-                              typename Interface<dim>::MaterialModelOutputs &out) const override;
+        void evaluate(const typename Interface<dim>::MaterialModelInputs &in,
+                      typename Interface<dim>::MaterialModelOutputs &out) const override;
 
         virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                      std::vector<double> &melt_fractions) const;


### PR DESCRIPTION
follow up to #5241. Found a few places outside the cpo plugin which have this.