### PR TITLE
Fix warnings when building documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ equal to those used by <a href="http://www.dealii.org">deal.II</a>
 upon which ASPECT is based, so as to keep the style of the source code
 consistent. This convention essentially consists of using
 [astyle](http://astyle.sourceforge.net/astyle.html) v.2.04 with a
-[style file](doc/astyle.rc) for indentation, CamelCase for classes and
+[style file](contrib/utilities/astyle.rc) for indentation, CamelCase for classes and
 namespaces, and lower_case_names_with_underscores for everything else. If you
 are new to the project then we will work with you to ensure your contributions
 are formatted with this style, so please do not think of it as a road block if

--- a/cookbooks/subduction_initiation/doc/subduction_initiation.md
+++ b/cookbooks/subduction_initiation/doc/subduction_initiation.md
@@ -29,7 +29,7 @@ are expressed in Poise with $1~\text{ Poise}=0.1~\text{ Pa s}$.
 
 The setup is shown in {numref}`fig:subduction-initiation-setup`
 and the list of simulations run by the authors is in
-{numref}`tab:quickref`.
+{numref}`tab:subductioninitiation`.
 
 ```{figure-md} fig:subduction-initiation-setup
 <img src="setup.*" width="70%" />
@@ -44,7 +44,7 @@ Taken from {cite:t}`matsumoto:tomoda:1983`.
 ```
 
 ```{table} List of all cases
-:name: tab:quickref
+:name: tab:subductioninitiation
 | Case                 | $\eta_l~(\text{ Pa s})$      | $\eta_a~(\text{ Pa s})$       | domain size  (km)|
 | :------------------- | :-----------: | :------------: | :---------: |
 1 | $10^{22}$ | $10^{21}$ | $400\times 180$ |

--- a/cookbooks/vankeken_subduction/doc/vankeken_subduction.md
+++ b/cookbooks/vankeken_subduction/doc/vankeken_subduction.md
@@ -10,15 +10,18 @@ The half space cooling model prescribed on the left boundary is advected downdip
 
 ```{figure-md} fig:vanKeken-temperature
 <img src="velocity_field.png" alt="Screenshot"  width="100%"/>
+
 The temperature field of the subducting slab after ~100 Myr. A half space cooling model is applied to the left boundary, which is advected at a 45 degree angle at a rate of 5 cm/yr within the subducting plate.
 ```
 
 ```{figure-md} fig:vanKeken-velocity
 <img src="velocity_field.png" alt="Screenshot"  width="100%"/>
+
 The velocity field of the subducting slab after ~100 Myr which is advected at a 45 degree angle at a rate of 5 cm/yr within the subducting plate.
 ```
 
 ```{figure-md} fig:vanKeken-pressure
 <img src="pressure_mesh.png" alt="Screenshot"  width="100%"/>
+
 The pressure field in the corner of the mantle wedge. The pressure solution was solved using a continuous $Q_1$ discretization, which was made possible with the custom mesh design used for this cookbook.
 ```

--- a/doc/sphinx/parameters/Initial_20composition_20model.md
+++ b/doc/sphinx/parameters/Initial_20composition_20model.md
@@ -1,4 +1,4 @@
-        (parameters:Initial_20composition_20model)=
+(parameters:Initial_20composition_20model)=
 # Initial composition model
 
 

--- a/doc/sphinx/user/cookbooks/geophysical-setups.md
+++ b/doc/sphinx/user/cookbooks/geophysical-setups.md
@@ -108,5 +108,6 @@ cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.md
 cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.md
 cookbooks/inclusions/doc/inclusions.md
 cookbooks/subduction_initiation/doc/subduction_initiation.md
+cookbooks/vankeken_subduction/doc/vankeken_subduction.md
 cookbooks/future/README.md
 :::


### PR DESCRIPTION
Fix a number of small warnings when building the sphinx documentation. Mostly formatting issues, duplicated labels, forgotten includes.