### PR TITLE
Fix automatic docker build on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
   release:
-    types: [created]
+    types: [published]
 
 # If a merged PR triggers a rebuild of this docker image, and another
 # PR is merged during the build, cancel the first of these since (i) this


### PR DESCRIPTION
During the release of v2.5.0 the docker release image was not automatically generated. I believe this is because the wrong `type` was listed as trigger in the workflow. The github documentation states:
```
Note: Workflows are not triggered for the created, edited, or deleted activity types for draft releases. When you create your release through the GitHub browser UI, your release may automatically be saved as a draft.
```
This seems a bit weird, but their own example lists the `published` type to perform actions during releases. There is also `released`, which as far as I understand only happens once when the release is finalized. I think `published` is what we want, because it is also triggered on creating a pre-release or draft release. This way we can test the docker image before finalizing the release. 