### PR TITLE
update global melt cookbook

### DIFF
--- a/cookbooks/global_melt/doc/global_melt.prm
+++ b/cookbooks/global_melt/doc/global_melt.prm
@@ -24,7 +24,7 @@ set Nonlinear solver tolerance             = 1e-5
 # advection time step, we want to do at least 10 reaction time steps.
 # If these time steps would be larger than 10,000 years, we will do
 # more reaction time steps (so that reaction time step size never exceeds
-# 10,000 years).  Here, we also specify the Stokes linear solver tolerance
+# 10,000 years). Here, we also specify the Stokes linear solver tolerance
 # and maximum number of cheap Stokes solver steps to improve the nonlinear
 # convergence behavior.
 set Use operator splitting                     = true
@@ -50,10 +50,10 @@ end
 # In models with melt transport, we always need a compositional field with
 # the name 'porosity'. Only the field with that name will be advected with
 # the melt velocity, all other compositional fields will continue to work
-# as before. Material model will typically query for the field with the
+# as before. Material models will typically query for the field with the
 # name porosity to compute all melt material properties.
-# In addition, the 'melt global' model also requires a field with the name
-# 'peridotite'. This field is used to track how much material has been
+# In addition, the 'melt global' material model also requires a field with the
+# name 'peridotite'. This field is used to track how much material has been
 # molten at each point of the model, so it tracks the information how the
 # composition of the rock changes due to partial melting events (sometimes
 # also called depletion). This is important, because usually less melt is
@@ -95,7 +95,7 @@ end
 # flow in and out of the model (even if the solid can not flow out) according to
 # the dynamic fluid pressure in the model. Conversely, if we choose the
 # fluid pressure gradient = fluid density * gravity, melt will flow in or out
-# with the same velocity as the solid (so for a closer boundary, no melt will
+# with the same velocity as the solid (so for a closed boundary, no melt will
 # flow in or out). This is what we choose as our boundary condition here.
 subsection Boundary fluid pressure model
   set Plugin name = density
@@ -146,9 +146,8 @@ subsection Material model
     # In dependence of how much melt is present, we also weaken the shear
     # viscosity: The more melt is present, the weaker the rock gets.
     # This scaling is exponential, following the relation
-    # viscosity ~ exp(-alpha * DeltaT),
-    # where alpha is the parameter given here, and DeltaT is the deviation from the
-    # reference temperature.
+    # viscosity ~ exp(-alpha * phi),
+    # where alpha is the parameter given here, and phi is the porosity.
     set Exponential melt weakening factor = 10
 
     # In the same way the shear viscosity is reduced with increasing temperature,
@@ -188,30 +187,33 @@ end
 ##################### Mesh refinement #########################
 
 # For the model with melt migration, we use adaptive refinement.
-# We make use of two different refinement criteria: we set a minimum of 4 global
+# We make use of two different refinement criteria: we set a minimum of 5 global
 # refinements everywhere in the model (which is the same resolution as for the
 # model without melt), and we refine in regions where melt is present, to be
-# precise, everywhere where the porosity is bigger than 1e-5.
+# precise, everywhere where the porosity is bigger than 1e-6.
 # We adapt the mesh every 5 time steps.
 subsection Mesh refinement
   set Coarsening fraction                      = 0.05
   set Refinement fraction                      = 0.8
 
   set Initial adaptive refinement              = 2
-  set Initial global refinement                = 4
-  set Strategy                                 = composition threshold, minimum refinement function
-  set Time steps between mesh refinement       = 4
+  set Initial global refinement                = 5
+  set Strategy                                 = composition threshold, minimum refinement function, boundary
+  set Time steps between mesh refinement       = 5
 
-  # minimum of 4 global refinements
+  # minimum of 5 global refinements
   subsection Minimum refinement function
-    set Coordinate system   = depth
-    set Function expression = 4
-    set Variable names      = depth,phi
+    set Function expression = 5
   end
 
-  # refine where the porosity is bigger than 1e-5
+  # refine where the porosity is bigger than 1e-6
   subsection Composition threshold
