### PR TITLE
Address a clang compiler problem.

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1277,31 +1277,16 @@ namespace aspect
       to_voigt_stiffness_vector(const SymmetricTensor<4,3> &input);
 
 
-      namespace internal
-      {
-        constexpr Tensor<3,3> create_levi_civita_tensor_3d()
-        {
-          Tensor<3,3> permutation_operator_3d;
-          permutation_operator_3d[0][1][2]  = 1;
-          permutation_operator_3d[1][2][0]  = 1;
-          permutation_operator_3d[2][0][1]  = 1;
-          permutation_operator_3d[0][2][1]  = -1;
-          permutation_operator_3d[1][0][2]  = -1;
-          permutation_operator_3d[2][1][0]  = -1;
-          return permutation_operator_3d;
-        }
-      }
-
       /**
-       * The Levi-Civita tensor, also called a permutation or "totally antisymmetric" tensor.
+       * Return the Levi-Civita tensor, also called a permutation or "totally antisymmetric" tensor.
        * See https://en.wikipedia.org/wiki/Levi-Civita_symbol for a definition.
-       * See https://en.wikipedia.org/wiki/Levi-Civita_symbol for more info.
        */
-      template<int dim>
-      constexpr Tensor<dim,dim> levi_civita;
+      template <int dim>
+      const Tensor<dim,dim> &levi_civita();
 
-      template <> constexpr Tensor<3,3> levi_civita<3> = internal::create_levi_civita_tensor_3d();
-
+      // Declare the existence of a specialization:
+      template <>
+      const Tensor<3,3> &levi_civita<3>();
     }
 
   }

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -780,7 +780,7 @@ namespace aspect
             const double volume_fraction_grain = get_volume_fractions_grains(cpo_index,data,mineral_i,grain_i);
             if (volume_fraction_grain >= threshold_GBS/n_grains)
               {
-                deriv_a_cosine_matrices[grain_i] = Utilities::Tensors::levi_civita<3> *w  * nondimensionalization_value;
+                deriv_a_cosine_matrices[grain_i] = Utilities::Tensors::levi_civita<3>() * w * nondimensionalization_value;
 
                 // volume averaged strain energy
                 mean_strain_energy += volume_fraction_grain * strain_energy[grain_i];

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3369,6 +3369,27 @@ namespace aspect
         });
 
       }
+
+
+      template <>
+      const Tensor<3,3> &levi_civita<3>()
+      {
+        static const Tensor<3,3> t =
+          []()
+        {
+          Tensor<3,3> permutation_operator_3d;
+
+          permutation_operator_3d[0][1][2]  = 1;
+          permutation_operator_3d[1][2][0]  = 1;
+          permutation_operator_3d[2][0][1]  = 1;
+          permutation_operator_3d[0][2][1]  = -1;
+          permutation_operator_3d[1][0][2]  = -1;
+          permutation_operator_3d[2][1][0]  = -1;
+          return permutation_operator_3d;
+        }();
+
+        return t;
+      }
     }
 
 

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -581,34 +581,34 @@ TEST_CASE("CPO elastic tensor transform functions")
    */
   {
 
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][0][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][0][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][0][2] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][1][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][1][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][1][2] == Approx(1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][2][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][2][1] == Approx(-1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[0][2][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][0][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][0][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][0][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][1][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][1][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][1][2] == Approx(1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][2][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][2][1] == Approx(-1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[0][2][2] == Approx(0.0));
 
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][0][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][0][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][0][2] == Approx(-1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][1][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][1][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][1][2] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][2][0] == Approx(1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][2][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[1][2][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][0][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][0][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][0][2] == Approx(-1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][1][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][1][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][1][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][2][0] == Approx(1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][2][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[1][2][2] == Approx(0.0));
 
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][0][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][0][1] == Approx(1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][0][2] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][1][0] == Approx(-1.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][1][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][1][2] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][2][0] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][2][1] == Approx(0.0));
-    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>[2][2][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][0][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][0][1] == Approx(1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][0][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][1][0] == Approx(-1.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][1][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][1][2] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][2][0] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][2][1] == Approx(0.0));
+    REQUIRE(aspect::Utilities::Tensors::levi_civita<3>()[2][2][2] == Approx(0.0));
   }
 }


### PR DESCRIPTION
On @danieldouglas92 's laptop, the Levi-Civita variable introduced by @MFraters yesterday in #5318 leads to a linker error: It complains that there are duplicate copies of the variable in every object file. That's a compiler error: `constexpr` implies `const`, and `const` variables at namespace scope are automatically `static`, i.e. every `.cc` file that `#include`s the header file has its own copy with internal linkage. Apparently, clang does not know that rule.

As verified by @danieldouglas92, the problem can be worked around by explicitly marking the variable as `static`.