### PR TITLE
Optimize strain dependent rheology

### DIFF
--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -219,11 +219,13 @@ namespace aspect
           double strain_healing_temperature_dependent_prefactor;
 
           /**
-           * We cache the evaluator that is necessary to evaluate the velocity
-           * gradients. By caching the evaluator, we can avoid recreating it
+           * We cache the evaluators that are necessary to evaluate the velocity
+           * gradients and compositions.
+           * By caching the evaluator, we can avoid recreating them
            * every time we need it.
            */
           mutable std::unique_ptr<FEPointEvaluation<dim, dim>> evaluator;
+          mutable std::vector<std::unique_ptr<FEPointEvaluation<1, dim>>> composition_evaluators;
       };
     }
   }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -559,14 +559,20 @@ namespace aspect
             // from the old timesteps.
             // Prepare the field function and extract the old solution values at the current cell.
             std::vector<Point<dim>> quadrature_positions(1,this->get_mapping().transform_real_to_unit_cell(in.current_cell, in.position[i]));
+
+            // Use a boost::small_vector to avoid memory allocation if possible.
+            // Create 100 values by default, which should be enough for most cases.
+            // If there are more than 100 DoFs per cell, this will work like a normal vector.
             boost::container::small_vector<double, 100> old_solution_values(this->get_fe().dofs_per_cell);
             in.current_cell->get_dof_values(this->get_old_solution(),
                                             old_solution_values.begin(),
                                             old_solution_values.end());
 
+            // If we have not been here before, create one evaluator for each compositional field
             if (composition_evaluators.size() == 0)
               composition_evaluators.resize(this->n_compositional_fields());
 
+            // Make sure the evaluators have been initialized correctly, and have not been tampered with
             Assert(composition_evaluators.size() == this->n_compositional_fields(),
                    ExcMessage("The number of composition evaluators should be equal to the number of compositional fields."));
 


### PR DESCRIPTION
This is an optimization of #4336. It makes the following changes:
- Using `FEPointEvaluation` instead of `FEFieldFunction` is much faster
- Only compute the solution values of one field instead of all fields, only at the current location, not at all in.positions
- Do not allocate std::vectors for every evaluation point, which are slow to create

@naliboff: Can you check that I didnt mess up the viscous vs plastic indices? I think I kept all functionality the same, it should just be significantly faster.