-    set Compositional field thresholds = 1e-5,1.0
+    set Compositional field thresholds = 1e-6,1.0
+  end
+
+  # refine at top and bottom boundary
+  subsection Boundary
+    set Boundary refinement indicators = top, bottom
   end
 end
 
@@ -239,6 +241,6 @@ subsection Postprocess
     end
 
     subsection Melt material properties
-      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity, p_c
+      set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
     end
 end

--- a/cookbooks/global_melt/doc/global_no_melt.prm
+++ b/cookbooks/global_melt/doc/global_no_melt.prm
@@ -6,13 +6,13 @@
 set Dimension                              = 2
 set Adiabatic surface temperature          = 1600
 set Maximum time step                      = 1e6
-set Output directory                       = no_melt
+set Output directory                       = output-global_no_melt
 set Use years in output instead of seconds = true
 
 # The end time of the simulation. Because we want to see how upwellings
 # and downwellings evolve over time, and if differences develop between
-# the model with and without melt migration, we set the end time to 140 Ma.
-set End time                               = 1.4e8
+# the model with and without melt migration, we set the end time to 200 Ma.
+set End time                               = 2e8
 
 # We choose a stricter than default linear Stokes solver tolerance,
 # to be consistent with the global_melt cookbook.
@@ -48,8 +48,8 @@ end
 # We choose an adiabatic temperature profile as initial condition,
 # with conductive temperature profiles in the top and bottom boundary
 # layers, which were computed using a half space cooling model.
-# The cold top boundary layer corresponds to an age of 300 Ma,
-# and the hot top boundary layer corresponds to an age of 500 Ma.
+# The cold top boundary layer corresponds to an age of 70 Ma,
+# and the hot top boundary layer corresponds to an age of 700 Ma.
 # A small temperature perturbation is added at the bottom of the
 # domain. To make the model asymmetric, we place it in a distance of
 # x = 2900 km from the left boundary.
@@ -58,8 +58,8 @@ end
 subsection Initial temperature model
   set List of model names = adiabatic, function
   subsection Adiabatic
-    set Age bottom boundary layer = 5e8
-    set Age top boundary layer    = 3e8
+    set Age bottom boundary layer = 7e8
+    set Age top boundary layer    = 7e7
 
     subsection Function
       set Function expression       = 0;0
@@ -76,14 +76,14 @@ end
 
 # As boundary conditions for the temperature, we just use the
 # initial conditions again. This temperature is applied as a prescribed
-# temperature at the top and bottom boundary, as specified above.
+# temperature at the top and bottom boundary.
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = top, bottom
   set List of model names = initial temperature
 
   subsection Initial temperature
     set Minimal temperature = 293
-    set Maximal temperature = 3700
+    set Maximal temperature = 3900
   end
 end
 
@@ -140,16 +140,31 @@ end
 # For the model without melt migration, we do not have to use
 # mesh adaptivity, because time- and length scales of material
 # motion does do not vary a lot across the model, and a global
-# resolution of 4 is sufficient to capture the behavior of
-# upwellings and downwellings.
+# resolution of 5 is sufficient to capture the behavior of
+# upwellings and downwellings. We nevertheless want to refine
+# the mesh near the top and bottom boundaries where large
+# thermal gradients occur.
 subsection Mesh refinement
-  set Initial adaptive refinement              = 0
-  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 2
+  set Initial global refinement                = 5
+  set Strategy                                 = minimum refinement function, boundary
   set Time steps between mesh refinement       = 0
+
+  # minimum of 5 global refinements
+  subsection Minimum refinement function
+    set Function expression = 5
+  end
+
+  # refine at top and bottom boundary
+  subsection Boundary
+    set Boundary refinement indicators = top, bottom
+  end
 end
 
 # As the model is compressible and has an adiabatic temperature profile, we include
 # adiabatic heating in the list of heating models.
+# To make this model as simple as possible, we do not include shear heating (although
+# usually, adiabatic heating and shear heating should always be used together).
 subsection Heating model
   set List of model names = adiabatic heating
 end
