### PR TITLE
Add drexpp v3 [WIP]

### DIFF
--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -1,0 +1,246 @@
+/*
+ Copyright (C) 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_property_cpo_elastic_tensor_h
+#define _aspect_particle_property_cpo_elastic_tensor_h
+
+#include <aspect/particle/property/interface.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/simulator_access.h>
+#include <array>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      /**
+       * Computes the elastic tensor $C_{ijkl} based on the cpo in both olivine
+       * and enstatite. It uses a Voigt average.
+       *
+       * The layout of the data vector per partcle is the following (note that
+       * for this plugin the following dim's are always 3):
+       * 1 unrolled tensor -> 3x3x3x3 (dim*dim*dim*dim) doubles, starts at:
+       *                                   data_position
+       *
+       * @ingroup ParticleProperties
+       */
+      template <int dim>
+      class CpoElasticTensor : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * constructor
+           */
+          CpoElasticTensor();
+
+          /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           */
+          virtual
+          void
+          initialize ();
+
+
+          /**
+           * This implements the Voigt averaging as described in the equation at the
+           * bottom of page 385 in Mainprice (1990):
+           * $C^V_{ijkl} = \sum^S_l F_s \sum^{N_s}_l C_{ijkl}/N_s$, where $F_s$ is the
+           * grain size, $N_s$ is the number of grains and $C_{ijkl}$ is the elastic
+           * tensor. This elastic tensor is computed by the equation above in
+           * Mainprice (1990): $C_{ijkl} = R_{ip} R_{jg} R_{kr} R_{is} C_{pgrs}$, where
+           * R_{ij} is the cpo orientation matrix.
+           */
+          virtual
+          SymmetricTensor<2,6>
+          voigt_average_elastic_tensor (const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property,
+                                        const unsigned int cpo_data_position,
+                                        const ArrayView<double> &data) const;
+
+          /**
+           * Initialization function. This function is called once at the
+           * creation of every particle for every property to initialize its
+           * value.
+           *
+           * @param [in] position The current particle position.
+           * @param [in,out] particle_properties The properties of the particle
+           * that is initialized within the call of this function. The purpose
+           * of this function should be to extend this vector by a number of
+           * properties.
+           */
+          virtual
+          void
+          initialize_one_particle_property (const Point<dim> &position,
+                                            std::vector<double> &particle_properties) const;
+
+          /**
+           * Update function. This function is called every time an update is
+           * request by need_update() for every particle for every property.
+           *
+           * @param [in] data_position An unsigned integer that denotes which
+           * component of the particle property vector is associated with the
+           * current property. For properties that own several components it
+           * denotes the first component of this property, all other components
+           * fill consecutive entries in the @p particle_properties vector.
+           *
+           * @param [in] position The current particle position.
+           *
+           * @param [in] solution The values of the solution variables at the
+           * current particle position.
+           *
+           * @param [in] gradients The gradients of the solution variables at
+           * the current particle position.
+           *
+           * @param [in,out] particle_properties The properties of the particle
+           * that is updated within the call of this function.
+           */
+          virtual
+          void
+          update_one_particle_property (const unsigned int data_position,
+                                        const Point<dim> &position,
+                                        const Vector<double> &solution,
+                                        const std::vector<Tensor<1,dim>> &gradients,
+                                        const ArrayView<double> &particle_properties) const;
+
+          /**
+           * This implementation tells the particle manager that
+           * we need to update particle properties every time step.
+           */
+          UpdateTimeFlags
+          need_update () const;
+
+          /**
+           * Return which data has to be provided to update the property.
+           * The integrated strains needs the gradients of the velocity.
+           */
+          virtual
+          UpdateFlags
+          get_needed_update_flags () const;
+
+          /**
+           * Set up the information about the names and number of components
+           * this property requires.
+           *
+           * @return A vector that contains pairs of the property names and the
+           * number of components this property plugin defines.
+           */
+          virtual
+          std::vector<std::pair<std::string, unsigned int>>
+          get_property_information() const;
+
+          /**
+           * Loads particle data into variables
+           */
+          static
+          SymmetricTensor<2,6>
+          get_elastic_tensor(unsigned int cpo_index,
+                             const ArrayView<double> &data);
+
+          /**
+           * Stores information in variables into the data array
+           */
+          static
+          void
+          set_elastic_tensor(unsigned int cpo_data_position,
+                             const ArrayView<double> &data,
+                             SymmetricTensor<2,6> &elastic_tensor);
+
+          /**
+           * Rotate a 3D 4th order tensor with an other 3D 4th
+           */
+          static
+          Tensor<4,3> rotate_4th_order_tensor(const Tensor<4,3> &input_tensor, const Tensor<2,3> &rotation_tensor);
+
+
+          /**
+           * Rotate a 6x6 voigt matrix with an other 3D 4th
+           */
+          static
+          SymmetricTensor<2,6> rotate_6x6_matrix(const Tensor<2,6> &input_tensor, const Tensor<2,3> &rotation_tensor);
+
+          /**
+           * Transform a 4th order tensor into a 6x6 matrix
+           */
+          static
+          SymmetricTensor<2,6> transform_4th_order_tensor_to_6x6_matrix(const Tensor<4,3> &input_tensor);
+
+
+          /**
+           * Transform a 6x6 matrix into a 4th order tensor
+           */
+          static
+          Tensor<4,3> transform_6x6_matrix_to_4th_order_tensor(const SymmetricTensor<2,6> &input_tensor);
+
+
+          /**
+           * From a 21D vector from a 6xt matrix
+           */
+          static
+          Tensor<1,21> transform_6x6_matrix_to_21D_vector(const SymmetricTensor<2,6> &input_tensor);
+
+          /**
+           * From a 21D vector from a 6xt matrix
+           */
+          static
+          SymmetricTensor<2,6> transform_21D_vector_to_6x6_matrix(const Tensor<1,21> &input_tensor);
+
+          /**
+           * Tranform a 4th order tensor directly into a 21D vector.
+           */
+          static
+          Tensor<1,21> transform_4th_order_tensor_to_21D_vector(const Tensor<4,3> &input);
+
+          /**
+           * Declare the parameters this class takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters this class declares from the parameter file.
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+        private:
+          unsigned int cpo_data_position;
+
+          SymmetricTensor<2,6> stiffness_matrix_olivine;
+          SymmetricTensor<2,6> stiffness_matrix_enstatite;
+
+          unsigned int n_grains;
+          unsigned int n_minerals;
+
+          /**
+           * The tensor representation of the permutation symbol.
+           */
+          Tensor<3,3> permutation_operator_3d;
+
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -23,6 +23,7 @@
 
 #include <aspect/particle/property/interface.h>
 #include <aspect/material_model/rheology/diffusion_creep.h>
+#include <aspect/material_model/rheology/dislocation_creep.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
@@ -669,6 +670,7 @@ namespace aspect
           double mobility;
 
           std::unique_ptr<MaterialModel::Rheology::DiffusionCreep<dim>> rheology;
+          std::unique_ptr<MaterialModel::Rheology::DislocationCreep<dim>> rheology_dis;
           std::vector<double> thermal_diffusivities;
 
           /**

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -83,7 +83,7 @@ namespace aspect
        */
       enum class CPODerivativeAlgorithm
       {
-        spin_tensor, drex_2004
+        spin_tensor, drex_2004, drexpp
       };
 
       /**
@@ -265,6 +265,41 @@ namespace aspect
                                         const std::array<double,4> ref_resolved_shear_stress,
                                         const bool prevent_nondimensionalization = false) const;
 
+
+          void
+          recrystalize_grains(const unsigned int cpo_index,
+                              const ArrayView<double> &data,
+                              const unsigned int mineral_i,
+                              const double recrystalized_grainsize,
+                              const std::vector<double> &recrystalized_fraction,
+                              std::vector<double> &strain_energy) const;
+
+
+          /**
+           * @brief Computes the CPO derivatives with the D-Rex 2004 algorithm.
+           *
+           * @param cpo_index The location where the CPO data starts in the data array.
+           * @param data The data array containing the CPO data.
+           * @param mineral_i The mineral for which to compute the derivatives for.
+           * @param strain_rate_3d The 3D strain rate
+           * @param velocity_gradient_tensor The velocity gradient tensor
+           * @param ref_resolved_shear_stress Represent one value per slip plane.
+           * The planes are ordered from weakest to strongest with relative values,
+           * where the inactive plane is infinity strong. So it is a measure of strength
+           * on each slip plane.
+           * @param recrystalized_grain_volume The volume of grains which recrystalize
+           * @param aggregate_recrystalization_increment How much of the aggregate is
+           * recrystalzing during this timestep
+           */
+          std::pair<std::vector<double>, std::vector<Tensor<2,3>>>
+          compute_derivatives_drexpp(const unsigned int cpo_index,
+                                     const ArrayView<double> &data,
+                                     const unsigned int mineral_i,
+                                     const SymmetricTensor<2,3> &strain_rate_3d,
+                                     const Tensor<2,3> &velocity_gradient_tensor,
+                                     const std::array<double,4> ref_resolved_shear_stress,
+                                     const double recrystalized_grain_volume,
+                                     const double aggregate_recrystalization_increment) const;
 
           /**
            * Declare the parameters this class takes through input files.

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -24,6 +24,7 @@
 #include <aspect/particle/property/interface.h>
 #include <aspect/material_model/rheology/diffusion_creep.h>
 #include <aspect/material_model/rheology/dislocation_creep.h>
+#include <aspect/material_model/rheology/visco_plastic.h>
 #include <aspect/material_model/utilities.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
@@ -304,7 +305,10 @@ namespace aspect
                                      const std::array<double,4> ref_resolved_shear_stress,
                                      const double recrystalized_grain_volume,
                                      const double aggregate_recrystalization_increment,
-                                     const double diffusion_creep_strain_rate) const;
+                                     const std::vector<double> &volume_fractions,
+                                     const std::vector<double> &diffusion_pre_viscosities,
+                                     const std::vector<double> &diffusion_grain_size_exponent,
+                                     const std::vector<double> &dislocation_viscosities) const;
 
           /**
            * Declare the parameters this class takes through input files.
@@ -669,8 +673,10 @@ namespace aspect
            */
           double mobility;
 
-          std::unique_ptr<MaterialModel::Rheology::DiffusionCreep<dim>> rheology;
-          std::unique_ptr<MaterialModel::Rheology::DislocationCreep<dim>> rheology_dis;
+          std::unique_ptr<MaterialModel::Rheology::DiffusionCreep<dim>> rheology_diff;
+          std::unique_ptr<MaterialModel::Rheology::DislocationCreep<dim>> rheology_disl;
+          std::unique_ptr<MaterialModel::Rheology::ViscoPlastic<dim>> rheology_vipl;
+          double min_strain_rate;
           std::vector<double> thermal_diffusivities;
 
           /**

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -22,6 +22,9 @@
 #define _aspect_particle_property_cpo_h
 
 #include <aspect/particle/property/interface.h>
+#include <aspect/material_model/rheology/diffusion_creep.h>
+#include <aspect/material_model/utilities.h>
+#include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>
 #include <array>
 
@@ -299,7 +302,8 @@ namespace aspect
                                      const Tensor<2,3> &velocity_gradient_tensor,
                                      const std::array<double,4> ref_resolved_shear_stress,
                                      const double recrystalized_grain_volume,
-                                     const double aggregate_recrystalization_increment) const;
+                                     const double aggregate_recrystalization_increment,
+                                     const double diffusion_creep_strain_rate) const;
 
           /**
            * Declare the parameters this class takes through input files.
@@ -664,6 +668,20 @@ namespace aspect
            */
           double mobility;
 
+          std::unique_ptr<MaterialModel::Rheology::DiffusionCreep<dim>> rheology;
+          std::vector<double> thermal_diffusivities;
+
+          /**
+           * Whether to use user-defined thermal conductivities instead of thermal diffusivities.
+           */
+          bool define_conductivities;
+
+          std::vector<double> thermal_conductivities;
+
+          /**
+           * Object that handles phase transitions.
+           */
+          MaterialModel::MaterialUtilities::PhaseFunction<dim> phase_function;
           /** @} */
 
       };

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -1,0 +1,202 @@
+/*
+ Copyright (C) 2023 by the authors of the ASPECT code.
+ This file is part of ASPECT.
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_property_elastic_tensor_decomposion_h
+#define _aspect_particle_property_elastic_tensor_decomposion_h
+
+#include <aspect/particle/property/interface.h>
+#include <aspect/simulator_access.h>
+#include <array>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      /**
+       * Computes several properties of a elastic tensor stored on a particle.
+       * These include the eigenvectors and several projectsion on symmetry axis.
+       *
+       * @ingroup ParticleProperties
+       */
+      template <int dim>
+      class ElasticTensorDecomposition : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * constructor
+           */
+          ElasticTensorDecomposition();
+
+          /**
+           * Initialization function. This function is called once at the
+           * beginning of the program after parse_parameters is run.
+           */
+          virtual
+          void
+          initialize ();
+
+          /**
+           * Initialization function. This function is called once at the
+           * creation of every particle for every property to initialize its
+           * value.
+           *
+           * @param [in] position The current particle position.
+           * @param [in,out] particle_properties The properties of the particle
+           * that is initialized within the call of this function. The purpose
+           * of this function should be to extend this vector by a number of
+           * properties.
+           */
+          virtual
+          void
+          initialize_one_particle_property (const Point<dim> &position,
+                                            std::vector<double> &particle_properties) const;
+
+          /**
+           * Update function. This function is called every time an update is
+           * request by need_update() for every particle for every property.
+           *
+           * @param [in] data_position An unsigned integer that denotes which
+           * component of the particle property vector is associated with the
+           * current property. For properties that own several components it
+           * denotes the first component of this property, all other components
+           * fill consecutive entries in the @p particle_properties vector.
+           *
+           * @param [in] position The current particle position.
+           *
+           * @param [in] solution The values of the solution variables at the
+           * current particle position.
+           *
+           * @param [in] gradients The gradients of the solution variables at
+           * the current particle position.
+           *
+           * @param [in,out] particle_properties The properties of the particle
+           * that is updated within the call of this function.
+           */
+          virtual
+          void
+          update_one_particle_property (const unsigned int data_position,
+                                        const Point<dim> &position,
+                                        const Vector<double> &solution,
+                                        const std::vector<Tensor<1,dim>> &gradients,
+                                        const ArrayView<double> &particle_properties) const;
+
+          /**
+           * This implementation tells the particle manager that
+           * we need to update particle properties every time step.
+           */
+          UpdateTimeFlags
+          need_update () const;
+
+          /**
+           * Return which data has to be provided to update the property.
+           * The integrated strains needs the gradients of the velocity.
+           */
+          virtual
+          UpdateFlags
+          get_needed_update_flags () const;
+
+          /**
+           * Return a specific permutation based on an index
+           */
+          static
+          std::array<unsigned short int, 3>
+          indexed_even_permutation(const unsigned short int index);
+
+          /**
+           * Computes the voigt stiffness tensor from the elastic tensor
+           */
+          static
+          SymmetricTensor<2,3>
+          compute_voigt_stiffness_tensor(const SymmetricTensor<2,6> &elastic_tensor);
+
+          /**
+           * Computes the dilatation stiffness tensor from the elastic tensor
+           */
+          static
+          SymmetricTensor<2,3>
+          compute_dilatation_stiffness_tensor(const SymmetricTensor<2,6> &elastic_tensor);
+
+          /**
+           * Computes the Symmetry Cartesian Coordinate System (SCCS).
+           * With the three SCCS directions, the elastic tensor can be decomposed into the different
+           * symmetries in those three SCCS direction, that is, triclinic, monoclinic, orthorhombic,
+           * tetragonal, hexagonal, and isotropic (Browaeys & Chevrot, 2004).
+           */
+          static
+          Tensor<2,3> compute_unpermutated_SCCS(const SymmetricTensor<2,3> &dilatation_stiffness_tensor,
+                                                const SymmetricTensor<2,3> &voigt_stiffness_tensor);
+
+          /**
+           * Uses the Symmetry Cartesian Coordinate System (SCCS) to try the different permutations to
+           * determine what is the best projections.
+           * This is based on Browaeys and Chevrot (2004), GJI (doi: 10.1111/j.1365-246X.2004.024115.x),
+           * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
+           * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
+           * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
+           * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
+           * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+           * but not the resulting decomposition.".
+           */
+          static
+          std::array<std::array<double,3>,7>
+          compute_elastic_tensor_SCCS_decompositions(
+            const Tensor<2,3> &unpermutated_SCCS,
+            const SymmetricTensor<2,6> &elastic_matrix);
+
+          /**
+           * Set up the information about the names and number of components
+           * this property requires.
+           *
+           * @return A vector that contains pairs of the property names and the
+           * number of components this property plugin defines.
+           */
+          virtual
+          std::vector<std::pair<std::string, unsigned int>>
+          get_property_information() const;
+
+          /**
+           * Declare paramters
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Parse parameters
+           */
+          virtual
+          void
+          parse_parameters (ParameterHandler &prm);
+
+
+          static SymmetricTensor<2,21> projection_matrix_tric_to_mono;
+          static SymmetricTensor<2,9> projection_matrix_mono_to_ortho;
+          static SymmetricTensor<2,9> projection_matrix_ortho_to_tetra;
+          static SymmetricTensor<2,9> projection_matrix_tetra_to_hexa;
+          static SymmetricTensor<2,9> projection_matrix_hexa_to_iso;
+
+        private:
+          unsigned int cpo_data_position;
+          unsigned int cpo_elastic_tensor_data_position;
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/postprocess/crystal_preferred_orientation.h
+++ b/include/aspect/postprocess/crystal_preferred_orientation.h
@@ -1,0 +1,290 @@
+/*
+ Copyright (C) 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_postprocess_crystal_preferred_orientation_h
+#define _aspect_postprocess_crystal_preferred_orientation_h
+
+#include <aspect/postprocess/interface.h>
+#include <aspect/particle/world.h>
+
+#include <aspect/simulator_access.h>
+
+#include <deal.II/particles/particle_handler.h>
+#include <deal.II/base/data_out_base.h>
+#include <tuple>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    /**
+     * A Postprocessor that writes out CPO specific particle data.
+     * It can write out the CPO data as it is stored (raw) and/or as a
+     * random draw volume weighted representation. The latter one
+     * is recommended for plotting against real data. For both representations
+     * the specific output fields and their order can be set.
+     */
+    template <int dim>
+    class CrystalPreferredOrientation : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        CrystalPreferredOrientation();
+
+        /**
+         * Destructor.
+         */
+        ~CrystalPreferredOrientation();
+
+
+        /**
+         * Initialize function.
+         */
+        virtual void initialize ();
+
+        /**
+         * A Postprocessor that writes out CPO specific particle data.
+         * It can write out the CPO data as it is stored (raw) and/or as a
+         * random draw volume weighted representation. The latter one
+         * is recommended for plotting against real data. For both representations
+         * the specific output fields and their order can be set.
+         */
+        virtual
+        std::pair<std::string,std::string> execute (TableHandler &statistics);
+
+        /**
+         * This funcion ensures that the particle postprocessor is run before
+         * this postprocessor.
+         */
+        virtual
+        std::list<std::string>
+        required_other_postprocessors () const;
+
+        /**
+        * Declare the parameters this class takes through input files.
+        */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        virtual
+        void
+        parse_parameters (ParameterHandler &prm);
+
+      private:
+
+
+        /**
+         * Get volume weighted euler angles, using random draws to convert
+         * to a discrete number of orientations, weighted by volume.
+         */
+        std::vector<std::vector<double>> random_draw_volume_weighting(const std::vector<double> &fv,
+                                                                       const std::vector<std::vector<double>> &angles) const;
+
+        /**
+         * Stores the simulation end time, so that it alwas procudes output
+         * at the last timestep.
+         */
+        double end_time;
+
+        /**
+         * Enums specifying what information to write:
+         *
+         * VolumeFraction: Write the volume fraction
+         * RotationMatrix: Write the whole rotation matrix of a grain (in Deal.ii order)
+         * EulerAngles: Write out the Z-X-Z Euler angle of a grain
+         * not_found: Error enum, the requested output was not found
+         */
+        enum class Output
+        {
+          VolumeFraction, RotationMatrix, EulerAngles, not_found
+        };
+
+        /**
+         * Converts a string to an Output enum.
+         */
+        Output string_to_output_enum(const std::string &string);
+
+        /**
+         * Random number generator used for random draw volume weighting.
+         */
+        mutable std::mt19937 random_number_generator;
+
+        /**
+         * Random number generator seed used to initialize the random number generator.
+         */
+        unsigned int random_number_seed;
+
+        /**
+         * Interval between output (in years if appropriate simulation
+         * parameter is set, otherwise seconds)
+         */
+        double output_interval;
+
+        /**
+         * Records time for next output to occur
+         */
+        double last_output_time;
+
+        /**
+         * Set the time output was supposed to be written. In the simplest
+         * case, this is the previous last output time plus the interval, but
+         * in general we'd like to ensure that it is the largest supposed
+         * output time, which is smaller than the current time, to avoid
+         * falling behind with last_output_time and having to catch up once
+         * the time step becomes larger. This is done after every output.
+         */
+        void set_last_output_time (const double current_time);
+
+        /**
+         * Consecutively counted number indicating the how-manyth time we will
+         * create output the next time we get to it.
+         */
+        unsigned int output_file_number;
+
+        /**
+         * Graphical output format.
+         */
+        std::vector<std::string> output_formats;
+
+        /**
+         * A list of pairs (time, pvtu_filename) that have so far been written
+         * and that we will pass to DataOutInterface::write_pvd_record
+         * to create a master file that can make the association
+         * between simulation time and corresponding file name (this
+         * is done because there is no way to store the simulation
+         * time inside the .pvtu or .vtu files).
+         */
+        std::vector<std::pair<double,std::string>> times_and_pvtu_file_names;
+
+        /**
+         * A corresponding variable that we use for the .visit files created
+         * by DataOutInterface::write_visit_record. The second part of a
+         * pair contains all files that together form a time step.
+         */
+        std::vector<std::pair<double,std::vector<std::string>>> times_and_vtu_file_names;
+
+        /**
+         * A list of list of filenames, sorted by timestep, that correspond to
+         * what has been created as output. This is used to create a master
+         * .visit file for the entire simulation.
+         */
+        std::vector<std::vector<std::string>> output_file_names_by_timestep;
+
+        /**
+         * A set of data related to XDMF file sections describing the HDF5
+         * heavy data files created. These contain things such as the
+         * dimensions and names of data written at all steps during the
+         * simulation.
+         */
+        std::vector<XDMFEntry>  xdmf_entries;
+
+        /**
+         * VTU file output supports grouping files from several CPUs into one
+         * file using MPI I/O when writing on a parallel filesystem. 0 means
+         * no grouping (and no parallel I/O). 1 will generate one big file
+         * containing the whole solution.
+         */
+        unsigned int group_files;
+
+        /**
+         * On large clusters it can be advantageous to first write the
+         * output to a temporary file on a local file system and later
+         * move this file to a network file system. If this variable is
+         * set to a non-empty string it will be interpreted as a temporary
+         * storage location.
+         */
+        std::string temporary_output_location;
+
+        /**
+         * File operations can potentially take a long time, blocking the
+         * progress of the rest of the model run. Setting this variable to
+         * 'true' moves this process into a background thread, while the
+         * rest of the model continues.
+         */
+        bool write_in_background_thread;
+
+        /**
+         * Handle to a thread that is used to write master file data in the
+         * background. The writer() function runs on this background thread.
+         */
+        std::thread background_thread_master;
+
+        /**
+         * What "raw" CPO data to write out.
+         */
+        std::vector<std::pair<unsigned int,Output>> write_raw_cpo;
+
+        /**
+         * Whether computing raw Euler angles is needed.
+         */
+        bool compute_raw_euler_angles;
+
+        /**
+         * Handle to a thread that is used to write content file data in the
+         * background. The writer() function runs on this background thread.
+         */
+        std::thread background_thread_content_raw;
+
+        /**
+         * What "draw volume weighted" CPO data to write out. Draw volume weighted means
+         * the grain properties (size and rotation) are put in a list sorted based by volume
+         * and picked randomly, with large volumes having a higher chance of being picked.
+         */
+        std::vector<std::pair<unsigned int,Output>> write_draw_volume_weighted_cpo;
+
+        /**
+         * Whether computing weighted A matrix is needed.
+         */
+        bool compute_weighted_A_matrix;
+
+        /**
+         * Handle to a thread that is used to write content file data in the
+         * background. The writer() function runs on this background thread.
+         */
+        std::thread background_thread_content_draw_volume_weighting;
+
+        /**
+         * Whether to compress the raw and weighed cpo data output files with zlib.
+         */
+        bool compress_cpo_data_files;
+
+        /**
+         * A function that writes the text in the second argument to a file
+         * with the name given in the first argument. The function is run on a
+         * separate thread to allow computations to continue even though
+         * writing data is still continuing. The function takes over ownership
+         * of these arguments and deletes them at the end of its work.
+         */
+        static
+        void writer (const std::string filename,
+                     const std::string temporary_filename,
+                     const std::string *file_contents,
+                     const bool compress_contents);
+    };
+  }
+}
+
+#endif

--- a/include/aspect/postprocess/crystal_preferred_orientation.h
+++ b/include/aspect/postprocess/crystal_preferred_orientation.h
@@ -95,14 +95,6 @@ namespace aspect
 
       private:
 
