### PR TITLE
Loosen tolerance for particle interpolation limiter

### DIFF
--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -252,8 +252,17 @@ namespace aspect
                       {
                         // Assert that the limiter was reasonably effective. We can not expect perfect accuracy
                         // due to inaccuracies e.g. in the inversion of the mapping.
-                        Assert(interpolated_value >= property_minimums[property_index] - 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
-                        Assert(interpolated_value <= property_maximums[property_index] + 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
+                        const double tolerance = std::sqrt(std::numeric_limits<double>::epsilon())
+                                                 * std::max(std::abs(property_minimums[property_index]),
+                                                            std::abs(property_maximums[property_index]));
+                        (void) tolerance;
+                        Assert(interpolated_value >= property_minimums[property_index] - tolerance,
+                               ExcMessage("The particle interpolation limiter did not succeed. Interpolated value: " + std::to_string(interpolated_value)
+                                          + " is smaller than the minimum particle property value: " + std::to_string(property_minimums[property_index]) + "."));
+                        Assert(interpolated_value <= property_maximums[property_index] + tolerance,
+                               ExcMessage("The particle interpolation limiter did not succeed. Interpolated value: " + std::to_string(interpolated_value)
+                                          + " is larger than the maximum particle property value: " + std::to_string(property_maximums[property_index]) + "."));
+
                         interpolated_value = std::min(interpolated_value, property_maximums[property_index]);
                         interpolated_value = std::max(interpolated_value, property_minimums[property_index]);
                       }

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -521,8 +521,17 @@ namespace aspect
                       {
                         // Assert that the limiter was reasonably effective. We can not expect perfect accuracy
                         // due to inaccuracies e.g. in the inversion of the mapping.
-                        Assert(interpolated_value >= property_minimums[property_index] - 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
-                        Assert(interpolated_value <= property_maximums[property_index] + 1e-9 * std::max(std::abs(property_minimums[property_index]), std::abs(property_maximums[property_index])), ExcInternalError());
+                        const double tolerance = std::sqrt(std::numeric_limits<double>::epsilon())
+                                                 * std::max(std::abs(property_minimums[property_index]),
+                                                            std::abs(property_maximums[property_index]));
+                        (void) tolerance;
+                        Assert(interpolated_value >= property_minimums[property_index] - tolerance,
+                               ExcMessage("The particle interpolation limiter did not succeed. Interpolated value: " + std::to_string(interpolated_value)
+                                          + " is smaller than the minimum particle property value: " + std::to_string(property_minimums[property_index]) + "."));
+                        Assert(interpolated_value <= property_maximums[property_index] + tolerance,
+                               ExcMessage("The particle interpolation limiter did not succeed. Interpolated value: " + std::to_string(interpolated_value)
+                                          + " is larger than the maximum particle property value: " + std::to_string(property_maximums[property_index]) + "."));
+
                         // This chopping is done to avoid values that are just outside
                         // of the limiting bounds.
                         interpolated_value = std::min(interpolated_value, property_maximums[property_index]);


### PR DESCRIPTION
I occasionally observe crashes with the particle limiter option that claim that the particle limiter did not succeed. I was finally able to track one down in the debugger and it seems that it only happens if the property to interpolate is essentially constant, and the tolerance is just barely exceeded (in my case 2e-9 instead of the 1e-9 tolerance we prescribe). This PR loosens the tolerance a bit (to around 2e-8) and binds it to the accuracy of the floating point number type used, which should hopefully take care of this. 
Also improve the error output.