### PR TITLE
Always provide strain rate to material model

### DIFF
--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -387,7 +387,7 @@ namespace aspect
     for (; cell != endc; ++cell)
       {
         fe_values.reinit (cell);
-        in.reinit(fe_values,cell,this->introspection(),this->get_solution(),true);
+        in.reinit(fe_values,cell,this->introspection(),this->get_solution());
 
         this->get_material_model().evaluate(in, out);
 

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -697,7 +697,7 @@ namespace aspect
                   {
                     fe_face_values.reinit (cell, f);
 
-                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), /*compute_strain_rates = */ false);
+                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution());
 
                     fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
                         temperature_gradients);

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -104,8 +104,7 @@ namespace aspect
               scratch.face_material_model_inputs.reinit  (scratch.face_finite_element_values,
                                                           cell,
                                                           this->introspection(),
-                                                          this->get_solution(),
-                                                          false);
+                                                          this->get_solution());
               scratch.face_material_model_inputs.requested_properties = MaterialModel::MaterialProperties::density;
 
               this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -57,7 +57,7 @@ namespace aspect
             bool clear_coarsen = false;
 
             fe_values.reinit(cell);
-            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), true);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
             MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();

--- a/source/mesh_refinement/density.cc
+++ b/source/mesh_refinement/density.cc
@@ -70,7 +70,7 @@ namespace aspect
           {
             fe_values.reinit(cell);
             // Set use_strain_rates to false since we don't need viscosity
-            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
             this->get_material_model().evaluate(in, out);
 

--- a/source/mesh_refinement/isosurfaces.cc
+++ b/source/mesh_refinement/isosurfaces.cc
@@ -181,7 +181,7 @@ namespace aspect
               bool clear_coarsen = false;
 
               fe_values.reinit(cell);
-              in.reinit(fe_values, cell, this->introspection(), this->get_solution(), true);
+              in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
               for (unsigned int i_quad=0; i_quad<quadrature.size(); ++i_quad)
                 {

--- a/source/mesh_refinement/thermal_energy_density.cc
+++ b/source/mesh_refinement/thermal_energy_density.cc
@@ -69,7 +69,7 @@ namespace aspect
           {
             fe_values.reinit(cell);
             // Set use_strain_rates to false since we don't need viscosity
-            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
             cell->get_dof_indices (local_dof_indices);

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -131,7 +131,7 @@ namespace aspect
                   {
                     fe_values.reinit (cell);
                     // Set use_strain_rates to false since we don't need viscosity.
-                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
                     this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/gravity_point_values.cc
+++ b/source/postprocess/gravity_point_values.cc
@@ -261,7 +261,7 @@ namespace aspect
             // Evaluate the solution at the quadrature points of this cell
             fe_values.reinit (cell);
 
-            in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+            in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
             // Pull some computations that are independent of the

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -130,7 +130,7 @@ namespace aspect
           if (cell->is_locally_owned() && cell->at_boundary())
             {
               fe_volume_values.reinit (cell);
-              in.reinit(fe_volume_values, cell, simulator_access.introspection(), simulator_access.get_solution(), true);
+              in.reinit(fe_volume_values, cell, simulator_access.introspection(), simulator_access.get_solution());
               simulator_access.get_material_model().evaluate(in, out);
 
               if (simulator_access.get_parameters().formulation_temperature_equation ==
@@ -251,7 +251,7 @@ namespace aspect
                   // Compute heat flux through Neumann boundary by integrating the heat flux
                   else if (fixed_heat_flux_boundaries.find(boundary_id) != fixed_heat_flux_boundaries.end())
                     {
-                      face_in.reinit(fe_face_values, cell, simulator_access.introspection(), simulator_access.get_solution(), true);
+                      face_in.reinit(fe_face_values, cell, simulator_access.introspection(), simulator_access.get_solution());
                       simulator_access.get_material_model().evaluate(face_in, face_out);
 
                       if (simulator_access.get_parameters().formulation_temperature_equation ==
@@ -402,7 +402,7 @@ namespace aspect
                     // if necessary, compute material properties for this face
                     if (prescribed_heat_flux || non_tangential_velocity)
                       {
-                        face_in.reinit(fe_face_values, cell, simulator_access.introspection(), simulator_access.get_solution(), true);
+                        face_in.reinit(fe_face_values, cell, simulator_access.introspection(), simulator_access.get_solution());
                         simulator_access.get_material_model().evaluate(face_in, face_out);
 
                         if (simulator_access.get_parameters().formulation_temperature_equation ==

--- a/source/postprocess/mass_flux_statistics.cc
+++ b/source/postprocess/mass_flux_statistics.cc
@@ -75,7 +75,7 @@ namespace aspect
               {
                 fe_face_values.reinit (cell, f);
                 // Set use_strain_rates to false since we don't need viscosity
-                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution(), false);
+                in.reinit(fe_face_values, cell, this->introspection(), this->get_solution());
 
                 this->get_material_model().evaluate(in, out);
 

--- a/source/postprocess/visualization/ISA_rotation_timescale.cc
+++ b/source/postprocess/visualization/ISA_rotation_timescale.cc
@@ -69,7 +69,7 @@ namespace aspect
               // Fill the material model objects for the cell (for strain rate)
               fe_values.reinit(cell);
               in.reinit(fe_values, cell, this->introspection(),
-                        this->get_solution(), true);
+                        this->get_solution());
 
               // Calculate eigenvalues of strain rate and take maximum (absolute value)
               // to get tauISA, the timescale for grain rotation toward the infinite strain axis

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -69,7 +69,7 @@ namespace aspect
               // Fill the material model objects for the cell (for strain rate)
               fe_values.reinit(cell);
               in.reinit(fe_values, cell, this->introspection(),
-                        this->get_solution(), true);
+                        this->get_solution());
               // Also get velocity gradients
               std::vector<Tensor<2, dim>> velocity_gradient(n_q_points,
                                                              Tensor<2, dim>());

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -121,7 +121,7 @@ namespace aspect
 
         // Set use_strain_rates to true since the compaction viscosity might also depend on the strain rate.
         MaterialModel::MaterialModelInputs<dim> in(input_data,
-                                                   this->introspection(), true);
+                                                   this->introspection());
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points, this->n_compositional_fields());
         MeltHandler<dim>::create_material_model_outputs(out);
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -85,7 +85,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
                     out.additional_outputs.push_back(
                       std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
@@ -144,7 +144,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    in.reinit (fe_values, cell, this->introspection(), this->get_solution(), /* compute_strain_rate = */ false);
+                    in.reinit (fe_values, cell, this->introspection(), this->get_solution());
 
                     out.additional_outputs.push_back(
                       std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
@@ -229,7 +229,7 @@ namespace aspect
                     // Get the pressure, temperature and composition in the cell
                     fe_values.reinit (cell);
 
-                    in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+                    in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
                     out.additional_outputs.push_back(
                       std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>>(n_q_points));

--- a/source/postprocess/visualization/stress_second_invariant.cc
+++ b/source/postprocess/visualization/stress_second_invariant.cc
@@ -56,8 +56,7 @@ namespace aspect
         // Create the material model inputs and outputs to
         // retrieve the current viscosity.
         MaterialModel::MaterialModelInputs<dim> in(input_data,
-                                                   this->introspection(),
-                                                   /*compute_strain_rate = */ true);
+                                                   this->introspection());
 
         in.requested_properties = MaterialModel::MaterialProperties::viscosity;
 

--- a/source/postprocess/visualization/vertical_heat_flux.cc
+++ b/source/postprocess/visualization/vertical_heat_flux.cc
@@ -60,8 +60,7 @@ namespace aspect
 
 
         MaterialModel::MaterialModelInputs<dim> in(input_data,
-                                                   this->introspection(),
-                                                   false);
+                                                   this->introspection());
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
         in.requested_properties = MaterialModel::MaterialProperties::density |

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -927,8 +927,7 @@ namespace aspect
               scratch.neighbor_face_material_model_inputs.reinit  (*scratch.neighbor_face_finite_element_values,
                                                                    neighbor,
                                                                    this->introspection(),
-                                                                   this->get_current_linearization_point(),
-                                                                   true);
+                                                                   this->get_current_linearization_point());
               this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
                                                   scratch.neighbor_face_material_model_outputs);
 
@@ -1259,8 +1258,7 @@ namespace aspect
               scratch.face_material_model_inputs.reinit  (*scratch.subface_finite_element_values,
                                                           cell,
                                                           this->introspection(),
-                                                          this->get_current_linearization_point(),
-                                                          true);
+                                                          this->get_current_linearization_point());
               this->get_material_model().evaluate(scratch.face_material_model_inputs,
                                                   scratch.face_material_model_outputs);
 
@@ -1283,8 +1281,7 @@ namespace aspect
               scratch.neighbor_face_material_model_inputs.reinit  (*scratch.neighbor_face_finite_element_values,
                                                                    neighbor_child,
                                                                    this->introspection(),
-                                                                   this->get_current_linearization_point(),
-                                                                   true);
+                                                                   this->get_current_linearization_point());
               this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
                                                   scratch.neighbor_face_material_model_outputs);
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -298,8 +298,7 @@ namespace aspect
     scratch.material_model_inputs.reinit  (scratch.finite_element_values,
                                            cell,
                                            this->introspection,
-                                           current_linearization_point,
-                                           true);
+                                           current_linearization_point);
 
     for (unsigned int i=0; i<assemblers->stokes_preconditioner.size(); ++i)
       assemblers->stokes_preconditioner[i]->create_additional_material_model_outputs(scratch.material_model_outputs);
