### PR TITLE
Fix outdated information on website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Publication List
 ----------------
 
 The publication list hosted at https://aspect.geodynamics.org/publications.html is built the following way:
- - Add citations to the file https://github.com/geodynamics/aspect/blob/master/doc/manual/citing_aspect.bib
+ - Add citations to the file https://github.com/geodynamics/aspect/blob/main/doc/manual/citing_aspect.bib
  - the webserver will automatically export the html page using JabRef html export and the template located at https://github.com/geodynamics/aspect/tree/www/jabref-template
 
 
@@ -23,8 +23,8 @@ Citing.html
 -----------
 
 The interactive citation tool hosted at https://aspect.geodynamics.org/citing.html is built the following way:
-- Add citations to https://github.com/geodynamics/aspect/blob/master/doc/manual/manual.bib
-- Run https://github.com/geodynamics/aspect/blob/master/doc/make_cite_html.py and update the code block in the .py file
+- Add citations to https://github.com/geodynamics/aspect/blob/main/doc/manual/manual.bib
+- Run https://github.com/geodynamics/aspect/blob/main/doc/make_cite_html.py and update the code block in the .py file
 - Copy newly created database.js to the www repository.
 - Change the date in the citing.html where the database.js is included.
 - To add new checkboxes:

--- a/ReadMe.html
+++ b/ReadMe.html
@@ -19,14 +19,14 @@
     <!-- LESS needs to come after the stylesheets -->
     <script src="js/less-1.4.1.min.js"></script>
 
-    <meta http-equiv="refresh" content="2; URL=https://github.com/geodynamics/aspect/blob/master/README.md#aspect---advanced-solver-for-problems-in-earths-convection">
+    <meta http-equiv="refresh" content="2; URL=https://github.com/geodynamics/aspect/blob/main/README.md#aspect---advanced-solver-for-problems-in-earths-convection">
     <meta name="keywords" content="automatic redirection">
   </head>
 
 <body>
   If your browser does not automatically forward you,
   please click
-  <a href="https://github.com/geodynamics/aspect/blob/master/README.md#aspect---advanced-solver-for-problems-in-earths-convection">here</a>. 
+  <a href="https://github.com/geodynamics/aspect/blob/main/README.md#aspect---advanced-solver-for-problems-in-earths-convection">here</a>.
 </body>
 
   <!-- Some JQuery needs to come after the body -->

--- a/download.html
+++ b/download.html
@@ -32,36 +32,20 @@
 	    <h1>Downloading <abbr>ASPECT</abbr></h1>
 
 	    <p>
-	      There are two ways to obtain <abbr>ASPECT</abbr>: download a
-	      release that we have tested thoroughly, or to work from the current
-	      development version that can be obtained from the github
-	      repository. As an alternative to setting up your environment yourself,
-	      we are also providing a virtual machine image that is ready to go.
+	      There are different ways to obtain <abbr>ASPECT</abbr> that we
+	      describe in the <a href="https://aspect-documentation.readthedocs.io/en/latest/user/install/index.html">manual</a>.
 	    </p>
-
-	    <p>
-	      Whether you use development sources or releases, you need to compile the sources. To this end, please
-	      follow the installation instructions in the <a href="ReadMe.html">ReadMe
-		file</a>.
-	    </p>
-
-
 
 	    <h3>Releases</h3>
 
 	    <p>
 	      You can download the latest release 
-	      <a href="https://github.com/geodynamics/aspect/releases/latest">here</a>
-	      or
-	      <a href="http://geodynamics.org/cig/software/aspect/">here</a>.
+	      <a href="https://github.com/geodynamics/aspect/releases/latest">here</a>.
 	    </p>
 
 	    <p>
-	      After downloading, unpack the file using the command
-	      <pre><code>
-  tar xvzf aspect-2.0.0.tar.gz
-	      </code></pre>
-	      Then again follow the installation instructions linked to above.
+	      After downloading, unpack the file.
+	      Then follow the installation instructions linked to above.
 	    </p>
 
 
@@ -73,7 +57,7 @@
 	      <pre><code>
   git clone https://github.com/geodynamics/aspect.git
 	      </code></pre>
