### PR TITLE
Replace manual contributing conent with CONTRIBUTING.md.

### DIFF
--- a/doc/sphinx/user/extending/contributing.md
+++ b/doc/sphinx/user/extending/contributing.md
@@ -1,31 +1,4 @@
 (sec:extending:contributing)=
-# How to contribute
 
-To end this section, let us repeat something already stated in the
-introduction:
-
-:::{important}
-ASPECT is a community project. As such, we strongly encourage contributions from
-the community to improve this code over time. Obvious candidates for such contributions are
-implementations of new plugins as discussed in {ref}`sec:extending:plugin-types` since they are typically self-contained
-and do not require much knowledge of the details of the remaining code. Other much appreciated
-contributions are new test models or benchmarks, extended documentation (every paragraph
-helps), and in particular fixing typos or updating outdated documentation. Obviously, however,
-we also encourage contributions to the core functionality in any form!
-:::
-
-Let us assume you found something in ASPECT to
-improve, something you did not understand, or something that is simply wrong.
-Do something about it! No matter whether you are a C++ expert or first-time
-user, there are no such things as too-unimportant contributions, and if you
-struggled with something, it is most likely somebody else will as well. The
-process of contributing to a new project can be daunting, but we appreciate
-every contribution and are happy to work with you on improving
-ASPECT. To get you started we have collected a set of
-guidelines and advice on how to get involved in the community. To avoid
-duplication we store these guidelines in a separate file `CONTRIBUTING.md`
-in the main folder of the repository, and you can also access them online at
-<https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md>. Even if
-something in that file is not clear, this is an opportunity for you to ask
-your question on the forum (see {ref}`cha:answers`), and let us know that file
-needs improvement.
+```{include} ../../../../CONTRIBUTING.md
+```


### PR DESCRIPTION
This unifies the content between the CONTRIBUTING.md file and the contributing section in the manual. Next step is to add some info on how to manually install astyle.