-
-        /**
-         * Get volume weighted euler angles, using random draws to convert
-         * to a discrete number of orientations, weighted by volume.
-         */
-        std::vector<std::vector<double>> random_draw_volume_weighting(const std::vector<double> &fv,
-                                                                       const std::vector<std::vector<double>> &angles) const;
-
         /**
          * Stores the simulation end time, so that it alwas procudes output
          * at the last timestep.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1198,6 +1198,27 @@ namespace aspect
       return sorted_vec;
     }
 
+
+    /**
+    * Wraps angle between 0 and 360 degrees.
+    */
+    double wrap_angle(const double angle);
+
+    /**
+     * Compute Z-X-Z Euler angles (https://en.wikipedia.org/wiki/Euler_angles) from rotation matrix.
+     * The Z-X-Z indicates the order of axis rotations to generate the Euler angles.
+     */
+    std::array<double,3> zxz_euler_angles_from_rotation_matrix(const Tensor<2,3> &rotation_matrix);
+
+    /**
+     * Compute rotation matrix from Z-X-Z Euler angles (https://en.wikipedia.org/wiki/Euler_angles)
+     * The Z-X-Z indicates the order of axis axis rotations to generate the Euler angles.
+     */
+    Tensor<2,3> zxz_euler_angles_to_rotation_matrix(const double phi1,
+                                                    const double theta,
+                                                    const double phi2);
+
+
   }
 }
 #endif

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -261,8 +261,7 @@ namespace aspect
             prm.enter_subsection("CPO Bingham Average");
             {
               // Get a pointer to the CPO particle property.
-              cpo_particle_property = std::make_unique<const Particle::Property::CrystalPreferredOrientation<dim>> (
-                                        this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>());
+              cpo_particle_property.reset(&this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>());
 
               random_number_seed = prm.get_integer ("Random number seed");
               n_grains = cpo_particle_property->get_number_of_grains();

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -165,12 +165,12 @@ namespace aspect
 
 
         SymmetricTensor<2,6> S_average = voigt_average_elastic_tensor(cpo_particle_property,
-                                                                cpo_data_position,
-                                                                data);
+                                                                      cpo_data_position,
+                                                                      data);
 
         Particle::Property::CpoElasticTensor<dim>::set_elastic_tensor(data_position,
-                                                                       data,
-                                                                       S_average);
+                                                                      data,
+                                                                      S_average);
 
 
       }

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -1,0 +1,582 @@
+/*
+  Copyright (C) 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+//#include <cstdlib>
+#include <aspect/particle/property/cpo_elastic_tensor.h>
+#include <aspect/particle/world.h>
+
+#include <aspect/utilities.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+
+      template <int dim>
+      CpoElasticTensor<dim>::CpoElasticTensor ()
+      {
+        permutation_operator_3d[0][1][2]  = 1;
+        permutation_operator_3d[1][2][0]  = 1;
+        permutation_operator_3d[2][0][1]  = 1;
+        permutation_operator_3d[0][2][1]  = -1;
+        permutation_operator_3d[1][0][2]  = -1;
+        permutation_operator_3d[2][1][0]  = -1;
+
+        // The following values are directly form D-Rex.
+        // Todo: make them a input parameter
+        // Stiffness matrix for Olivine (GigaPascals)
+        stiffness_matrix_olivine[0][0] = 320.71;
+        stiffness_matrix_olivine[0][1] = 69.84;
+        stiffness_matrix_olivine[0][2] = 71.22;
+        stiffness_matrix_olivine[1][1] = 197.25;
+        stiffness_matrix_olivine[1][2] = 74.8;
+        stiffness_matrix_olivine[2][2] = 234.32;
+        stiffness_matrix_olivine[3][3] = 63.77;
+        stiffness_matrix_olivine[4][4] = 77.67;
+        stiffness_matrix_olivine[5][5] = 78.36;
+
+
+        // Stiffness matrix for Enstatite (GPa)
+        stiffness_matrix_enstatite[0][0] = 236.9;
+        stiffness_matrix_enstatite[0][1] = 79.6;
+        stiffness_matrix_enstatite[0][2] = 63.2;
+        stiffness_matrix_enstatite[1][1] = 180.5;
+        stiffness_matrix_enstatite[1][2] = 56.8;
+        stiffness_matrix_enstatite[2][2] = 230.4;
+        stiffness_matrix_enstatite[3][3] = 84.3;
+        stiffness_matrix_enstatite[4][4] = 79.4;
+        stiffness_matrix_enstatite[5][5] = 80.1;
+      }
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::initialize ()
+      {
+        const auto &manager = this->get_particle_world().get_property_manager();
+        AssertThrow(manager.plugin_name_exists("crystal preferred orientation"),
+                    ExcMessage("No crystal preferred orientation property plugin found."));
+        Assert(manager.plugin_name_exists("cpo elastic tensor"),
+               ExcMessage("No s wave anisotropy property plugin found."));
+
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","cpo elastic tensor"),
+                    ExcMessage("To use the cpo elastic tensor plugin, the cpo plugin need to be defined before this plugin."));
+
+        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo"));
+      }
+
+
+
+
+
+      template <int dim>
+      SymmetricTensor<2,6>
+      CpoElasticTensor<dim>::voigt_average_elastic_tensor (const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property,
+                                                           const unsigned int cpo_data_position,
+                                                           const ArrayView<double> &data) const
+      {
+        SymmetricTensor<2,6,double> Sav;
+        const SymmetricTensor<2,6> *stiffness_matrix = &stiffness_matrix_olivine;
+        for (size_t mineral_i = 0; mineral_i < n_minerals; mineral_i++)
+          {
+            if (cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_a_fabric
+                || cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_b_fabric
+                || cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_c_fabric
+                || cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_d_fabric
+                || cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_e_fabric
+                || cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::olivine_karato_2008
+               )
+              {
+                stiffness_matrix = &stiffness_matrix_olivine;
+              }
+            else if (cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i) == (unsigned int)DeformationTypeSelector::enstatite)
+              {
+                stiffness_matrix = &stiffness_matrix_enstatite;
+              }
+            else
+              {
+                AssertThrow(false, ExcMessage("Stiffness matrix not implemented for deformation type " + std::to_string(cpo_particle_property.get_deformation_type(cpo_data_position,data,mineral_i))));
+              }
+
+            for (size_t grain_i = 0; grain_i < n_grains; grain_i++)
+              {
+                auto rotated_matrix = rotate_6x6_matrix(*stiffness_matrix, transpose(cpo_particle_property.get_rotation_matrix_grains(cpo_data_position,data,mineral_i,grain_i)));
+                Sav += cpo_particle_property.get_volume_fractions_grains(cpo_data_position,data,mineral_i,grain_i) * cpo_particle_property.get_volume_fraction_mineral(cpo_data_position,data,mineral_i) * rotated_matrix;
+              }
+          }
+
+        return Sav;
+      }
+
+
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::initialize_one_particle_property(const Point<dim> &,
+                                                              std::vector<double> &data) const
+      {
+
+        // Get a reference to the CPO particle property.
+        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+        SymmetricTensor<2,6> S_average = voigt_average_elastic_tensor(cpo_particle_property,
+                                                                      cpo_data_position,
+                                                                      data);
+
+        for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
+          {
+            data.push_back(S_average[SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
+          }
+
+
+      }
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::update_one_particle_property(const unsigned int data_position,
+                                                          const Point<dim> &,
+                                                          const Vector<double> &,
+                                                          const std::vector<Tensor<1,dim>> &,
+                                                          const ArrayView<double> &data) const
+      {
+        // Get a reference to the CPO particle property.
+        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+
+        SymmetricTensor<2,6> S_average = voigt_average_elastic_tensor(cpo_particle_property,
+                                                                cpo_data_position,
+                                                                data);
+
+        Particle::Property::CpoElasticTensor<dim>::set_elastic_tensor(data_position,
+                                                                       data,
+                                                                       S_average);
+
+
+      }
+
+
+      template <int dim>
+      SymmetricTensor<2,6>
+      CpoElasticTensor<dim>::get_elastic_tensor(unsigned int cpo_data_position,
+                                                const ArrayView<double> &data)
+      {
+        SymmetricTensor<2,6> elastic_tensor;
+        for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
+          elastic_tensor[SymmetricTensor<2,6>::unrolled_to_component_indices(i)] = data[cpo_data_position + i];
+        return elastic_tensor;
+      }
+
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::set_elastic_tensor(unsigned int cpo_data_position,
+                                                const ArrayView<double> &data,
+                                                SymmetricTensor<2,6> &elastic_tensor)
+      {
+        for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
+          data[cpo_data_position + i] = elastic_tensor[SymmetricTensor<2,6>::unrolled_to_component_indices(i)];
+      }
+
+
+      template<int dim>
+      Tensor<4,3>
+      CpoElasticTensor<dim>::rotate_4th_order_tensor(const Tensor<4,3> &input_tensor, const Tensor<2,3> &rotation_tensor)
+      {
+        Tensor<4,3> output;
+
+        for (unsigned short int i1 = 0; i1 < 3; i1++)
+          {
+            for (unsigned short int i2 = 0; i2 < 3; i2++)
+              {
+                for (unsigned short int i3 = 0; i3 < 3; i3++)
+                  {
+                    for (unsigned short int i4 = 0; i4 < 3; i4++)
+                      {
+                        for (unsigned short int j1 = 0; j1 < 3; j1++)
+                          {
+                            for (unsigned short int j2 = 0; j2 < 3; j2++)
+                              {
+                                for (unsigned short int j3 = 0; j3 < 3; j3++)
+                                  {
+                                    for (unsigned short int j4 = 0; j4 < 3; j4++)
+                                      {
+                                        output[i1][i2][i3][i4] = output[i1][i2][i3][i4] + rotation_tensor[i1][j1]*rotation_tensor[i2][j2]*rotation_tensor[i3][j3]*rotation_tensor[i4][j4]*input_tensor[j1][j2][j3][j4];
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+
+        return output;
+      }
+
+      template<int dim>
+      SymmetricTensor<2,6>
+      CpoElasticTensor<dim>::rotate_6x6_matrix(const Tensor<2,6> &input_tensor, const Tensor<2,3> &rotation_tensor)
+      {
+        // we can represent the roation of the 4th order tensor as a rotation in the voigt
+        // notation by computing $C'=MCM^{-1}$. Because M is orhtogonal we can replace $M^{-1}$
+        // with $M^T$ resutling in $C'=MCM^{T}$ (Carcione, J. M. (2007). Wave Fields in Real Media:
+        // Wave Propagation in Anisotropic, Anelastic, Porous and Electromagnetic Media. Netherlands:
+        // Elsevier Science. Pages 8-9).
+        Tensor<2,6> rotation_matrix;
+        // top left block
+        rotation_matrix[0][0] = rotation_tensor[0][0] * rotation_tensor[0][0];
+        rotation_matrix[1][0] = rotation_tensor[1][0] * rotation_tensor[1][0];
+        rotation_matrix[2][0] = rotation_tensor[2][0] * rotation_tensor[2][0];
+        rotation_matrix[0][1] = rotation_tensor[0][1] * rotation_tensor[0][1];
+        rotation_matrix[1][1] = rotation_tensor[1][1] * rotation_tensor[1][1];
+        rotation_matrix[2][1] = rotation_tensor[2][1] * rotation_tensor[2][1];
+        rotation_matrix[0][2] = rotation_tensor[0][2] * rotation_tensor[0][2];
+        rotation_matrix[1][2] = rotation_tensor[1][2] * rotation_tensor[1][2];
+        rotation_matrix[2][2] = rotation_tensor[2][2] * rotation_tensor[2][2];
+
+        // top right block
+        rotation_matrix[0][3] = 2.0 * rotation_tensor[0][1] * rotation_tensor[0][2];
+        rotation_matrix[1][3] = 2.0 * rotation_tensor[1][1] * rotation_tensor[1][2];
+        rotation_matrix[2][3] = 2.0 * rotation_tensor[2][1] * rotation_tensor[2][2];
+        rotation_matrix[0][4] = 2.0 * rotation_tensor[0][2] * rotation_tensor[0][0];
+        rotation_matrix[1][4] = 2.0 * rotation_tensor[1][2] * rotation_tensor[1][0];
+        rotation_matrix[2][4] = 2.0 * rotation_tensor[2][2] * rotation_tensor[2][0];
+        rotation_matrix[0][5] = 2.0 * rotation_tensor[0][0] * rotation_tensor[0][1];
+        rotation_matrix[1][5] = 2.0 * rotation_tensor[1][0] * rotation_tensor[1][1];
+        rotation_matrix[2][5] = 2.0 * rotation_tensor[2][0] * rotation_tensor[2][1];
+
+        // bottom left block
+        rotation_matrix[3][0] = rotation_tensor[1][0] * rotation_tensor[2][0];
+        rotation_matrix[4][0] = rotation_tensor[2][0] * rotation_tensor[0][0];
+        rotation_matrix[5][0] = rotation_tensor[0][0] * rotation_tensor[1][0];
+        rotation_matrix[3][1] = rotation_tensor[1][1] * rotation_tensor[2][1];
+        rotation_matrix[4][1] = rotation_tensor[2][1] * rotation_tensor[0][1];
+        rotation_matrix[5][1] = rotation_tensor[0][1] * rotation_tensor[1][1];
+        rotation_matrix[3][2] = rotation_tensor[1][2] * rotation_tensor[2][2];
+        rotation_matrix[4][2] = rotation_tensor[2][2] * rotation_tensor[0][2];
+        rotation_matrix[5][2] = rotation_tensor[0][2] * rotation_tensor[1][2];
+
+        // bottom right block
+        rotation_matrix[3][3] = rotation_tensor[1][1] * rotation_tensor[2][2] + rotation_tensor[1][2] * rotation_tensor[2][1];
+        rotation_matrix[4][3] = rotation_tensor[0][1] * rotation_tensor[2][2] + rotation_tensor[0][2] * rotation_tensor[2][1];
+        rotation_matrix[5][3] = rotation_tensor[0][1] * rotation_tensor[1][2] + rotation_tensor[0][2] * rotation_tensor[1][1];
+        rotation_matrix[3][4] = rotation_tensor[1][0] * rotation_tensor[2][2] + rotation_tensor[1][2] * rotation_tensor[2][0];
+        rotation_matrix[4][4] = rotation_tensor[0][2] * rotation_tensor[2][0] + rotation_tensor[0][0] * rotation_tensor[2][2];
+        rotation_matrix[5][4] = rotation_tensor[0][2] * rotation_tensor[1][0] + rotation_tensor[0][0] * rotation_tensor[1][2];
+        rotation_matrix[3][5] = rotation_tensor[1][1] * rotation_tensor[2][0] + rotation_tensor[1][0] * rotation_tensor[2][1];
+        rotation_matrix[4][5] = rotation_tensor[0][0] * rotation_tensor[2][1] + rotation_tensor[0][1] * rotation_tensor[2][0];
+        rotation_matrix[5][5] = rotation_tensor[0][0] * rotation_tensor[1][1] + rotation_tensor[0][1] * rotation_tensor[1][0];
+
+        Tensor<2,6> rotation_matrix_tranposed = transpose(rotation_matrix);
+
+        return symmetrize((rotation_matrix*input_tensor)*rotation_matrix_tranposed);
+      }
+
+
+
+      template<int dim>
+      SymmetricTensor<2,6>
+      CpoElasticTensor<dim>::transform_4th_order_tensor_to_6x6_matrix(const Tensor<4,3> &input_tensor)
+      {
+        SymmetricTensor<2,6> output;
+
+        for (unsigned short int i = 0; i < 3; i++)
+          {
+            output[i][i] = input_tensor[i][i][i][i];
+          }
+
+        for (unsigned short int i = 1; i < 3; i++)
+          {
+            output[0][i] = 0.5*(input_tensor[0][0][i][i] + input_tensor[i][i][0][0]);
+            //symmetry: output[0][i] = output[i][0];
+          }
+        output[1][2]=0.5*(input_tensor[1][1][2][2]+input_tensor[2][2][1][1]);
+        //symmetry: output[2][1]=output[1][2];
+
+        for (unsigned short int i = 0; i < 3; i++)
+          {
+            output[i][3]=0.25*(input_tensor[i][i][1][2]+input_tensor[i][i][2][1]+ input_tensor[1][2][i][i]+input_tensor[2][1][i][i]);
+            //symmetry: output[3][i]=output[i][3];
+          }
+
+        for (unsigned short int i = 0; i < 3; i++)
+          {
+            output[i][4]=0.25*(input_tensor[i][i][0][2]+input_tensor[i][i][2][0]+ input_tensor[0][2][i][i]+input_tensor[2][0][i][i]);
+            //symmetry: output[4][i]=output[i][4];
+          }
+
+        for (unsigned short int i = 0; i < 3; i++)
+          {
+            output[i][5]=0.25*(input_tensor[i][i][0][1]+input_tensor[i][i][1][0]+input_tensor[0][1][i][i]+input_tensor[1][0][i][i]);
+            //symmetry: output[5][i]=output[i][5];
+          }
+
+        output[3][3]=0.25*(input_tensor[1][2][1][2]+input_tensor[1][2][2][1]+input_tensor[2][1][1][2]+input_tensor[2][1][2][1]);
+        output[4][4]=0.25*(input_tensor[0][2][0][2]+input_tensor[0][2][2][0]+input_tensor[2][0][0][2]+input_tensor[2][0][2][0]);
+        output[5][5]=0.25*(input_tensor[1][0][1][0]+input_tensor[1][0][0][1]+input_tensor[0][1][1][0]+input_tensor[0][1][0][1]);
+
+        output[3][4]=0.125*(input_tensor[1][2][0][2]+input_tensor[1][2][2][0]+input_tensor[2][1][0][2]+input_tensor[2][1][2][0]+input_tensor[0][2][1][2]+input_tensor[0][2][2][1]+input_tensor[2][0][1][2]+input_tensor[2][0][2][1]);
+        //symmetry: output[4][3]=output[3][4];
+        output[3][5]=0.125*(input_tensor[1][2][0][1]+input_tensor[1][2][1][0]+input_tensor[2][1][0][1]+input_tensor[2][1][1][0]+input_tensor[0][1][1][2]+input_tensor[0][1][2][1]+input_tensor[1][0][1][2]+input_tensor[1][0][2][1]);
+        //symmetry: output[5][3]=output[3][5];
+        output[4][5]=0.125*(input_tensor[0][2][0][1]+input_tensor[0][2][1][0]+input_tensor[2][0][0][1]+input_tensor[2][0][1][0]+input_tensor[0][1][0][2]+input_tensor[0][1][2][0]+input_tensor[1][0][0][2]+input_tensor[1][0][2][0]);
+        //symmetry: output[5][4]=output[4][5];
+
+        return output;
+      }
+
+      template<int dim>
+      Tensor<4,3>
+      CpoElasticTensor<dim>::transform_6x6_matrix_to_4th_order_tensor(const SymmetricTensor<2,6> &input_tensor)
+      {
+        Tensor<4,3> output;
+
+        for (unsigned short int i = 0; i < 3; i++)
+          for (unsigned short int j = 0; j < 3; j++)
+            for (unsigned short int k = 0; k < 3; k++)
+              for (unsigned short int l = 0; l < 3; l++)
+                {
+                  // The first part of the inline if statment gets the diagonal.
+                  // The second part is never higher then 5 (which is the limit of the tensor index)
+                  // because to reach this part the variables need to be different, which results in
+                  // at least a minus 1.
+                  const unsigned short int p = (i == j ? i : 6 - i - j);
+                  const unsigned short int q = (k == l ? k : 6 - k - l);
+                  output[i][j][k][l] = input_tensor[p][q];
+                }
+        return output;
+      }
+
+      template<int dim>
+      Tensor<1,21>
+      CpoElasticTensor<dim>::transform_6x6_matrix_to_21D_vector(const SymmetricTensor<2,6> &input)
+      {
+        return Tensor<1,21,double> (
+        {
+          input[0][0],           // 0  // 1
+          input[1][1],           // 1  // 2
+          input[2][2],           // 2  // 3
+          sqrt(2)*input[1][2],   // 3  // 4
+          sqrt(2)*input[0][2],   // 4  // 5
+          sqrt(2)*input[0][1],   // 5  // 6
+          2*input[3][3],         // 6  // 7
+          2*input[4][4],         // 7  // 8
+          2*input[5][5],         // 8  // 9
+          2*input[0][3],         // 9  // 10
+          2*input[1][4],         // 10 // 11
+          2*input[2][5],         // 11 // 12
+          2*input[2][3],         // 12 // 13
+          2*input[0][4],         // 13 // 14
+          2*input[1][5],         // 14 // 15
+          2*input[1][3],         // 15 // 16
+          2*input[2][4],         // 16 // 17
+          2*input[0][5],         // 17 // 18
+          2*sqrt(2)*input[4][5], // 18 // 19
+          2*sqrt(2)*input[3][5], // 19 // 20
+          2*sqrt(2)*input[3][4]  // 20 // 21
+        });
+
+      }
+
+
+      template<int dim>
+      SymmetricTensor<2,6>
+      CpoElasticTensor<dim>::transform_21D_vector_to_6x6_matrix(const Tensor<1,21> &input)
+      {
+        SymmetricTensor<2,6> result;
+
+        constexpr double sqrt_2_inv = 1/sqrt(2);
+
+        result[0][0] = input[0];
+        result[1][1] = input[1];
+        result[2][2] = input[2];
+        result[1][2] = sqrt_2_inv * input[3];
+        result[0][2] = sqrt_2_inv * input[4];
+        result[0][1] = sqrt_2_inv * input[5];
+        result[3][3] = 0.5 * input[6];
+        result[4][4] = 0.5 * input[7];
+        result[5][5] = 0.5 * input[8];
+        result[0][3] = 0.5 * input[9];
+        result[1][4] = 0.5 * input[10];
+        result[2][5] = 0.5 * input[11];
+        result[2][3] = 0.5 * input[12];
+        result[0][4] = 0.5 * input[13];
+        result[1][5] = 0.5 * input[14];
+        result[1][3] = 0.5 * input[15];
+        result[2][4] = 0.5 * input[16];
+        result[0][5] = 0.5 * input[17];
+        result[4][5] = 0.5 * sqrt_2_inv * input[18];
+        result[3][5] = 0.5 * sqrt_2_inv * input[19];
+        result[3][4] = 0.5 * sqrt_2_inv * input[20];
+
+        return result;
+
+      }
+
+
+      template<int dim>
+      Tensor<1,21>
+      CpoElasticTensor<dim>::transform_4th_order_tensor_to_21D_vector(const Tensor<4,3> &input_tensor)
+      {
+        return Tensor<1,21,double> (
+        {
+          input_tensor[0][0][0][0],           // 0  // 1
+          input_tensor[1][1][1][1],           // 1  // 2
+          input_tensor[2][2][2][2],           // 2  // 3
+          sqrt(2)*0.5*(input_tensor[1][1][2][2] + input_tensor[2][2][1][1]),   // 3  // 4
+          sqrt(2)*0.5*(input_tensor[0][0][2][2] + input_tensor[2][2][0][0]),   // 4  // 5
+          sqrt(2)*0.5*(input_tensor[0][0][1][1] + input_tensor[1][1][0][0]),   // 5  // 6
+          0.5*(input_tensor[1][2][1][2]+input_tensor[1][2][2][1]+input_tensor[2][1][1][2]+input_tensor[2][1][2][1]),         // 6  // 7
+          0.5*(input_tensor[0][2][0][2]+input_tensor[0][2][2][0]+input_tensor[2][0][0][2]+input_tensor[2][0][2][0]),         // 7  // 8
+          0.5*(input_tensor[1][0][1][0]+input_tensor[1][0][0][1]+input_tensor[0][1][1][0]+input_tensor[0][1][0][1]),         // 8  // 9
+          0.5*(input_tensor[0][0][1][2]+input_tensor[0][0][2][1]+input_tensor[1][2][0][0]+input_tensor[2][1][0][0]),         // 9  // 10
+          0.5*(input_tensor[1][1][0][2]+input_tensor[1][1][2][0]+input_tensor[0][2][1][1]+input_tensor[2][0][1][1]),         // 10 // 11
+          0.5*(input_tensor[2][2][0][1]+input_tensor[2][2][1][0]+input_tensor[0][1][2][2]+input_tensor[1][0][2][2]),         // 11 // 12
+          0.5*(input_tensor[2][2][1][2]+input_tensor[2][2][2][1]+input_tensor[1][2][2][2]+input_tensor[2][1][2][2]),         // 12 // 13
+          0.5*(input_tensor[0][0][0][2]+input_tensor[0][0][2][0]+input_tensor[0][2][0][0]+input_tensor[2][0][0][0]),         // 13 // 14
+          0.5*(input_tensor[1][1][0][1]+input_tensor[1][1][1][0]+input_tensor[0][1][1][1]+input_tensor[1][0][1][1]),         // 14 // 15
+          0.5*(input_tensor[1][1][1][2]+input_tensor[1][1][2][1]+input_tensor[1][2][1][1]+input_tensor[2][1][1][1]),         // 15 // 16
+          0.5*(input_tensor[2][2][0][2]+input_tensor[2][2][2][0]+input_tensor[0][2][2][2]+input_tensor[2][0][2][2]),         // 16 // 17
+          0.5*(input_tensor[0][0][0][1]+input_tensor[0][0][1][0]+input_tensor[0][1][0][0]+input_tensor[1][0][0][0]),         // 17 // 18
+          sqrt(2)*0.25*(input_tensor[0][2][0][1]+input_tensor[0][2][1][0]+input_tensor[2][0][0][1]+input_tensor[2][0][1][0]+input_tensor[0][1][0][2]+input_tensor[0][1][2][0]+input_tensor[1][0][0][2]+input_tensor[1][0][2][0]), // 18 // 19
+          sqrt(2)*0.25*(input_tensor[1][2][0][1]+input_tensor[1][2][1][0]+input_tensor[2][1][0][1]+input_tensor[2][1][1][0]+input_tensor[0][1][1][2]+input_tensor[0][1][2][1]+input_tensor[1][0][1][2]+input_tensor[1][0][2][1]), // 19 // 20
+          sqrt(2)*0.25*(input_tensor[1][2][0][2]+input_tensor[1][2][2][0]+input_tensor[2][1][0][2]+input_tensor[2][1][2][0]+input_tensor[0][2][1][2]+input_tensor[0][2][2][1]+input_tensor[2][0][1][2]+input_tensor[2][0][2][1])  // 20 // 21
+        });
+
+      }
+
+      template <int dim>
+      UpdateTimeFlags
+      CpoElasticTensor<dim>::need_update() const
+      {
+        return update_output_step;
+      }
+
+      template <int dim>
+      UpdateFlags
+      CpoElasticTensor<dim>::get_needed_update_flags () const
+      {
+        return update_default;
+      }
+
+      template <int dim>
+      std::vector<std::pair<std::string, unsigned int>>
+      CpoElasticTensor<dim>::get_property_information() const
+      {
+        std::vector<std::pair<std::string,unsigned int>> property_information;
+
+        property_information.push_back(std::make_pair("cpo_elastic_tensor",SymmetricTensor<2,6>::n_independent_components));
+
+        return property_information;
+      }
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            prm.enter_subsection("Crystal Preferred Orientation");
+            {
+              prm.declare_entry ("Number of grains per particle", "50",
+                                 Patterns::Integer (1),
+                                 "The number of grains of each different mineral "
+                                 "each particle contains.");
+
+              prm.enter_subsection("Initial grains");
+              {
+                prm.enter_subsection("Uniform grains and random uniform rotations");
+                {
+                  prm.declare_entry ("Minerals", "Olivine: Karato 2008, Enstatite",
+                                     Patterns::List(Patterns::Anything()),
+                                     "This determines what minerals and fabrics or fabric selectors are used used for the LPO calculation. "
+                                     "The options are Olivine: Passive, A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric, "
+                                     "Olivine: E-fabric, Olivine: Karato 2008 or Enstatite. Passive sets all RRSS entries to the maximum. The "
+                                     "Karato 2008 selector selects a fabric based on stress and water content as defined in "
+                                     "figure 4 of the Karato 2008 review paper (doi: 10.1146/annurev.earth.36.031207.124120).");
+                }
+                prm.leave_subsection ();
+              }
+              prm.leave_subsection ();
+            }
+            prm.leave_subsection ();
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+      }
+
+
+      template <int dim>
+      void
+      CpoElasticTensor<dim>::parse_parameters (ParameterHandler &prm)
+      {
+
+        prm.enter_subsection("Postprocess");
+        {
+          prm.enter_subsection("Particles");
+          {
+            prm.enter_subsection("Crystal Preferred Orientation");
+            {
+              n_grains = prm.get_integer("Number of grains per particle");
+              prm.enter_subsection("Initial grains");
+              {
+                prm.enter_subsection("Uniform grains and random uniform rotations");
+                {
+                  n_minerals = dealii::Utilities::split_string_list(prm.get("Minerals")).size();
+                }
+                prm.leave_subsection();
+              }
+              prm.leave_subsection();
+            }
+            prm.leave_subsection();
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+
+
+      }
+    }
+  }
+}
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+      ASPECT_REGISTER_PARTICLE_PROPERTY(CpoElasticTensor,
+                                        "cpo elastic tensor",
+                                        "A plugin in which the particle property tensor is "
+                                        "defined as the deformation the Voigt average of the "
+                                        "elastic tensors of the cpo grains of the minerals."
+                                        "Currently only Olivine and Enstatite are supported.")
+    }
+  }
+}

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -81,7 +81,7 @@ namespace aspect
         AssertThrow(manager.check_plugin_order("crystal preferred orientation","cpo elastic tensor"),
                     ExcMessage("To use the cpo elastic tensor plugin, the cpo plugin need to be defined before this plugin."));
 
-        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo"));
+        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("crystal preferred orientation"));
       }
 
 
@@ -136,12 +136,12 @@ namespace aspect
       {
 
         // Get a reference to the CPO particle property.
-        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
-          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+        //const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+        //  this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
 
-        SymmetricTensor<2,6> S_average = voigt_average_elastic_tensor(cpo_particle_property,
-                                                                      cpo_data_position,
-                                                                      data);
+        SymmetricTensor<2,6> S_average;// = voigt_average_elastic_tensor(cpo_particle_property,
+        //                               cpo_data_position,
+        //                               data);
 
         for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
           {

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -671,7 +671,6 @@ namespace aspect
                 {
                   diffusion_viscosities.emplace_back(rheology->compute_viscosity(pressure, temperature, 0, phase_function_values, phase_function.n_phase_transitions_for_each_composition()));
                 }
-              //const double diffusion_creep_strain_rate = rheology->compute_viscosity(pressure, temperature, 0, phase_function_values, phase_function.n_phase_transitions_for_each_composition()); // TODO: compute it
 
               const double diffusion_viscosity = MaterialModel::MaterialUtilities::average_value(volume_fractions, diffusion_viscosities, MaterialModel::MaterialUtilities::harmonic);
 

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -73,6 +73,7 @@ namespace aspect
       CrystalPreferredOrientation<dim>::compute_random_rotation_matrix(Tensor<2,3> &rotation_matrix) const
       {
 
+        const double dt = this -> get_time();  
         // This function is based on an article in Graphic Gems III, written by James Arvo, Cornell University (p 116-120).
         // The original code can be found on  http://www.realtimerendering.com/resources/GraphicsGems/gemsiii/rand_rotation.c
         // and is licenced according to this website with the following licence:
@@ -95,7 +96,7 @@ namespace aspect
 
         double theta = 2.0 * numbers::PI * one; // Rotation about the pole (Z)
         double phi = 2.0 * numbers::PI * two; // For direction of pole deflection.
-        double z = 2.0* three; //For magnitude of pole deflection.
+        double z = dt != 0.0 ? 0.1 * three : 2.0 * three; //For magnitude of pole deflection. 
 
         // Compute a vector V used for distributing points over the sphere
         // via the reflection I - V Transpose(V).  This formulation of V
@@ -191,7 +192,7 @@ namespace aspect
                 for (unsigned int grain_i = 0; grain_i < n_grains ; ++grain_i)
                   {
                     // set volume fraction
-                    if (n_grains < n_grains/10.)
+                    if (grain_i < n_grains/10.)
                       volume_fractions_grains[mineral_i][grain_i] = initial_volume_fraction;
                     else
                       {
@@ -635,7 +636,8 @@ namespace aspect
               const double homologous_T = 1770+273.15; // in Kelvin I assume. TODO: make this a function of temperature and pressure? Both are avaible as variables with those names here.
               const double aggregate_recrystalization_increment = const_C*exp(const_g*temperature/homologous_T)*strain; // TODO: compute actual value with equation 5
               // compute paleowatt/pizometer grainsize
-              const double recrystalized_grain_size = 0.5; // TODO: actually compute the grainsize with the paleowatt/pizometer
+              
+              const double recrystalized_grain_size = 0.01; // TODO: actually compute the grainsize with the paleowatt/pizometer
               const double half_recrystalized_grain_size = 0.5 * recrystalized_grain_size;
               const double recrystalized_grain_volume = (4./3.)*numbers::PI*half_recrystalized_grain_size*half_recrystalized_grain_size*half_recrystalized_grain_size;
 
@@ -712,6 +714,12 @@ namespace aspect
               const double stress_invariant = std::sqrt(std::max(-second_invariant(deviatoric_stress), 0.));
 
               const double diffusion_creep_strain_rate = stress_invariant/(2.0*diffusion_viscosity);
+              //const double eff_vis =std::max(second_invariant(deviatoric_strain_rate), 0.);
+              //const long double pre_exponent_term =(3*1*1.92*std::pow(1/10.0,10.))/(0.1*stress_invariant*((eff_vis-diffusion_creep_strain_rate)*3));
+              //const long double exponent_term = -1*(400*1000)/(8.314*temperature);
+              //const long double recrystalized_grain_size = pre_exponent_term*std::pow(std::exp(exponent_term),0.25); // TODO: actually compute the grainsize with the paleowatt/pizometer
+              //const long double half_recrystalized_grain_size = 0.5 * recrystalized_grain_size;
+              //const long double recrystalized_grain_volume = (4./3.)*numbers::PI*half_recrystalized_grain_size*half_recrystalized_grain_size*half_recrystalized_grain_size;
 
               return compute_derivatives_drexpp(cpo_index,
                                                 data,

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -345,7 +345,7 @@ namespace aspect
               }
 
             // normalize the volume fractions back to a total of 1 for each mineral
-            const double inv_sum_volume_mineral = 1.0/sum_volume_mineral;
+            const double inv_sum_volume_mineral = 1.0;///sum_volume_mineral;
 
             Assert(std::isfinite(inv_sum_volume_mineral),
                    ExcMessage("inv_sum_volume_mineral is not finite. sum_volume_enstatite = "
@@ -1247,12 +1247,28 @@ namespace aspect
           }
 
         // Secondly recrystalize grains
+        std::cout << "A: recrystalized_grain_volume = " << recrystalized_grain_volume << ", recrystalized_fractions = ";
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << recrystalized_fractions[i] << ", ";
+        std::cout << ", volumes = ";
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << get_volume_fractions_grains(cpo_index,data,mineral_i,i)  << ", ";
+        std::cout << std::endl;
+
         this->recrystalize_grains(cpo_index,
                                   data,
                                   mineral_i,
                                   recrystalized_grain_volume,
                                   recrystalized_fractions,
                                   strain_energy);
+
+        std::cout << "B: recrystalized_grain_volume = " << recrystalized_grain_volume << ", recrystalized_fractions = ";
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << recrystalized_fractions[i] << ", ";
+        std::cout << ", volumes = ";
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << get_volume_fractions_grains(cpo_index,data,mineral_i,i)  << ", ";
+        std::cout << std::endl;
 
         double mean_strain_energy = 0.0;
         // Change of volume fraction of grains by grain boundary migration
@@ -1284,6 +1300,14 @@ namespace aspect
                    ExcMessage("deriv_volume_fractions[" + std::to_string(grain_i) + "] is not finite: "
                               + std::to_string(deriv_volume_fractions[grain_i])));
           }
+
+        std::cout << "C: deriv_volume_fractions[grain_i] = " ;
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << deriv_volume_fractions[i] << ", ";
+        std::cout << ", volumes = ";
+        for (unsigned int i = 0; i < recrystalized_fractions.size(); ++i)
+          std::cout << get_volume_fractions_grains(cpo_index,data,mineral_i,i)  << ", ";
+        std::cout << std::endl;
 
         return std::pair<std::vector<double>, std::vector<Tensor<2,3>>>(deriv_volume_fractions, deriv_a_cosine_matrices);
       }

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -187,10 +187,10 @@ namespace aspect
             else
               {
                 // set volume fraction
-               
+
                 /*
                 To use D-Rex uncomment the first statement, setting the initial volume fraction = 1/n_grains
-                To use D-Rex ++ uncomment the other lines 
+                To use D-Rex ++ uncomment the other lines
                 */
 
                 //const double initial_volume_fraction = 1.0/n_grains;