-	      Then follow the installation instructions linked to above.
+	      Then again follow the installation instructions linked to above.
 	    </p>
 
 	    <h3>Experimental VirtualBox Image</h3>

--- a/funding.html
+++ b/funding.html
@@ -54,8 +54,8 @@
 		<td>
 		  Computational Infrastructure in Geodynamics initiative (CIG), through the
 		  National Science Foundation under Awards
-		  No. EAR-0949446 and EAR-1550901 via The University of
-		  California - Davis.
+		  No. EAR-0949446, EAR-1550901, and EAR-2149126
+		  via The University of California - Davis.
 		</td>
 	      </tr>
 

--- a/header.include
+++ b/header.include
@@ -24,16 +24,13 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Info<b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <li><a href="../doc/parameter_view/parameters.xml">Parameter documentation</a></li>
-                <li><a href="manual.pdf">Manual (pdf)</a></li>
-                <li><a href="index.html#contact">Forum and contact</a></li>
+                <li><a href="https://aspect-documentation.readthedocs.io">Manual</a></li>
+                <li><a href="../doc/parameter_view/parameters.xml">Parameters</a></li>
+                <li><a href="https://github.com/geodynamics/aspect#more-information">Help</a></li>
+                <li><a href="https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md">Participate</a></li>
                 <li><a href="citing.html?src=www&ver=release">How to cite?</a></li>
                 <li><a href="publications.html">Publications</a></li>
-                <li><a href="https://github.com/geodynamics/aspect/blob/master/LICENSE">License</a></li>
-                <li><a href="https://github.com/geodynamics/aspect/wiki">Installation instructions</a></li>
-                <li><a href="https://github.com/geodynamics/aspect#more-information">Help!</a></li>
-                <li><a href="https://geodynamics.org/cig/events/calendar/2016-cig-all-hands-meeting/aspect-tutorial/tutorial/">Online tutorial</a></li>
-                <li><a href="https://github.com/geodynamics/aspect/blob/master/CONTRIBUTING.md">Participate</a></li>
+                <li><a href="https://github.com/geodynamics/aspect/blob/main/LICENSE">License</a></li>
               </ul>
             </li>
 
@@ -72,7 +69,7 @@
                 <li><a href="../doc/doxygen/changes_between_0_81_and_0_82.html">Changes v0.1&#10142;0.2</a></li>
 
 
-                <li><a href="https://github.com/geodynamics/aspect/commits/master">Revision logs</a></li>
+                <li><a href="https://github.com/geodynamics/aspect/commits/main">Recent commits</a></li>
                 <li><a href="http://www.dealii.org/">deal.II homepage</a></li>
               </ul>
             </li>

--- a/index.html
+++ b/index.html
@@ -79,10 +79,36 @@
                 <td style="vertical-align:top">
                   <p>
                     <i>
-                      <abbr>ASPECT</abbr> is <a href="https://github.com/geodynamics/aspect/blob/master/LICENSE">open source</a> and available for
+                      <abbr>ASPECT</abbr> is <a href="https://github.com/geodynamics/aspect/blob/main/LICENSE">open source</a> and available for
                       free!
                     </i>
                   </p>
+                </td>
+              </tr>
+
+              <tr>
+                <td style="vertical-align:top;height:4em">
+                  <a class="btn btn-success" style="width:100%" href="https://aspect-documentation.readthedocs.io/en/latest/">Manual! &raquo;</a>
+                </td>
+                <td></td>
+                <td style="vertical-align:top">
+                  <i>
+                    The online manual explains most of what you may want to know
+                    about <abbr>ASPECT</abbr>. <br>
+		    <a href="manual.pdf">The old pdf manual is available by clicking here.</a>
+                  </i>
+                </td>
+              </tr>
+
+              <tr>
+                <td style="vertical-align:top;height:4em">
+                  <a class="btn btn-success" style="width:100%" href="../doc/parameter_view/parameters.xml">Parameters! &raquo;</a>
+                </td>
+                <td></td>
+                <td style="vertical-align:top">
+                  <i>
+                    <abbr>ASPECT</abbr> is controlled by input parameters. Find all available options.
+                  </i>
                 </td>
               </tr>
 