@@ -541,8 +540,7 @@ namespace aspect
     scratch.material_model_inputs.reinit  (scratch.finite_element_values,
                                            cell,
                                            this->introspection,
-                                           current_linearization_point,
-                                           need_viscosity);
+                                           current_linearization_point);
     scratch.material_model_inputs.requested_properties
       =
         MaterialModel::MaterialProperties::equation_of_state_properties |
@@ -603,11 +601,16 @@ namespace aspect
                   scratch.face_material_model_inputs.reinit  (scratch.face_finite_element_values,
                                                               cell,
                                                               this->introspection,
-                                                              current_linearization_point,
-                                                              need_viscosity);
+                                                              current_linearization_point);
 
                   for (unsigned int i=0; i<assemblers->stokes_system_on_boundary_face.size(); ++i)
                     assemblers->stokes_system_on_boundary_face[i]->create_additional_material_model_outputs(scratch.face_material_model_outputs);
+
+                  scratch.face_material_model_inputs.requested_properties
+                    = (MaterialModel::MaterialProperties::equation_of_state_properties |
+                       MaterialModel::MaterialProperties::additional_outputs |
+                       (need_viscosity ? MaterialModel::MaterialProperties::viscosity : MaterialModel::MaterialProperties::uninitialized));
+
 
                   material_model->evaluate(scratch.face_material_model_inputs,
                                            scratch.face_material_model_outputs);
