### PR TITLE
Do not assign a signaling NaN to a bool

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -260,7 +260,6 @@ namespace aspect
               isostrain_viscosities.current_cohesions.clear();
 
               out.viscosities[i] = numbers::signaling_nan<double>();
-              plastic_yielding = numbers::signaling_nan<double>();
 
               if (MaterialModel::MaterialModelDerivatives<dim> *derivatives =
                     out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>())


### PR DESCRIPTION
This was merged in #5247, but it triggers floating point exceptions on my system and assigning a signaling nan to a bool is not what we want anyway. Remove this assignment.