### PR TITLE
Follow-up: Do not leave NaN values in output vectors.

### DIFF
--- a/source/postprocess/visualization/artificial_viscosity_composition.cc
+++ b/source/postprocess/visualization/artificial_viscosity_composition.cc
@@ -47,6 +47,19 @@ namespace aspect
         return_value ("artificial_viscosity_composition",
                       new Vector<float>(this->get_triangulation().n_active_cells()));
         this->get_artificial_viscosity_composition(*return_value.second, compositional_field);
+
+        // The function we call above sets the artificial viscosity to
+        // signaling_nan on all artificial cells and, possibly, ghost cells.
+        // This runs into trouble in DataOut that wants to copy this vector
+        // from Vector<float> to Vector<double>, and the conversion trips
+        // up over the NaNs, causing a floating point exception.
+        //
+        // To avoid this, strip out the NaNs and instead set these values
+        // to zero -- we won't be outputting these values anyway.
+        for (const auto &cell : this->get_triangulation().active_cell_iterators())
+          if (cell->is_locally_owned() == false)
+            (*return_value.second)[cell->active_cell_index()] = 0;
+
         return return_value;
       }
 

--- a/tests/composition_active_nans.prm
+++ b/tests/composition_active_nans.prm
@@ -12,6 +12,10 @@ set End time                               = 0.1
 
 subsection Postprocess
   subsection Visualization
-    set List of output variables = density, artificial viscosity
+    set List of output variables = density, artificial viscosity, artificial viscosity composition
+
+    subsection Artificial viscosity composition
+      set Name of compositional field = C_1
+    end
   end
 end


### PR DESCRIPTION
Follow-up on #5253. This PR does the same for the artificial viscosity composition postprocessor. We can reuse the same test. 

This addresses #5238. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).