@@ -168,7 +183,8 @@ subsection Postprocess
   # For the model without melt migration, we only compute the
   # equilibrium melt fraction in dependence of temperature and
   # pressure. This is done as a postprocessing step, by adding
-  # "melt fraction" to the list of visualization postprocessors.
+  # "melt fraction" to the list of material properties in the
+  # corresponding visualization postprocessor.
 
   subsection Visualization
     set List of output variables      = material properties, nonadiabatic temperature
@@ -180,7 +196,6 @@ subsection Postprocess
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 6e5
-    set Interpolate output            = true
   end
 
   subsection Depth average

--- a/cookbooks/global_melt/global_melt.prm
+++ b/cookbooks/global_melt/global_melt.prm
@@ -47,8 +47,8 @@ end
 
 # The end time of the simulation. Because we want to see how upwellings
 # and downwellings evolve over time, and if differences develop between
-# the model with and without melt migration, we set the end time to 140 Ma.
-set End time                               = 1.4e8
+# the model with and without melt migration, we set the end time to 200 Ma.
+set End time                               = 2e8
 
 
 # We prescribe free-slip boundary conditions on all sides.
@@ -102,8 +102,8 @@ end
 # We choose an adiabatic temperature profile as initial condition,
 # with conductive temperature profiles in the top and bottom boundary
 # layers, which were computed using a half space cooling model.
-# The cold top boundary layer corresponds to an age of 300 Ma,
-# and the hot top boundary layer corresponds to an age of 500 Ma.
+# The cold top boundary layer corresponds to an age of 70 Ma,
+# and the hot top boundary layer corresponds to an age of 700 Ma.
 # A small temperature perturbation is added at the bottom of the
 # domain. To make the model asymmetric, we place it in a distance of
 # x = 2900 km from the left boundary.
@@ -112,8 +112,8 @@ end
 subsection Initial temperature model
   set List of model names = adiabatic, function
   subsection Adiabatic
-    set Age bottom boundary layer = 5e8
-    set Age top boundary layer    = 3e8
+    set Age bottom boundary layer = 7e8
+    set Age top boundary layer    = 7e7
 
     subsection Function
       set Function expression       = 0;0
@@ -149,7 +149,7 @@ subsection Boundary temperature model
 
   subsection Initial temperature
     set Minimal temperature = 293
-    set Maximal temperature = 3700
+    set Maximal temperature = 3900
   end
 end
 
@@ -288,28 +288,33 @@ end
 ##################### Mesh refinement #########################
 
 # For the model with melt migration, we use adaptive refinement.
-# We make use of two different refinement criteria: we set a minimum of 4 global
+# We make use of two different refinement criteria: we set a minimum of 5 global
 # refinements everywhere in the model (which is the same resolution as for the
 # model without melt), and we refine in regions where melt is present, to be
-# precise, everywhere where the porosity is bigger than 1e-5.
+# precise, everywhere where the porosity is bigger than 1e-6.
 # We adapt the mesh every 5 time steps.
 subsection Mesh refinement
   set Coarsening fraction                      = 0.05
   set Refinement fraction                      = 0.8
 
   set Initial adaptive refinement              = 2
-  set Initial global refinement                = 4
-  set Strategy                                 = composition threshold, minimum refinement function
+  set Initial global refinement                = 5
+  set Strategy                                 = composition threshold, minimum refinement function, boundary
   set Time steps between mesh refinement       = 5
 
-  # minimum of 4 global refinements
+  # minimum of 5 global refinements
   subsection Minimum refinement function
-    set Function expression = 4
+    set Function expression = 5
   end
 
-  # refine where the porosity is bigger than 1e-8
+  # refine where the porosity is bigger than 1e-6
   subsection Composition threshold
-    set Compositional field thresholds = 1e-8,1.0
+    set Compositional field thresholds = 1e-6,1.0
+  end
+
+  # refine at top and bottom boundary
+  subsection Boundary
+    set Boundary refinement indicators = top, bottom
   end
 end
 