@@ -100,7 +126,7 @@
 
               <tr>
                 <td style="vertical-align:top;height:4em">
-                  <a class="btn btn-success" style="width:100%" href="https://github.com/geodynamics/aspect/blob/master/CONTRIBUTING.md">Participate! &raquo;</a>
+                  <a class="btn btn-success" style="width:100%" href="https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md">Participate! &raquo;</a>
                 </td>
                 <td></td>
                 <td style="vertical-align:top">
@@ -118,37 +144,11 @@
                 <td></td>
                 <td style="vertical-align:top">
                   <i>
-                    Are you using <abbr>ASPECT</abbr> in your work? You want to give us credit in your publication? Thanks!
+                    Are you using <abbr>ASPECT</abbr> in your work? Please give us credit in your publication. Thanks!
                   </i>
                 </td>
               </tr>
 
-              <tr>
-                <td style="vertical-align:top;height:4em">
-                  <a class="btn btn-success" style="width:100%" href="../doc/parameter_view/parameters.xml">Parameters &raquo;</a>
-                </td>
-                <td></td>
-                <td style="vertical-align:top">
-                  <i>
-                          <abbr>ASPECT</abbr> is controlled by input parameters. Find all available options.
-                  </i>
-                </td>
-              </tr>
-
-              <tr>
-                <td style="vertical-align:top;height:4em">
-                  <a class="btn btn-success" style="width:100%" href="https://aspect-documentation.readthedocs.io/en/latest/">Manual &raquo;</a>
-                </td>
-                <td></td>
-                <td style="vertical-align:top">
-                  <i>
-                    The online manual explains most of what you may want to know
-                    about <abbr>ASPECT</abbr>. See the <i>Info</i> tab
-                    above for more resources. <br>
-		    <a href="manual.pdf">The old pdf manual is available by clicking here.</a>
-                  </i>
-                </td>
-              </tr>
             </table>
           </div>
 
@@ -206,7 +206,7 @@
               </ul>
             </p>
 
-            <p> <abbr>ASPECT</abbr> is published under the <a href="https://github.com/geodynamics/aspect/blob/master/LICENSE">GNU GPL v2 or newer license.</a>
+            <p> <abbr>ASPECT</abbr> is published under the <a href="https://github.com/geodynamics/aspect/blob/main/LICENSE">GNU GPL v2 or newer license.</a>
             </p>
 
           </div>
@@ -228,17 +228,13 @@
             </p>
 
             <p>
-              Bug reports can be submitted on our <a href="https://github.com/geodynamics/aspect/blob/master/CONTRIBUTING.md#bug-reports">github page</a>.
+              Bug reports can be submitted on our <a href="https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md#bug-reports">github page</a>.
             </p>
 
             <p>
-              Send an email to
-              <a href="mailto:bangerth@math.colostate.edu">Wolfgang Bangerth</a>,
-              <a href="mailto:judannberg@gmail.com">Juliane Dannberg</a>,
-              <a href="mailto:rene.gassmoeller@mailbox.org">Rene Gassmoeller</a>,
-              or <a href="mailto:heister@clemson.edu">Timo Heister</a>
-              if
-              you have questions that are not appropriate for a public and
+              Send an email to one of the
+              <a href="https://github.com/geodynamics/aspect/#more-information">maintainers</a>
+              if you have questions that are not appropriate for a public and
               archived forum.
             </p>
 


### PR DESCRIPTION
This started off as addressing #5312, but I quickly found a lot of places on the website that were outdated in one or the other way. I also found some information that was slightly outdated and already available in better form in the online manual (e.g. on the Download page). Therefore this turned into a general update to the website.

 I also noticed that the order of green buttons on the start page seems not optimal (we first give information how to ask questions, before linking to the manual and parameter documentation), and that the order of buttons is different from the order of menu options in the 'Info' dropdown menu. So I reordered them.

Some of these changes are a bit subjective, I am not bound to any. If we want to handle things differently or changes are unclear let me know.