### PR TITLE
add notebook for grain size plunge

### DIFF
--- a/benchmarks/grain_size_pinned_state/grain_size_plunge.ipynb
+++ b/benchmarks/grain_size_pinned_state/grain_size_plunge.ipynb
@@ -149,7 +149,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "This is the same field boundary grain size that is plotted in Figure 4 of Mulyokiva & Bercovici (1.6e-5 m). Note that we still had to convert from roughness to grain size after calculating $r_f$ from their equation (8), so their naming scheme is a bit misleading (one would expect it to be field boundary roughness, not grain size)."
+        "This is the same field boundary grain size that is plotted in Figure 4 of Mulyukova & Bercovici (1.6e-5 m). Note that we still had to convert from roughness to grain size after calculating $r_f$ from their equation (8), so their naming scheme is a bit misleading (one would expect it to be field boundary roughness, not grain size)."
       ],
       "metadata": {
         "id": "udMPN8F2nx0S"
@@ -351,7 +351,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Again, our viscosity (2.89e18 Pa s) is similar but slightly smaller than what is plotted in the figure (approximately 3.4e18 Pa s). This is expected, since we are in the diffusion creep regime, where a lower grain sizes reduces the viscosity."
+        "Again, our viscosity (2.89e18 Pa s) is similar but slightly smaller than what is plotted in the figure (approximately 3.4e18 Pa s). This is expected, since we are in the diffusion creep regime, where a lower grain size reduces the viscosity."
       ],
       "metadata": {
         "id": "TVLMrFnklzw3"
@@ -431,7 +431,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "We can see that the results given in the paper only approximately fuflfil the equation.\n",
+        "We can see that the results given in the paper only approximately fulfil the equation.\n",
         "\n",
         "Our computed analytical solution gives us the correct result (which is expected assuming we have not made any mistakes in the implementation)."
       ],

