### PR TITLE
Resized the rotation matrix vector in the weighted outputs for the CPO postprocessor

### DIFF
--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -389,11 +389,14 @@ namespace aspect
               std::vector<std::vector<std::array<double,3>>> weighted_euler_angles;
 
               weighted_euler_angles.resize(n_minerals);
+              weighted_rotation_matrices.resize(n_minerals);
               std::vector<std::vector<double>> volume_fractions_grains(n_minerals,std::vector<double>(n_grains,-1.));
               for (unsigned int mineral = 0; mineral < n_minerals; ++mineral)
                 {
                   for (unsigned int i_grain = 0; i_grain < n_grains; ++i_grain)
                     {
+                      weighted_euler_angles[mineral].resize(n_grains);
+                      weighted_rotation_matrices[mineral].resize(n_grains);
                       volume_fractions_grains[mineral][i_grain] = cpo_particle_property.get_volume_fractions_grains(
                                                                     cpo_data_position,
                                                                     properties,


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

Resized the rotation matrix vector while generating weighted outputs in Crystal preferred orientation postprocessor. Before the fix if the option of generating a weighted CPO was chosen in the input file, a segmentation fault was thrown. This PR looks to fix that

### For all pull requests:

* [X ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ X] I have tested my new feature locally to ensure it is correct.

