### PR TITLE
Fix macos constexpr tensor utilities

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3281,9 +3281,9 @@ namespace aspect
           input[0][0],           // 0  // 1
           input[1][1],           // 1  // 2
           input[2][2],           // 2  // 3
-          sqrt(2)*input[1][2],   // 3  // 4
-          sqrt(2)*input[0][2],   // 4  // 5
-          sqrt(2)*input[0][1],   // 5  // 6
+          numbers::SQRT2 *input[1][2],  // 3  // 4
+          numbers::SQRT2 *input[0][2],  // 4  // 5
+          numbers::SQRT2 *input[0][1],  // 5  // 6
           2*input[3][3],         // 6  // 7
           2*input[4][4],         // 7  // 8
           2*input[5][5],         // 8  // 9
@@ -3296,9 +3296,9 @@ namespace aspect
           2*input[1][3],         // 15 // 16
           2*input[2][4],         // 16 // 17
           2*input[0][5],         // 17 // 18
-          2*sqrt(2)*input[4][5], // 18 // 19
-          2*sqrt(2)*input[3][5], // 19 // 20
-          2*sqrt(2)*input[3][4]  // 20 // 21
+          2*numbers::SQRT2 *input[4][5], // 18 // 19
+          2*numbers::SQRT2 *input[3][5], // 19 // 20
+          2*numbers::SQRT2 *input[3][4] // 20 // 21
         });
 
       }
@@ -3310,7 +3310,7 @@ namespace aspect
       {
         SymmetricTensor<2,6> result;
 
-        constexpr double sqrt_2_inv = 1/sqrt(2);
+        const double sqrt_2_inv = 1/numbers::SQRT2;
 
         result[0][0] = input[0];
         result[1][1] = input[1];
@@ -3348,9 +3348,9 @@ namespace aspect
           input_tensor[0][0][0][0],           // 0  // 1
           input_tensor[1][1][1][1],           // 1  // 2
           input_tensor[2][2][2][2],           // 2  // 3
-          sqrt(2)*0.5*(input_tensor[1][1][2][2] + input_tensor[2][2][1][1]),   // 3  // 4
-          sqrt(2)*0.5*(input_tensor[0][0][2][2] + input_tensor[2][2][0][0]),   // 4  // 5
-          sqrt(2)*0.5*(input_tensor[0][0][1][1] + input_tensor[1][1][0][0]),   // 5  // 6
+          numbers::SQRT2*0.5*(input_tensor[1][1][2][2] + input_tensor[2][2][1][1]),   // 3  // 4
+          numbers::SQRT2*0.5*(input_tensor[0][0][2][2] + input_tensor[2][2][0][0]),   // 4  // 5
+          numbers::SQRT2*0.5*(input_tensor[0][0][1][1] + input_tensor[1][1][0][0]),   // 5  // 6
           0.5*(input_tensor[1][2][1][2]+input_tensor[1][2][2][1]+input_tensor[2][1][1][2]+input_tensor[2][1][2][1]),         // 6  // 7
           0.5*(input_tensor[0][2][0][2]+input_tensor[0][2][2][0]+input_tensor[2][0][0][2]+input_tensor[2][0][2][0]),         // 7  // 8
           0.5*(input_tensor[1][0][1][0]+input_tensor[1][0][0][1]+input_tensor[0][1][1][0]+input_tensor[0][1][0][1]),         // 8  // 9
@@ -3363,9 +3363,9 @@ namespace aspect
           0.5*(input_tensor[1][1][1][2]+input_tensor[1][1][2][1]+input_tensor[1][2][1][1]+input_tensor[2][1][1][1]),         // 15 // 16
           0.5*(input_tensor[2][2][0][2]+input_tensor[2][2][2][0]+input_tensor[0][2][2][2]+input_tensor[2][0][2][2]),         // 16 // 17
           0.5*(input_tensor[0][0][0][1]+input_tensor[0][0][1][0]+input_tensor[0][1][0][0]+input_tensor[1][0][0][0]),         // 17 // 18
-          sqrt(2)*0.25*(input_tensor[0][2][0][1]+input_tensor[0][2][1][0]+input_tensor[2][0][0][1]+input_tensor[2][0][1][0]+input_tensor[0][1][0][2]+input_tensor[0][1][2][0]+input_tensor[1][0][0][2]+input_tensor[1][0][2][0]), // 18 // 19
-          sqrt(2)*0.25*(input_tensor[1][2][0][1]+input_tensor[1][2][1][0]+input_tensor[2][1][0][1]+input_tensor[2][1][1][0]+input_tensor[0][1][1][2]+input_tensor[0][1][2][1]+input_tensor[1][0][1][2]+input_tensor[1][0][2][1]), // 19 // 20
-          sqrt(2)*0.25*(input_tensor[1][2][0][2]+input_tensor[1][2][2][0]+input_tensor[2][1][0][2]+input_tensor[2][1][2][0]+input_tensor[0][2][1][2]+input_tensor[0][2][2][1]+input_tensor[2][0][1][2]+input_tensor[2][0][2][1])  // 20 // 21
+          numbers::SQRT2*0.25*(input_tensor[0][2][0][1]+input_tensor[0][2][1][0]+input_tensor[2][0][0][1]+input_tensor[2][0][1][0]+input_tensor[0][1][0][2]+input_tensor[0][1][2][0]+input_tensor[1][0][0][2]+input_tensor[1][0][2][0]), // 18 // 19
+          numbers::SQRT2*0.25*(input_tensor[1][2][0][1]+input_tensor[1][2][1][0]+input_tensor[2][1][0][1]+input_tensor[2][1][1][0]+input_tensor[0][1][1][2]+input_tensor[0][1][2][1]+input_tensor[1][0][1][2]+input_tensor[1][0][2][1]), // 19 // 20
+          numbers::SQRT2*0.25*(input_tensor[1][2][0][2]+input_tensor[1][2][2][0]+input_tensor[2][1][0][2]+input_tensor[2][1][2][0]+input_tensor[0][2][1][2]+input_tensor[0][2][2][1]+input_tensor[2][0][1][2]+input_tensor[2][0][2][1])  // 20 // 21
         });
 
       }


### PR DESCRIPTION
This fixes an issue reported by @anne-glerum. On mac the compiler seems not to be able to make sqrt(2) into a constexpr. So this pull request just makes it into a const. It also changes sqrt(2) it into a deal.ii number as suggested by @gassmoeller  in #4987. Maybe that constexpr would be possible with that again, but I think fixing it quickly should have priority now. We can test that out later.