@@ -645,12 +645,12 @@ namespace aspect
               set_deformation_type(cpo_index,data,mineral_i,static_cast<unsigned int>(deformation_type));
 
               /*
-                The following part of the algorithm describes the rate of recrystalization of new strain-free grains. This is done by using the 
-                Johnson- Avrami-Mehl_Kolmogodorov theory of transformation. The equations and the values for the variables are taken from Cross and Skemer 
-                (2019). 
+                The following part of the algorithm describes the rate of recrystalization of new strain-free grains. This is done by using the
+                Johnson- Avrami-Mehl_Kolmogodorov theory of transformation. The equations and the values for the variables are taken from Cross and Skemer
+                (2019).
 
                 Incremental recrystalization fraction = n * beta * (strain - critical strain)^(n - 1) * exp( -beta * (strain - critical strain)^ n )
-                 where 
+                 where
                  n -> avrami exponent
                  beta -> rate of transformation
                   where beta -> C * exp(g * (T/T_melt))
@@ -741,7 +741,7 @@ namespace aspect
               // now compute the normal viscosity to be able to computes the stress
               // Create the material model inputs and outputs to
               // retrieve the current viscosity.
-              
+
               MaterialModel::MaterialModelInputs<dim> in = MaterialModel::MaterialModelInputs<dim>(1,compositions.size());
               in.pressure[0] = pressure;
               in.temperature[0] = temperature;
@@ -775,7 +775,7 @@ namespace aspect
               // strain rate is computed in the viscoplastic material model.
               // TODO check that this is valid for the compressible case.
               //const double stress_invariant = (std::sqrt(std::max(-second_invariant(deviatoric_stress), 0.)));
-            
+
               const std::array< double, dim > eigenvalues = dealii::eigenvalues(deviatoric_stress);
               double differential_stress = eigenvalues[0]-eigenvalues[dim-1];
               const double dislocation_creep_strain_rate = differential_stress/(2.0*dislocation_viscosities[0]);
@@ -810,7 +810,7 @@ namespace aspect
 
               // The terms related to the paleowattmeter are declared here
               // Note : These values prescribe to the piezometer for olivine alone
-            
+
               const double C      = 3;
               const double gamma  = 1.0;
               const double k_g    = 1.92 * std::pow(10,-10);
@@ -819,7 +819,7 @@ namespace aspect
               const double E_g    = 400 * std::pow(10,3);
               const double V_g    = 0;
               const double R      = 8.314;
-            
+
               if (t!=0)
                 {
                   const long double pre_exponent_term_num = C * gamma * k_g;
@@ -1108,7 +1108,7 @@ namespace aspect
               }
 
             size_t n_recrystalized_grains = std::floor((recrystalization_fractions[grain_i]*grain_volume)/recrystalized_grain_volume);
-            
+
             if (n_recrystalized_grains > 0)
               {
                 const double grain_volume_left = grain_volume-n_recrystalized_grains*recrystalized_grain_volume;

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -189,7 +189,12 @@ namespace aspect
                 for (unsigned int grain_i = 0; grain_i < n_grains ; ++grain_i)
                   {
                     // set volume fraction
-                    volume_fractions_grains[mineral_i][grain_i] = initial_volume_fraction;
+                    if (n_grains < n_grains/10.)
+                      volume_fractions_grains[mineral_i][grain_i] = initial_volume_fraction;
+                    else
+                      {
+                        volume_fractions_grains[mineral_i][grain_i] = initial_volume_fraction/1000.;
+                      }
 
                     // set a uniform random rotation_matrix per grain
                     this->compute_random_rotation_matrix(rotation_matrices_grains[mineral_i][grain_i]);
@@ -358,6 +363,15 @@ namespace aspect
                  * of finding the nearest orthonormal matrix using the SVD
                  */
                 Tensor<2,3> rotation_matrix = get_rotation_matrix_grains(data_position,data,mineral_i,grain_i);
+                for (size_t i = 0; i < 3; i++)
+                  for (size_t j = 0; j < 3; j++)
+                    Assert(abs(rotation_matrix[i][j]) <= 1.0,
+                           ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                      "] is larger than one: " + std::to_string(rotation_matrix[i][j]) + " (" + std::to_string(rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                                      + std::to_string(rotation_matrix[0][0]) + " " + std::to_string(rotation_matrix[0][1]) + " " + std::to_string(rotation_matrix[0][2]) + "\n"
+                                      + std::to_string(rotation_matrix[1][0]) + " " + std::to_string(rotation_matrix[1][1]) + " " + std::to_string(rotation_matrix[1][2]) + "\n"
+                                      + std::to_string(rotation_matrix[2][0]) + " " + std::to_string(rotation_matrix[2][1]) + " " + std::to_string(rotation_matrix[2][2])));
+
                 for (size_t i = 0; i < 3; ++i)
                   {
                     for (size_t j = 0; j < 3; ++j)
@@ -388,6 +402,8 @@ namespace aspect
                                         + std::to_string(rotation_matrix[1][0]) + " " + std::to_string(rotation_matrix[1][1]) + " " + std::to_string(rotation_matrix[1][2]) + "\n"
                                         + std::to_string(rotation_matrix[2][0]) + " " + std::to_string(rotation_matrix[2][1]) + " " + std::to_string(rotation_matrix[2][2])));
                     }
+
+                set_rotation_matrix_grains(data_position,data,mineral_i,grain_i,rotation_matrix);
               }
           }
       }