@@ -889,8 +892,7 @@ namespace aspect
     scratch.material_model_inputs.reinit  (scratch.finite_element_values,
                                            cell,
                                            this->introspection,
-                                           current_linearization_point,
-                                           true);
+                                           current_linearization_point);
 
     for (unsigned int i=0; i<1+introspection.n_compositional_fields; ++i)
       for (unsigned int j=0; j<assemblers->advection_system[i].size(); ++j)
@@ -1004,8 +1006,7 @@ namespace aspect
                 scratch.face_material_model_inputs.reinit  (*scratch.face_finite_element_values,
                                                             cell,
                                                             this->introspection,
-                                                            current_linearization_point,
-                                                            true);
+                                                            current_linearization_point);
 
                 for (unsigned int i=0; i<assemblers->advection_system_on_boundary_face[advection_field.field_index()].size(); ++i)
                   assemblers->advection_system_on_boundary_face[advection_field.field_index()][i]->create_additional_material_model_outputs(scratch.face_material_model_outputs);

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1297,8 +1297,7 @@ namespace aspect
             in.reinit(fe_values,
                       cell,
                       this->introspection(),
-                      solution,
-                      false);
+                      solution);
 
             this->get_material_model().evaluate(in, out);
 
@@ -1508,8 +1507,7 @@ namespace aspect
             material_model_inputs.reinit(finite_element_values,
                                          cell,
                                          this->introspection(),
-                                         this->get_current_linearization_point(),
-                                         false);
+                                         this->get_current_linearization_point());
             // We only need access to the MeltOutputs in p_c_scale().
             material_model_inputs.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
 
