### PR TITLE
Create additional inputs and outputs for DG faces neighbouring cells

### DIFF
--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -964,6 +964,16 @@ namespace aspect
                                                                    neighbor,
                                                                    this->introspection(),
                                                                    this->get_current_linearization_point());
+
+              this->create_additional_material_model_outputs(scratch.neighbor_face_material_model_outputs);
+              this->get_heating_model_manager().create_additional_material_model_inputs_and_outputs(scratch.neighbor_face_material_model_inputs,
+                  scratch.neighbor_face_material_model_outputs);
+
+              this->get_material_model().fill_additional_material_model_inputs(scratch.neighbor_face_material_model_inputs,
+                                                                               this->get_current_linearization_point(),
+                                                                               *scratch.neighbor_face_finite_element_values,
+                                                                               this->introspection());
+
               this->get_material_model().evaluate(scratch.neighbor_face_material_model_inputs,
                                                   scratch.neighbor_face_material_model_outputs);
 


### PR DESCRIPTION
Found while working on #4370.

When assembling advection equations on cell faces that are not on the domain boundary, the material model and heating model are evaluated for the neighbouring cell without setting up the additional material model inputs and outputs. The modifications I made in #4370 to the shear heating plugin require ElasticOutputs, which were thus not created. 

The tests that use DG for composition use either the simple, the SolKz or the Annulus material model, which do not have additional material outputs. So a test with DG and additional outputs would be good to add?

With this PR, all the additional material model input and output is set up.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