@@ -810,6 +826,7 @@ namespace aspect
               {
                 const double rhos = std::pow(tau[indices[slip_system_i]],exponent_p-stress_exponent) *
                                     std::pow(std::abs(gamma*beta[indices[slip_system_i]]),exponent_p/stress_exponent);
+
                 strain_energy[grain_i] += rhos * std::exp(-nucleation_efficiency * rhos * rhos);
 
                 Assert(isfinite(strain_energy[grain_i]), ExcMessage("strain_energy[" + std::to_string(grain_i) + "] is not finite: " + std::to_string(strain_energy[grain_i])
@@ -876,6 +893,15 @@ namespace aspect
         unsigned int permutation_vector_counter = 0;
         Tensor<2,3> main_rotation_matrix = get_rotation_matrix_grains(cpo_index,data,mineral_i,permutation_vector[permutation_vector_counter]);
 
+        for (size_t i = 0; i < 3; i++)
+          for (size_t j = 0; j < 3; j++)
+            Assert(abs(main_rotation_matrix[i][j]) <= 1.0,
+                   ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                              "] is larger than one: " + std::to_string(main_rotation_matrix[i][j]) + " (" + std::to_string(main_rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                              + std::to_string(main_rotation_matrix[0][0]) + " " + std::to_string(main_rotation_matrix[0][1]) + " " + std::to_string(main_rotation_matrix[0][2]) + "\n"
+                              + std::to_string(main_rotation_matrix[1][0]) + " " + std::to_string(main_rotation_matrix[1][1]) + " " + std::to_string(main_rotation_matrix[1][2]) + "\n"
+                              + std::to_string(main_rotation_matrix[2][0]) + " " + std::to_string(main_rotation_matrix[2][1]) + " " + std::to_string(main_rotation_matrix[2][2])));
+
         for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
           {
             const double grain_volume = get_volume_fractions_grains(cpo_index,data,mineral_i,grain_i);
@@ -884,7 +910,7 @@ namespace aspect
               {
                 temp_total_volume += get_volume_fractions_grains(cpo_index,data,mineral_i,i);
               }
-            const size_t n_recrystalized_grains = std::floor(recrystalization_fractions[grain_i]*grain_volume/recrystalized_grain_volume);
+            const size_t n_recrystalized_grains = std::floor(recrystalization_fractions[grain_i]*grain_volume/temp_total_volume);
             if (n_recrystalized_grains > 0)
               {
                 const double grain_volume_left = grain_volume-n_recrystalized_grains*recrystalized_grain_volume;
@@ -901,6 +927,14 @@ namespace aspect
 
                 Tensor<2,3> random_rotation_matrix;
                 this->compute_random_rotation_matrix(random_rotation_matrix);
+                for (size_t i = 0; i < 3; i++)
+                  for (size_t j = 0; j < 3; j++)
+                    Assert(abs(random_rotation_matrix[i][j]) <= 1.0,
+                           ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                      "] is larger than one: " + std::to_string(random_rotation_matrix[i][j]) + " (" + std::to_string(random_rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                                      + std::to_string(random_rotation_matrix[0][0]) + " " + std::to_string(random_rotation_matrix[0][1]) + " " + std::to_string(random_rotation_matrix[0][2]) + "\n"
+                                      + std::to_string(random_rotation_matrix[1][0]) + " " + std::to_string(random_rotation_matrix[1][1]) + " " + std::to_string(random_rotation_matrix[1][2]) + "\n"
+                                      + std::to_string(random_rotation_matrix[2][0]) + " " + std::to_string(random_rotation_matrix[2][1]) + " " + std::to_string(random_rotation_matrix[2][2])));
                 set_rotation_matrix_grains(cpo_index,data,mineral_i,permutation_vector[permutation_vector_counter],random_rotation_matrix);
                 strain_energy[permutation_vector[permutation_vector_counter]] = 0.0;
 
@@ -913,6 +947,15 @@ namespace aspect
 
                     // TODO: compute random rotation matrix between two degrees and apply it
                     this->compute_random_rotation_matrix(random_deflection);
+                    main_rotation_matrix = main_rotation_matrix*random_deflection;
+                    for (size_t i = 0; i < 3; i++)
+                      for (size_t j = 0; j < 3; j++)
+                        Assert(abs(main_rotation_matrix[i][j]) <= 1.0,
+                               ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                          "] is larger than one: " + std::to_string(main_rotation_matrix[i][j]) + " (" + std::to_string(main_rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                                          + std::to_string(main_rotation_matrix[0][0]) + " " + std::to_string(main_rotation_matrix[0][1]) + " " + std::to_string(main_rotation_matrix[0][2]) + "\n"
+                                          + std::to_string(main_rotation_matrix[1][0]) + " " + std::to_string(main_rotation_matrix[1][1]) + " " + std::to_string(main_rotation_matrix[1][2]) + "\n"
+                                          + std::to_string(main_rotation_matrix[2][0]) + " " + std::to_string(main_rotation_matrix[2][1]) + " " + std::to_string(main_rotation_matrix[2][2])));
 
                     // apply deflection TODO: test!
                     set_rotation_matrix_grains(cpo_index,data,mineral_i,permutation_vector[permutation_vector_counter],main_rotation_matrix*random_deflection);
@@ -976,6 +1019,14 @@ namespace aspect
             // compute G and beta
             Tensor<1,4> bigI;
             const Tensor<2,3> rotation_matrix = get_rotation_matrix_grains(cpo_index,data,mineral_i,grain_i);
+            for (size_t i = 0; i < 3; i++)
+              for (size_t j = 0; j < 3; j++)
+                Assert(abs(rotation_matrix[i][j]) <= 1.0,
+                       ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                  "] is larger than one: " + std::to_string(rotation_matrix[i][j]) + " (" + std::to_string(rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                                  + std::to_string(rotation_matrix[0][0]) + " " + std::to_string(rotation_matrix[0][1]) + " " + std::to_string(rotation_matrix[0][2]) + "\n"
+                                  + std::to_string(rotation_matrix[1][0]) + " " + std::to_string(rotation_matrix[1][1]) + " " + std::to_string(rotation_matrix[1][2]) + "\n"
+                                  + std::to_string(rotation_matrix[2][0]) + " " + std::to_string(rotation_matrix[2][1]) + " " + std::to_string(rotation_matrix[2][2])));
             const Tensor<2,3> rotation_matrix_transposed = transpose(rotation_matrix);
             for (unsigned int slip_system_i = 0; slip_system_i < 4; ++slip_system_i)
               {
@@ -1104,9 +1155,12 @@ namespace aspect
 
         for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
           {
-            recrystalized_fractions[grain_i] = (grain_boundary_sliding_fractions[grain_i]/total_grain_boundary_sliding_fraction)
+            recrystalized_fractions[grain_i] = total_grain_boundary_sliding_fraction != 0 && total_subgrain_rotation_fraction !=0 ?
+                                               (grain_boundary_sliding_fractions[grain_i]/total_grain_boundary_sliding_fraction)
                                                * (subgrain_rotation_fractions[grain_i]/total_subgrain_rotation_fraction)
-                                               * aggregate_recrystalization_increment;
+                                               * aggregate_recrystalization_increment
+                                               :
+                                               0.0;
           }
 
         // Secondly recrystalize grains
@@ -1395,7 +1449,6 @@ namespace aspect
                                    "Karato 2008 selector selects a fabric based on stress and water content as defined in "
                                    "figure 4 of the Karato 2008 review paper (doi: 10.1146/annurev.earth.36.031207.124120).");
 
-
                 prm.declare_entry ("Volume fractions minerals", "0.7, 0.3",
                                    Patterns::List(Patterns::Double(0)),
                                    "The volume fractions for the different minerals. "
@@ -1407,7 +1460,6 @@ namespace aspect
 
               prm.enter_subsection("D-Rex 2004");
               {
-
                 prm.declare_entry ("Mobility", "50",
                                    Patterns::Double(0),
                                    "The dimensionless intrinsic grain boundary mobility for both olivine and enstatite.");
@@ -1441,14 +1493,6 @@ namespace aspect
 
               prm.enter_subsection("D-Rex++");
               {
-                prm.declare_entry ("Minerals", "Olivine: Karato 2008, Enstatite",
-                                   Patterns::List(Patterns::Anything()),
-                                   "This determines what minerals and fabrics or fabric selectors are used used for the LPO calculation. "
-                                   "The options are Olivine: A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric, "
-                                   "Olivine: E-fabric, Olivine: Karato 2008 or Enstatite. The "
-                                   "Karato 2008 selector selects a fabric based on stress and water content as defined in "
-                                   "figure 4 of the Karato 2008 review paper (doi: 10.1146/annurev.earth.36.031207.124120).");
-
                 prm.declare_entry ("Mobility", "50",
                                    Patterns::Double(0),
                                    "The dimensionless intrinsic grain boundary mobility for both olivine and enstatite.");
@@ -1519,6 +1563,10 @@ namespace aspect
                 {
                   cpo_derivative_algorithm = CPODerivativeAlgorithm::drex_2004;
                 }
+              else if (temp_cpo_derivative_algorithm ==  "D-Rex++")
+                {
+                  cpo_derivative_algorithm = CPODerivativeAlgorithm::drexpp;
+                }
               else
                 {
                   AssertThrow(false,
@@ -1546,8 +1594,9 @@ namespace aspect
                 AssertThrow(model_name == "Uniform grains and random uniform rotations",
                             ExcMessage("No model named " + model_name + "for CPO particle property initialization. "
                                        + "Only the model \"Uniform grains and random uniform rotations\" is available."));
-
                 const std::vector<std::string> temp_deformation_type_selector = dealii::Utilities::split_string_list(prm.get("Minerals"));
+                //prm.enter_subsection("Uniform grains and random uniform rotations");
+                //{
                 n_minerals = temp_deformation_type_selector.size();
                 deformation_type_selector.resize(n_minerals);
 
@@ -1603,6 +1652,8 @@ namespace aspect
 
                 AssertThrow(abs(volume_fractions_minerals_sum-1.0) < 2.0 * std::numeric_limits<double>::epsilon(),
                             ExcMessage("The sum of the CPO volume fractions should be one."));
+                //}
+                //prm.leave_subsection();
               }
               prm.leave_subsection();
 

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -1,0 +1,617 @@
+/*
+ Copyright (C) 2023 by the authors of the ASPECT code.
+ This file is part of ASPECT.
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+//#include <cstdlib>
+#include <aspect/particle/property/elastic_tensor_decomposition.h>
+#include <aspect/particle/property/cpo_elastic_tensor.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/particle/world.h>
+
+#include <aspect/utilities.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+
+      template <int dim> SymmetricTensor<2,21> ElasticTensorDecomposition<dim>::projection_matrix_tric_to_mono;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_mono_to_ortho;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_ortho_to_tetra;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_tetra_to_hexa;
+      template <int dim> SymmetricTensor<2,9> ElasticTensorDecomposition<dim>::projection_matrix_hexa_to_iso;
+
+
+
+      template <int dim>
+      ElasticTensorDecomposition<dim>::ElasticTensorDecomposition ()
+      {
+        // setup projection matrices
+        // projection_matrix_tric_to_mono
+        projection_matrix_tric_to_mono[0][0] = 1.0;
+        projection_matrix_tric_to_mono[1][1] = 1.0;
+        projection_matrix_tric_to_mono[2][2] = 1.0;
+        projection_matrix_tric_to_mono[3][3] = 1.0;
+        projection_matrix_tric_to_mono[4][4] = 1.0;
+        projection_matrix_tric_to_mono[5][5] = 1.0;
+        projection_matrix_tric_to_mono[6][6] = 1.0;
+        projection_matrix_tric_to_mono[7][7] = 1.0;
+        projection_matrix_tric_to_mono[8][8] = 1.0;
+        projection_matrix_tric_to_mono[11][11] = 1.0;
+        projection_matrix_tric_to_mono[14][14] = 1.0;
+        projection_matrix_tric_to_mono[17][17] = 1.0;
+        projection_matrix_tric_to_mono[20][20] = 1.0;
+
+
+        // projection_matrix_mono_to_ortho;
+        projection_matrix_mono_to_ortho[0][0] = 1.0;
+        projection_matrix_mono_to_ortho[1][1] = 1.0;
+        projection_matrix_mono_to_ortho[2][2] = 1.0;
+        projection_matrix_mono_to_ortho[3][3] = 1.0;
+        projection_matrix_mono_to_ortho[4][4] = 1.0;
+        projection_matrix_mono_to_ortho[5][5] = 1.0;
+        projection_matrix_mono_to_ortho[6][6] = 1.0;
+        projection_matrix_mono_to_ortho[7][7] = 1.0;
+        projection_matrix_mono_to_ortho[8][8] = 1.0;
+
+        // projection_matrix_ortho_to_tetra;
+        projection_matrix_ortho_to_tetra[0][0] = 0.5;
+        projection_matrix_ortho_to_tetra[0][1] = 0.5;
+        projection_matrix_ortho_to_tetra[1][1] = 0.5;
+        projection_matrix_ortho_to_tetra[2][2] = 1.0;
+        projection_matrix_ortho_to_tetra[3][3] = 0.5;
+        projection_matrix_ortho_to_tetra[3][4] = 0.5;
+        projection_matrix_ortho_to_tetra[4][4] = 0.5;
+        projection_matrix_ortho_to_tetra[5][5] = 1.0;
+        projection_matrix_ortho_to_tetra[6][6] = 0.5;
+        projection_matrix_ortho_to_tetra[6][7] = 0.5;
+        projection_matrix_ortho_to_tetra[7][7] = 0.5;
+        projection_matrix_ortho_to_tetra[8][8] = 1.0;
+
+        // projection_matrix_tetra_to_hexa;
+        projection_matrix_tetra_to_hexa[0][0] = 3./8.;
+        projection_matrix_tetra_to_hexa[0][1] = 3./8.;
+        projection_matrix_tetra_to_hexa[1][1] = 3./8.;
+        projection_matrix_tetra_to_hexa[2][2] = 1.0;
+        projection_matrix_tetra_to_hexa[3][3] = 0.5;
+        projection_matrix_tetra_to_hexa[3][4] = 0.5;
+        projection_matrix_tetra_to_hexa[4][4] = 0.5;
+        projection_matrix_tetra_to_hexa[5][5] = 3./4.;
+        projection_matrix_tetra_to_hexa[6][6] = 0.5;
+        projection_matrix_tetra_to_hexa[6][7] = 0.5;
+        projection_matrix_tetra_to_hexa[7][7] = 0.5;
+        projection_matrix_tetra_to_hexa[8][8] = 0.5;
+        projection_matrix_tetra_to_hexa[5][0] = 1./(4.*std::sqrt(2.0));
+        projection_matrix_tetra_to_hexa[5][1] = 1./(4.*std::sqrt(2.0));
+        projection_matrix_tetra_to_hexa[8][0] = 0.25;
+        projection_matrix_tetra_to_hexa[8][1] = 0.25;
+        projection_matrix_tetra_to_hexa[8][5] = -1/(2*std::sqrt(2.0));
+
+
+        // projection_matrix_hexa_to_iso;
+        projection_matrix_hexa_to_iso[0][0] = 3./15.;
+        projection_matrix_hexa_to_iso[0][1] = 3./15.;
+        projection_matrix_hexa_to_iso[0][2] = 3./15.;
+        projection_matrix_hexa_to_iso[1][1] = 3./15.;
+        projection_matrix_hexa_to_iso[1][2] = 3./15.;
+        projection_matrix_hexa_to_iso[2][2] = 3./15.;
+        projection_matrix_hexa_to_iso[3][3] = 4./15.;
+        projection_matrix_hexa_to_iso[3][4] = 4./15.;
+        projection_matrix_hexa_to_iso[3][5] = 4./15.;
+        projection_matrix_hexa_to_iso[4][4] = 4./15.;
+        projection_matrix_hexa_to_iso[4][5] = 4./15.;
+        projection_matrix_hexa_to_iso[5][5] = 4./15.;
+        projection_matrix_hexa_to_iso[6][6] = 1./5.;
+        projection_matrix_hexa_to_iso[6][7] = 1./5.;
+        projection_matrix_hexa_to_iso[6][8] = 1./5.;
+        projection_matrix_hexa_to_iso[7][7] = 1./5.;
+        projection_matrix_hexa_to_iso[7][8] = 1./5.;
+        projection_matrix_hexa_to_iso[8][8] = 1./5.;
+
+        projection_matrix_hexa_to_iso[0][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[1][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][3] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][4] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[2][5] = std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[0][6] = 2./15.;
+        projection_matrix_hexa_to_iso[0][7] = 2./15.;
+        projection_matrix_hexa_to_iso[0][8] = 2./15.;
+        projection_matrix_hexa_to_iso[1][6] = 2./15.;
+        projection_matrix_hexa_to_iso[1][7] = 2./15.;
+        projection_matrix_hexa_to_iso[1][8] = 2./15.;
+        projection_matrix_hexa_to_iso[2][6] = 2./15.;
+        projection_matrix_hexa_to_iso[2][7] = 2./15.;
+        projection_matrix_hexa_to_iso[2][8] = 2./15.;
+        projection_matrix_hexa_to_iso[3][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[3][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[3][8] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[4][8] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][6] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][7] = -std::sqrt(2.0)/15.;
+        projection_matrix_hexa_to_iso[5][8] = -std::sqrt(2.0)/15.;
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::initialize ()
+      {
+        const Particle::Property::Manager<dim> &manager = this->get_particle_world().get_property_manager();
+        AssertThrow(manager.plugin_name_exists("crystal preferred orientation"),
+                    ExcMessage("No cpo property plugin found."));
+        AssertThrow(manager.plugin_name_exists("cpo elastic tensor"),
+                    ExcMessage("No cpo elastic tensor property plugin found."));
+        Assert(manager.plugin_name_exists("decompose elastic matrix"),
+               ExcMessage("No hexagonal axes property plugin found."));
+
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","decompose elastic matrix"),
+                    ExcMessage("To use the decompose elastic matrix plugin, the cpo plugin need to be defined before this plugin."));
+
+        AssertThrow(manager.check_plugin_order("cpo elastic tensor","decompose elastic matrix"),
+                    ExcMessage("To use the decompose elastic matrix plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
+
+        cpo_elastic_tensor_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo elastic tensor"));
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::initialize_one_particle_property(const Point<dim> &,
+                                                                        std::vector<double> &data) const
+      {
+        const SymmetricTensor<2,6> elastic_matrix = Particle::Property::CpoElasticTensor<dim>::get_elastic_tensor(cpo_elastic_tensor_data_position,
+                                                    data);
+
+        const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = compute_dilatation_stiffness_tensor(elastic_matrix);
+        const SymmetricTensor<2,3> voigt_stiffness_tensor_full = compute_voigt_stiffness_tensor(elastic_matrix);
+        Tensor<2,3> SCCS_full = compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+
+        std::array<std::array<double,3>,7 > norms = compute_elastic_tensor_SCCS_decompositions(SCCS_full, elastic_matrix);
+
+        // get max hexagonal element index, which is the same as the permutation index
+        const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+        std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
+        // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
+        Tensor<2,3> hexa_permutated_SCCS;
+        for (size_t index = 0; index < 3; index++)
+          {
+            hexa_permutated_SCCS[index] = SCCS_full[perumation[index]];
+          }
+
+        data.push_back(SCCS_full[0][0]);
+        data.push_back(SCCS_full[0][1]);
+        data.push_back(SCCS_full[0][2]);
+        data.push_back(SCCS_full[1][0]);
+        data.push_back(SCCS_full[1][1]);
+        data.push_back(SCCS_full[1][2]);
+        data.push_back(SCCS_full[2][0]);
+        data.push_back(SCCS_full[2][1]);
+        data.push_back(SCCS_full[2][2]);
+        data.push_back(hexa_permutated_SCCS[2][0]);
+        data.push_back(hexa_permutated_SCCS[2][1]);
+        data.push_back(hexa_permutated_SCCS[2][2]);
+        data.push_back(norms[6][0]);
+        data.push_back(norms[0][0]); // triclinic
+        data.push_back(norms[0][1]); // triclinic
+        data.push_back(norms[0][2]); // triclinic
+        data.push_back(norms[1][0]); // monoclinic
+        data.push_back(norms[1][1]); // monoclinic
+        data.push_back(norms[1][2]); // monoclinic
+        data.push_back(norms[2][0]); // orthorhomic
+        data.push_back(norms[2][1]); // orthorhomic
+        data.push_back(norms[2][2]); // orthorhomic
+        data.push_back(norms[3][0]); // tetragonal
+        data.push_back(norms[3][1]); // tetragonal
+        data.push_back(norms[3][2]); // tetragonal
+        data.push_back(norms[4][0]); // hexagonal
+        data.push_back(norms[4][1]); // hexagonal
+        data.push_back(norms[4][2]); // hexagonal
+        data.push_back(norms[5][0]); // isotropic
+
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::update_one_particle_property(const unsigned int data_position,
+                                                                    const Point<dim> &,
+                                                                    const Vector<double> &,
+                                                                    const std::vector<Tensor<1,dim>> &,
+                                                                    const ArrayView<double> &data) const
+      {
+        const SymmetricTensor<2,6> elastic_matrix = Particle::Property::CpoElasticTensor<dim>::get_elastic_tensor(cpo_elastic_tensor_data_position,
+                                                    data);
+
+
+        const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = compute_dilatation_stiffness_tensor(elastic_matrix);
+        const SymmetricTensor<2,3> voigt_stiffness_tensor_full = compute_voigt_stiffness_tensor(elastic_matrix);
+        Tensor<2,3> SCCS_full = compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+
+        std::array<std::array<double,3>,7 > norms = compute_elastic_tensor_SCCS_decompositions(SCCS_full, elastic_matrix);
+
+        // get max hexagonal element index, which is the same as the permutation index
+        const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+        std::array<unsigned short int, 3> perumation = indexed_even_permutation(max_hexagonal_element_index);
+        // reorder the SCCS be the SCCS permutation which yields the largest hexagonal vector (percentage of anisotropy)
+        Tensor<2,3> hexa_permutated_SCCS;
+        for (size_t index = 0; index < 3; index++)
+          {
+            hexa_permutated_SCCS[index] = SCCS_full[perumation[index]];
+          }
+
+        data[data_position]    = SCCS_full[0][0];
+        data[data_position+1]  = SCCS_full[0][1];
+        data[data_position+2]  = SCCS_full[0][2];
+        data[data_position+3]  = SCCS_full[1][0];
+        data[data_position+4]  = SCCS_full[1][1];
+        data[data_position+5]  = SCCS_full[1][2];
+        data[data_position+6]  = SCCS_full[2][0];
+        data[data_position+7]  = SCCS_full[2][1];
+        data[data_position+8]  = SCCS_full[2][2];
+        data[data_position+9]  = hexa_permutated_SCCS[2][0];
+        data[data_position+10] = hexa_permutated_SCCS[2][1];
+        data[data_position+11] = hexa_permutated_SCCS[2][2];
+        data[data_position+12] = norms[6][0];
+        data[data_position+13] = norms[0][0]; // triclinic
+        data[data_position+14] = norms[0][1]; // triclinic
+        data[data_position+15] = norms[0][2]; // triclinic
+        data[data_position+16] = norms[1][0]; // monoclinic
+        data[data_position+17] = norms[1][1]; // monoclinic
+        data[data_position+18] = norms[1][2]; // monoclinic
+        data[data_position+19] = norms[2][0]; // orthorhomic
+        data[data_position+20] = norms[2][1]; // orthorhomic
+        data[data_position+21] = norms[2][2]; // orthorhomic
+        data[data_position+22] = norms[3][0]; // tetragonal
+        data[data_position+23] = norms[3][1]; // tetragonal
+        data[data_position+24] = norms[3][2]; // tetragonal
+        data[data_position+25] = norms[4][0]; // hexagonal
+        data[data_position+26] = norms[4][1]; // hexagonal
+        data[data_position+27] = norms[4][2]; // hexagonal
+        data[data_position+28] = norms[5][0]; // isotropic
+      }
+
+
+
+      template<int dim>
+      std::array<unsigned short int, 3>
+      ElasticTensorDecomposition<dim>::indexed_even_permutation(const unsigned short int index)
+      {
+        // there are 6 permutations, but only the odd or even are needed. We use the even
+        // permutation here.
+        switch (index)
+          {
+            case 0 :
+              return {{0,1,2}};
+            case 1 :
+              return {{1,2,0}};
+            case 2:
+              return {{2,0,1}};
+            /*case 3:
+              return {0,2,1};
+            case 4 :
+              return {1,0,2};
+            case 5:
+              return {2,1,0};*/
+            default:
+              AssertThrow(false,ExcMessage("Provided index larger then 2 (" + std::to_string(index)+ ")."));
+              return {{0,0,0}};
+          }
+
+      }
+
+
+
+      template<int dim>
+      SymmetricTensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_voigt_stiffness_tensor(const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * the Voigt stiffness tensor (see Browaeys and chevrot, 2004)
+         * It defines the stress needed to cause an isotropic strain in the
+         * material
+         */
+        SymmetricTensor<2,3> voigt_stiffness_tensor;
+        voigt_stiffness_tensor[0][0]=elastic_matrix[0][0]+elastic_matrix[5][5]+elastic_matrix[4][4];
+        voigt_stiffness_tensor[1][1]=elastic_matrix[5][5]+elastic_matrix[1][1]+elastic_matrix[3][3];
+        voigt_stiffness_tensor[2][2]=elastic_matrix[4][4]+elastic_matrix[3][3]+elastic_matrix[2][2];
+        voigt_stiffness_tensor[1][0]=elastic_matrix[0][5]+elastic_matrix[1][5]+elastic_matrix[3][4];
+        voigt_stiffness_tensor[2][0]=elastic_matrix[0][4]+elastic_matrix[2][4]+elastic_matrix[3][5];
+        voigt_stiffness_tensor[2][1]=elastic_matrix[1][3]+elastic_matrix[2][3]+elastic_matrix[4][5];
+
+        return voigt_stiffness_tensor;
+      }
+
+
+
+      template<int dim>
+      SymmetricTensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_dilatation_stiffness_tensor(const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * The dilatational stiffness tensor (see Browaeys and chevrot, 2004)
+         * It defines the stress to cause isotropic dilatation in the material.
+         */
+        SymmetricTensor<2,3> dilatation_stiffness_tensor;
+        for (size_t i = 0; i < 3; i++)
+          {
+            dilatation_stiffness_tensor[0][0]=elastic_matrix[0][i]+dilatation_stiffness_tensor[0][0];
+            dilatation_stiffness_tensor[1][1]=elastic_matrix[1][i]+dilatation_stiffness_tensor[1][1];
+            dilatation_stiffness_tensor[2][2]=elastic_matrix[2][i]+dilatation_stiffness_tensor[2][2];
+            dilatation_stiffness_tensor[1][0]=elastic_matrix[5][i]+dilatation_stiffness_tensor[1][0];
+            dilatation_stiffness_tensor[2][0]=elastic_matrix[4][i]+dilatation_stiffness_tensor[2][0];
+            dilatation_stiffness_tensor[2][1]=elastic_matrix[3][i]+dilatation_stiffness_tensor[2][1];
+          }
+        return dilatation_stiffness_tensor;
+      }
+
+
+
+      template<int dim>
+      Tensor<2,3>
+      ElasticTensorDecomposition<dim>::compute_unpermutated_SCCS(const SymmetricTensor<2,3> &dilatation_stiffness_tensor,
+                                                                 const SymmetricTensor<2,3> &voigt_stiffness_tensor)
+      {
+        // computing the eigenvector of the dilation and voigt stiffness matrices and then averaging them by bysection.
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> voigt_eigenvectors_a = eigenvectors(voigt_stiffness_tensor, SymmetricTensorEigenvectorMethod::jacobi);
+        const std::array<std::pair<double,Tensor<1,3,double>>, 3> dilatation_eigenvectors_a = eigenvectors(dilatation_stiffness_tensor, SymmetricTensorEigenvectorMethod::jacobi);
+
+
+        std::vector<Tensor<1,3,double>> unpermutated_SCCS(3);
+        // averaging eigenvectors
+        // the next function looks for the smallest angle
+        // and returns the corresponding vecvo index for that
+        // vector.
+        size_t NDVC = 0;
+        for (size_t i1 = 0; i1 < 3; i1++)
+          {
+            NDVC = 0;
+            double ADVC = 10.0;
+            //double SCN = 0.0;
+            for (size_t i2 = 0; i2 < 3; i2++)
+              {
+                double dv_dot_product = dilatation_eigenvectors_a[i1].second*voigt_eigenvectors_a[i2].second;
+                // limit the dot product between 1 and -1 so we can use the arccos function safely.
+                if (std::abs(dv_dot_product) >= 1.0)
+                  dv_dot_product = std::copysign(1.0,dv_dot_product);
+                // compute the angle bewteen the vectors and account for that vectors in the oposit
+                // direction are the same. So limit them between 0 and 90 degrees such that it
+                // represents the minimum angle between the two lines.
+                double ADV = dv_dot_product < 0.0 ? std::acos(-1.0)-std::acos(dv_dot_product) : std::acos(dv_dot_product);
+                // store this if the angle is smaller
+                if (ADV < ADVC)
+                  {
+                    NDVC=std::copysign(1.0, dv_dot_product)*i2;
+                    ADVC = ADV;
+                  }
+              }
+
+            // Adds/substracting to vecdi the vecvo with the smallest
+            // angle times the i2/j index with the sign of SVD to vecdi
+            // (effectively turning the eigenvector),and then nomalizing it.
+            unpermutated_SCCS[i1] = 0.5*(dilatation_eigenvectors_a[i1].second + (double)NDVC*voigt_eigenvectors_a[std::abs((int)NDVC)].second);
+            unpermutated_SCCS[i1] = unpermutated_SCCS[i1]/unpermutated_SCCS[i1].norm();
+          }
+
+        return Tensor<2,3>(
+        {
+          {unpermutated_SCCS[0][0],unpermutated_SCCS[0][1],unpermutated_SCCS[0][2]},
+          {unpermutated_SCCS[1][0],unpermutated_SCCS[1][1],unpermutated_SCCS[1][2]},
+          {unpermutated_SCCS[2][0],unpermutated_SCCS[2][1],unpermutated_SCCS[2][2]}
+        });
+      }
+
+
+
+      template<int dim>
+      std::array<std::array<double,3>,7>
+      ElasticTensorDecomposition<dim>::compute_elastic_tensor_SCCS_decompositions(
+        const Tensor<2,3> &unpermutated_SCCS,
+        const SymmetricTensor<2,6> &elastic_matrix)
+      {
+        /**
+         * Try the different permutations to determine what is the best hexagonal projection.
+         * This is based on Browaeys and Chevrot (2004), GJI (doi: 10.1111/j.1365-246X.2004.024115.x),
+         * which states at the end of paragraph 3.3 that "... an important property of an orthogonal projection
+         * is that the distance between a vector $X$ and its orthogonal projection $X_H = p(X)$ on a given
+         * subspace is minimum. These two features ensure that the decomposition is optimal once a 3-D Cartesian
+         * coordiante systeem is chosen.". The other property they talk about is that "The space of elastic
+         * vectors has a finite dimension [...], i.e. using a differnt norm from eq. (2.3 will change disstances
+         * but not the resulting decomposition.".
+         */
+        Tensor<2,3> permutated[3];
+        SymmetricTensor<2,6> rotated_elastic_matrix[3];
+        std::array<std::array<double,3>,7> norms;
+
+        for (unsigned short int permutation_i = 0; permutation_i < 3; permutation_i++)
+          {
+            std::array<unsigned short int, 3> perumation = indexed_even_permutation(permutation_i);
+
+            for (size_t j = 0; j < 3; j++)
+              {
+                permutated[permutation_i][j] = unpermutated_SCCS[perumation[j]];
+              }
+
+            rotated_elastic_matrix[permutation_i] = CpoElasticTensor<dim>::rotate_6x6_matrix(elastic_matrix,(permutated[permutation_i]));
+
+            const Tensor<1,21> full_elastic_vector_rotated = CpoElasticTensor<dim>::transform_6x6_matrix_to_21D_vector(rotated_elastic_matrix[permutation_i]);
+
+
+            const double full_norm_square = full_elastic_vector_rotated.norm_square();
+            norms[6][permutation_i] = full_norm_square;
+
+            // The following line would do the same as the lines below, but is is very slow. It has therefore been
+            // replaced by the lines below.
+            //auto mono_and_higher_vector = projection_matrix_tric_to_mono*full_elastic_vector_rotated;
+            dealii::Tensor<1,21> mono_and_higher_vector;
+            mono_and_higher_vector[0] = full_elastic_vector_rotated[0];
+            mono_and_higher_vector[1] = full_elastic_vector_rotated[1];
+            mono_and_higher_vector[2] = full_elastic_vector_rotated[2];
+            mono_and_higher_vector[3] = full_elastic_vector_rotated[3];
+            mono_and_higher_vector[4] = full_elastic_vector_rotated[4];
+            mono_and_higher_vector[5] = full_elastic_vector_rotated[5];
+            mono_and_higher_vector[6] = full_elastic_vector_rotated[6];
+            mono_and_higher_vector[7] = full_elastic_vector_rotated[7];
+            mono_and_higher_vector[8] = full_elastic_vector_rotated[8];
+            mono_and_higher_vector[11] = full_elastic_vector_rotated[11];
+            mono_and_higher_vector[14] = full_elastic_vector_rotated[14];
+            mono_and_higher_vector[17] = full_elastic_vector_rotated[17];
+            mono_and_higher_vector[20] = full_elastic_vector_rotated[20];
+
+            auto tric_vector = full_elastic_vector_rotated-mono_and_higher_vector;
+            //auto tric = CpoElasticTensor<dim>::transform_21D_vector_to_6x6_matrix(tric_vector);
+            norms[0][permutation_i] = tric_vector.norm_square();
+
+            // The following line would do the same as the lines below, but is is slow. It has therefore been
+            // replaced by the lines below.
+            //auto ortho_and_higher_vector = projection_matrix_mono_to_ortho*mono_and_higher_vector;
+            dealii::Tensor<1,9>  mono_and_higher_vector_croped;
+            mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
+            mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
+            mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];
+            mono_and_higher_vector_croped[3] = mono_and_higher_vector[3];
+            mono_and_higher_vector_croped[4] = mono_and_higher_vector[4];
+            mono_and_higher_vector_croped[5] = mono_and_higher_vector[5];
+            mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
+            mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
+            mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
+            dealii::Tensor<1,9> ortho_and_higher_vector;
+            ortho_and_higher_vector[0] = mono_and_higher_vector[0];
+            ortho_and_higher_vector[1] = mono_and_higher_vector[1];
+            ortho_and_higher_vector[2] = mono_and_higher_vector[2];
+            ortho_and_higher_vector[3] = mono_and_higher_vector[3];
+            ortho_and_higher_vector[4] = mono_and_higher_vector[4];
+            ortho_and_higher_vector[5] = mono_and_higher_vector[5];
+            ortho_and_higher_vector[6] = mono_and_higher_vector[6];
+            ortho_and_higher_vector[7] = mono_and_higher_vector[7];
+            ortho_and_higher_vector[8] = mono_and_higher_vector[8];
+            auto mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
+            //auto mono = CpoElasticTensor<dim>::transform_21D_vector_to_6x6_matrix(mono_vector);
+            norms[1][permutation_i] = mono_vector.norm_square();
+
+
+            auto tetra_and_higher_vector = projection_matrix_ortho_to_tetra*ortho_and_higher_vector;
+            auto ortho_vector = ortho_and_higher_vector-tetra_and_higher_vector;
+            norms[2][permutation_i] = ortho_vector.norm_square();
+
+            auto hexa_and_higher_vector = projection_matrix_tetra_to_hexa*tetra_and_higher_vector;
+            auto tetra_vector = tetra_and_higher_vector-hexa_and_higher_vector;
+            norms[3][permutation_i] = tetra_vector.norm_square();
+
+            auto iso_vector = projection_matrix_hexa_to_iso*hexa_and_higher_vector;
+            auto hexa_vector = hexa_and_higher_vector-iso_vector;
+            norms[4][permutation_i] = hexa_vector.norm_square();
+            norms[5][permutation_i] = iso_vector.norm_square();
+
+          }
+        return norms;
+
+      }
+
+
+
+      template <int dim>
+      UpdateTimeFlags
+      ElasticTensorDecomposition<dim>::need_update() const
+      {
+        return update_output_step;
+      }
+
+
+
+      template <int dim>
+      UpdateFlags
+      ElasticTensorDecomposition<dim>::get_needed_update_flags () const
+      {
+        return update_default;
+      }
+
+
+
+      template <int dim>
+      std::vector<std::pair<std::string, unsigned int>>
+      ElasticTensorDecomposition<dim>::get_property_information() const
+      {
+        std::vector<std::pair<std::string,unsigned int>> property_information;
+
+        property_information.push_back(std::make_pair("cpo elastic axis e1",3));
+        property_information.push_back(std::make_pair("cpo elastic axis e2",3));
+        property_information.push_back(std::make_pair("cpo elastic axis e3",3));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal axis",3));
+        property_information.push_back(std::make_pair("cpo elastic vector norm square",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic triclinic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic monoclinic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic orthorhombic vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic tetragonal vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p1",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p2",1));
+        property_information.push_back(std::make_pair("cpo elastic hexagonal vector norm square p3",1));
+        property_information.push_back(std::make_pair("cpo elastic isotropic vector norm square",1));
+
+        return property_information;
+      }
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::declare_parameters (ParameterHandler &)
+      {}
+
+
+
+      template <int dim>
+      void
+      ElasticTensorDecomposition<dim>::parse_parameters (ParameterHandler &)
+      {}
+    }
+  }
+}
+
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Property
+    {
+      ASPECT_REGISTER_PARTICLE_PROPERTY(ElasticTensorDecomposition,
+                                        "elastic tensor decomposition",
+                                        "A plugin in which decomposes the elastic tensor "
+                                        "into different approximations and provides the "
+                                        "eigenvectors of the tensor.")
+    }
+  }
+}

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -162,14 +162,14 @@ namespace aspect
                     ExcMessage("No cpo property plugin found."));
         AssertThrow(manager.plugin_name_exists("cpo elastic tensor"),
                     ExcMessage("No cpo elastic tensor property plugin found."));
-        Assert(manager.plugin_name_exists("decompose elastic matrix"),
+        Assert(manager.plugin_name_exists("elastic tensor decomposition"),
                ExcMessage("No hexagonal axes property plugin found."));
 
-        AssertThrow(manager.check_plugin_order("crystal preferred orientation","decompose elastic matrix"),
-                    ExcMessage("To use the decompose elastic matrix plugin, the cpo plugin need to be defined before this plugin."));
+        AssertThrow(manager.check_plugin_order("crystal preferred orientation","elastic tensor decomposition"),
+                    ExcMessage("To use the elastic tensor decomposition plugin, the cpo plugin need to be defined before this plugin."));
 
-        AssertThrow(manager.check_plugin_order("cpo elastic tensor","decompose elastic matrix"),
-                    ExcMessage("To use the decompose elastic matrix plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
+        AssertThrow(manager.check_plugin_order("cpo elastic tensor","elastic tensor decomposition"),
+                    ExcMessage("To use the elastic tensor decomposition plugin, the cpo elastic tensor plugin need to be defined before this plugin."));
 
         cpo_elastic_tensor_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo elastic tensor"));
       }

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -254,7 +254,7 @@ namespace aspect
           string_stream_master << id << " " << position << " " << properties[cpo_data_position] <<  std::endl;
 
           // write content file
-          std::vector<std::vector<std::vector<double>>> euler_angles;
+          std::vector<std::vector<std::array<double,3>>> euler_angles;
           if (compute_raw_euler_angles == true)
             {
               euler_angles.resize(n_minerals);
@@ -357,7 +357,7 @@ namespace aspect
           if (write_draw_volume_weighted_cpo.size() != 0)
             {
               std::vector<std::vector<dealii::Tensor<2,3>>> weighted_rotation_matrices;
-              std::vector<std::vector<std::vector<double>>> weighted_euler_angles;
+              std::vector<std::vector<std::array<double,3>>> weighted_euler_angles;
 
               weighted_euler_angles.resize(n_minerals);
               std::vector<std::vector<double>> volume_fractions_grains(n_minerals,std::vector<double>(n_grains,-1.));

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -261,10 +261,19 @@ namespace aspect
               for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
                 {
                   euler_angles[mineral_i].resize(n_grains);
-                  for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
+                  for (unsigned int grain_i = 0; grain_i < n_grains; grain_i++)
                     {
-                      euler_angles[mineral_i][i_grain] = Utilities::zxz_euler_angles_from_rotation_matrix(
-                                                           rotation_matrices[mineral_i][i_grain]);
+                      for (size_t i = 0; i < 3; i++)
+                        for (size_t j = 0; j < 3; j++)
+                          Assert(abs(rotation_matrices[mineral_i][grain_i][i][j]) <= 1.0,
+                                 ExcMessage("grain " + std::to_string(grain_i) + " of " + std::to_string(n_grains) + ": rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                            "] is larger than one: " + std::to_string(rotation_matrices[mineral_i][grain_i][i][j]) + " (" + std::to_string(rotation_matrices[mineral_i][grain_i][i][j]-1.0) + "). rotation_matrix = \n"
+                                            + std::to_string(rotation_matrices[mineral_i][grain_i][0][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][0][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][0][2]) + "\n"
+                                            + std::to_string(rotation_matrices[mineral_i][grain_i][1][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][1][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][1][2]) + "\n"
+                                            + std::to_string(rotation_matrices[mineral_i][grain_i][2][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][2][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][2][2])));
+
+                      euler_angles[mineral_i][grain_i] = Utilities::zxz_euler_angles_from_rotation_matrix(
+                                                           rotation_matrices[mineral_i][grain_i]);
                     }
                 }
             }
@@ -364,6 +373,26 @@ namespace aspect
                     }
                   weighted_rotation_matrices[mineral_i] = Utilities::rotation_matrices_random_draw_volume_weighting(volume_fractions_grains[mineral_i], rotation_matrices[mineral_i], n_grains, this->random_number_generator);
 
+                  for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+                    for (size_t i = 0; i < 3; i++)
+                      for (size_t j = 0; j < 3; j++)
+                        Assert(abs(rotation_matrices[mineral_i][grain_i][i][j]) <= 1.0,
+                               ExcMessage("grain" + std::to_string(grain_i) + "rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                          "] is larger than one: " + std::to_string(rotation_matrices[mineral_i][grain_i][i][j]) + " (" + std::to_string(rotation_matrices[mineral_i][grain_i][i][j]-1.0) + "). rotation_matrix = \n"
+                                          + std::to_string(rotation_matrices[mineral_i][grain_i][0][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][0][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][0][2]) + "\n"
+                                          + std::to_string(rotation_matrices[mineral_i][grain_i][1][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][1][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][1][2]) + "\n"
+                                          + std::to_string(rotation_matrices[mineral_i][grain_i][2][0]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][2][1]) + " " + std::to_string(rotation_matrices[mineral_i][grain_i][2][2])));
+
+                  for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+                    for (size_t i = 0; i < 3; i++)
+                      for (size_t j = 0; j < 3; j++)
+                        Assert(abs(weighted_rotation_matrices[mineral_i][grain_i][i][j]) <= 1.0,
+                               ExcMessage("grain" + std::to_string(grain_i) + "rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                                          "] is larger than one: " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][i][j]) + " (" + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][i][j]-1.0) + "). rotation_matrix = \n"
+                                          + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][0][0]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][0][1]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][0][2]) + "\n"
+                                          + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][1][0]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][1][1]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][1][2]) + "\n"
+                                          + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][2][0]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][2][1]) + " " + std::to_string(weighted_rotation_matrices[mineral_i][grain_i][2][2])));
+
                   Assert(weighted_rotation_matrices[mineral_i].size() == euler_angles[mineral_i].size(),
                          ExcMessage("Weighted rotation matrices vector (size = " + std::to_string(weighted_rotation_matrices[mineral_i].size()) +
                                     ") has different size from input angles (size = " + std::to_string(euler_angles[mineral_i].size()) + ")."));