@@ -1865,8 +1863,7 @@ namespace aspect
             scratch.face_material_model_inputs.reinit  (scratch.face_finite_element_values,
                                                         cell,
                                                         this->introspection(),
-                                                        this->get_solution(),
-                                                        true);
+                                                        this->get_solution());
 
             this->get_material_model().evaluate(scratch.face_material_model_inputs, scratch.face_material_model_outputs);
 

--- a/source/simulator/nullspace.cc
+++ b/source/simulator/nullspace.cc
@@ -424,7 +424,7 @@ namespace aspect
           if (use_constant_density == false)
             {
               // Set use_strain_rates to false since we don't need viscosity
-              in.reinit(fe, cell, introspection, solution, false);
+              in.reinit(fe, cell, introspection, solution);
               material_model->evaluate(in, out);
             }
           else

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1390,8 +1390,7 @@ namespace aspect
                                                                                 &(sim.dof_handler));
 
                   fe_values.reinit(simulator_cell);
-                  in.reinit(fe_values, simulator_cell, sim.introspection, sim.current_linearization_point,
-                            true /* = compute_strain_rate */);
+                  in.reinit(fe_values, simulator_cell, sim.introspection, sim.current_linearization_point);
 
                   sim.material_model->fill_additional_material_model_inputs(in, sim.current_linearization_point, fe_values, sim.introspection);
                   sim.material_model->evaluate(in, out);
@@ -1526,8 +1525,7 @@ namespace aspect
                   face_material_inputs.reinit  (fe_face_values,
                                                 simulator_cell,
                                                 sim.introspection,
-                                                sim.solution,
-                                                false);
+                                                sim.solution);
                   face_material_inputs.requested_properties = MaterialModel::MaterialProperties::density;
                   sim.material_model->evaluate(face_material_inputs, face_material_outputs);
 

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -129,7 +129,7 @@ namespace aspect
             {
               fe_values.reinit(cell);
               // Set use_strain_rates to false since we don't need viscosity
-              in.reinit(fe_values, cell, this->introspection(), this->get_solution(), false);
+              in.reinit(fe_values, cell, this->introspection(), this->get_solution());
 
               this->get_material_model().evaluate(in, out);
 

--- a/tests/prescribed_temperature_in_field.cc
+++ b/tests/prescribed_temperature_in_field.cc
@@ -112,7 +112,7 @@ namespace aspect
           if (! cell->is_artificial())
             {
               fe_values.reinit (cell);
-              in.reinit(fe_values, cell, simulator_access.introspection(), simulator_access.get_solution(), false);
+              in.reinit(fe_values, cell, simulator_access.introspection(), simulator_access.get_solution());
 
               std::vector<types::global_dof_index> local_dof_indices(simulator_access.get_fe().dofs_per_cell);
               cell->get_dof_indices (local_dof_indices);


### PR DESCRIPTION
I ran into more problems in #5239 because the strain rate is not always provided to material models if `additional_outputs` are requested but not `viscosity`. With the advent of material models that may use the strain rate even if no viscosity is requested I think our system of guessing whether we need to compute the strain rate finally breaks down. I would suggest we just always compute the strain rate. It is slightly more expensive, but there is no way for the calling side to figure out which inputs are required by a material model and the current system is very fragile.