--- a/cookbooks/global_melt/global_no_melt.prm
+++ b/cookbooks/global_melt/global_no_melt.prm
@@ -11,8 +11,8 @@ set Use years in output instead of seconds = true
 
 # The end time of the simulation. Because we want to see how upwellings
 # and downwellings evolve over time, and if differences develop between
-# the model with and without melt migration, we set the end time to 140 Ma.
-set End time                               = 1.4e8
+# the model with and without melt migration, we set the end time to 200 Ma.
+set End time                               = 2e8
 
 # We choose a stricter than default linear Stokes solver tolerance,
 # to be consistent with the global_melt cookbook.
@@ -23,7 +23,7 @@ subsection Solver parameters
   end
 end
 
-# We fix prescribe free-slip boundary conditions on all
+# We prescribe free-slip boundary conditions on all
 # sides.
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = left, right, top, bottom
@@ -48,8 +48,8 @@ end
 # We choose an adiabatic temperature profile as initial condition,
 # with conductive temperature profiles in the top and bottom boundary
 # layers, which were computed using a half space cooling model.
-# The cold top boundary layer corresponds to an age of 300 Ma,
-# and the hot top boundary layer corresponds to an age of 500 Ma.
+# The cold top boundary layer corresponds to an age of 70 Ma,
+# and the hot top boundary layer corresponds to an age of 700 Ma.
 # A small temperature perturbation is added at the bottom of the
 # domain. To make the model asymmetric, we place it in a distance of
 # x = 2900 km from the left boundary.
@@ -58,8 +58,8 @@ end
 subsection Initial temperature model
   set List of model names = adiabatic, function
   subsection Adiabatic
-    set Age bottom boundary layer = 5e8
-    set Age top boundary layer    = 3e8
+    set Age bottom boundary layer = 7e8
+    set Age top boundary layer    = 7e7
 
     subsection Function
       set Function expression       = 0;0
@@ -83,7 +83,7 @@ subsection Boundary temperature model
 
   subsection Initial temperature
     set Minimal temperature = 293
-    set Maximal temperature = 3700
+    set Maximal temperature = 3900
   end
 end
 
@@ -140,12 +140,25 @@ end
 # For the model without melt migration, we do not have to use
 # mesh adaptivity, because time- and length scales of material
 # motion does do not vary a lot across the model, and a global
-# resolution of 4 is sufficient to capture the behavior of
-# upwellings and downwellings.
+# resolution of 5 is sufficient to capture the behavior of
+# upwellings and downwellings. We nevertheless want to refine
+# the mesh near the top and bottom boundaries where large
+# thermal gradients occur.
 subsection Mesh refinement
-  set Initial adaptive refinement              = 0
-  set Initial global refinement                = 4
+  set Initial adaptive refinement              = 2
+  set Initial global refinement                = 5
+  set Strategy                                 = minimum refinement function, boundary
   set Time steps between mesh refinement       = 0
+
+  # minimum of 5 global refinements
+  subsection Minimum refinement function
+    set Function expression = 5
+  end
+
+  # refine at top and bottom boundary
+  subsection Boundary
+    set Boundary refinement indicators = top, bottom
+  end
 end
 
 # As the model is compressible and has an adiabatic temperature profile, we include


### PR DESCRIPTION
At the moment, this cookbook crashes on main (after a few time steps). 
This fix is in response to https://community.geodynamics.org/t/problems-with-global-melt-cookbook/3043 and https://community.geodynamics.org/t/unable-to-reproduce-global-melt-cookbook-results-in-the-aspect-manual/3093. 
As mentioned on the forum, I believe this is because of our changes to the artificial diffusion. 

To make the cookbook work again, I
- increased the resolution
- refined the mesh near the top and bottom
- increased the temperature and age of the bottom boundary (we had more conduction before with the old artificial viscosity, so the plumes on the current main are thinner/colder than they used to be, and this makes them hotter again so that there actually is some melting)
- increased the end time

I updated the figure in the cookbook accordingly. I also updated the prm files in the doc folder, which are just copies of parts of the actual cookbooks. Those had gotten out of date as well, so the typo/documentation changes in those files are just because I copied over the actual cookbook prm files. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).