@@ -446,7 +475,6 @@ namespace aspect
                 }
             }
         }
-
       std::string filename_master = particle_file_prefix_master + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
       std::string filename_raw = particle_file_prefix_content_raw + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
       std::string filename_draw_volume_weighting = particle_file_prefix_content_draw_volume_weighting + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
@@ -454,12 +482,12 @@ namespace aspect
       std::string *file_contents_master = new std::string (string_stream_master.str());
       std::string *file_contents_raw = new std::string (string_stream_content_raw.str());
       std::string *file_contents_draw_volume_weighting = new std::string (string_stream_content_draw_volume_weighting.str());
-
       if (write_in_background_thread)
         {
           // Wait for all previous write operations to finish, should
           // any be still active,
-          background_thread_master.join ();
+          if (background_thread_master.joinable())
+            background_thread_master.join ();
 
           // then continue with writing the master file
           background_thread_master = std::thread (&writer,
@@ -472,7 +500,8 @@ namespace aspect
             {
               // Wait for all previous write operations to finish, should
               // any be still active,
-              background_thread_content_raw.join ();
+              if (background_thread_content_raw.joinable())
+                background_thread_content_raw.join ();
 
               // then continue with writing our own data.
               background_thread_content_raw = std::thread (&writer,
@@ -486,7 +515,8 @@ namespace aspect
             {
               // Wait for all previous write operations to finish, should
               // any be still active,
-              background_thread_content_draw_volume_weighting.join ();
+              if (background_thread_content_draw_volume_weighting.joinable())
+                background_thread_content_draw_volume_weighting.join ();
 
               // then continue with writing our own data.
               background_thread_content_draw_volume_weighting = std::thread (&writer,

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -235,6 +235,21 @@ namespace aspect
 
           Point<dim> position = it->get_location();
 
+          // always make a vector of rotation matrices
+          std::vector<std::vector<Tensor<2,3>>> rotation_matrices;
+          rotation_matrices.resize(n_minerals);
+          for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
+            {
+              rotation_matrices[mineral_i].resize(n_grains);
+              for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
+                {
+                  rotation_matrices[mineral_i][i_grain] = cpo_particle_property.get_rotation_matrix_grains(
+                                                            cpo_data_position,
+                                                            properties,
+                                                            mineral_i,
+                                                            i_grain);
+                }
+            }
           // write master file
           string_stream_master << id << " " << position << " " << properties[cpo_data_position] <<  std::endl;
 
@@ -249,11 +264,7 @@ namespace aspect
                   for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
                     {
                       euler_angles[mineral_i][i_grain] = Utilities::zxz_euler_angles_from_rotation_matrix(
-                                                           cpo_particle_property.get_rotation_matrix_grains(
-                                                             cpo_data_position,
-                                                             properties,
-                                                             mineral_i,
-                                                             i_grain));
+                                                           rotation_matrices[mineral_i][i_grain]);
                     }
                 }
             }
@@ -315,11 +326,7 @@ namespace aspect
                             break;
 
                           case Output::RotationMatrix:
-                            string_stream_content_raw << cpo_particle_property.get_rotation_matrix_grains(
-                                                        cpo_data_position,
-                                                        properties,
-                                                        write_raw_cpo[property_i].first,
-                                                        grain_i) << " ";
+                            string_stream_content_raw << rotation_matrices[write_raw_cpo[property_i].first][grain_i]<< " ";
                             break;
 
                           case Output::EulerAngles:
@@ -340,6 +347,7 @@ namespace aspect
             }
           if (write_draw_volume_weighted_cpo.size() != 0)
             {
+              std::vector<std::vector<dealii::Tensor<2,3>>> weighted_rotation_matrices;
               std::vector<std::vector<std::vector<double>>> weighted_euler_angles;
 
               weighted_euler_angles.resize(n_minerals);
@@ -354,30 +362,16 @@ namespace aspect
                                                                       mineral_i,
                                                                       i_grain);
                     }
-                  weighted_euler_angles[mineral_i] = random_draw_volume_weighting(volume_fractions_grains[mineral_i], euler_angles[mineral_i]);
+                  weighted_rotation_matrices[mineral_i] = Utilities::rotation_matrices_random_draw_volume_weighting(volume_fractions_grains[mineral_i], rotation_matrices[mineral_i], n_grains, this->random_number_generator);
 
-                  Assert(weighted_euler_angles[mineral_i].size() == euler_angles[mineral_i].size(),
-                         ExcMessage("Weighted angles vector (size = " + std::to_string(weighted_euler_angles[mineral_i].size()) +
+                  Assert(weighted_rotation_matrices[mineral_i].size() == euler_angles[mineral_i].size(),
+                         ExcMessage("Weighted rotation matrices vector (size = " + std::to_string(weighted_rotation_matrices[mineral_i].size()) +
                                     ") has different size from input angles (size = " + std::to_string(euler_angles[mineral_i].size()) + ")."));
 
-                }
-
-
-              std::vector<std::vector<Tensor<2,3>>> weighted_a_cosine_matrices;
-
-              if (compute_weighted_A_matrix == true)
-                {
-                  weighted_a_cosine_matrices.resize(n_minerals);
-                  for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
+                  for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
                     {
-                      weighted_a_cosine_matrices[mineral_i].resize(weighted_euler_angles[mineral_i].size());
-
-                      for (unsigned int i = 0; i < weighted_euler_angles.size(); ++i)
-                        {
-                          weighted_a_cosine_matrices[mineral_i][i] = Utilities::zxz_euler_angles_to_rotation_matrix(weighted_euler_angles[mineral_i][i][0],
-                                                                     weighted_euler_angles[mineral_i][i][1],
-                                                                     weighted_euler_angles[mineral_i][i][2]);
-                        }
+                      weighted_euler_angles[mineral_i][i_grain] = Utilities::zxz_euler_angles_from_rotation_matrix(
+                                                                    weighted_rotation_matrices[mineral_i][i_grain]);
                     }
                 }
 
@@ -432,7 +426,7 @@ namespace aspect
                             break;
 
                           case Output::RotationMatrix:
-                            string_stream_content_draw_volume_weighting << weighted_a_cosine_matrices[write_draw_volume_weighted_cpo[property_i].first][grain_i] << " ";
+                            string_stream_content_draw_volume_weighting << weighted_rotation_matrices[write_draw_volume_weighted_cpo[property_i].first][grain_i] << " ";
                             break;
 
                           case Output::EulerAngles:
@@ -522,69 +516,6 @@ namespace aspect
                             particle_cpo_output);
       return std::make_pair("Writing particle cpo output:", particle_cpo_output);
     }
