### PR TITLE
fix crash in GMG mesh deformation with deal.II master

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1428,6 +1428,11 @@ namespace aspect
       mg_transfer.interpolate_to_mg(mesh_deformation_dof_handler,
                                     level_displacements,
                                     displacements);
+
+      const unsigned int n_levels = sim.triangulation.n_global_levels();
+      for (unsigned int level = 0; level < n_levels; ++level)
+        level_displacements[level].update_ghost_values();
+
     }
 
 


### PR DESCRIPTION
fixes #5347

This is a change that happend in a recent change to deal.II master (https://github.com/dealii/dealii/pull/15793).
