### PR TITLE
Remove todo to assert that viscosity has been requested and computed

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -279,8 +279,7 @@ namespace aspect
 
           // Fill plastic outputs if they exist.
           // The values in isostrain_viscosities only make sense when the calculate_isostrain_viscosities function
-          // has been called. TODO check here for in.requests_property(MaterialProperties::viscosity) or
-          // in fill_plastic_outputs as is done now?
+          // has been called.
           // TODO do we even need a separate function? We could compute the PlasticAdditionalOutputs here like
           // the ElasticAdditionalOutputs.
           rheology->fill_plastic_outputs(i, volume_fractions, plastic_yielding, in, out, isostrain_viscosities);


### PR DESCRIPTION
Since #5247, using out.viscosity when it is not set will trigger a signalling NaN. So this TODO that says to check whether the viscosity was requested (and therefore computed) for filling the force and reaction terms outputs by the elastic rheology (lines 305-309) is no longer necessary. Or would we want to AssertThrow it anyway?