-
-    template<int dim>
-    std::vector<std::vector<double>>
-    CrystalPreferredOrientation<dim>::random_draw_volume_weighting(const std::vector<double> &fv,
-                                                                   const std::vector<std::vector<double>> &angles) const
-    {
-      // Get volume weighted euler angles, using random draws to convert odf
-      // to a discrete number of orientations, weighted by volume
-      // 1a. Get index that would sort volume fractions AND
-      //ix = np.argsort(fv[q,:]);
-      // 1b. Get the sorted volume and angle arrays
-      std::vector<double> fv_to_sort = fv;
-      std::vector<double> fv_sorted = fv;
-      std::vector<std::vector<double>> angles_sorted = angles;
-
-      unsigned int n_grains = fv_to_sort.size();
-
-      for (int i = n_grains-1; i >= 0; --i)
-        {
-          unsigned int index_max_fv = std::distance(fv_to_sort.begin(),max_element(fv_to_sort.begin(), fv_to_sort.end()));
-
-          fv_sorted[i] = fv_to_sort[index_max_fv];
-          angles_sorted[i] = angles[index_max_fv];
-          Assert(angles[index_max_fv].size() == 3, ExcMessage("angles vector (size = " + std::to_string(angles[index_max_fv].size()) +
-                                                              ") should have size 3."));
-          Assert(angles_sorted[i].size() == 3, ExcMessage("angles_sorted vector (size = " + std::to_string(angles_sorted[i].size()) +
-                                                          ") should have size 3."));
-          fv_to_sort[index_max_fv] = -1;
-        }
-
-
-      // 2. Get cumulative weight for volume fraction
-      std::vector<double> cum_weight(n_grains);
-      std::partial_sum(fv_sorted.begin(),fv_sorted.end(),cum_weight.begin());
-      // 3. Generate random indices
-      boost::random::uniform_real_distribution<> dist(0, 1);
-      std::vector<double> idxgrain(n_grains);
-      for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
-        idxgrain[grain_i] = dist(this->random_number_generator); //random.rand(ngrains,1);
-
-      // 4. Find the maximum cum_weight that is less than the random value.
-      // the euler angle index is +1. For example, if the idxGrain(g) < cumWeight(1),
-      // the index should be 1 not zero)
-      std::vector<std::vector<double>> angles_out(n_grains,std::vector<double>(3));
-      for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
-        {
-          unsigned int counter = 0;
-          for (unsigned int grain_j = 0; grain_j < n_grains; ++grain_j)
-            {
-              if (cum_weight[grain_j] < idxgrain[grain_i])
-                {
-                  counter++;
-                }
-              else
-                {
-                  break;
-                }
-            }
-          angles_out[grain_i] = angles_sorted[counter];
-        }
-      return angles_out;
-    }
-
 
 
     template <int dim>

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -1,0 +1,882 @@
+/*
+  Copyright (C) 2022 by the authors of the ASPECT code.
+ This file is part of ASPECT.
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#include <aspect/global.h>
+#include <aspect/postprocess/crystal_preferred_orientation.h>
+#include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/utilities.h>
+
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+
+#include <stdio.h>
+#include <unistd.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    template <int dim>
+    CrystalPreferredOrientation<dim>::CrystalPreferredOrientation ()
+      :
+      // the following value is later read from the input file
+      output_interval (0),
+      // initialize this to a nonsensical value; set it to the actual time
+      // the first time around we get to check it
+      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      output_file_number (numbers::invalid_unsigned_int),
+      group_files(0),
+      write_in_background_thread(false)
+    {}
+
+    template <int dim>
+    CrystalPreferredOrientation<dim>::~CrystalPreferredOrientation ()
+    {
+      // make sure a thread that may still be running in the background,
+      // writing data, finishes
+      if (background_thread_master.joinable())
+        background_thread_master.join ();
+
+      if (background_thread_content_raw.joinable())
+        background_thread_content_raw.join ();
+
+      if (background_thread_content_draw_volume_weighting.joinable())
+        background_thread_content_draw_volume_weighting.join ();
+    }
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::initialize ()
+    {
+      const unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+      this->random_number_generator.seed(random_number_seed+my_rank);
+    }
+
+    template <int dim>
+    std::list<std::string>
+    CrystalPreferredOrientation<dim>::required_other_postprocessors () const
+    {
+      return {"particles"};
+    }
+
+
+    template <int dim>
+    // We need to pass the arguments by value, as this function can be called on a separate thread:
+    void CrystalPreferredOrientation<dim>::writer (const std::string filename, //NOLINT(performance-unnecessary-value-param)
+                                                   const std::string temporary_output_location, //NOLINT(performance-unnecessary-value-param)
+                                                   const std::string *file_contents,
+                                                   const bool compress_contents)
+    {
+      std::string tmp_filename = filename;
+      if (temporary_output_location != "")
+        {
+          tmp_filename = temporary_output_location + "/aspect.tmp.XXXXXX";
+
+          // Create the temporary file; get at the actual filename
+          // by using a C-style string that mkstemp will then overwrite
+          std::vector<char> tmp_filename_x (tmp_filename.size()+1);
+          std::strcpy(tmp_filename_x.data(), tmp_filename.c_str());
+          const int tmp_file_desc = mkstemp(tmp_filename_x.data());
+          tmp_filename = tmp_filename_x.data();
+
+          // If we failed to create the temp file, just write directly to the target file.
+          // We also provide a warning about this fact. There are places where
+          // this fails *on every node*, so we will get a lot of warning messages
+          // into the output; in these cases, just writing multiple pieces to
+          // std::cerr will produce an unreadable mass of text; rather, first
+          // assemble the error message completely, and then output it atomically
+          if (tmp_file_desc == -1)
+            {
+              const std::string x = ("***** WARNING: could not create temporary file <"
+                                     +
+                                     tmp_filename
+                                     +
+                                     ">, will output directly to final location. This may negatively "
+                                     "affect performance. (On processor "
+                                     + Utilities::int_to_string(Utilities::MPI::this_mpi_process (MPI_COMM_WORLD))
+                                     + ".)\n");
+
+              std::cerr << x << std::flush;
+
+              tmp_filename = filename;
+            }
+          else
+            close(tmp_file_desc);
+        }
+
+      std::ofstream out(tmp_filename.c_str(), std::ofstream::binary);
+
+      AssertThrow (out, ExcMessage(std::string("Trying to write to file <") +
+                                   filename +
+                                   ">, but the file can't be opened!"))
+
+      // now write and then move the tmp file to its final destination
+      // if necessary
+      if (compress_contents)
+        {
+          namespace bio = boost::iostreams;
+
+          std::stringstream compressed;
+          std::stringstream origin(*file_contents);
+
+          bio::filtering_streambuf<bio::input> compress_out;
+          compress_out.push(bio::zlib_compressor());
+          compress_out.push(origin);
+          bio::copy(compress_out, out);
+        }
+      else
+        {
+          out << *file_contents;
+        }
+
+      out.close ();
+
+      if (tmp_filename != filename)
+        {
+          std::string command = std::string("mv ") + tmp_filename + " " + filename;
+          int error = system(command.c_str());
+
+          AssertThrow(error == 0,
+                      ExcMessage("Could not move " + tmp_filename + " to "
+                                 + filename + ". On processor "
+                                 + Utilities::int_to_string(Utilities::MPI::this_mpi_process (MPI_COMM_WORLD)) + "."));
+        }
+
+      // destroy the pointer to the data we needed to write
+      delete file_contents;
+    }
+
+    template <int dim>
+    std::pair<std::string,std::string>
+    CrystalPreferredOrientation<dim>::execute (TableHandler &statistics)
+    {
+
+      const Particle::Property::Manager<dim> &manager = this->get_particle_world().get_property_manager();
+
+      // Get a reference to the CPO particle property.
+      const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
+        manager.template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
+
+      const unsigned int n_grains = cpo_particle_property.get_number_of_grains();
+      const unsigned int n_minerals = cpo_particle_property.get_number_of_minerals();
+
+      // if this is the first time we get here, set the last output time
+      // to the current time - output_interval. this makes sure we
+      // always produce data during the first time step
+      if (std::isnan(last_output_time))
+        last_output_time = this->get_time() - output_interval;
+
+      // If it's not time to generate an output file or we do not write output
+      // return early.
+      if (this->get_time() < last_output_time + output_interval && this->get_time() != end_time)
+        return std::make_pair("","");
+
+      if (output_file_number == numbers::invalid_unsigned_int)
+        output_file_number = 0;
+      else
+        ++output_file_number;
+
+      // Now prepare everything for writing the output and choose output format
+      std::string particle_file_prefix_master = this->get_output_directory() +  "particle_CPO/particles-" + Utilities::int_to_string (output_file_number, 5);
+      std::string particle_file_prefix_content_raw = this->get_output_directory() +  "particle_CPO/CPO-" + Utilities::int_to_string (output_file_number, 5);
+      std::string particle_file_prefix_content_draw_volume_weighting = this->get_output_directory() +  "particle_CPO/weighted_CPO-" + Utilities::int_to_string (output_file_number, 5);
+
+      const auto &particle_handler = this->get_particle_world().get_particle_handler();
+
+      std::stringstream string_stream_master;
+      std::stringstream string_stream_content_raw;
+      std::stringstream string_stream_content_draw_volume_weighting;
+
+      string_stream_master << "id x y" << (dim == 3 ? " z" : " ") << " olivine_deformation_type" << std::endl;
+
+      // get particle data
+      bool wrote_weighted_header = false;
+      bool wrote_unweighted_header = false;
+      for (typename dealii::Particles::ParticleHandler<dim>::particle_iterator it = particle_handler.begin(); it != particle_handler.end(); ++it)
+        {
+
+          AssertThrow(it->has_properties(),
+                      ExcMessage("No particle properties found. Make sure that the CPO particle property plugin is selected."));
+
+
+
+          unsigned int id = it->get_id();
+          const ArrayView<double> &properties = it->get_properties();
+
+          const Particle::Property::ParticlePropertyInformation &property_information = this->get_particle_world().get_property_manager().get_data_info();
+
+          AssertThrow(property_information.fieldname_exists("cpo mineral 0 type") ,
+                      ExcMessage("No CPO particle properties found. Make sure that the CPO particle property plugin is selected."));
+
+
+
+          const unsigned int cpo_data_position = property_information.n_fields() == 0
+                                                 ?
+                                                 0
+                                                 :
+                                                 property_information.get_position_by_field_name("cpo mineral 0 type");
+
+          Point<dim> position = it->get_location();
+
+          // write master file
+          string_stream_master << id << " " << position << " " << properties[cpo_data_position] <<  std::endl;
+
+          // write content file
+          std::vector<std::vector<std::vector<double>>> euler_angles;
+          if (compute_raw_euler_angles == true)
+            {
+              euler_angles.resize(n_minerals);
+              for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
+                {
+                  euler_angles[mineral_i].resize(n_grains);
+                  for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
+                    {
+                      euler_angles[mineral_i][i_grain] = Utilities::zxz_euler_angles_from_rotation_matrix(
+                                                           cpo_particle_property.get_rotation_matrix_grains(
+                                                             cpo_data_position,
+                                                             properties,
+                                                             mineral_i,
+                                                             i_grain));
+                    }
+                }
+            }
+
+          if (write_raw_cpo.size() != 0)
+            {
+              // write unweighted header
+              if (wrote_unweighted_header == false)
+                {
+                  string_stream_content_raw << "id" << " " << std::setprecision(12);
+                  for (unsigned int property_i = 0; property_i < write_raw_cpo.size(); ++property_i)
+                    {
+                      switch (write_raw_cpo[property_i].second)
+                        {
+                          case Output::VolumeFraction:
+                            string_stream_content_raw << "mineral_" << write_raw_cpo[property_i].first << "_volume_fraction" << " ";
+                            break;
+
+                          case Output::RotationMatrix:
+                            string_stream_content_raw << "mineral_" << write_raw_cpo[property_i].first << "_RM_0" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_1" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_2" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_3" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_4" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_5" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_6" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_7" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_RM_8" << " ";
+                            break;
+
+                          case Output::EulerAngles:
+                            string_stream_content_raw << "mineral_" << write_raw_cpo[property_i].first << "_EA_phi" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_EA_theta" << " "
+                                                      << "mineral_" << write_raw_cpo[property_i].first << "_EA_z" << " ";
+                            break;
+                          default:
+                            Assert(false, ExcMessage("Internal error: raw CPO postprocess case not found."));
+                            break;
+                        }
+                    }
+                  string_stream_content_raw << std::endl;
+                  wrote_unweighted_header = true;
+                }
+
+              // write unweighted data
+              for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+                {
+                  string_stream_content_raw << id << " ";
+                  for (unsigned int property_i = 0; property_i < write_raw_cpo.size(); ++property_i)
+                    {
+                      switch (write_raw_cpo[property_i].second)
+                        {
+                          case Output::VolumeFraction:
+                            string_stream_content_raw << cpo_particle_property.get_volume_fractions_grains(
+                                                        cpo_data_position,
+                                                        properties,
+                                                        write_raw_cpo[property_i].first,
+                                                        grain_i) << " ";
+                            break;
+
+                          case Output::RotationMatrix:
+                            string_stream_content_raw << cpo_particle_property.get_rotation_matrix_grains(
+                                                        cpo_data_position,
+                                                        properties,
+                                                        write_raw_cpo[property_i].first,
+                                                        grain_i) << " ";
+                            break;
+
+                          case Output::EulerAngles:
+                            Assert(compute_raw_euler_angles == true,
+                                   ExcMessage("Internal error: writing out raw Euler angles, without them being computed."));
+                            string_stream_content_raw << euler_angles[write_raw_cpo[property_i].first][grain_i][0] << " "
+                                                      <<  euler_angles[write_raw_cpo[property_i].first][grain_i][1] << " "
+                                                      <<  euler_angles[write_raw_cpo[property_i].first][grain_i][2] << " ";
+                            break;
+                          default:
+                            Assert(false, ExcMessage("Internal error: raw CPO postprocess case not found."));
+                            break;
+                        }
+                    }
+                  string_stream_content_raw << std::endl;
+                }
+
+            }
+          if (write_draw_volume_weighted_cpo.size() != 0)
+            {
+              std::vector<std::vector<std::vector<double>>> weighted_euler_angles;
+
+              weighted_euler_angles.resize(n_minerals);
+              std::vector<std::vector<double>> volume_fractions_grains(n_minerals,std::vector<double>(n_grains,-1.));
+              for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
+                {
+                  for (unsigned int i_grain = 0; i_grain < n_grains; i_grain++)
+                    {
+                      volume_fractions_grains[mineral_i][i_grain] = cpo_particle_property.get_volume_fractions_grains(
+                                                                      cpo_data_position,
+                                                                      properties,
+                                                                      mineral_i,
+                                                                      i_grain);
+                    }
+                  weighted_euler_angles[mineral_i] = random_draw_volume_weighting(volume_fractions_grains[mineral_i], euler_angles[mineral_i]);
+
+                  Assert(weighted_euler_angles[mineral_i].size() == euler_angles[mineral_i].size(),
+                         ExcMessage("Weighted angles vector (size = " + std::to_string(weighted_euler_angles[mineral_i].size()) +
+                                    ") has different size from input angles (size = " + std::to_string(euler_angles[mineral_i].size()) + ")."));
+
+                }
+
+
+              std::vector<std::vector<Tensor<2,3>>> weighted_a_cosine_matrices;
+
+              if (compute_weighted_A_matrix == true)
+                {
+                  weighted_a_cosine_matrices.resize(n_minerals);
+                  for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
+                    {
+                      weighted_a_cosine_matrices[mineral_i].resize(weighted_euler_angles[mineral_i].size());
+
+                      for (unsigned int i = 0; i < weighted_euler_angles.size(); ++i)
+                        {
+                          weighted_a_cosine_matrices[mineral_i][i] = Utilities::zxz_euler_angles_to_rotation_matrix(weighted_euler_angles[mineral_i][i][0],
+                                                                     weighted_euler_angles[mineral_i][i][1],
+                                                                     weighted_euler_angles[mineral_i][i][2]);
+                        }
+                    }
+                }
+
+              // write weighted header
+              if (wrote_weighted_header == false)
+                {
+                  string_stream_content_draw_volume_weighting << "id" << " ";
+                  for (unsigned int property_i = 0; property_i < write_draw_volume_weighted_cpo.size(); ++property_i)
+                    {
+                      switch (write_draw_volume_weighted_cpo[property_i].second)
+                        {
+                          case Output::VolumeFraction:
+                            string_stream_content_draw_volume_weighting << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_volume_fraction" << " ";
+                            break;
+
+                          case Output::RotationMatrix:
+                            string_stream_content_draw_volume_weighting << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_0" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_1" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_2" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_3" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_4" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_5" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_6" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_7" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_RM_8" << " ";
+                            break;
+
+                          case Output::EulerAngles:
+                            string_stream_content_draw_volume_weighting << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_EA_phi" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_EA_theta" << " "
+                                                                        << "mineral_" << write_draw_volume_weighted_cpo[property_i].first << "_EA_z" << " ";
+                            break;
+                          default:
+                            Assert(false, ExcMessage("Internal error: raw CPO postprocess case not found."));
+                            break;
+                        }
+                    }
+                  string_stream_content_draw_volume_weighting << std::endl;
+                  wrote_weighted_header = true;
+                }
+
+              // write data
+              for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+                {
+                  string_stream_content_draw_volume_weighting << id << " ";
+                  for (unsigned int property_i = 0; property_i < write_draw_volume_weighted_cpo.size(); ++property_i)
+                    {
+                      switch (write_draw_volume_weighted_cpo[property_i].second)
+                        {
+                          case Output::VolumeFraction:
+                            string_stream_content_draw_volume_weighting << volume_fractions_grains[write_draw_volume_weighted_cpo[property_i].first][grain_i] << " ";
+                            break;
+
+                          case Output::RotationMatrix:
+                            string_stream_content_draw_volume_weighting << weighted_a_cosine_matrices[write_draw_volume_weighted_cpo[property_i].first][grain_i] << " ";
+                            break;
+
+                          case Output::EulerAngles:
+                            Assert(compute_raw_euler_angles == true,
+                                   ExcMessage("Internal error: writing out raw Euler angles, without them being computed."));
+                            string_stream_content_draw_volume_weighting << weighted_euler_angles[write_draw_volume_weighted_cpo[property_i].first][grain_i][0] << " "
+                                                                        <<  weighted_euler_angles[write_draw_volume_weighted_cpo[property_i].first][grain_i][1] << " "
+                                                                        <<  weighted_euler_angles[write_draw_volume_weighted_cpo[property_i].first][grain_i][2] << " ";
+                            break;
+
+                          default:
+                            Assert(false, ExcMessage("Internal error: raw CPO postprocess case not found."));
+                            break;
+                        }
+                    }
+                  string_stream_content_draw_volume_weighting << std::endl;
+                }
+            }
+        }
+
+      std::string filename_master = particle_file_prefix_master + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
+      std::string filename_raw = particle_file_prefix_content_raw + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
+      std::string filename_draw_volume_weighting = particle_file_prefix_content_draw_volume_weighting + "." + Utilities::int_to_string(dealii::Utilities::MPI::this_mpi_process (MPI_COMM_WORLD),4) + ".dat";
+
+      std::string *file_contents_master = new std::string (string_stream_master.str());
+      std::string *file_contents_raw = new std::string (string_stream_content_raw.str());
+      std::string *file_contents_draw_volume_weighting = new std::string (string_stream_content_draw_volume_weighting.str());
+
+      if (write_in_background_thread)
+        {
+          // Wait for all previous write operations to finish, should
+          // any be still active,
+          background_thread_master.join ();
+
+          // then continue with writing the master file
+          background_thread_master = std::thread (&writer,
+                                                  filename_master,
+                                                  temporary_output_location,
+                                                  file_contents_master,
+                                                  false);
+
+          if (write_raw_cpo.size() != 0)
+            {
+              // Wait for all previous write operations to finish, should
+              // any be still active,
+              background_thread_content_raw.join ();
+
+              // then continue with writing our own data.
+              background_thread_content_raw = std::thread (&writer,
+                                                           filename_raw,
+                                                           temporary_output_location,
+                                                           file_contents_raw,
+                                                           compress_cpo_data_files);
+            }
+
+          if (write_draw_volume_weighted_cpo.size() != 0)
+            {
+              // Wait for all previous write operations to finish, should
+              // any be still active,
+              background_thread_content_draw_volume_weighting.join ();
+
+              // then continue with writing our own data.
+              background_thread_content_draw_volume_weighting = std::thread (&writer,
+                                                                             filename_draw_volume_weighting,
+                                                                             temporary_output_location,
+                                                                             file_contents_draw_volume_weighting,
+                                                                             compress_cpo_data_files);
+            }
+        }
+      else
+        {
+          writer(filename_master,temporary_output_location,file_contents_master, false);
+          if (write_raw_cpo.size() != 0)
+            writer(filename_raw,temporary_output_location,file_contents_raw, compress_cpo_data_files);
+          if (write_draw_volume_weighted_cpo.size() != 0)
+            writer(filename_draw_volume_weighting,temporary_output_location,file_contents_draw_volume_weighting, compress_cpo_data_files);
+        }
+
+
+      // up the next time we need output
+      set_last_output_time (this->get_time());
+
+      const std::string particle_cpo_output = particle_file_prefix_content_raw;
+
+      // record the file base file name in the output file
+      statistics.add_value ("Particle CPO file name",
+                            particle_cpo_output);
+      return std::make_pair("Writing particle cpo output:", particle_cpo_output);
+    }
+
+    template<int dim>
+    std::vector<std::vector<double>>
+    CrystalPreferredOrientation<dim>::random_draw_volume_weighting(const std::vector<double> &fv,
+                                                                   const std::vector<std::vector<double>> &angles) const
+    {
+      // Get volume weighted euler angles, using random draws to convert odf
+      // to a discrete number of orientations, weighted by volume
+      // 1a. Get index that would sort volume fractions AND
+      //ix = np.argsort(fv[q,:]);
+      // 1b. Get the sorted volume and angle arrays
+      std::vector<double> fv_to_sort = fv;
+      std::vector<double> fv_sorted = fv;
+      std::vector<std::vector<double>> angles_sorted = angles;
+
+      unsigned int n_grains = fv_to_sort.size();
+
+      for (int i = n_grains-1; i >= 0; --i)
+        {
+          unsigned int index_max_fv = std::distance(fv_to_sort.begin(),max_element(fv_to_sort.begin(), fv_to_sort.end()));
+
+          fv_sorted[i] = fv_to_sort[index_max_fv];
+          angles_sorted[i] = angles[index_max_fv];
+          Assert(angles[index_max_fv].size() == 3, ExcMessage("angles vector (size = " + std::to_string(angles[index_max_fv].size()) +
+                                                              ") should have size 3."));
+          Assert(angles_sorted[i].size() == 3, ExcMessage("angles_sorted vector (size = " + std::to_string(angles_sorted[i].size()) +
+                                                          ") should have size 3."));
+          fv_to_sort[index_max_fv] = -1;
+        }
+
+
+      // 2. Get cumulative weight for volume fraction
+      std::vector<double> cum_weight(n_grains);
+      std::partial_sum(fv_sorted.begin(),fv_sorted.end(),cum_weight.begin());
+      // 3. Generate random indices
+      boost::random::uniform_real_distribution<> dist(0, 1);
+      std::vector<double> idxgrain(n_grains);
+      for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+        idxgrain[grain_i] = dist(this->random_number_generator); //random.rand(ngrains,1);
+
+      // 4. Find the maximum cum_weight that is less than the random value.
+      // the euler angle index is +1. For example, if the idxGrain(g) < cumWeight(1),
+      // the index should be 1 not zero)
+      std::vector<std::vector<double>> angles_out(n_grains,std::vector<double>(3));
+      for (unsigned int grain_i = 0; grain_i < n_grains; ++grain_i)
+        {
+          unsigned int counter = 0;
+          for (unsigned int grain_j = 0; grain_j < n_grains; ++grain_j)
+            {
+              if (cum_weight[grain_j] < idxgrain[grain_i])
+                {
+                  counter++;
+                }
+              else
+                {
+                  break;
+                }
+            }
+          angles_out[grain_i] = angles_sorted[counter];
+        }
+      return angles_out;
+    }
+
+
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::set_last_output_time (const double current_time)
+    {
+      // if output_interval is positive, then update the last supposed output
+      // time
+      if (output_interval > 0)
+        {
+          // We need to find the last time output was supposed to be written.
+          // this is the last_output_time plus the largest positive multiple
+          // of output_intervals that passed since then. We need to handle the
+          // edge case where last_output_time+output_interval==current_time,
+          // we did an output and std::floor sadly rounds to zero. This is done
+          // by forcing std::floor to round 1.0-eps to 1.0.
+          const double magic = 1.0+2.0*std::numeric_limits<double>::epsilon();
+          last_output_time = last_output_time + std::floor((current_time-last_output_time)/output_interval*magic) * output_interval/magic;
+        }
+    }
+
+    template <int dim>
+    typename CrystalPreferredOrientation<dim>::Output
+    CrystalPreferredOrientation<dim>::string_to_output_enum(const std::string &string)
+    {
+      //olivine volume fraction, olivine A matrix, olivine Euler angles, enstatite volume fraction, enstatite A matrix, enstatite Euler angles
+      if (string == "volume fraction")
+        return Output::VolumeFraction;
+      if (string == "rotation matrix")
+        return Output::RotationMatrix;
+      if (string == "Euler angles")
+        return Output::EulerAngles;
+      return Output::not_found;
+    }
+
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Crystal Preferred Orientation");
+        {
+          prm.declare_entry ("Time between data output", "1e8",
+                             Patterns::Double (0),
+                             "The time interval between each generation of "
+                             "output files. A value of zero indicates that "
+                             "output should be generated every time step.\n\n"
+                             "Units: years if the "
+                             "'Use years in output instead of seconds' parameter is set; "
+                             "seconds otherwise.");
+
+          prm.declare_entry ("Random number seed", "1",
+                             Patterns::Integer (0),
+                             "The seed used to generate random numbers. This will make sure that "
+                             "results are reproducable as long as the problem is run with the "
+                             "same amount of MPI processes. It is implemented as final seed = "
+                             "user seed + MPI Rank. ");
+
+          prm.declare_entry ("Write in background thread", "false",
+                             Patterns::Bool(),
+                             "File operations can potentially take a long time, blocking the "
+                             "progress of the rest of the model run. Setting this variable to "
+                             "`true' moves this process into a background threads, while the "
+                             "rest of the model continues.");
+
+          prm.declare_entry ("Temporary output location", "",
+                             Patterns::Anything(),
+                             "On large clusters it can be advantageous to first write the "
+                             "output to a temporary file on a local file system and later "
+                             "move this file to a network file system. If this variable is "
+                             "set to a non-empty string it will be interpreted as a "
+                             "temporary storage location.");
+
+          prm.declare_entry ("Write out raw cpo data",
+                             "olivine volume fraction,olivine Euler angles,enstatite volume fraction,enstatite Euler angles",
+                             Patterns::List(Patterns::Anything()),
+                             "A list containing the what part of the particle cpo data needs "
+                             "to be written out after the particle id. This writes out the raw "
+                             "cpo data files for each MPI process. It can write out the following data: "
+                             "olivine volume fraction, olivine A matrix, olivine Euler angles, "
+                             "enstatite volume fraction, enstatite A matrix, enstatite Euler angles. \n"
+                             "Note that the A matrix and Euler angles both contain the same "
+                             "information, but in a different format. Euler angles are recommended "
+                             "over the A matrix since they only require to write 3 values instead "
+                             "of 9. If the list is empty, this file will not be written."
+                             "Furthermore, the entries will be written out in the order given, "
+                             "and if entries are entered muliple times, they will be written "
+                             "out multiple times.");
+
+          prm.declare_entry ("Write out draw volume weighted cpo data",
+                             "olivine Euler angles,enstatite Euler angles",
+                             Patterns::List(Patterns::Anything()),
+                             "A list containing the what part of the random draw volume "
+                             "weighted particle cpo data needs to be written out after "
+                             "the particle id. after using a random draw volume weighting. "
+                             "The random draw volume weigthing uses a uniform random distribution "
+                             "This writes out the raw cpo data files for "
+                             "each MPI process. It can write out the following data: "
+                             "olivine volume fraction, olivine A matrix, olivine Euler angles, "
+                             "enstatite volume fraction, enstatite A matrix, enstatite Euler angles. \n"
+                             "Note that the A matrix and Euler angles both contain the same "
+                             "information, but in a different format. Euler angles are recommended "
+                             "over the A matrix since they only require to write 3 values instead "
+                             "of 9. If the list is empty, this file will not be written. "
+                             "Furthermore, the entries will be written out in the order given, "
+                             "and if entries are entered muliple times, they will be written "
+                             "out multiple times.");
+          prm.declare_entry ("Compress cpo data files", "true",
+                             Patterns::Bool(),
+                             "Wether to compress the raw and weighted cpo data output files with zlib.");
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+
+    }
+
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      end_time = prm.get_double ("End time");
+      if (this->convert_output_to_years())
+        end_time *= year_in_seconds;
+
+      unsigned int n_minerals;
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Particles");
+        {
+          prm.enter_subsection("Crystal Preferred Orientation");
+          {
+            prm.enter_subsection("Initial grains");
+            {
+              // Static variable of CPO has not been initialize yet, so we need to get it directly.
+              const std::vector<std::string> temp_deformation_type_selector = dealii::Utilities::split_string_list(prm.get("Minerals"));
+              n_minerals = temp_deformation_type_selector.size();
+            }
+            prm.leave_subsection();
+          }
+          prm.leave_subsection ();
+        }
+        prm.leave_subsection ();
+        prm.enter_subsection("Crystal Preferred Orientation");
+        {
+          output_interval = prm.get_double ("Time between data output");
+          if (this->convert_output_to_years())
+            output_interval *= year_in_seconds;
+
+          random_number_seed = prm.get_integer ("Random number seed");
+
+          //AssertThrow(this->get_parameters().run_postprocessors_on_nonlinear_iterations == false,
+          //            ExcMessage("Postprocessing nonlinear iterations in models with "
+          //                       "particles is currently not supported."));
+
+          aspect::Utilities::create_directory (this->get_output_directory() + "particle_CPO/",
+                                               this->get_mpi_communicator(),
+                                               true);
+
+          write_in_background_thread = prm.get_bool("Write in background thread");
+          temporary_output_location = prm.get("Temporary output location");
+
+          if (temporary_output_location != "")
+            {
+              // Check if a command-processor is available by calling system() with a
+              // null pointer. System is guaranteed to return non-zero if it finds
+              // a terminal and zero if there is none (like on the compute nodes of
+              // some cluster architectures, e.g. IBM BlueGene/Q)
+              AssertThrow(system((char *)nullptr) != 0,
+                          ExcMessage("Usage of a temporary storage location is only supported if "
+                                     "there is a terminal available to move the files to their final location "
+                                     "after writing. The system() command did not succeed in finding such a terminal."));
+            }
+
+          std::vector<std::string> write_raw_cpo_list = Utilities::split_string_list(prm.get("Write out raw cpo data"));
+          write_raw_cpo.resize(write_raw_cpo_list.size());
+          bool found_euler_angles = false;
+          for (unsigned int i = 0; i < write_raw_cpo_list.size(); ++i)
+            {
+              std::vector<std::string> split_raw_cpo_instructions = Utilities::split_string_list(write_raw_cpo_list[i],':');
+
+              AssertThrow(split_raw_cpo_instructions.size() == 2,
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option "
+                                     + "because it should contain a mineral identification and a output specifier seprated by a colon (:). This entry "
+                                     + "does not follow those rules."));
+
+              // get mineral number
+              std::vector<std::string> mineral_instructions = Utilities::split_string_list(split_raw_cpo_instructions[0],' ');
+              AssertThrow(mineral_instructions.size() == 2,
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option "
+                                     + "because the mineral identification part should contain two elements, the word mineral and a number."));
+
+              AssertThrow(mineral_instructions[0] == "mineral",
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option "
+                                     + "because the mineral identification part should start with the word mineral and it starts with \""
+                                     + mineral_instructions[0] + "\"."));
+
+              int mineral_number = Utilities::string_to_int(mineral_instructions[1]);
+
+              AssertThrow((unsigned int) mineral_number < n_minerals,
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option "
+                                     + "because the mineral number (" + std::to_string(mineral_number) + ") is larger than the number of minerals "
+                                     + "provided in the CPO subsection (" + std::to_string(n_minerals) + ")."));
+
+              // get mineral fabric/deformation type
+              Output cpo_fabric_instruction = string_to_output_enum(split_raw_cpo_instructions[1]);
+
+              AssertThrow(cpo_fabric_instruction != Output::not_found,
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option."))
+
+              if (cpo_fabric_instruction == Output::EulerAngles)
+                found_euler_angles = true;
+
+              write_raw_cpo[i] = std::make_pair(mineral_number,cpo_fabric_instruction);
+            }
+
+          std::vector<std::string> write_draw_volume_weighted_cpo_list = Utilities::split_string_list(prm.get("Write out draw volume weighted cpo data"));
+          write_draw_volume_weighted_cpo.resize(write_draw_volume_weighted_cpo_list.size());
+          bool found_A_matrix = false;
+          for (unsigned int i = 0; i < write_draw_volume_weighted_cpo_list.size(); ++i)
+            {
+              std::vector<std::string> split_draw_volume_weighted_cpo_instructions = Utilities::split_string_list(write_draw_volume_weighted_cpo_list[i],':');
+
+              AssertThrow(split_draw_volume_weighted_cpo_instructions.size() == 2,
+                          ExcMessage("Value \""+ write_draw_volume_weighted_cpo_list[i] +"\", set in \"Write out draw volume weighted cpo data\", is not a correct option "
+                                     + "because it should contain a mineral identification and a output specifier seprated by a colon (:). This entry "
+                                     + "does not follow those rules."));
+
+              // get mineral number
+              std::vector<std::string> mineral_instructions = Utilities::split_string_list(split_draw_volume_weighted_cpo_instructions[0],' ');
+              AssertThrow(mineral_instructions.size() == 2,
+                          ExcMessage("Value \""+ write_draw_volume_weighted_cpo_list[i] +"\", set in \"Write out draw volume weighted cpo data\", is not a correct option "
+                                     + "because the mineral identification part should contain two elements, the word mineral and a number."));
+
+              AssertThrow(mineral_instructions[0] == "mineral",
+                          ExcMessage("Value \""+ write_draw_volume_weighted_cpo_list[i] +"\", set in \"Write out draw volume weighted cpo data\", is not a correct option "
+                                     + "because the mineral identification part should start with the word mineral and it starts with \""
+                                     + mineral_instructions[0] + "\"."));
+
+              int mineral_number = Utilities::string_to_int(mineral_instructions[1]);
+              AssertThrow((unsigned int) mineral_number < n_minerals,
+                          ExcMessage("Value \""+ write_raw_cpo_list[i] +"\", set in \"Write out raw cpo data\", is not a correct option "
+                                     + "because the mineral number (" + std::to_string(mineral_number) + ") is larger than the number of minerals "
+                                     + "provided in the CPO subsection (" + std::to_string(n_minerals) + ")."));
+
+              // get mineral fabric/deformation type
+              Output cpo_fabric_instruction = string_to_output_enum(split_draw_volume_weighted_cpo_instructions[1]);
+
+              AssertThrow(cpo_fabric_instruction != Output::not_found,
+                          ExcMessage("Value \""+ write_draw_volume_weighted_cpo_list[i] +"\", set in \"Write out draw volume weighted cpo data\", is not a correct option."))
+
+              if (cpo_fabric_instruction == Output::RotationMatrix)
+                found_A_matrix = true;
+
+              write_draw_volume_weighted_cpo[i] = std::make_pair(mineral_number,cpo_fabric_instruction);
+            }
+
+          if (write_draw_volume_weighted_cpo_list.size() != 0 || found_euler_angles == true)
+            compute_raw_euler_angles = true;
+          else
+            compute_raw_euler_angles = false;
+
+          if (write_draw_volume_weighted_cpo_list.size() != 0 && found_A_matrix == true)
+            compute_weighted_A_matrix = true;
+          else
+            compute_weighted_A_matrix = false;
+
+          compress_cpo_data_files = prm.get_bool("Compress cpo data files");
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    ASPECT_REGISTER_POSTPROCESSOR(CrystalPreferredOrientation,
+                                  "crystal preferred orientation",
+                                  "A Postprocessor that writes out CPO specific particle data."
+                                  "It can write out the CPO data as it is stored (raw) and/or as a"
+                                  "random draw volume weighted representation. The latter one"
+                                  "is recommended for plotting against real data. For both representations"
+                                  "the specific output fields and their order can be set.")
+  }
+}

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2993,6 +2993,99 @@ namespace aspect
       return matrices_out;
     }
 
+    double
+    wrap_angle(const double angle)
+    {
+      return angle - 360.0*std::floor(angle/360.0);
+    }
+
+    std::vector<double>
+    zxz_euler_angles_from_rotation_matrix(const Tensor<2,3> &rotation_matrix)
+    {
+      // ZXZ Euler angles
+      std::vector<double> euler_angles(3);
+      for (size_t i = 0; i < 3; i++)
+        for (size_t j = 0; j < 3; j++)
+          Assert(abs(rotation_matrix[i][j]) <= 1.0,
+                 ExcMessage("rotation_matrix[" + std::to_string(i) + "][" + std::to_string(j) +
+                            "] is larger than one: " + std::to_string(rotation_matrix[i][j]) + " (" + std::to_string(rotation_matrix[i][j]-1.0) + "). rotation_matrix = \n"
+                            + std::to_string(rotation_matrix[0][0]) + " " + std::to_string(rotation_matrix[0][1]) + " " + std::to_string(rotation_matrix[0][2]) + "\n"
+                            + std::to_string(rotation_matrix[1][0]) + " " + std::to_string(rotation_matrix[1][1]) + " " + std::to_string(rotation_matrix[1][2]) + "\n"
+                            + std::to_string(rotation_matrix[2][0]) + " " + std::to_string(rotation_matrix[2][1]) + " " + std::to_string(rotation_matrix[2][2])));
+
+
+      AssertThrow(rotation_matrix[2][2] <= 1.0, ExcMessage("rot_matrix[2][2] > 1.0"));
+
+      const double theta = std::acos(rotation_matrix[2][2]);
+      double phi1 = 0.0;
+      double phi2 = 0.0;
+
+      if (theta != 0.0 && theta != dealii::numbers::PI)
+        {
+          //
+          phi1  = std::atan2(rotation_matrix[2][0]/-sin(theta),rotation_matrix[2][1]/-sin(theta));
+          phi2  = std::atan2(rotation_matrix[0][2]/-sin(theta),rotation_matrix[1][2]/sin(theta));
+        }
+      else
+        {
+          // note that in the case theta is 0 or phi a dimension is lost
+          // see: https://en.wikipedia.org/wiki/Gimbal_lock. We set phi1
+          // to 0 and compute the corresponding phi2. The resulting direction
+          // (cosine matrix) should be the same.
+          if (theta == 0.0)
+            {
+              phi2 = - phi1 - std::atan2(rotation_matrix[0][1],rotation_matrix[0][0]);
+            }
+          else
+            {
+              phi2 = phi1 + std::atan2(rotation_matrix[0][1],rotation_matrix[0][0]);
+            }
+
+        }
+
+      AssertThrow(!std::isnan(phi1), ExcMessage(" phi1 is nan. theta = " + std::to_string(theta) + ", rotation_matrix[2][2]= " + std::to_string(rotation_matrix[2][2])
+                                                + ", acos(rotation_matrix[2][2]) = " + std::to_string(std::acos(rotation_matrix[2][2])) + ", acos(1.0) = " + std::to_string(std::acos(1.0))));
+      AssertThrow(!std::isnan(theta), ExcMessage(" theta is nan."));
+      AssertThrow(!std::isnan(phi2), ExcMessage(" phi2 is nan."));
+
+      euler_angles[0] = wrap_angle(phi1 * 180.0/numbers::PI);
+      euler_angles[1] = wrap_angle(theta * 180.0/numbers::PI);
+      euler_angles[2] = wrap_angle(phi2 * 180.0/numbers::PI);
+
+
+      AssertThrow(!std::isnan(euler_angles[0]), ExcMessage(" euler_angles[0] is nan."));
+      AssertThrow(!std::isnan(euler_angles[1]), ExcMessage(" euler_angles[1] is nan."));
+      AssertThrow(!std::isnan(euler_angles[2]), ExcMessage(" euler_angles[2] is nan."));
+
+      return euler_angles;
+    }
+
+    Tensor<2,3>
+    zxz_euler_angles_to_rotation_matrix(double phi1_d, double theta_d, double phi2_d)
+    {
+      // ZXZ Euler angles
+      const double phi1 = phi1_d * numbers::PI/180.0;
+      const double theta = theta_d * numbers::PI/180.0;
+      const double phi2 = phi2_d * numbers::PI/180.0;
+      Tensor<2,3> rot_matrix;
+
+
+      rot_matrix[0][0] = cos(phi2)*cos(phi1) - cos(theta)*sin(phi1)*sin(phi2);
+      rot_matrix[0][1] = -cos(phi2)*sin(phi1) - cos(theta)*cos(phi1)*sin(phi2);
+      rot_matrix[0][2] = -sin(phi2)*sin(theta);
+
+      rot_matrix[1][0] = sin(phi2)*cos(phi1) + cos(theta)*sin(phi1)*cos(phi2);
+      rot_matrix[1][1] = -sin(phi2)*sin(phi1) + cos(theta)*cos(phi1)*cos(phi2);
+      rot_matrix[1][2] = cos(phi2)*sin(theta);
+
+      rot_matrix[2][0] = -sin(theta)*sin(phi1);
+      rot_matrix[2][1] = -sin(theta)*cos(phi1);
+      rot_matrix[2][2] = cos(theta);
+      AssertThrow(rot_matrix[2][2] <= 1.0, ExcMessage("rot_matrix[2][2] > 1.0"));
+      return rot_matrix;
+    }
+
+
 
 // Explicit instantiations
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2999,11 +2999,11 @@ namespace aspect
       return angle - 360.0*std::floor(angle/360.0);
     }
 
-    std::vector<double>
+    std::array<double,3>
     zxz_euler_angles_from_rotation_matrix(const Tensor<2,3> &rotation_matrix)
     {
       // ZXZ Euler angles
-      std::vector<double> euler_angles(3);
+      std::array<double,3> euler_angles;
       for (size_t i = 0; i < 3; i++)
         for (size_t j = 0; j < 3; j++)
           Assert(abs(rotation_matrix[i][j]) <= 1.0,

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -20,6 +20,7 @@
 
 #include "common.h"
 #include <aspect/particle/property/crystal_preferred_orientation.h>
+#include <aspect/particle/property/cpo_elastic_tensor.h>
 #include <deal.II/base/parameter_handler.h>
 
 
@@ -238,10 +239,6 @@ TEST_CASE("CPO core: Store and Load")
   cpo.set_volume_fractions_grains(cpo_data_position,data,1,0,0.4);
   cpo.set_volume_fractions_grains(cpo_data_position,data,1,1,0.5);
   cpo.set_volume_fractions_grains(cpo_data_position,data,1,2,0.6);
-
-  std::vector<unsigned int> deformation_types_ref = {(unsigned int)aspect::Particle::Property::DeformationType::passive,
-                                                     (unsigned int)aspect::Particle::Property::DeformationType::passive
-                                                    };
 
   data[0] = 20847932.2;
   data[65] = 6541684.3;
@@ -1066,4 +1063,659 @@ TEST_CASE("CPO")
           }
       }
   }
+}
+
+TEST_CASE("CPO elastic tensor transform functions")
+{
+  dealii::SymmetricTensor<2,6> reference_elastic_tensor({1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21});
+
+// first test whether the functions are invertable
+  {
+    dealii::SymmetricTensor<2,6> result_up_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor));
+
+    for (size_t i = 0; i < 6; i++)
+      {
+        for (size_t j = 0; j < 6; j++)
+          {
+            REQUIRE(reference_elastic_tensor[i][j] == Approx(result_up_down[i][j]));
+          }
+      }
+  }
+  {
+    dealii::SymmetricTensor<2,6> result_down_up = aspect::Particle::Property::CpoElasticTensor<3>::transform_21D_vector_to_6x6_matrix(aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(reference_elastic_tensor));
+
+    for (size_t i = 0; i < 6; i++)
+      {
+        for (size_t j = 0; j < 6; j++)
+          {
+            REQUIRE(reference_elastic_tensor[i][j] == Approx(result_down_up[i][j]));
+          }
+      }
+  }
+  {
+    dealii::SymmetricTensor<2,6> result_up_2down_up = aspect::Particle::Property::CpoElasticTensor<3>::transform_21D_vector_to_6x6_matrix(aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_21D_vector(aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor)));
+
+    for (size_t i = 0; i < 6; i++)
+      {
+        for (size_t j = 0; j < 6; j++)
+          {
+            REQUIRE(reference_elastic_tensor[i][j] == Approx(result_up_2down_up[i][j]));
+          }
+      }
+  }
+
+  // test rotations
+  // rotation matrix
+  dealii::Tensor<2,3> rotation_tensor;
+
+  {
+    // fill the rotation matrix with a rotations in all directions
+    {
+      double radians = (dealii::numbers::PI/180.0)*(360/5); //0.35*dealii::numbers::PI; //(dealii::numbers::PI/180.0)*36;
+      double alpha = radians;
+      double beta = radians;
+      double gamma = radians;
+      rotation_tensor[0][0] = cos(alpha) * cos(beta);
+      rotation_tensor[0][1] = sin(alpha) * cos(beta);
+      rotation_tensor[0][2] = -sin(beta);
+      rotation_tensor[1][0] = cos(alpha) * sin(beta) * sin(gamma) - sin(alpha)*cos(gamma);
+      rotation_tensor[1][1] = sin(alpha) * sin(beta) * sin(gamma) + cos(alpha)*cos(gamma);
+      rotation_tensor[1][2] = cos(beta) * sin(gamma);
+      rotation_tensor[2][0] = cos(alpha) * sin(beta) * cos(gamma) + sin(alpha)*sin(gamma);
+      rotation_tensor[2][1] = sin(alpha) * sin(beta) * cos(gamma) - cos(alpha)*sin(gamma);
+      rotation_tensor[2][2] = cos(beta) * cos(gamma);
+    }
+
+    {
+      dealii::SymmetricTensor<2,6> result_up_1_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(
+                                                               aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(
+                                                                 aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor),rotation_tensor));
+      dealii::SymmetricTensor<2,6> result_1_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(reference_elastic_tensor,rotation_tensor);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_1_rotate[i][j] == Approx(result_up_1_rotate_down[i][j]));
+            }
+        }
+
+      dealii::Tensor<4,3> result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(result_up_1_rotate_down);
+
+      dealii::SymmetricTensor<2,6> result_5_rotate = result_1_rotate;
+
+      for (size_t i = 0; i < 4; i++)
+        {
+          result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(result_up_10_rotate, rotation_tensor);
+          result_5_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(result_5_rotate, rotation_tensor);
+        }
+
+      dealii::SymmetricTensor<2,6> result_up_10_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(result_up_10_rotate);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_5_rotate[i][j] == Approx(result_up_10_rotate_down[i][j]));
+              // This test doesn't work when rotating in all rotations at the same time.
+              //REQUIRE(result_1_rotate[i][j] == Approx(reference_elastic_tensor[i][j]));
+            }
+        }
+    }
+  }
+  {
+    // fill the rotation matrix with a rotations in the alpha direction
+    {
+      double radians = (dealii::numbers::PI/180.0)*(360/5); //0.35*dealii::numbers::PI; //(dealii::numbers::PI/180.0)*36;
+      double alpha = radians;
+      double beta = 0;
+      double gamma = 0;
+      rotation_tensor[0][0] = cos(alpha) * cos(beta);
+      rotation_tensor[0][1] = sin(alpha) * cos(beta);
+      rotation_tensor[0][2] = -sin(beta);
+      rotation_tensor[1][0] = cos(alpha) * sin(beta) * sin(gamma) - sin(alpha)*cos(gamma);
+      rotation_tensor[1][1] = sin(alpha) * sin(beta) * sin(gamma) + cos(alpha)*cos(gamma);
+      rotation_tensor[1][2] = cos(beta) * sin(gamma);
+      rotation_tensor[2][0] = cos(alpha) * sin(beta) * cos(gamma) + sin(alpha)*sin(gamma);
+      rotation_tensor[2][1] = sin(alpha) * sin(beta) * cos(gamma) - cos(alpha)*sin(gamma);
+      rotation_tensor[2][2] = cos(beta) * cos(gamma);
+    }
+
+    {
+      dealii::SymmetricTensor<2,6> result_up_1_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(
+                                                               aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(
+                                                                 aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor),rotation_tensor));
+      dealii::SymmetricTensor<2,6> result_1_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(reference_elastic_tensor,rotation_tensor);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_1_rotate[i][j] == Approx(result_up_1_rotate_down[i][j]));
+            }
+        }
+
+      dealii::Tensor<4,3> result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(result_up_1_rotate_down);
+
+      dealii::SymmetricTensor<2,6> result_5_rotate = result_1_rotate;
+
+      for (size_t i = 0; i < 4; i++)
+        {
+          result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(result_up_10_rotate, rotation_tensor);
+          result_5_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(result_5_rotate, rotation_tensor);
+        }
+
+      dealii::SymmetricTensor<2,6> result_up_10_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(result_up_10_rotate);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_5_rotate[i][j] == Approx(result_up_10_rotate_down[i][j]));
+              REQUIRE(result_5_rotate[i][j] == Approx(reference_elastic_tensor[i][j]));
+            }
+        }
+    }
+  }
+  {
+    // fill the rotation matrix with a rotations in the beta direction
+    {
+      double radians = (dealii::numbers::PI/180.0)*(360/5); //0.35*dealii::numbers::PI; //(dealii::numbers::PI/180.0)*36;
+      double alpha = 0;
+      double beta = radians;
+      double gamma = 0;
+      rotation_tensor[0][0] = cos(alpha) * cos(beta);
+      rotation_tensor[0][1] = sin(alpha) * cos(beta);
+      rotation_tensor[0][2] = -sin(beta);
+      rotation_tensor[1][0] = cos(alpha) * sin(beta) * sin(gamma) - sin(alpha)*cos(gamma);
+      rotation_tensor[1][1] = sin(alpha) * sin(beta) * sin(gamma) + cos(alpha)*cos(gamma);
+      rotation_tensor[1][2] = cos(beta) * sin(gamma);
+      rotation_tensor[2][0] = cos(alpha) * sin(beta) * cos(gamma) + sin(alpha)*sin(gamma);
+      rotation_tensor[2][1] = sin(alpha) * sin(beta) * cos(gamma) - cos(alpha)*sin(gamma);
+      rotation_tensor[2][2] = cos(beta) * cos(gamma);
+    }
+
+    {
+      dealii::SymmetricTensor<2,6> result_up_1_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(
+                                                               aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(
+                                                                 aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor),rotation_tensor));
+      dealii::SymmetricTensor<2,6> result_1_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(reference_elastic_tensor,rotation_tensor);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_1_rotate[i][j] == Approx(result_up_1_rotate_down[i][j]));
+            }
+        }
+
+      dealii::Tensor<4,3> result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(result_up_1_rotate_down);
+
+      dealii::SymmetricTensor<2,6> result_5_rotate = result_1_rotate;
+
+      for (size_t i = 0; i < 4; i++)
+        {
+          result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(result_up_10_rotate, rotation_tensor);
+          result_5_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(result_5_rotate, rotation_tensor);
+        }
+
+      dealii::SymmetricTensor<2,6> result_up_10_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(result_up_10_rotate);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_5_rotate[i][j] == Approx(result_up_10_rotate_down[i][j]));
+              REQUIRE(result_5_rotate[i][j] == Approx(reference_elastic_tensor[i][j]));
+            }
+        }
+    }
+  }
+
+  {
+    // fill the rotation matrix with a rotations in the gamma direction
+    {
+      double radians = (dealii::numbers::PI/180.0)*(360/5); //0.35*dealii::numbers::PI; //(dealii::numbers::PI/180.0)*36;
+      double alpha = 0;
+      double beta = 0;
+      double gamma = radians;
+      rotation_tensor[0][0] = cos(alpha) * cos(beta);
+      rotation_tensor[0][1] = sin(alpha) * cos(beta);
+      rotation_tensor[0][2] = -sin(beta);
+      rotation_tensor[1][0] = cos(alpha) * sin(beta) * sin(gamma) - sin(alpha)*cos(gamma);
+      rotation_tensor[1][1] = sin(alpha) * sin(beta) * sin(gamma) + cos(alpha)*cos(gamma);
+      rotation_tensor[1][2] = cos(beta) * sin(gamma);
+      rotation_tensor[2][0] = cos(alpha) * sin(beta) * cos(gamma) + sin(alpha)*sin(gamma);
+      rotation_tensor[2][1] = sin(alpha) * sin(beta) * cos(gamma) - cos(alpha)*sin(gamma);
+      rotation_tensor[2][2] = cos(beta) * cos(gamma);
+    }
+
+    {
+      dealii::SymmetricTensor<2,6> result_up_1_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(
+                                                               aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(
+                                                                 aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(reference_elastic_tensor),rotation_tensor));
+      dealii::SymmetricTensor<2,6> result_1_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(reference_elastic_tensor,rotation_tensor);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_1_rotate[i][j] == Approx(result_up_1_rotate_down[i][j]));
+            }
+        }
+
+      dealii::Tensor<4,3> result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::transform_6x6_matrix_to_4th_order_tensor(result_up_1_rotate_down);
+
+      dealii::SymmetricTensor<2,6> result_5_rotate = result_1_rotate;
+
+      for (size_t i = 0; i < 4; i++)
+        {
+          result_up_10_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_4th_order_tensor(result_up_10_rotate, rotation_tensor);
+          result_5_rotate = aspect::Particle::Property::CpoElasticTensor<3>::rotate_6x6_matrix(result_5_rotate, rotation_tensor);
+        }
+
+      dealii::SymmetricTensor<2,6> result_up_10_rotate_down = aspect::Particle::Property::CpoElasticTensor<3>::transform_4th_order_tensor_to_6x6_matrix(result_up_10_rotate);
+
+      for (size_t i = 0; i < 6; i++)
+        {
+          for (size_t j = 0; j < 6; j++)
+            {
+              REQUIRE(result_5_rotate[i][j] == Approx(result_up_10_rotate_down[i][j]));
+              REQUIRE(result_5_rotate[i][j] == Approx(reference_elastic_tensor[i][j]));
+            }
+        }
+    }
+  }
+
+}
+
+
+TEST_CASE("CPO elastic tensor")
+{
+
+  std::vector<double> volume_fraction_mineral = {0.7,0.3};
+  std::vector<std::vector<double>> volume_fractions_grains(2,std::vector<double>(8));
+  std::vector<std::vector<dealii::Tensor<2,3>>> a_cosine_matrices_grains(2,std::vector<dealii::Tensor<2,3>>(8));
+
+  dealii::Tensor<2,6> reference_elastic_tensor;
+  dealii::Tensor<2,6> computed_elastic_tensor;
+
+
+  unsigned int cpo_data_position = 0;
+  std::vector<double> data_array(200,-1.);
+  dealii::ArrayView<double> data_cpo(&data_array[0],200);
+
+
+  // test the averaging function
+  aspect::Particle::Property::CrystalPreferredOrientation<3> cpo;
+  aspect::Particle::Property::CpoElasticTensor<3> cpo_elastic_tensor;
+  aspect::ParameterHandler prm;
+  cpo.declare_parameters(prm);
+  cpo_elastic_tensor.declare_parameters(prm);
+  prm.enter_subsection("Postprocess");
+  {
+    prm.enter_subsection("Particles");
+    {
+      prm.enter_subsection("Crystal Preferred Orientation");
+      {
+        prm.set("Random number seed","1");
+        prm.set("Number of grains per particle","8");
+        prm.set("CPO derivatives algorithm","Spin tensor");
+        prm.set("Property advection method","Backward Euler");
+        prm.enter_subsection("Initial grains");
+        {
+          prm.set("Model name","Uniform grains and random uniform rotations");
+          prm.enter_subsection("Uniform grains and random uniform rotations");
+          {
+            // Let the minerals just passively rotate with the rotation of
+            // the particle caused by the flow.
+            prm.set("Minerals","Passive,Passive");
+            prm.set("Volume fractions minerals","0.7,0.3");
+          }
+          prm.leave_subsection();
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection ();
+    }
+    prm.leave_subsection ();
+  }
+  prm.leave_subsection ();
+
+  cpo.parse_parameters(prm);
+  cpo.initialize();
+
+
+  cpo_elastic_tensor.parse_parameters(prm);
+  //cpo_elastic_tensor.initialize();
+
+
+  // All these numbers are directly from the Fortran D-Rex
+  // Had to fix the random seed to get consistent awnsers.
+  // Fixed the random set to an array filled with zeros.
+  using namespace dealii;
+  Tensor<2,3> rotation_matrix;
+  rotation_matrix[TableIndices<2>(0,0)] = -0.87492387659370430;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.47600252255715020;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.10151800968122601;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.13036031917262200;
+  rotation_matrix[TableIndices<2>(1,1)] = -2.6406769698713056E-002;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.99232315682823224;
+  rotation_matrix[TableIndices<2>(2,0)] = 0.46957683898444408;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.87974004016081919;
+  rotation_matrix[TableIndices<2>(2,2)] = 8.6098835151007691E-002;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,0,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.98046837857873570;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.19463893778994429;
+  rotation_matrix[TableIndices<2>(0,2)] = -2.8239743415760400E-002;
+  rotation_matrix[TableIndices<2>(1,0)] = 6.8942963409018593E-002;
+  rotation_matrix[TableIndices<2>(1,1)] = 0.20565757913350766;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.97619251975954824;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.18419735979776022;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.95907282258851756;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.21505972600848655;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,1,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.60475851993637786;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.70843624030907060;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.36543256811748415;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.14301138974031016;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.35406726088673490;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.92567249145068109;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.78533679283378455;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.61106385979914768;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.11279851062549377;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,2,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.86791495614143876;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.11797028562530290;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.48441508819120616;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.29623368357270952;
+  rotation_matrix[TableIndices<2>(1,1)] = 0.66075310029034506;
+  rotation_matrix[TableIndices<2>(1,2)] = 0.69114249890201696;
+  rotation_matrix[TableIndices<2>(2,0)] = 0.40054408016972737;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.74231595966649988;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.53869116329275069;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,3,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 6.2142369991145308E-002;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.99798524450925208;
+  rotation_matrix[TableIndices<2>(0,2)] = 1.4733749724082583E-002;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.16313304505497195;
+  rotation_matrix[TableIndices<2>(1,1)] = 3.9946223138032123E-003;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.99141604427573704;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.98947772660983668;
+  rotation_matrix[TableIndices<2>(2,1)] = 6.3633828841832010E-002;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.16253511002663851;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,4,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.95811162445076037;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.24047036409864109;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.18394917461469307;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.26945849516984494;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.95216866624585605;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.14816174866727450;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.13948857525086517;
+  rotation_matrix[TableIndices<2>(2,1)] = 0.18918653693665904;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.97685775746677384;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,5,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.54599545795872684;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.79260950430410815;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.27534584625644454;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.83567561116582212;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.55085590166106368;
+  rotation_matrix[TableIndices<2>(1,2)] = -6.8746495709015629E-002;
+  rotation_matrix[TableIndices<2>(2,0)] = -9.6081601263635075E-002;
+  rotation_matrix[TableIndices<2>(2,1)] = 0.26479508638287669;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.96221681521835400;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,6,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.14540407652501869;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.61649901222701298;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.77881206212059828;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.59216315099851768;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.68282211925029168;
+  rotation_matrix[TableIndices<2>(1,2)] = 0.43341920614609419;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.79819736735552915;
+  rotation_matrix[TableIndices<2>(2,1)] = 0.39350172081601731;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.46322016633770996;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,0,7,rotation_matrix);
+
+
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,0,2.5128593570287589E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,1,0.83128842847575013);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,2,2.4387041141724769E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,3,2.4763275182773107E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,4,2.4801714431754770E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,5,2.3943562805875843E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,6,2.1493810045792379E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,0,7,2.4193574346041427E-002);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.66168933252008499;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.27722421136423192;
+  rotation_matrix[TableIndices<2>(0,2)] = 0.70016104334335305;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.45052346117292291;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.59946225647123619;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.66370395454608444;
+  rotation_matrix[TableIndices<2>(2,0)] = 0.60350910238307343;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.75116099269655345;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.27207473610935284;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,0,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.70309122563849258;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.23393734574397834;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.67775637808568567;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.68298185906364617;
+  rotation_matrix[TableIndices<2>(1,1)] = -6.6406501211459870E-002;
+  rotation_matrix[TableIndices<2>(1,2)] = 0.73168002139436472;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.21654097292603913;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.97001835897279087;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.11341644508992850;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,1,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.37892641930874921;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.92610670487847191;
+  rotation_matrix[TableIndices<2>(0,2)] = 3.9338024409460159E-002;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.10014673867324062;
+  rotation_matrix[TableIndices<2>(1,1)] = 2.1922389732184896E-004;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.99514251026853373;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.92466780075091537;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.37833500123197994;
+  rotation_matrix[TableIndices<2>(2,2)] = 9.2539397053637271E-002;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,2,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 0.73973803569795438;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.58084801380447959;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.35134329241205425;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.30883050284698427;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.17349072757172229;
+  rotation_matrix[TableIndices<2>(1,2)] = 0.94047567596335968;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.60686583881969203;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.79564553570809793;
+  rotation_matrix[TableIndices<2>(2,2)] = 5.0387432541084881E-002;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,3,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = 4.2730545437086563E-002;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.99790446393350407;
+  rotation_matrix[TableIndices<2>(0,2)] = 4.9677348699965519E-002;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.24607319829629554;
+  rotation_matrix[TableIndices<2>(1,1)] = 3.7594987859276820E-002;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.97243353311600111;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.97326576151708344;
+  rotation_matrix[TableIndices<2>(2,1)] = 5.2990062123162360E-002;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.24420040893728351;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,4,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.92112012021624434;
+  rotation_matrix[TableIndices<2>(0,1)] = 0.17590913101287936;
+  rotation_matrix[TableIndices<2>(0,2)] = 0.34726602737040008;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.27292179963530816;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.92793421776529450;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.25387354780599874;
+  rotation_matrix[TableIndices<2>(2,0)] = 0.27758135269283285;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.32862450412044819;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.90274831467569783;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,5,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -4.6028553384029648E-002;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.82828827663204008;
+  rotation_matrix[TableIndices<2>(0,2)] = -0.56150509327989218;
+  rotation_matrix[TableIndices<2>(1,0)] = -0.62780239844730912;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.41264414122407550;
+  rotation_matrix[TableIndices<2>(1,2)] = 0.66416683570654200;
+  rotation_matrix[TableIndices<2>(2,0)] = -0.78150657001547463;
+  rotation_matrix[TableIndices<2>(2,1)] = 0.37975977805647526;
+  rotation_matrix[TableIndices<2>(2,2)] = -0.50060220610535922;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,6,rotation_matrix);
+
+  rotation_matrix[TableIndices<2>(0,0)] = -0.69974343277254114;
+  rotation_matrix[TableIndices<2>(0,1)] = -0.60514581197791628;
+  rotation_matrix[TableIndices<2>(0,2)] = 0.38074455421574593;
+  rotation_matrix[TableIndices<2>(1,0)] = 0.27181144918830025;
+  rotation_matrix[TableIndices<2>(1,1)] = -0.71756260285634454;
+  rotation_matrix[TableIndices<2>(1,2)] = -0.64160793166977359;
+  rotation_matrix[TableIndices<2>(2,0)] = 0.66130789657394939;
+  rotation_matrix[TableIndices<2>(2,1)] = -0.34496383827187421;
+  rotation_matrix[TableIndices<2>(2,2)] = 0.66656470768691123;
+  cpo.set_rotation_matrix_grains(cpo_data_position,data_cpo,1,7,rotation_matrix);
+
+
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,0,2.4802805652404735E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,1,2.4917064186342413E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,2,2.4790722064907112E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,3,2.4932751194567736E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,4,2.4896744967217745E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,5,0.79902139535472505);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,6,2.4861121542485400E-002);
+  cpo.set_volume_fractions_grains(cpo_data_position,data_cpo,1,7,5.1777395037349808E-002);
+
+  reference_elastic_tensor[0][0] = 282.99195951271281;
+  reference_elastic_tensor[0][1] = 74.161110997372660;
+  reference_elastic_tensor[0][2] = 69.528000044099443;
+  reference_elastic_tensor[0][3] = 0.85449958913948032;
+  reference_elastic_tensor[0][4] = 0.15156631865980030;
+  reference_elastic_tensor[0][5] = -10.295196344728696;
+  reference_elastic_tensor[1][0] = 74.161110997372674;
+  reference_elastic_tensor[1][1] = 223.44404040361212;
+  reference_elastic_tensor[1][2] = 70.938305212304968;
+  reference_elastic_tensor[1][3] = 1.4935368335052783;
+  reference_elastic_tensor[1][4] = -1.5555954844298270;
+  reference_elastic_tensor[1][5] = -3.5461136157235025;
+  reference_elastic_tensor[2][0] = 69.528000044099443;
+  reference_elastic_tensor[2][1] = 70.938305212304940;
+  reference_elastic_tensor[2][2] = 208.89404139751849;
+  reference_elastic_tensor[2][3] = 0.48656291118743428;
+  reference_elastic_tensor[2][4] = 0.49424401802786699;
+  reference_elastic_tensor[2][5] = -0.15651560991351129;
+  reference_elastic_tensor[3][0] = 0.85449958913948365;
+  reference_elastic_tensor[3][1] = 1.4935368335052732;
+  reference_elastic_tensor[3][2] = 0.48656291118742612;
+  reference_elastic_tensor[3][3] = 71.502776245041289;
+  reference_elastic_tensor[3][4] = -2.3939425644793477;
+  reference_elastic_tensor[3][5] = 0.62714033620769472;
+  reference_elastic_tensor[4][0] = 0.15156631865980935;
+  reference_elastic_tensor[4][1] = -1.5555954844298292;
+  reference_elastic_tensor[4][2] = 0.49424401802786488;
+  reference_elastic_tensor[4][3] = -2.3939425644793459;
+  reference_elastic_tensor[4][4] = 78.565442407530099;
+  reference_elastic_tensor[4][5] = -0.69890743507815323;
+  reference_elastic_tensor[5][0] = -10.295196344728710;
+  reference_elastic_tensor[5][1] = -3.5461136157235131;
+  reference_elastic_tensor[5][2] = -0.15651560991350758;
+  reference_elastic_tensor[5][3] = 0.62714033620769460;
+  reference_elastic_tensor[5][4] = -0.69890743507815523;
+  reference_elastic_tensor[5][5] = 80.599981331604567;
+
+
+  cpo.set_volume_fraction_mineral(cpo_data_position,data_cpo,0,0.7);
+  cpo.set_volume_fraction_mineral(cpo_data_position,data_cpo,1,0.3);
+
+  cpo.set_deformation_type(cpo_data_position,data_cpo,0,(double)aspect::Particle::Property::DeformationType::olivine_a_fabric);
+  cpo.set_deformation_type(cpo_data_position,data_cpo,1,(double)aspect::Particle::Property::DeformationType::enstatite);
+
+  computed_elastic_tensor = cpo_elastic_tensor.voigt_average_elastic_tensor(cpo,
+                                                                            cpo_data_position,
+                                                                            data_cpo);
+
+
+  for (size_t i = 0; i < 6; i++)
+    {
+      for (size_t j = 0; j < 6; j++)
+        {
+          CHECK(computed_elastic_tensor[i][j] == Approx(reference_elastic_tensor[i][j]));
+        }
+    }
+
+  // test store and load functions
+  // the first and last element should not be changed
+  // by these functions.
+  std::vector<double> array_ref = {0.0,
+                                   1.,2.,3.,4.,5,6,
+                                   7.,8.,9.,10,11,12,
+                                   13,14,15,16,17,18,
+                                   19,20,21,22,23,24,
+                                   25,26,27,28,29,30,
+                                   31,32,33,34,35,36,
+                                   37
+                                  };
+
+  std::vector<double> array = {0.0,
+                               1.,2.,3.,4.,5.,6.,
+                               7.,8.,9.,10,11,12,
+                               13,14,15,16,17,18,
+                               19,20,21,22,23,24,
+                               25,26,27,28,29,30,
+                               31,32,33,34,35,36,
+                               37
+                              };
+
+  // There used be be 36 unique entries, but now because we are using the
+  // symmetric tensor, there are only 21 unique entries.
+  std::vector<double> array_plus_100 = {0.0,
+                                        101.,102.,103.,104.,105.,106.,
+                                        107.,108.,109.,110.,111.,112.,
+                                        113.,114.,115.,116.,117.,118.,
+                                        119.,120.,121.,22.,23.,24.,
+                                        25.,26.,27.,28.,29.,30.,
+                                        31.,32.,33.,34.,35.,36.,
+                                        37.
+                                       };
+
+  cpo_data_position = 1;
+  dealii::ArrayView<double> data(&array[0],38);
+  dealii::SymmetricTensor<2,6> tensor = cpo_elastic_tensor.get_elastic_tensor(cpo_data_position,data);
+
+  for (unsigned int i = 0; i < dealii::SymmetricTensor<2,6>::n_independent_components ; ++i)
+    {
+      CHECK(data[cpo_data_position + i] == tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
+    }
+
+  cpo_elastic_tensor.set_elastic_tensor(cpo_data_position,data,tensor);
+
+  for (unsigned int i = 0; i < array.size() ; ++i)
+    CHECK(data[i] == array_ref[i]);
+
+  for (unsigned int i = 0; i < dealii::SymmetricTensor<2,6>::n_independent_components ; ++i)
+    {
+      tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)] += 100;
+    }
+
+  cpo_elastic_tensor.set_elastic_tensor(cpo_data_position,data,tensor);
+
+  for (unsigned int i = 0; i < array.size() ; ++i)
+    CHECK(data[i] == array_plus_100[i]);
+
+  tensor = cpo_elastic_tensor.get_elastic_tensor(cpo_data_position,data);
+
+  for (unsigned int i = 0; i < dealii::SymmetricTensor<2,6>::n_independent_components ; ++i)
+    {
+      CHECK(data[cpo_data_position + i] == tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
+    }
+
+  for (unsigned int i = 0; i < dealii::SymmetricTensor<2,6>::n_independent_components ; ++i)
+    {
+      CHECK(array_plus_100[cpo_data_position + i] == tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
+    }
 }

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -141,10 +141,15 @@ TEST_CASE("CPO core: Store and Load")
         prm.enter_subsection("Initial grains");
         {
           prm.set("Model name","Uniform grains and random uniform rotations");
+
+          prm.set("Minerals","Passive,Passive");
+          //prm.enter_subsection("Uniform grains and random uniform rotations");
+          //{
           // Let the minerals just passively rotate with the rotation of
           // the particle caused by the flow.
-          prm.set("Minerals","Passive,Passive");
           prm.set("Volume fractions minerals","0.7,0.3");
+          //}
+          //prm.leave_subsection();
         }
         prm.leave_subsection();
       }
@@ -320,11 +325,14 @@ TEST_CASE("CPO core: Spin tensor")
           prm.set("Property advection method","Forward Euler");
           prm.enter_subsection("Initial grains");
           {
-            prm.set("Model name","Uniform grains and random uniform rotations");
+            prm.set("Minerals","Passive,Passive");
+            //prm.enter_subsection("Uniform grains and random uniform rotations");
+            //{
             // Let the minerals just passively rotate with the rotation of
             // the particle caused by the flow.
-            prm.set("Minerals","Passive,Passive");
             prm.set("Volume fractions minerals","0.5,0.5");
+            //}
+            //prm.leave_subsection();
           }
           prm.leave_subsection();
         }
@@ -622,8 +630,15 @@ TEST_CASE("CPO drex 2004")
         {
           prm.set("Random number seed","1");
           prm.set("Number of grains per particle","5");
-
-
+          prm.enter_subsection("Initial grains");
+          {
+            prm.set("Minerals","Olivine: A-fabric, Enstatite");
+          }
+          prm.leave_subsection();
+          //prm.enter_subsection("D-Rex 2004");
+          //{
+          //}
+          //prm.leave_subsection();
         }
         prm.leave_subsection ();
       }
@@ -835,6 +850,15 @@ TEST_CASE("CPO drex 2004")
         {
           prm.set("Random number seed","1");
           prm.set("Number of grains per particle","5");
+          prm.enter_subsection("Initial grains");
+          {
+            prm.set("Minerals","Olivine: A-fabric, Enstatite");
+          }
+          prm.leave_subsection();
+          //prm.enter_subsection("D-Rex 2004");
+          //{
+          //}
+          //prm.leave_subsection();
         }
         prm.leave_subsection ();
       }
@@ -1366,14 +1390,14 @@ TEST_CASE("CPO elastic tensor")
         prm.enter_subsection("Initial grains");
         {
           prm.set("Model name","Uniform grains and random uniform rotations");
-          prm.enter_subsection("Uniform grains and random uniform rotations");
-          {
-            // Let the minerals just passively rotate with the rotation of
-            // the particle caused by the flow.
-            prm.set("Minerals","Passive,Passive");
-            prm.set("Volume fractions minerals","0.7,0.3");
-          }
-          prm.leave_subsection();
+          prm.set("Minerals","Passive,Passive");
+          //prm.enter_subsection("Uniform grains and random uniform rotations");
+          //{
+          // Let the minerals just passively rotate with the rotation of
+          // the particle caused by the flow.
+          prm.set("Volume fractions minerals","0.7,0.3");
+          //}
+          //prm.leave_subsection();
         }
         prm.leave_subsection();
       }
@@ -2597,12 +2621,15 @@ TEST_CASE("CPO drex++")
         {
           prm.set("Random number seed","1");
           prm.set("Number of grains per particle","10");
-
-          prm.enter_subsection("D-Rex++");
+          prm.enter_subsection("Initial grains");
           {
             prm.set("Minerals","Olivine: A-fabric");
           }
           prm.leave_subsection();
+          //prm.enter_subsection("D-Rex++");
+          //{
+          //}
+          //prm.leave_subsection();
         }
         prm.leave_subsection ();
       }

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -19,6 +19,7 @@
 */
 
 #include "common.h"