--- a/benchmarks/grain_size_pinned_state/grain_size_plunge.ipynb
+++ b/benchmarks/grain_size_pinned_state/grain_size_plunge.ipynb
@@ -1,0 +1,467 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "4zk-Wo4M0xqa"
+      },
+      "outputs": [],
+      "source": [
+        "import numpy as np"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This notebook computes the equilibrium grain size based on the models shown in Figure 4 of Mulyukova and Bercovici, 2018. The output can be compared to the ASPECT model output generated using the `grain_size_plunge.prm` input file.\n",
+        "The first step of reproducing these results is to convert all parameters into SI units.\n",
+        "\n",
+        "We can compute the grain growth prefactor $k_g$ using the properties given in Table 1 in the paper, which gives us\n",
+        "\n",
+        "\\begin{equation}\n",
+        "k_g = G_0 (10^{-6})^q \\frac {q}{p} \\frac{1}{250}\n",
+        "\\end{equation}\n",
+        "\n",
+        "We want the growth rate $k_g$ to have units of m/s.\n",
+        "\n",
+        "$G_0$ is qiven as $2 \\cdot 10^4 \\mu \\text{m}^p/\\text{s}$, so to get it in $\\text{m}^p/\\text{s}$, we have to divide by $(10^6)^p$."
+      ],
+      "metadata": {
+        "id": "C5p0EEEpj2MA"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "p   = 2.\n",
+        "G_0 = 2e4 * (10**(-6))**p\n",
+        "q   = 4.\n",
+        "k_g = G_0 * q/p * 1./250. * (10**(-6))**(q-p)\n",
+        "\n",
+        "print(k_g)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "G04f-gEmkhOG",
+        "outputId": "d432d0ba-6b98-43b2-afcd-66fdd351ad48"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "1.6000000000000002e-22\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "id": "hsX6qF1q0xqe"
+      },
+      "outputs": [],
+      "source": [
+        "# define other constants from the paper here\n",
+        "q                       = 4.\n",
+        "grain_growth_prefactor  = k_g\n",
+        "grain_growth_activation = 3e5\n",
+        "f1                      = 5e-3\n",
+        "phase_distribution      = 0.6*0.4\n",
+        "\n",
+        "hg                      = (2/np.pi)*(2/np.pi)\n",
+        "temperature             = 1100.\n",
+        "R_times_T               = 8.314*temperature"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The setup we compare against uses a constant shear stress of 50 MPa (in ASPECT, we use a setup with simple shear for this)."
+      ],
+      "metadata": {
+        "id": "HW2Av1UoCq4P"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# In our test case of simple shear, we apply vx = y/10^5 per year and vy = 0. Therefore, we only have the yx\n",
+        "# component of the strain rate tensor = 1/2*(vx/y) or 1/2*(1/10^5) per year.\n",
+        "\n",
+        "# Computation of the prefactors:\n",
+        "# From Table 1\n",
+        "n = 3.\n",
+        "m = 3.\n",
+        "\n",
+        "# A is given in MPa^(-n)/s, so we have to convert it to Pa^(-n)/s\n",
+        "A0 = 1.1e5 * (1.e-6)**n\n",
+        "\n",
+        "# B0 is given in micro m^m/MPa/s, so we have to convert it to m^m/Pa/s\n",
+        "# In addition, diffusion creep depends on the grain size, so we have to include the conversion from grain size to roughness\n",
+        "B0 = 13.6 * (1.e-6)**m * 1.e-6 * (np.pi/2)**(-m)\n",
+        "\n",
+        "strain_rate            = (1.e-5/(3600.*24.*365.25))/2.\n",
+        "stress                 = 50.e6\n",
+        "\n",
+        "dislocation_activation = 530000\n",
+        "diffusion_activation   = 300000\n",
+        "stress_exponent        = 3\n",
+        "grain_size_exponent    = 3\n",
+        "\n",
+        "# Note that there is no factor of 1/n in the exponent here\n",
+        "# because we compute the viscosity based on the stress, and not on the strain rate\n",
+        "A                      = A0 * np.exp(-dislocation_activation / R_times_T)\n",
+        "B                      = B0 * np.exp(-diffusion_activation / R_times_T)\n",
+        "\n",
+        "# This is the field boundary roughness\n",
+        "r_f = (B / (A * stress**(n-1.))) ** (1./m)\n",
+        "\n",
+        "# Convert back to grain size from roughness. This is now no longer what their equation says,\n",
+        "# but it is what they plot.\n",
+        "R_f = r_f * np.pi/2\n",
+        "\n",
+        "print (\"Field boundary grain size:\", R_f, \"m\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "rhGuEDI6ElMP",
+        "outputId": "742e3f4b-73f3-4270-948d-6108c41dcc83"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Field boundary grain size: 1.604955569793287e-05 m\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This is the same field boundary grain size that is plotted in Figure 4 of Mulyokiva & Bercovici (1.6e-5 m). Note that we still had to convert from roughness to grain size after calculating $r_f$ from their equation (8), so their naming scheme is a bit misleading (one would expect it to be field boundary roughness, not grain size)."
+      ],
+      "metadata": {
+        "id": "udMPN8F2nx0S"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IDHPgY5X0xqh"
+      },
+      "source": [
+        "In steady state, we can compute the equilibrium grain size in the pinned state using Eq. 8 of Mulyukova and Bercovici (2018):\n",
+        "\n",
+        "\\begin{equation}\n",
+        "0 = \\frac {3 \\phi_1 \\phi_2 k_g \\sqrt h_g^{-q}}{q R^{q-1}} \\exp \\left(-\\frac{E_g}{R_gT}\\right)  - \\frac{f_{I} \\sqrt h_g \\Psi}{3 \\phi_1 \\phi_2} R^2\n",
+        "\\end{equation}\n",
+        "\n",
+        "Here, $\\phi_1 \\phi_2$ is the phase distribution function and $\\sqrt{h_g} = 2/\\pi$.\n",
+        "\n",
+        "We can rewrite this equation as\n",
+        "\n",
+        "\\begin{equation}\n",
+        "0 = \\frac{q f_{I} (\\sqrt h_g R)^{q+1} \\Psi}{(3 \\phi_1 \\phi_2)^2 k_g \\exp \\left(-\\frac{E_g}{R_gT}\\right)} - 1\n",
+        "\\end{equation}\n",
+        "\n",
+        "The shear heating term $\\Psi$ is $2\\dot\\varepsilon\\tau$ and the strain rate depends on the grain size. We can use equation (9) to rewrite the shear heating as\n",
+        "\n",
+        "\\begin{equation}\n",
+        "\\Psi = 2 A  \\tau^{n+1} \\left( 1 + \\left( \\frac{r_f}{r} \\right)^m \\right)\n",
+        "\\end{equation}\n",
+        "\n",
+        "with the roughness $r = R \\sqrt{h_g}$,\n",
+        "so\n",
+        "\n",
+        "\\begin{equation}\n",
+        "\\Psi = 2 A  \\tau^{n+1} \\left( 1 + \\left( \\frac{r_f}{R \\sqrt{h_g}} \\right)^m \\right)\n",
+        "\\end{equation}\n",
+        "\n",
+        "We can now see that we can not solve the equation analytically any more and instead need to find an iterative solution for the grain size. We implement this using a Newton-Raphson scheme:\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Compute the steady state grain size from eq (12) using N-R scheme.\n",
+        "\n",
+        "G1 = grain_growth_prefactor * np.exp (-grain_growth_activation/R_times_T)\n",
+        "\n",
+        "def steady_state_grain_size (grain_size):\n",
+        "  # we have to replace the roughness by grain size times 2/pi\n",
+        "  shear_heating = 2 * A * stress**(n + 1) * (1 + (r_f / (grain_size * np.sqrt(hg))) ** m)\n",
+        "  prefactors    = q * f1 * (grain_size * np.sqrt(hg))**(q + 1) / (phase_distribution * phase_distribution * 3 * 3 * G1)\n",
+        "  return (shear_heating * prefactors - 1)\n",
+        "\n",
+        "def derivative (f, x, h):\n",
+        "    return (f(x + h) - f(x)) / h\n",
+        "\n",
+        "def solve_r (f, x0, h):\n",
+        "    lastX = x0\n",
+        "    nextX = lastX + 10 * h  # different than lastX so loop starts OK\n",
+        "\n",
+        "    while (abs(lastX - nextX) > h):\n",
+        "        newY  = steady_state_grain_size(nextX)\n",
+        "        print (\"residual:\", newY)\n",
+        "        lastX = nextX\n",
+        "        nextX = lastX - newY / derivative(f, lastX, h)  # update estimate\n",
+        "    return nextX"
+      ],
+      "metadata": {
+        "id": "7KUDdCphPWAZ"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "After having defined a function that can compute the equilibrium grain size, we can now call this function, starting from the initial grain size `x0`."
+      ],
+      "metadata": {
+        "id": "p8_EgN2HjKhI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x0             = 1e-4;\n",
+        "h              = 1e-15;\n",
+        "grain_size     = solve_r (steady_state_grain_size, x0, h)\n",
+        "grain_size"
+      ],
+      "metadata": {
+        "id": "rFs46eY0B9zi",
+        "outputId": "ea024209-7a49-4c7f-e885-68300ce54152",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "residual: 4164445.1831699545\n",
+            "residual: 1365728.109414279\n",
+            "residual: 448244.85460342816\n",
+            "residual: 147343.03759121656\n",
+            "residual: 48574.41737952688\n",
+            "residual: 16101.159423364772\n",
+            "residual: 5389.150453665025\n",
+            "residual: 1832.1009018650964\n",
+            "residual: 634.4511041788161\n",
+            "residual: 219.46288967803093\n",
+            "residual: 70.1702735513497\n",
+            "residual: 19.164404733383968\n",
+            "residual: 4.649966270305967\n",
+            "residual: 0.9603983794093769\n",
+            "residual: 0.11775780149618598\n",
+            "residual: 0.003103649263562991\n",
+            "residual: 2.402064276596505e-06\n",
+            "residual: 1.2703171847761041e-12\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "7.63658755912162e-07"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 6
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Our grain size (7.64e-5 m) is similar, but slightly smaller than plotted in Figure 4 of the paper.\n",
+        "\n",
+        "In addition, we can also compare the viscosity (plotted in Figure 4, right panel):"
+      ],
+      "metadata": {
+        "id": "VhDvzRp_janV"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "D7ou_Eq60xqm"
+      },
+      "source": [
+        "In ASPECT, we compute the viscosity in the following way:\n",
+        "\n",
+        "\\begin{equation}\n",
+        "\\eta = \\frac{1}{A^{1/n}} R^m \\dot\\varepsilon_{II}^\\frac{1-n}{n} \\exp\\left({\\frac{E_d}{nR_gT}}\\right)\n",
+        "\\end{equation}\n",
+        "\n",
+        "Note that there is a difference compared to the definition in the Mulyukova paper, which uses\n",
+        "\n",
+        "\\begin{equation}\n",
+        "\\eta_\\text{disl} = \\frac{1}{2} \\frac{1}{A \\tau^{n-1}}  = \\frac{1}{2} \\frac{1}{A_0} \\tau^{1-n} \\exp\\left({\\frac{E_\\text{disl}}{R_gT}}\\right)\\\\\n",
+        "\\eta_\\text{diff} = \\frac{1}{2} \\frac{r^m}{B}  = \\frac{1}{2} \\frac{1}{B_0} R^m \\sqrt{h_G}^{m} \\exp\\left({\\frac{E_\\text{diff}}{R_gT}}\\right)\n",
+        "\\end{equation}\n",
+        "\n",
+        "They use the roughness rather than the grain size in their equation.\n",
+        "So we have to either scale our prefactor B for diffusion creep by $\\sqrt{h_G}^m$, or convert from grain size to roughness first."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "dislocation_viscosity = 1/(2 * A * stress ** (stress_exponent - 1))\n",
+        "diffusion_viscosity   = (grain_size*2/np.pi) ** (grain_size_exponent)/(2 * B)\n",
+        "\n",
+        "viscosity             = diffusion_viscosity * dislocation_viscosity / (diffusion_viscosity + dislocation_viscosity)\n",
+        "\n",
+        "print(viscosity)"
+      ],
+      "metadata": {
+        "id": "kwGM8MvEKtRj",
+        "outputId": "cbbb1b90-a6ba-4c6f-a864-1007b34703fb",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "2.8867405314847165e+18\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Again, our viscosity (2.89e18 Pa s) is similar but slightly smaller than what is plotted in the figure (approximately 3.4e18 Pa s). This is expected, since we are in the diffusion creep regime, where a lower grain sizes reduces the viscosity."
+      ],
+      "metadata": {
+        "id": "TVLMrFnklzw3"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Mulyukova and Bercovici give their equilibrium roughness in equation (12).\n",
+        "As a second check, we here convert our grain size to roughness and use that equation to check if our grain size fulfils it. In addition, we also use the grain size and $r_f$ from their Figure 4 (estimated) and check if they fulfil the equation.\n"
+      ],
+      "metadata": {
+        "id": "Z5hRP_9noGP0"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Equation (12) from Mulyukova & Bercovici\n",
+        "# Result should be 1\n",
+        "import numpy as np\n",
+        "\n",
+        "# Use r and r_f from Figure 4 (so these are approximate)\n",
+        "# If I take Figure 4 as grain sizes and then convert them to roughness multiplying by sqrt(h_G)\n",
+        "r       = 8.04e-7 * (2. / np.pi)\n",
+        "r_f     = 1.6e-5 * (2. / np.pi)\n",
+        "\n",
+        "# This is our analytical solution for r_f and r, again converted to roughness\n",
+        "r2       = 7.636587559121621e-07 / (np.pi / 2.)\n",
+        "r_f2     = 1.604955569793287e-05 / (np.pi / 2.)\n",
+        "\n",
+        "# Parameters from Table 1\n",
+        "q       = 4.\n",
+        "f_I     = 5.e-3\n",
+        "eta     = 3. * 0.6 * 0.4\n",
+        "gamma   = 1.\n",
+        "tau     = 50.e6\n",
+        "\n",
+        "# Compute A: A is given in MPa^(-n)/s, so we have to convert it to Pa^(-n)/s\n",
+        "n       = 3.\n",
+        "m       = 3.\n",
+        "A0      = 1.1e5 * (1.e-6)**n\n",
+        "E_disl  = 530000.\n",
+        "R       = 8.314\n",
+        "T       = 1100.\n",
+        "\n",
+        "A       = A0 * np.exp(-E_disl / (R * T))\n",
+        "\n",
+        "# Compute G_I\n",
+        "p      = 2.\n",
+        "G_0    = 2.e4 * (10.**(-6))**p\n",
+        "E_G    = 300000.\n",
+        "G_I    = G_0 * q/p * 1./250. * (10**(-6))**(q-p) * np.exp(- E_G / (R * T))\n",
+        "\n",
+        "print(\"From Fig. 4:\", 2. * q * f_I * A / (gamma * eta * eta * G_I) * r**(q+1) * tau**(n+1) * (1 + (r_f / r)**m))\n",
+        "print(\"From our notebook:\", 2. * q * f_I * A / (gamma * eta * eta * G_I) * r2**(q+1) * tau**(n+1) * (1 + (r_f2 / r2)**m))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "NAgdD6nHob_f",
+        "outputId": "e8955856-51b3-44dd-ff5c-b3d1c723f1b7"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "From Fig. 4: 1.0982283538272577\n",
+            "From our notebook: 1.0000000000000002\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can see that the results given in the paper only approximately fuflfil the equation.\n",
+        "\n",
+        "Our computed analytical solution gives us the correct result (which is expected assuming we have not made any mistakes in the implementation)."
+      ],
+      "metadata": {
+        "id": "v-f9zNrplJH4"
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.5"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/benchmarks/grain_size_pinned_state/grain_size_plunge.prm
+++ b/benchmarks/grain_size_pinned_state/grain_size_plunge.prm
@@ -3,6 +3,9 @@
 # from Mulyukova and Bercovici (2018) at constant
 # temperature and stress in their Figure 4.
 
+# The output can be compared to the analytical solution computed in the
+# grain_size_plunge.ipynb notebook located in the same folder as this input file.
+
 set Dimension                              = 2
 set End time                               = 1e7
 set Output directory                       = output-grain_size_plunge


### PR DESCRIPTION
This is a follow-up PR to #5363 that adds documentation. Specifically, it adds a jupyter notebook that computes the analytical solution that the benchmark reproduces. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
