### PR TITLE
[WIP] Adds Publishing guidance to manual

### DIFF
--- a/doc/sphinx/user/intro.md
+++ b/doc/sphinx/user/intro.md
@@ -58,16 +58,29 @@ Also see {cite:t}`aspectmanual,aspect-doi-v1.5.0,aspect-doi-v2.0.0,aspect-doi-v2
 
 ## Publishing with ASPECT
 Open research statements are now a common requirement when publishing research. These support reuse, validation, and citation and often take the form of *Data availability, Data access, Code availability, Open Research*, and *Software availability* statements.
- We recommend depositing input files that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
+ We recommend depositing input files in an approved repository that allows your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
 
+Recommended files to deposit include: 
+- Input files (.prm files)
 
-Remember to cite software and data in your text as well as in your Data Availability or similar statement.
+  - Original input parameter file. Use `original.prm` in the output directory if you modified the input parameter file after running the model.
+  - If specified as separate files:
+    - Material model
+    - Geometry model
+    - Gravity model
+    - Initial conditions
+    - Boundary conditions
 
-File should be deposited in an approved repository.
+  - Install configuration specifications and code changes unless fully documented by `log.txt` output.
 
-Specifc guidance in meeting publisher’s data availability requirements for ASPECT is available here: **insert aspect website here**.
+- Output files
+  - `Log.txt` files
+  - Data and scripts needed to reproduce figures
+  - Solutions relevant to the conclusions (.vtu, hdf5/xdmf, etc.)
 
-Additional information on [Publishing](https://geodynamics.org/software/software-bp/software-publishing) is available on the CIG website.
+Remember to cite software and data in your text as well as in your data availability or similar statement. For suggestions on crafting a data availability statement, please see <https://aspect.geodynamics.org/cite.html>.
+
+Additional information on publishing and guidance on approved repositories is available on the CIG website: <https://geodynamics.org/software/software-bp/software-publishing>.
 
 ## Acknowledgments
 

--- a/doc/sphinx/user/intro.md
+++ b/doc/sphinx/user/intro.md
@@ -58,16 +58,31 @@ Also see {cite:t}`aspectmanual,aspect-doi-v1.5.0,aspect-doi-v2.0.0,aspect-doi-v2
 
 ## Publishing with ASPECT
 Open research statements are now a common requirement when publishing research. These support reuse, validation, and citation and often take the form of *Data availability, Data access, Code availability, Open Research*, and *Software availability* statements.
- We recommend depositing input files that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
+ We recommend depositing input files in an approved repository that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
+
+Recommended files to deposit include: 
+
+- Input files (.prm files)
+ 
+  - Original input parameter file. Use `original.prm` in the output directory if you modified the input parameter file after running the model.
+  - If specified as separate files:
+    - Material model
+    - Geometry model
+    - Gravity model
+    - Initial conditions
+    - Boundary conditions
+	
+  - Install configuration specifications and code changes unless fully documented by `log.txt` output.
+
+- Output files
+  - `Log.txt` files
+  - Data and scripts needed to reproduce figures
+  - Solutions relevant to the conclusions (.vtu, hdf5/xdmf, etc.)
+
+Remember to cite software and data in your text as well as in your data availability or similar statement. For suggestions on crafting a data availability statement, please see **<https://aspect.geodynamics.org/cite.html>**.
 
 
-Remember to cite software and data in your text as well as in your Data Availability or similar statement.
-
-File should be deposited in an approved repository.
-
-Specifc guidance in meeting publisher’s data availability requirements for ASPECT is available here: **insert aspect website here**.
-
-Additional information on [Publishing](https://geodynamics.org/software/software-bp/software-publishing) is available on the CIG website.
+Additional information on publishing and guidance on approved repositories is available on the CIG website: **<https://geodynamics.org/software/software-bp/software-publishing>**.
 
 ## Acknowledgments
 

--- a/doc/sphinx/user/intro.md
+++ b/doc/sphinx/user/intro.md
@@ -56,6 +56,19 @@ For what exactly to cite and suggestions for acknowledgments, please see **<http
 
 Also see {cite:t}`aspectmanual,aspect-doi-v1.5.0,aspect-doi-v2.0.0,aspect-doi-v2.0.1,kronbichler:etal:2012,heister:etal:2017`.
 
+## Publishing with ASPECT
+Open research statements are now a common requirement when publishing research. These support reuse, validation, and citation and often take the form of *Data availability, Data access, Code availability, Open Research*, and *Software availability* statements.
+ We recommend depositing input files that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
+
+
+Remember to cite software and data in your text as well as in your Data Availability or similar statement.
+
+File should be deposited in an approved repository.
+
+Specifc guidance in meeting publisher’s data availability requirements for ASPECT is available here: **insert aspect website here**.
+
+Additional information on [Publishing](https://geodynamics.org/software/software-bp/software-publishing) is available on the CIG website.
+
 ## Acknowledgments
 
 The development of ASPECT has been funded through a variety of grants to the authors.

--- a/doc/sphinx/user/intro.md
+++ b/doc/sphinx/user/intro.md
@@ -58,31 +58,16 @@ Also see {cite:t}`aspectmanual,aspect-doi-v1.5.0,aspect-doi-v2.0.0,aspect-doi-v2
 
 ## Publishing with ASPECT
 Open research statements are now a common requirement when publishing research. These support reuse, validation, and citation and often take the form of *Data availability, Data access, Code availability, Open Research*, and *Software availability* statements.
- We recommend depositing input files in an approved repository that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
-
-Recommended files to deposit include: 
-
-- Input files (.prm files)
- 
-  - Original input parameter file. Use `original.prm` in the output directory if you modified the input parameter file after running the model.
-  - If specified as separate files:
-    - Material model
-    - Geometry model
-    - Gravity model
-    - Initial conditions
-    - Boundary conditions
-	
-  - Install configuration specifications and code changes unless fully documented by `log.txt` output.
-
-- Output files
-  - `Log.txt` files
-  - Data and scripts needed to reproduce figures
-  - Solutions relevant to the conclusions (.vtu, hdf5/xdmf, etc.)
-
-Remember to cite software and data in your text as well as in your data availability or similar statement. For suggestions on crafting a data availability statement, please see **<https://aspect.geodynamics.org/cite.html>**.
+ We recommend depositing input files that allow your published research to be reproduced and output model data in support of your research outcomes and figures. In addition, consider depositing model files that may be reused by others.
 
 
-Additional information on publishing and guidance on approved repositories is available on the CIG website: **<https://geodynamics.org/software/software-bp/software-publishing>**.
+Remember to cite software and data in your text as well as in your Data Availability or similar statement.
+
+File should be deposited in an approved repository.
+
+Specifc guidance in meeting publisher’s data availability requirements for ASPECT is available here: **insert aspect website here**.
+
+Additional information on [Publishing](https://geodynamics.org/software/software-bp/software-publishing) is available on the CIG website.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Initial pull request to add Publishing guidance to the ASPECT manual.

This is labeled WIP as it is dependent on adding specific guidance to the ASPECT webpage. @gassmoeller and I discussed that specific guidance should be added similarly to How to Cite? is implemented.  Hence @tjhei (?), additional work needs to be done to add a webpage with the specific guidance specified here for ASPECT: https://docs.google.com/document/d/1MOr5Zh1uZYxQs_B3YHMTHQBvc44Vrv3_gpVftTGc6rw/edit

When the new webpage is implemented, the manual should be updated with the correct link along with any other edits needed.

Thanks.