+#include <aspect/particle/property/elastic_tensor_decomposition.h>
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/particle/property/cpo_elastic_tensor.h>
 #include <deal.II/base/parameter_handler.h>
@@ -1718,4 +1719,856 @@ TEST_CASE("CPO elastic tensor")
     {
       CHECK(array_plus_100[cpo_data_position + i] == tensor[dealii::SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
     }
+}
+
+
+
+
+TEST_CASE("LPO elastic tensor decomposition")
+{
+  using namespace dealii;
+  using namespace aspect::Particle::Property;
+  {
+    auto elastic_composition_class = ElasticTensorDecomposition<3>();
+
+    // the matrix from Browaeys and Chevrot, 2004, Geophys. J. Int. (doi: 10.1111/j.1365-246X.2004.02415.x)
+    // Note that the computed norms are not in the papers, but are an extra check.
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192;
+    full_elastic_matrix[0][1] = 66;
+    full_elastic_matrix[0][2] = 60;
+    full_elastic_matrix[1][1] = 160;
+    full_elastic_matrix[1][2] = 56;
+    full_elastic_matrix[2][2] = 272;
+    full_elastic_matrix[3][3] = 60;
+    full_elastic_matrix[4][4] = 62;
+    full_elastic_matrix[5][5] = 49;
+
+    SymmetricTensor<2,6> reference_isotropic_matrix;
+    reference_isotropic_matrix[0][0] = 194.7;
+    reference_isotropic_matrix[0][1] = 67.3;
+    reference_isotropic_matrix[0][2] = 67.3;
+    reference_isotropic_matrix[1][1] = 194.7;
+    reference_isotropic_matrix[1][2] = 67.3;
+    reference_isotropic_matrix[2][2] = 194.7;
+    reference_isotropic_matrix[3][3] = 63.7;
+    reference_isotropic_matrix[4][4] = 63.7;
+    reference_isotropic_matrix[5][5] = 63.7;
+
+    SymmetricTensor<2,6> reference_hex_matrix;
+    reference_hex_matrix[0][0] = -21.7;
+    reference_hex_matrix[1][1] = -21.7;
+    reference_hex_matrix[2][2] = 77.3;
+    reference_hex_matrix[1][2] = -9.3;
+    reference_hex_matrix[0][2] = -9.3;
+    reference_hex_matrix[0][1] = 1.7;
+    reference_hex_matrix[3][3] = -2.7;
+    reference_hex_matrix[4][4] = -2.7;
+    reference_hex_matrix[5][5] = -11.7;
+
+    SymmetricTensor<2,6> reference_T_matrix;
+    reference_T_matrix[0][0] = 3;
+    reference_T_matrix[1][1] = 3;
+    reference_T_matrix[0][1] = -3;
+    reference_T_matrix[5][5] = -3;
+
+    SymmetricTensor<2,6> reference_O_matrix;
+    reference_O_matrix[0][0] = 16;
+    reference_O_matrix[1][1] = -16;
+    reference_O_matrix[1][2] = -2;
+    reference_O_matrix[0][2] = 2;
+    reference_O_matrix[3][3] = -1;
+    reference_O_matrix[4][4] = 1;
+
+    const Tensor<1,21> full_elastic_vector = CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(full_elastic_matrix);
+    const Tensor<1,21> reference_isotropic_vector = CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(reference_isotropic_matrix);
+    const Tensor<1,21> reference_hex_vector = CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(reference_hex_matrix);
+    const Tensor<1,21> reference_T_vector = CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(reference_T_matrix);
+    const Tensor<1,21> reference_O_vector = CpoElasticTensor<3>::transform_6x6_matrix_to_21D_vector(reference_O_matrix);
+
+    // this matrix is alreay in the SCCSS, so no rotation needed, only the  projection.
+    CHECK(full_elastic_vector.norm_square() == Approx(198012.0));
+    const Tensor<1,21> mono_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tric_to_mono * full_elastic_vector;
+    const Tensor<1,21> tric_vector = full_elastic_vector-mono_and_higher_vector;
+    for (size_t iii = 0; iii < 21; iii++)
+      {
+        CHECK(std::abs(tric_vector[iii]) < 1e-15);
+      }
+    CHECK(tric_vector.norm_square() == Approx(0.0));
+
+    dealii::Tensor<1,9>  mono_and_higher_vector_croped;
+    mono_and_higher_vector_croped[0] = mono_and_higher_vector[0];
+    mono_and_higher_vector_croped[1] = mono_and_higher_vector[1];
+    mono_and_higher_vector_croped[2] = mono_and_higher_vector[2];
+    mono_and_higher_vector_croped[3] = mono_and_higher_vector[3];
+    mono_and_higher_vector_croped[4] = mono_and_higher_vector[4];
+    mono_and_higher_vector_croped[5] = mono_and_higher_vector[5];
+    mono_and_higher_vector_croped[6] = mono_and_higher_vector[6];
+    mono_and_higher_vector_croped[7] = mono_and_higher_vector[7];
+    mono_and_higher_vector_croped[8] = mono_and_higher_vector[8];
+    const Tensor<1,9> ortho_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_mono_to_ortho*mono_and_higher_vector_croped;
+    const Tensor<1,9> mono_vector = mono_and_higher_vector_croped-ortho_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(std::abs(mono_vector[iii]) < 1e-15);
+      }
+    CHECK(mono_vector.norm_square() == Approx(0.0));
+
+    const Tensor<1,9> tetra_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_ortho_to_tetra*ortho_and_higher_vector;
+    const Tensor<1,9> ortho_vector = ortho_and_higher_vector-tetra_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(ortho_vector[iii] == Approx(reference_O_vector[iii]));
+      }
+    CHECK(ortho_vector.norm_square() == Approx(536.0));
+
+    const Tensor<1,9> hexa_and_higher_vector = ElasticTensorDecomposition<3>::projection_matrix_tetra_to_hexa*tetra_and_higher_vector;
+    const Tensor<1,9> tetra_vector = tetra_and_higher_vector-hexa_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        CHECK(tetra_vector[iii] == Approx(reference_T_vector[iii]));
+      }
+    CHECK(tetra_vector.norm_square() == Approx(72.0));
+
+    const Tensor<1,9> iso_vector = ElasticTensorDecomposition<3>::projection_matrix_hexa_to_iso*hexa_and_higher_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        // something weird is going on with the approx, somehow without a very large
+        // epsilon it thinks for example that "194.6666666667 == Approx( 194.7 )" is false.
+        CHECK(iso_vector[iii] == Approx(reference_isotropic_vector[iii]).epsilon(1e-3));
+      }
+    CHECK(iso_vector.norm_square() == Approx(189529.3333333334));
+
+    const Tensor<1,9> hexa_vector = hexa_and_higher_vector-iso_vector;
+    for (size_t iii = 0; iii < 9; iii++)
+      {
+        // same as above.
+        CHECK(hexa_vector[iii] == Approx(reference_hex_vector[iii]).epsilon(2.5e-2));
+      }
+    CHECK(hexa_vector.norm_square() == Approx(7874.6666666667));
+
+  }
+
+  {
+    // now compute the distribution in a elastic tensor which is not in SCCS.
+    // We will use the result (with the results of the steps in between) from
+    // Cowin and Mehrabadi, 1985, Mech. appl. Math.
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 1769.50;
+    full_elastic_matrix[0][1] = 873.50;
+    full_elastic_matrix[0][2] = 838.22;
+    full_elastic_matrix[0][3] = -17.68;
+    full_elastic_matrix[0][4] = -110.32;
+    full_elastic_matrix[0][5] = 144.92;
+    full_elastic_matrix[1][0] = 873.50;
+    full_elastic_matrix[1][1] = 1846.64;
+    full_elastic_matrix[1][2] = 836.66;
+    full_elastic_matrix[1][3] = -37.60;
+    full_elastic_matrix[1][4] = -32.32;
+    full_elastic_matrix[1][5] = 153.80;
+    full_elastic_matrix[2][0] = 838.22;
+    full_elastic_matrix[2][1] = 836.66;
+    full_elastic_matrix[2][2] = 1603.28;
+    full_elastic_matrix[2][3] = -29.68;
+    full_elastic_matrix[2][4] = -93.52;
+    full_elastic_matrix[2][5] = 22.40;
+    full_elastic_matrix[3][0] = -17.68;
+    full_elastic_matrix[3][1] = -37.60;
+    full_elastic_matrix[3][2] = -29.68;
+    full_elastic_matrix[3][3] = 438.77;
+    full_elastic_matrix[3][4] = 57.68;
+    full_elastic_matrix[3][5] = -50.50;
+    full_elastic_matrix[4][0] = -110.32;
+    full_elastic_matrix[4][1] = -32.32;
+    full_elastic_matrix[4][2] = -93.52;
+    full_elastic_matrix[4][3] = 57.68;
+    full_elastic_matrix[4][4] = 439.79;
+    full_elastic_matrix[4][5] = -34.78;
+    full_elastic_matrix[5][0] = 144.92;
+    full_elastic_matrix[5][1] = 153.80;
+    full_elastic_matrix[5][2] = 22.40;
+    full_elastic_matrix[5][3] = -50.50;
+    full_elastic_matrix[5][4] = -34.78;
+    full_elastic_matrix[5][5] = 501.80;
+    full_elastic_matrix /= 81.;
+
+    SymmetricTensor<2,3> reference_dilatation_matrix;
+    reference_dilatation_matrix[0][0] = 386.80;
+    reference_dilatation_matrix[0][1] = 35.68;
+    reference_dilatation_matrix[0][2] = -26.24;
+    //reference_dilatation_matrix[1][0] = ;
+    reference_dilatation_matrix[1][1] = 395.20;
+    reference_dilatation_matrix[1][2] = -9.44;
+    //reference_dilatation_matrix[2][0] = ;
+    //reference_dilatation_matrix[2][1] = ;
+    reference_dilatation_matrix[2][2] = 364.24;
+    reference_dilatation_matrix /= 9.;
+
+    SymmetricTensor<2,3> reference_voigt_matrix;
+    reference_voigt_matrix[0][0] = 33.47;
+    reference_voigt_matrix[0][1] = 4.4;
+    reference_voigt_matrix[0][2] = -3.14;
+    //reference_voigt_matrix[1][0] = ;
+    reference_voigt_matrix[1][1] = 34.41;
+    reference_voigt_matrix[1][2] = -1.26;
+    //reference_voigt_matrix[2][0] = ;
+    //reference_voigt_matrix[2][1] = ;
+    reference_voigt_matrix[2][2] = 30.64;
+
+    // Q in equation 2.17, but reordered from
+    // largest to smallest eigenvalue.
+    Tensor<2,3> reference_SCCS;
+    reference_SCCS[2][0] = 2./3.;
+    reference_SCCS[2][1] = -1./3.;
+    reference_SCCS[2][2] = 2./3.;
+    reference_SCCS[1][0] = 1./3.;
+    reference_SCCS[1][1] = -2./3.;
+    reference_SCCS[1][2] = -2./3.;
+    reference_SCCS[0][0] = 2./3.;
+    reference_SCCS[0][1] = 2./3.;
+    reference_SCCS[0][2] = -1./3.;
+
+    SymmetricTensor<2,6> reference_rotated_elastic_matrix;
+    reference_rotated_elastic_matrix[0][0] = 18;
+    reference_rotated_elastic_matrix[0][1] = 9.98;
+    reference_rotated_elastic_matrix[0][2] = 10.1;
+    //reference_rotated_elastic_matrix[1][0] = ;
+    reference_rotated_elastic_matrix[1][1] = 20.2;
+    reference_rotated_elastic_matrix[1][2] = 10.07;
+    //reference_rotated_elastic_matrix[2][0] = ;
+    //reference_rotated_elastic_matrix[2][1] = ;
+    reference_rotated_elastic_matrix[2][2] = 27.6;
+    reference_rotated_elastic_matrix[3][3] = 6.23;
+    reference_rotated_elastic_matrix[4][4] = 5.61;
+    reference_rotated_elastic_matrix[5][5] = 4.52;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            CHECK(reference_dilatation_matrix[iii][jjj] == Approx(dilatation_stiffness_tensor_full[iii][jjj]));
+          }
+      }
+
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            CHECK(reference_voigt_matrix[iii][jjj] == Approx(voigt_stiffness_tensor_full[iii][jjj]));
+          }
+      }
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    // chose the permutation which fits the solution given in the paper.
+    // This is not a even permutation.
+    std::array<unsigned short int, 3> perumation = {{2,1,0}};
+    Tensor<2,3> permutated_SCCS;
+    for (size_t j = 0; j < 3; j++)
+      {
+        permutated_SCCS[j] = unpermutated_SCCS[perumation[j]];
+      }
+    SymmetricTensor<2,6> rotated_elastic_matrix = CpoElasticTensor<3>::rotate_6x6_matrix(full_elastic_matrix,permutated_SCCS);
+
+    for (size_t iii = 0; iii < 6; iii++)
+      {
+        for (size_t jjj = 0; jjj < 6; jjj++)
+          {
+            CHECK(reference_rotated_elastic_matrix[iii][jjj] == Approx(rotated_elastic_matrix[iii][jjj]).margin(1e-4).epsilon(7.5e-2));
+          }
+      }
+  }
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 1.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192;
+    full_elastic_matrix[0][1] = 66;
+    full_elastic_matrix[0][2] = 56;
+    full_elastic_matrix[1][1] = 192;
+    full_elastic_matrix[1][2] = 56;
+    full_elastic_matrix[2][2] = 272;
+    full_elastic_matrix[3][3] = 60;
+    full_elastic_matrix[4][4] = 60;
+    full_elastic_matrix[5][5] = 0.5*(full_elastic_matrix[0][0] + full_elastic_matrix[0][1]);
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{12822.0,0,12822.0}}; // orthorhomic depedent on direction (remember, this is basically just one grain)
+    reference_norms[3] = {{1568.0,8712.0,1568.0}}; // tetragonal could be present
+    reference_norms[4] = {{2759.3333333333,8437.3333333333,2759.3333333333}}; // hexagonal is expected
+    reference_norms[5] = {{247182.6666666667,247182.6666666667,247182.6666666667}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{264332.0,264332.0,264332.0}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 0;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 1;
+    reference_unpermutated_SCCS[1][0] = 1;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 2: a more complicated matrix.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 225;
+    full_elastic_matrix[0][1] = 54;
+    full_elastic_matrix[0][2] = 72;
+    full_elastic_matrix[1][1] = 214;
+    full_elastic_matrix[1][2] = 53;
+    full_elastic_matrix[2][2] = 178;
+    full_elastic_matrix[3][3] = 78;
+    full_elastic_matrix[4][4] = 82;
+    full_elastic_matrix[5][5] = 76;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{453.5,1044.0,1113.5}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{91.125,84.5,595.125}}; // tetragonal could be present
+    reference_norms[4] = {{1350.175,766.3,186.175}}; // hexagonal is expected
+    reference_norms[5] = {{222364.2,222364.2,222364.2}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{224259.0,224259.0,224259.0}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 1;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 0;
+    reference_unpermutated_SCCS[2][2] = 1;
+
+    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {0,1,2};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 3: olivine from experiments as used in D-Rex.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 320.71;
+    full_elastic_matrix[0][1] = 69.84;
+    full_elastic_matrix[0][2] = 71.22;
+    full_elastic_matrix[1][1] = 197.25;
+    full_elastic_matrix[1][2] = 74.8;
+    full_elastic_matrix[2][2] = 234.32;
+    full_elastic_matrix[3][3] = 63.77;
+    full_elastic_matrix[4][4] = 77.67;
+    full_elastic_matrix[5][5] = 78.36;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{4181.95385,689.94905,8020.4222}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{1298.2060125,90.3840125,525.5282}}; // tetragonal could be present
+    reference_norms[4] = {{4364.6051908333,9064.4319908333,1298.8146533333}}; // hexagonal is expected
+    reference_norms[5] = {{282871.5975466666,282871.5975466666,282871.5975466666}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{292716.3626,292716.3626,292716.3626}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 1;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 0;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 1;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 1;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 0;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 4: enstatite from experiments as used in D-Rex.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 236.9;
+    full_elastic_matrix[0][1] = 79.6;
+    full_elastic_matrix[0][2] = 63.2;
+    full_elastic_matrix[1][1] = 180.5;
+    full_elastic_matrix[1][2] = 56.8;
+    full_elastic_matrix[2][2] = 230.4;
+    full_elastic_matrix[3][3] = 84.3;
+    full_elastic_matrix[4][4] = 79.4;
+    full_elastic_matrix[5][5] = 80.1;
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{576.245,1514.945,1679.46}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{67.86125,199.00125,483.605}}; // tetragonal could be present
+    reference_norms[4] = {{2076.64175,1006.80175,557.683}}; // hexagonal is expected
+    reference_norms[5] = {{245485.992,245485.992,245485.992}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{248206.74,248206.74,248206.74}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 1;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 0;
+    reference_unpermutated_SCCS[1][0] = 0;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 1;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 1 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {0,1,2};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 0;
+    reference_hexa_permutated_SCCS[1][2] = 1;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 1;
+    reference_hexa_permutated_SCCS[2][2] = 0;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
+
+  {
+    // This is testing some other elastic matrices of which the properties can
+    // be resonaly predicted (for example, mostly hexagonal) and some coverage
+    // testing: Case 4: from http://solidmechanics.org/Text/Chapter3_2/Chapter3_2.php (Be).
+    // This one should have at least in one direction almost all the the anistropy be
+    // hexagonal anisotropy.
+
+    SymmetricTensor<2,6> full_elastic_matrix;
+    full_elastic_matrix[0][0] = 192.3;
+    full_elastic_matrix[0][1] = 26.7;
+    full_elastic_matrix[0][2] = 14;
+    full_elastic_matrix[1][1] = full_elastic_matrix[0][0];
+    full_elastic_matrix[1][2] = full_elastic_matrix[0][2];
+    full_elastic_matrix[2][2] = 336.4;
+    full_elastic_matrix[3][3] = 162.5;
+    full_elastic_matrix[4][4] = full_elastic_matrix[3][3];
+    full_elastic_matrix[5][5] = 0.5*(full_elastic_matrix[0][0] + full_elastic_matrix[0][1]);
+
+    std::array<std::array<double,3>,7 > reference_norms;
+    reference_norms[0] = {{0,0,0}}; // no triclinic
+    reference_norms[1] = {{0,0,0}}; // no monoclinic
+    reference_norms[2] = {{16161.695,0.0,16161.695}}; // orthorhomic depedent on direction
+    reference_norms[3] = {{2786.31125,1425.78,2786.31125}}; // tetragonal could be present
+    reference_norms[4] = {{8079.22575,25601.452,8079.22575}}; // hexagonal is expected
+    reference_norms[5] = {{421517.088,421517.088,421517.088}}; // isotropic should be the same for every permuation
+    reference_norms[6] = {{448544.32,448544.32,448544.32}}; // total should be the same for every direction
+
+    // It is already in a SCCS frame, so they should be
+    // unit vectors. The order is irrelevant.
+    Tensor<2,3> reference_unpermutated_SCCS;
+    reference_unpermutated_SCCS[0][0] = 0;
+    reference_unpermutated_SCCS[0][1] = 0;
+    reference_unpermutated_SCCS[0][2] = 1;
+    reference_unpermutated_SCCS[1][0] = 1;
+    reference_unpermutated_SCCS[1][1] = 0;
+    reference_unpermutated_SCCS[1][2] = 0;
+    reference_unpermutated_SCCS[2][0] = 0;
+    reference_unpermutated_SCCS[2][1] = 1;
+    reference_unpermutated_SCCS[2][2] = 0;
+
+    // Permuation 2 has the heighest norm, so reference_unpermutated_SCCS
+    // is permuated by {1,2,0};
+    Tensor<2,3> reference_hexa_permutated_SCCS;
+    reference_hexa_permutated_SCCS[0][0] = 1;
+    reference_hexa_permutated_SCCS[0][1] = 0;
+    reference_hexa_permutated_SCCS[0][2] = 0;
+    reference_hexa_permutated_SCCS[1][0] = 0;
+    reference_hexa_permutated_SCCS[1][1] = 1;
+    reference_hexa_permutated_SCCS[1][2] = 0;
+    reference_hexa_permutated_SCCS[2][0] = 0;
+    reference_hexa_permutated_SCCS[2][1] = 0;
+    reference_hexa_permutated_SCCS[2][2] = 1;
+
+    const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_dilatation_stiffness_tensor(full_elastic_matrix);
+    const SymmetricTensor<2,3> voigt_stiffness_tensor_full = ElasticTensorDecomposition<3>::compute_voigt_stiffness_tensor(full_elastic_matrix);
+    Tensor<2,3> unpermutated_SCCS = ElasticTensorDecomposition<3>::compute_unpermutated_SCCS(dilatation_stiffness_tensor_full, voigt_stiffness_tensor_full);
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("unpermutated_SCCS[" << iii << "] = " << unpermutated_SCCS[iii][0] << ":" << unpermutated_SCCS[iii][1] << ":" << unpermutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_unpermutated_SCCS[iii][0] == Approx(unpermutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][1] == Approx(unpermutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_unpermutated_SCCS[iii][2] == Approx(unpermutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_unpermutated_SCCS[iii][0] == Approx(-unpermutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][1] == Approx(-unpermutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_unpermutated_SCCS[iii][2] == Approx(-unpermutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+    std::array<std::array<double,3>,7 > norms = ElasticTensorDecomposition<3>::compute_elastic_tensor_SCCS_decompositions(unpermutated_SCCS, full_elastic_matrix);
+    std::array<double,3> totals = {{0,0,0}};
+    for (size_t iii = 0; iii < 7; iii++)
+      {
+        // also check that the total is equal to the full norm.
+
+        for (size_t jjj = 0; jjj < 3; jjj++)
+          {
+            INFO("i:j = " << iii << ":" << jjj );
+            CHECK(reference_norms[iii][jjj] == Approx(norms[iii][jjj]));
+            if (iii < 6)
+              {
+                totals[jjj] += norms[iii][jjj];
+              }
+          }
+      }
+    for (size_t jjj = 0; jjj < 3; jjj++)
+      {
+        INFO("j = " << jjj );
+        CHECK(totals[jjj] == Approx(norms[6][jjj]));
+      }
+
+    // also check that all the isotropic and totals are the same
+    for (size_t iii = 1; iii < 3; iii++)
+      {
+        CHECK(norms[5][0] == Approx(norms[5][iii]));
+        CHECK(norms[6][0] == Approx(norms[6][iii]));
+      }
+
+
+    const size_t max_hexagonal_element_index = std::max_element(norms[4].begin(),norms[4].end())-norms[4].begin();
+    std::array<unsigned short int, 3> perumation = ElasticTensorDecomposition<3>::indexed_even_permutation(max_hexagonal_element_index);
+    Tensor<2,3> hexa_permutated_SCCS;
+    for (size_t index = 0; index < 3; index++)
+      {
+        hexa_permutated_SCCS[index] = unpermutated_SCCS[perumation[index]];
+      }
+    for (size_t iii = 0; iii < 3; iii++)
+      {
+        const double epsilon = 1e-3;
+        INFO("hexa_permutated_SCCS[" << iii << "] = " << hexa_permutated_SCCS[iii][0] << ":" << hexa_permutated_SCCS[iii][1] << ":" << hexa_permutated_SCCS[iii][2]);
+        // The direction of the eigenvectors is not important, but they do need to be consistent
+        CHECK((reference_hexa_permutated_SCCS[iii][0] == Approx(hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][1] == Approx(hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+               && reference_hexa_permutated_SCCS[iii][2] == Approx(hexa_permutated_SCCS[iii][2]).epsilon(epsilon)
+               || (reference_hexa_permutated_SCCS[iii][0] == Approx(-hexa_permutated_SCCS[iii][0]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][1] == Approx(-hexa_permutated_SCCS[iii][1]).epsilon(epsilon)
+                   && reference_hexa_permutated_SCCS[iii][2] == Approx(-hexa_permutated_SCCS[iii][2]).epsilon(epsilon))));
+      }
+  }
 }


### PR DESCRIPTION
This pull request is to bring up merging D-Rex ++, an algorithm for simulating the microstructural evolution of deforming olivine aggregates. This plugin serves as an improvement over the existing LPO particle property plugin. While the code is still a work in progress, the structure of the plugin is ready to be tested and would appreciate it if others could have a look at it and let me if they run into more bugs than what is expected. Was not sure where to place the input file so added it as an attachment in .txt format.

Note: The model needs to be run under dry conditions, by setting the water amount to zero. This is because the variable introduced in parts of the code are derived from experiments carried out in dry conditions. 

Known issues : 

-  When the number of grains is low, an error is thrown up as the number of grains recrystalized is more than the number of grains initiated. 


### Before your first pull request:

* [X ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [ X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

[drexpp.txt](https://github.com/geodynamics/aspect/files/12009364/drexpp.txt)
