### PR TITLE
Move particle parameters into their own top-level subsection

### DIFF
--- a/benchmarks/annulus/transient/transient_annulus.prm
+++ b/benchmarks/annulus/transient/transient_annulus.prm
@@ -59,14 +59,6 @@ subsection Postprocess
 
   subsection Particles
     set Time between data output = 2.6
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set List of particle properties = particle density
-    set Update ghost particles = true
-    set Particle generator name = random uniform
-    set Number of particles = 49152
-    set Load balancing strategy = add particles
-    set Minimum particles per cell = 12
   end
 end
 
@@ -77,5 +69,21 @@ subsection Solver parameters
     set Stokes solver type = block GMG
     set Krylov method for cheap solver steps = IDR(s)
     set IDR(s) parameter = 4
+  end
+end
+
+subsection Particles
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set List of particle properties = particle density
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+  set Load balancing strategy = add particles
+  set Minimum particles per cell = 12
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 49152
+    end
   end
 end

--- a/benchmarks/finite_strain/pure_shear.prm
+++ b/benchmarks/finite_strain/pure_shear.prm
@@ -127,17 +127,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = ./
-        set Data file name = pure_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = ./
+      set Data file name = pure_shear_particle.dat
     end
   end
 end

--- a/benchmarks/finite_strain/simple_shear.prm
+++ b/benchmarks/finite_strain/simple_shear.prm
@@ -115,17 +115,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = ./
-        set Data file name = simple_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = ./
+      set Data file name = simple_shear_particle.dat
     end
   end
 end

--- a/benchmarks/inclusion/adaptive.prm.base
+++ b/benchmarks/inclusion/adaptive.prm.base
@@ -1,16 +1,11 @@
 ############### Global parameters
 
 set Additional shared libraries            = ./libinclusion.so
-
-
 set Dimension                              = 2
-
 set Start time                             = 0
 set End time                               = 0
-
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = no Advection, iterated Stokes
-
 set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
@@ -24,15 +19,12 @@ subsection Geometry model
   end
 end
 
-
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = left  : InclusionBoundary, \
                                                 right : InclusionBoundary, \
                                                 bottom: InclusionBoundary, \
                                                 top   : InclusionBoundary
 end
-
 
 subsection Material model
   set Model name = InclusionMaterial
@@ -42,19 +34,15 @@ subsection Material model
   end
 end
 
-
 subsection Gravity model
   set Model name = vertical
 end
-
 
 ############### Parameters describing the temperature field
 
 subsection Initial temperature model
   set Model name = perturbed box
 end
-
-
 
 ############### Parameters describing the discretization
 
@@ -63,30 +51,22 @@ subsection Discretization
   set Use locally conservative discretization = false
 end
 
-
 subsection Mesh refinement
   set Initial adaptive refinement              = 13
   set Initial global refinement                = 4
-
   set Strategy = velocity#viscosity
   set Run postprocessors on initial refinement = true
   set Coarsening fraction                      = 0.0
   set Refinement fraction                      = 0.5
-
-
 end
-
 
 ############### Parameters describing what to do with the solution
 
 subsection Postprocess
   set List of postprocessors = InclusionPostprocessor, visualization
 
-
-
   subsection Visualization
     set List of output variables = viscosity
     set Time between graphical output = 0
   end
-
 end

--- a/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
@@ -92,26 +92,28 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 16384
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = cell average
-    set Maximum particles per cell = 16384
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function constants  = eta_b=1e3, rmax=0.2
-      set Function expression = if((x-1.0)*(x-1.0)+(z-1.0)*(z-1.0)<=0.04,eta_b,1.0)
-    end
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = cell average
+  set Maximum particles per cell = 16384
+  set Update ghost particles = true
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = eta_b=1e3, rmax=0.2
+    set Function expression = if((x-1.0)*(x-1.0)+(z-1.0)*(z-1.0)<=0.04,eta_b,1.0)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
   end
 end

--- a/benchmarks/inclusion/global.prm.base
+++ b/benchmarks/inclusion/global.prm.base
@@ -1,16 +1,11 @@
 ############### Global parameters
 
 set Additional shared libraries            = ./libinclusion.so
-
-
 set Dimension                              = 2
-
 set Start time                             = 0
 set End time                               = 0
-
 set Pressure normalization                 = volume
 set Nonlinear solver scheme                = no Advection, iterated Stokes
-
 set Use years in output instead of seconds = false
 
 ############### Parameters describing the model
@@ -24,15 +19,12 @@ subsection Geometry model
   end
 end
 
-
-
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = left  : InclusionBoundary, \
                                                 right : InclusionBoundary, \
                                                 bottom: InclusionBoundary, \
                                                 top   : InclusionBoundary
 end
-
 
 subsection Material model
   set Model name = InclusionMaterial
@@ -42,19 +34,15 @@ subsection Material model
   end
 end
 
-
 subsection Gravity model
   set Model name = vertical
 end
-
 
 ############### Parameters describing the temperature field
 
 subsection Initial temperature model
   set Model name = perturbed box
 end
-
-
 
 ############### Parameters describing the discretization
 
@@ -63,13 +51,10 @@ subsection Discretization
   set Use locally conservative discretization = false
 end
 
-
 subsection Mesh refinement
   set Initial global refinement                = 5
   set Initial adaptive refinement              = 0
 end
-
-
 
 ############### Parameters describing what to do with the solution
 

--- a/benchmarks/particle_integration_scheme/circle.prm
+++ b/benchmarks/particle_integration_scheme/circle.prm
@@ -5,9 +5,11 @@ set Use years in output instead of seconds = false
 set CFL number                             = 1.0
 set Output directory                       = circle_euler_1.0
 set Timing output frequency                = 100
+set Nonlinear solver scheme                = Advection only
 
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent = 4
     set Y extent = 4
@@ -16,21 +18,18 @@ subsection Geometry model
   end
 end
 
-
 subsection Prescribed Stokes solution
   set Model name = function
+
   subsection Velocity function
     set Variable names = x,y,t
     set Function expression = 2 * pi * (1+0.0*sin(t))*-y; 2 * pi * (1+0.0*sin(t))*x
   end
 end
 
-set Nonlinear solver scheme                = Advection only
-
 subsection Initial temperature model
   set Model name = function
 end
-
 
 subsection Gravity model
   set Model name = vertical
@@ -40,11 +39,9 @@ subsection Gravity model
   end
 end
 
-
 subsection Material model
   set Model name = simple
 end
-
 
 subsection Mesh refinement
   set Initial global refinement                = 4
@@ -63,18 +60,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 50
     set Time between data output = 0.1
     set Data output format = ascii
+  end
+end
 
-    set Particle generator name = ascii file
-    set Integration scheme = rk2
+subsection Particles
+  set Particle generator name = ascii file
+  set Integration scheme = rk2
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/particle_integration_scheme/
-        set Data file name = particle.dat
-      end
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/particle_integration_scheme/
+      set Data file name = particle.dat
     end
   end
 end

--- a/benchmarks/particle_integration_scheme/euler.part.prm
+++ b/benchmarks/particle_integration_scheme/euler.part.prm
@@ -1,5 +1,6 @@
 subsection Postprocess
-  subsection Particles
-    set Integration scheme = euler
-  end
+end
+
+subsection Particles
+  set Integration scheme = euler
 end

--- a/benchmarks/particle_integration_scheme/rk2.part.prm
+++ b/benchmarks/particle_integration_scheme/rk2.part.prm
@@ -1,5 +1,6 @@
 subsection Postprocess
-  subsection Particles
-    set Integration scheme = rk2
-  end
+end
+
+subsection Particles
+  set Integration scheme = rk2
 end

--- a/benchmarks/particle_integration_scheme/rk4.part.prm
+++ b/benchmarks/particle_integration_scheme/rk4.part.prm
@@ -1,5 +1,6 @@
 subsection Postprocess
-  subsection Particles
-    set Integration scheme = rk4
-  end
+end
+
+subsection Particles
+  set Integration scheme = rk4
 end

--- a/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
+++ b/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
@@ -10,6 +10,7 @@
 set Dimension                              = 2
 set Start time                             = 0
 set End time                               = 6e6
+
 # For a timestep of 2500 yr and no stabilization,
 # the model is stable. For a timestep of 10000 yr,
 # it is not ("drunken sailor").
@@ -20,18 +21,17 @@ set Output directory                       = output_nostab_10000
 set Nonlinear solver scheme                = single Advection, single Stokes
 set Pressure normalization                 = no
 
-
 ############## Element types
 # Use dicontinuous composition elements for a sharp interface
 subsection Discretization
   set Use discontinuous composition discretization = true
+
   subsection Stabilization parameters
     set Use limiter for discontinuous composition solution = true
     set Global composition maximum = 1
     set Global composition minimum = 0
   end
 end
-
 
 ############### Geometry
 # We consider a 2D box of 500x500 km
@@ -43,7 +43,6 @@ subsection Geometry model
     set Y extent  = 500e3
   end
 end
-
 
 ############### Boundary conditions
 # Vertical boundaries are free slip,
@@ -58,11 +57,13 @@ end
 subsection Mesh deformation
   set Mesh deformation boundary indicators                    = top: free surface
   set Additional tangential mesh velocity boundary indicators = left, right
+
   subsection Free surface
     # We test the stability of the free surface
     # for a timestep of 2500 and 10000 yr with
     # (0.5) and without (0.0) stabilization.
     set Free surface stabilization theta = 0.0
+
     # We compare the vertical and normal projection of
     # the free surface.
     #set Surface velocity projection      = normal
@@ -70,24 +71,23 @@ subsection Mesh deformation
   end
 end
 
-
 ############### Material properties
 # No temperature effects.
 # The top layer is denser and more viscous.
 subsection Material model
   set Model name = simple
+
   subsection Simple model
-   set Viscosity                                      = 1.0e20
-   set Composition viscosity prefactor                = 10
-   set Reference temperature                          = 1.0
-   set Reference density                              = 3200.0
-   set Density differential for compositional field 1 = 100
-   set Thermal expansion coefficient                  = 0.0
-   set Thermal conductivity                           = 2.7
-   set Reference specific heat                        = 1250
+    set Viscosity                                      = 1.0e20
+    set Composition viscosity prefactor                = 10
+    set Reference temperature                          = 1.0
+    set Reference density                              = 3200.0
+    set Density differential for compositional field 1 = 100
+    set Thermal expansion coefficient                  = 0.0
+    set Thermal conductivity                           = 2.7
+    set Reference specific heat                        = 1250
   end
 end
-
 
 ############## Gravity
 subsection Gravity model
@@ -97,7 +97,6 @@ subsection Gravity model
     set Magnitude = 9.81
   end
 end
-
 
 ############### Parameters describing the temperature field
 # We ignore any temperature effects.
@@ -114,14 +113,13 @@ subsection Initial temperature model
   end
 end
 
-
 ############### Parameters describing the compositional fields
 # We include one compositional field plus the background material.
 # The material interface is sinusoidally perturbed with an amplitude
 # A of 5 km.
 
 subsection Compositional fields
-   set Number of fields = 1
+  set Number of fields = 1
 end
 
 subsection Initial composition model
@@ -133,7 +131,6 @@ subsection Initial composition model
   end
 end
 
-
 ############### Mesh refinement
 # The Kaus paper considers a resolution of 50x50 elements.
 # We use 64x64.
@@ -142,7 +139,6 @@ subsection Mesh refinement
   set Initial global refinement          = 6
   set Time steps between mesh refinement = 0
 end
-
 
 ############### Parameters describing what to do with the solution
 # We monitor the topography over time.
@@ -154,6 +150,7 @@ subsection Postprocess
     set List of output variables      = viscosity, density
     set Output mesh velocity          = true
   end
+
   subsection Topography
     set Output to file           = true
     set Time between text output = 2.e5

--- a/benchmarks/rayleigh_taylor_instability_free_surface/rose_rayleigh_taylor_instability.prm
+++ b/benchmarks/rayleigh_taylor_instability_free_surface/rose_rayleigh_taylor_instability.prm
@@ -12,6 +12,7 @@
 
 ############### Global parameters
 set Dimension                              = 2
+
 include $ASPECT_SOURCE_DIR/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
 
 set Start time                             = 0
@@ -24,6 +25,7 @@ set Output directory                       = output_Rose_stab_CFL02
 subsection Mesh deformation
   set Mesh deformation boundary indicators                    = top: free surface
   set Additional tangential mesh velocity boundary indicators = left, right
+
   subsection Free surface
     set Free surface stabilization theta = 0.5
     set Surface velocity projection      = vertical
@@ -40,6 +42,7 @@ subsection Mesh refinement
   set Coarsening fraction                = 0.05
   set Strategy                           = composition, boundary
   set Time steps between mesh refinement = 5
+
   subsection Boundary
     set Boundary refinement indicators = top
   end

--- a/benchmarks/rigid_shear/steady-state/rigid_shear.prm
+++ b/benchmarks/rigid_shear/steady-state/rigid_shear.prm
@@ -86,23 +86,25 @@ subsection Postprocess
   subsection Particles
     set Time between data output = 0.1
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set Update ghost particles = true
-    set Minimum particles per cell = 9
-    set Maximum particles per cell = 16384
-    set Particle generator name = reference cell
-    set Number of particles = 8192
+  end
+end
 
-    subsection Function
-      set Function expression = sin(pi*x)*sin(pi*y) + 2.0
-    end
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set Update ghost particles = true
+  set Minimum particles per cell = 9
+  set Maximum particles per cell = 16384
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 9
-      end
+  subsection Function
+    set Function expression = sin(pi*x)*sin(pi*y) + 2.0
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 9
     end
   end
 end

--- a/benchmarks/rigid_shear/transient/rigid_shear.prm
+++ b/benchmarks/rigid_shear/transient/rigid_shear.prm
@@ -103,24 +103,32 @@ subsection Postprocess
   subsection Particles
     set Time between data output = 0.1
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set Update ghost particles = true
-    set Minimum particles per cell = 12
-    set Maximum particles per cell = 16384
-    set Particle generator name = random uniform
-    set Number of particles = 8192
-    set Load balancing strategy = add particles
+  end
+end
 
-    subsection Function
-      set Function expression = sin(pi*x)*sin(pi*y) + 2
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set Update ghost particles = true
+  set Minimum particles per cell = 12
+  set Maximum particles per cell = 16384
+  set Particle generator name = random uniform
+  set Load balancing strategy = add particles
+
+  subsection Function
+    set Function expression = sin(pi*x)*sin(pi*y) + 2
+  end
+
+  subsection Interpolator
+    subsection Quadratic least squares
+      set Use boundary extrapolation = true
     end
+  end
 
-    subsection Interpolator
-      subsection Quadratic least squares
-        set Use boundary extrapolation = true
-      end
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 8192
     end
   end
 end

--- a/benchmarks/slab_detachment/slab_detachment.prm
+++ b/benchmarks/slab_detachment/slab_detachment.prm
@@ -125,20 +125,9 @@ subsection Postprocess
     set List of output variables      = strain rate, viscosity, density
   end
 
-  # We read a file with 22 initial particle locations and
-  # output the new particle locations over time to an ascii file.
   subsection Particles
-    set Number of particles         = 22
     set Time between data output  = 1e6
     set Data output format        = ascii
-    set Particle generator name   = ascii file
-
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/slab_detachment/
-        set Data file name = initial_particle_location.dat
-      end
-    end
   end
 end
 
@@ -146,5 +135,18 @@ subsection Solver parameters
   subsection Stokes solver parameters
     set Linear solver tolerance = 1e-7
     set Number of cheap Stokes solver steps = 0
+  end
+end
+
+# We read a file with 22 initial particle locations and
+# output the new particle locations over time to an ascii file.
+subsection Particles
+  set Particle generator name   = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/slab_detachment/
+      set Data file name = initial_particle_location.dat
+    end
   end
 end

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -100,27 +100,29 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 16384
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = cell average
-    set Maximum particles per cell = 16384
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, y
-      set Function constants  = pi=3.1415926, eta_b=1e6, background_density=0.0
-      set Function expression =  background_density - sin(pi*y) * cos(pi*x); if(x<0.5, 1, eta_b)
-    end
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = cell average
+  set Maximum particles per cell = 16384
+  set Update ghost particles = true
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, y
+    set Function constants  = pi=3.1415926, eta_b=1e6, background_density=0.0
+    set Function expression =  background_density - sin(pi*y) * cos(pi*x); if(x<0.5, 1, eta_b)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
   end
 end

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -89,27 +89,29 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 16384
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = cell average
-    set Maximum particles per cell = 16384
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, z
-      set Function constants  = pi=3.1415926, eta_b=1e6
-      set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
-    end
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = cell average
+  set Maximum particles per cell = 16384
+  set Update ghost particles = true
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, z
+    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
   end
 end

--- a/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
+++ b/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
@@ -137,33 +137,15 @@ end
 subsection Postprocess
   set List of postprocessors = time dependent annulus, particles, visualization
 
-  subsection Particles
-    set Time between data output = 0.0009817477042468104
-    set Integration scheme = rk2 # or rk4
-    set Interpolation scheme = bilinear least squares # or cell average
-    set List of particle properties = function
-    set Update ghost particles = true
-    set Particle generator name = reference cell
-    set Load balancing strategy = none # not necessary for uniform mesh
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4 # or 5, 6, 7, 10, 15, 20, 32, 45, 64, 80
-      end
-    end
-
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x,y
-      set Function expression = 48*sqrt(x^2 + y^2)^5;if(0<y,if(y<1/4,1,0),0)
-    end
-  end
-
   subsection Visualization
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0.0009817477042468104
     set List of output variables      = density, gravity
+  end
+
+  subsection Particles
+    set Time between data output = 0.0009817477042468104
   end
 end
 
@@ -173,4 +155,25 @@ end
 
 subsection Checkpointing
   set Time between checkpoint  = 7200
+end
+
+subsection Particles
+  set Integration scheme = rk2 # or rk4
+  set Interpolation scheme = bilinear least squares # or cell average
+  set List of particle properties = function
+  set Update ghost particles = true
+  set Particle generator name = reference cell
+  set Load balancing strategy = none # not necessary for uniform mesh
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4 # or 5, 6, 7, 10, 15, 20, 32, 45, 64, 80
+    end
+  end
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x,y
+    set Function expression = 48*sqrt(x^2 + y^2)^5;if(0<y,if(y<1/4,1,0),0)
+  end
 end

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
@@ -19,15 +19,23 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, basic statistics, particles, temperature statistics, visualization
 
   subsection Particles
-    set Number of particles = 4e5
-    set Minimum particles per cell  = 95
-    set Maximum particles per cell  = 105
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = nearest neighbor
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 0
     set Data output format          = vtu
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 95
+  set Maximum particles per cell  = 105
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = nearest neighbor
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 4e5
+    end
   end
 end

--- a/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
@@ -43,6 +43,7 @@ subsection Solver parameters
     set GMRES solver restart length         = 50
     set Use full A block as preconditioner  = true
   end
+
   subsection Newton solver parameters
     set Max pre-Newton nonlinear iterations      = 5
     set SPD safety factor                        = 0.9
@@ -90,10 +91,11 @@ end
 
 subsection Mesh deformation
   set Mesh deformation boundary indicators = top: free surface
+  set Additional tangential mesh velocity boundary indicators = left, right
+
   subsection Free surface
     set Surface velocity projection = normal
   end
-  set Additional tangential mesh velocity boundary indicators = left, right
 end
 
 # Velocity boundary conditions
@@ -166,41 +168,31 @@ end
 
 # Material model
 subsection Material model
-
   set Model name = visco plastic
-
   set Material averaging = harmonic average only viscosity
 
   subsection Visco Plastic
-
     set Densities                   = 2700
     set Reference strain rate       = 1.e-15
     set Maximum viscosity           = 1.e25
     set Minimum viscosity           = 1.e20
-
     set Prefactors for dislocation creep          = 5e-26, 5e-26, 5e-26, 5e-26, 5e-26, 5e-21
     set Stress exponents for dislocation creep    = 1.0
     set Activation energies for dislocation creep = 0.
     set Activation volumes for dislocation creep  = 0.
-
     set Elastic shear moduli        = 5.e10, 5.e10, 5.e10, 5.e10, 5.e10, 1.e50
     set Use fixed elastic time step = false
     set Fixed elastic time step     = 1e3
-
     set Viscosity averaging scheme  = harmonic
-
     set Angles of internal friction = 30.
     set Cohesions                   = 40.e6, 40.e6, 40.e6, 40.e6, 40.e6, 1.e20
-
     set Strain weakening mechanism                   = plastic weakening with plastic strain only
     set Start plasticity strain weakening intervals  = 0.0
     set End plasticity strain weakening intervals    = 0.1
     set Cohesion strain weakening factors            = 0.1
     set Friction strain weakening factors            = 1.0
-
     set Use plastic damper       = true
     set Plastic damper viscosity = 1e20
-
   end
 end
 
@@ -219,25 +211,28 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Minimum particles per cell  = 40
-    set Maximum particles per cell  = 60
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, viscoplastic strain invariants, elastic stress
-    set Interpolation scheme        = cell average
-    set Update ghost particles      = true
-    set Particle generator name     = reference cell
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 7
-      end
-    end
     set Time between data output    = 0.e3
     set Data output format          = vtu
   end
-
 end
 
 # Termination criteria
 subsection Termination criteria
   set Termination criteria = end time
+end
+
+subsection Particles
+  set Minimum particles per cell  = 40
+  set Maximum particles per cell  = 60
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, viscoplastic strain invariants, elastic stress
+  set Interpolation scheme        = cell average
+  set Update ghost particles      = true
+  set Particle generator name     = reference cell
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 7
+    end
+  end
 end

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
@@ -16,20 +16,28 @@ end
 subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, particles, temperature statistics, velocity statistics, visualization
 
+  subsection Visualization
+    set Time between graphical output = 0e3
+  end
+
   subsection Particles
-    set Number of particles = 1e5
-    set Minimum particles per cell  = 25
-    set Maximum particles per cell  = 35
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = bilinear least squares
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 0
     set Data output format          = vtu
   end
+end
 
-  subsection Visualization
-    set Time between graphical output = 0e3
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = bilinear least squares
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
@@ -52,15 +52,23 @@ subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, particles, temperature statistics, velocity statistics, visualization
 
   subsection Particles
-    set Number of particles = 1e5
-    set Minimum particles per cell  = 25
-    set Maximum particles per cell  = 35
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = bilinear least squares
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 0
     set Data output format          = vtu
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = bilinear least squares
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/contrib/python/scripts/aspect_input.py
+++ b/contrib/python/scripts/aspect_input.py
@@ -10,6 +10,44 @@ __copyright__ = 'Copyright 2023, ASPECT'
 __license__ = 'GNU GPL 2 or later'
 
 
+def get_parameter_value(parameters, name):
+    """ Given a dictionary of parameters with a structure as
+    the one created by read_parameter_file(), return the value
+    of the parameter with the given name. Returns None if the
+    parameter is not found.
+    """
+
+    if name in parameters:
+        return parameters[name]["value"]
+    else:
+        for entry in parameters:
+            if parameters[entry]["type"] == "subsection":
+                value = get_parameter_value(parameters[entry]["value"], name)
+                if value != None:
+                    return value
+
+    return None
+
+
+
+def set_parameter_value(parameters, name, value):
+    """ Given a dictionary of parameters with a structure as
+    the one created by read_parameter_file(), set the value
+    of the parameter with the given name to the given value.
+    Returns 0 if the parameter was found and set, 1 otherwise.
+    """
+
+    if name in parameters:
+        parameters[name]["value"] = value
+        return 0
+    else:
+        for entry in parameters:
+            if parameters[entry]["type"] == "subsection":
+                if set_parameter_value(parameters[entry]["value"], name, value) == 0:
+                    return 0
+
+    return 1
+
 
 def split_parameter_line(line):
     """ Read a 'set parameter' line and extract the name, value, and format. """

--- a/contrib/utilities/update_prm_files.sh
+++ b/contrib/utilities/update_prm_files.sh
@@ -38,6 +38,7 @@ done
 
 for script in `ls ${SCRIPT_FOLDER}/*.py`; do
   for file in $@ ; do
+    echo $file
     python3 $script $file "$file.tmp"
     mv "$file.tmp" "$file"
   done

--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+""" This script reformats the given .prm files to move particle parameters
+to the correct subsection.
+"""
+
+import sys
+import os
+import re
+import argparse
+
+__author__ = 'The authors of the ASPECT code'
+__copyright__ = 'Copyright 2023, ASPECT'
+__license__ = 'GNU GPL 2 or later'
+
+# Add the ASPECT root directory to the path so we can import from the aspect_data module
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+import python.scripts.aspect_input as aspect
+
+
+
+def move_particle_parameters_to_own_subsection(parameters):
+    """ Move the particle parameters to their own subsection. """
+
+    # Find the particle parameters and move
+    if "Postprocess" in parameters:
+        if "Particles" in parameters["Postprocess"]["value"]:
+            parameters["Particles"] = parameters["Postprocess"]["value"]["Particles"]
+            del parameters["Postprocess"]["value"]["Particles"]
+
+    return parameters
+
+
+
+def move_number_of_particles_to_correct_subsection(parameters):
+    """ Move the number of particles to the correct subsection. """
+
+    # Find the particle parameters and move
+    if "Particles" in parameters:
+        if "Number of particles" in parameters["Particles"]["value"]:
+            parameter = parameters["Particles"]["value"]["Number of particles"]
+            del parameters["Particles"]["value"]["Number of particles"]
+
+            # We need to move the parameter, create the subsection if necessary
+            if not "Generator" in parameters["Particles"]["value"]:
+                parameters["Particles"]["value"]["Generator"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+
+            # Figure out if a generator is manually selected, if so move the parameter into their subsection
+            if "Particle generator name" in parameters["Particles"]["value"]:
+                generator = parameters["Particles"]["value"]["Particle generator name"]["value"]
+
+                # if one of the generators was selected that use 'Number of particles' move it
+                if generator == "uniform box":
+                    if not "Uniform box" in parameters["Particles"]["value"]["Generator"]["value"]:
+                        parameters["Particles"]["value"]["Generator"]["value"]["Uniform box"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+                    parameters["Particles"]["value"]["Generator"]["value"]["Uniform box"]["value"]["Number of particles"] = parameter
+
+                elif generator == "uniform radial":
+                    if not "Uniform radial" in parameters["Particles"]["value"]["Generator"]["value"]:
+                        parameters["Particles"]["value"]["Generator"]["value"]["Uniform radial"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+                    parameters["Particles"]["value"]["Generator"]["value"]["Uniform radial"]["value"]["Number of particles"] = parameter
+
+                elif generator == "random uniform" or generator == "probability density function":
+                    if not "Probability density function" in parameters["Particles"]["value"]["Generator"]["value"]:
+                        parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+                    parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"]["value"]["Number of particles"] = parameter
+
+                # the parameter was not used by other generators. silently delete it
+            else:
+                # No generator was manually selected, move the parameter into the default generator subsection
+                if not "Probability density function" in parameters["Particles"]["value"]["Generator"]["value"]:
+                    parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+
+                parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"]["value"]["Number of particles"] = parameter
+            
+    return parameters
+
+def move_particle_postprocess_parameters_back(parameters):
+    """ Move the particle postprocessor parameters back to the postprocess subsection. """
+
+    parameters_to_move = ["Time between data output", \
+                          "Data output format", \
+                          "Number of grouped files", \
+                          "Write in background thread", \
+                          "Temporary output location", \
+                          "Exclude output properties"]
+
+    # Find the particle parameters and move
+    if "Particles" in parameters:
+        for param in parameters_to_move:
+            if param in parameters["Particles"]["value"]:
+                # Create a new particles subsection in postprocess if necessary
+                if "Particles" not in parameters["Postprocess"]["value"]:
+                    parameters["Postprocess"]["value"]["Particles"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+
+                parameters["Postprocess"]["value"]["Particles"]["value"][param] = parameters["Particles"]["value"][param]
+                del parameters["Particles"]["value"][param]
+
+    return parameters
+
+
+
+def main(input_file, output_file):
+    """Echo the input arguments to standard output"""
+    parameters = aspect.read_parameter_file(input_file)
+
+    parameters = move_particle_parameters_to_own_subsection(parameters)
+    parameters = move_number_of_particles_to_correct_subsection(parameters)
+    parameters = move_particle_postprocess_parameters_back(parameters)
+
+    aspect.write_parameter_file(parameters, output_file)
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog='ASPECT .prm file reformatter',
+                    description='Reformats ASPECT .prm files to follow our general formatting guidelines. See the documentation of this script for details.')
+    parser.add_argument('input_file', type=str, help='The .prm file to reformat')
+    parser.add_argument('output_file', type=str, help='The .prm file to write the reformatted file to')
+    args = parser.parse_args()
+
+    sys.exit(main(args.input_file, args.output_file))

--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -11,7 +11,7 @@ import re
 import argparse
 
 __author__ = 'The authors of the ASPECT code'
-__copyright__ = 'Copyright 2023, ASPECT'
+__copyright__ = 'Copyright 2024, ASPECT'
 __license__ = 'GNU GPL 2 or later'
 
 # Add the ASPECT root directory to the path so we can import from the aspect_data module

--- a/contrib/utilities/update_scripts/prm_files/reformat.py
+++ b/contrib/utilities/update_scripts/prm_files/reformat.py
@@ -68,6 +68,7 @@ def reformat (parameters):
     return parameters
 
 
+
 def main(input_file, output_file):
     """Echo the input arguments to standard output"""
     parameters = aspect.read_parameter_file(input_file)

--- a/contrib/utilities/update_scripts/prm_files/reformat.py
+++ b/contrib/utilities/update_scripts/prm_files/reformat.py
@@ -68,7 +68,6 @@ def reformat (parameters):
     return parameters
 
 
-
 def main(input_file, output_file):
     """Echo the input arguments to standard output"""
     parameters = aspect.read_parameter_file(input_file)

--- a/cookbooks/allken_et_al_2012_rift_interaction/allken.prm
+++ b/cookbooks/allken_et_al_2012_rift_interaction/allken.prm
@@ -21,6 +21,7 @@ end
 
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X repetitions = 7
     set Y repetitions = 7
@@ -44,6 +45,7 @@ end
 subsection Mesh deformation
   set Mesh deformation boundary indicators = top: free surface
   set Additional tangential mesh velocity boundary indicators = left,right
+
   subsection Free surface
     set Surface velocity projection = normal
   end
@@ -54,6 +56,7 @@ end
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = front,back,bottom
   set Prescribed velocity boundary indicators = left x: function, right x:function
+
   subsection Function
     set Variable names      = x,y,z
     set Function constants  = cm=0.01, year=1, vel=0.5
@@ -70,6 +73,7 @@ end
 # Spatial domain of different compositional fields
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Variable names      = x,y,z
     set Function constants  = xL=85e3 , xR=135e3
@@ -89,6 +93,7 @@ end
 # Temperature initial conditions (isothermal)
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 293
   end
@@ -97,6 +102,7 @@ end
 # Gravity model
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 9.81
   end
@@ -105,6 +111,7 @@ end
 # Material model
 subsection Material model
   set Model name = visco plastic
+
   subsection Visco Plastic
     set Densities                   = 2800
     set Reference strain rate       = 1.51e-15
@@ -118,6 +125,7 @@ subsection Material model
     set Viscosity averaging scheme  = maximum composition
     set Angles of internal friction = 15.
     set Cohesions                   = 20.e6
+
     # The parameters below weaken the friction and cohesion by a
     # a factor of 4 between plastic strain values of 0.25 and 1.25.
     set Strain weakening mechanism                   = plastic weakening with plastic strain only
@@ -133,12 +141,14 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, velocity statistics, visualization, topography
+
   subsection Visualization
     set List of output variables = material properties, strain rate, named additional outputs
+    set Time between graphical output = 10e3
+    set Interpolate output = true
+
     subsection Material properties
       set List of material properties = density, viscosity
     end
-    set Time between graphical output = 10e3
-    set Interpolate output = true
   end
 end

--- a/cookbooks/composition_active_particles/composition_active_particles.prm
+++ b/cookbooks/composition_active_particles/composition_active_particles.prm
@@ -87,13 +87,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 100000
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = velocity, initial composition
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
-    set Particle generator name = random uniform
   end
 end
 
@@ -115,5 +110,18 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = velocity, initial composition
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100000
+    end
   end
 end

--- a/cookbooks/composition_active_particles/doc/particles.part.prm
+++ b/cookbooks/composition_active_particles/doc/particles.part.prm
@@ -1,10 +1,18 @@
 subsection Postprocess
   subsection Particles
-    set Number of particles         = 100000
     set Time between data output  = 0
     set Data output format        = vtu
-    set List of particle properties = velocity, initial composition
-    set Interpolation scheme      = cell average
-    set Particle generator name   = random uniform
+  end
+end
+
+subsection Particles
+  set List of particle properties = velocity, initial composition
+  set Interpolation scheme      = cell average
+  set Particle generator name   = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles         = 100000
+    end
   end
 end

--- a/cookbooks/composition_passive_particles/composition_passive_particles.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles.prm
@@ -81,7 +81,6 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 1000
     set Time between data output = 0.1
     set Data output format       = vtu
   end
@@ -103,5 +102,13 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 1000
+    end
   end
 end

--- a/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
@@ -81,15 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 50000
     set Time between data output = 0.1
     set Data output format       = vtu
-    set List of particle properties = function, initial composition, initial position, pT path
-
-    subsection Function
-      set Variable names      = x,y
-      set Function expression = if(y<0.2, 1, 0)
-    end
   end
 end
 
@@ -109,5 +102,20 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = function, initial composition, initial position, pT path
+
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if(y<0.2, 1, 0)
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 50000
+    end
   end
 end

--- a/cookbooks/composition_passive_particles/doc/particle-properties.part.prm
+++ b/cookbooks/composition_passive_particles/doc/particle-properties.part.prm
@@ -1,11 +1,17 @@
 subsection Postprocess
-  subsection Particles
-    set Number of particles        = 50000
-    set List of particle properties = function, initial composition, initial position, pT path
+end
 
-    subsection Function
-      set Variable names      = x,y
-      set Function expression = if(y<0.2, 1, 0)
+subsection Particles
+  set List of particle properties = function, initial composition, initial position, pT path
+
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if(y<0.2, 1, 0)
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 50000
     end
   end
 end

--- a/cookbooks/composition_passive_particles/doc/particles.part.prm
+++ b/cookbooks/composition_passive_particles/doc/particles.part.prm
@@ -6,8 +6,15 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 1000
     set Time between data output = 0.1
     set Data output format       = vtu
+  end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 1000
+    end
   end
 end

--- a/cookbooks/convection-box-particles/convection-box-particles.prm
+++ b/cookbooks/convection-box-particles/convection-box-particles.prm
@@ -152,7 +152,6 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1000
     set Time between data output = 1e7
     set Data output format = vtu
   end
@@ -160,4 +159,12 @@ end
 
 subsection Solver parameters
   set Temperature solver tolerance = 1e-10
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
+  end
 end

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box.prm
@@ -19,7 +19,6 @@ set Output directory                       = output-convection-box
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
 
-
 # Then come a number of sections that deal with the setup
 # of the problem to solve. The first one deals with the
 # geometry of the domain within which we want to solve.
@@ -36,7 +35,6 @@ subsection Geometry model
     set Y extent = 1
   end
 end
-
 
 # The next section deals with the initial conditions for the
 # temperature. Note that there are no initial conditions for the
@@ -65,7 +63,6 @@ subsection Initial temperature model
   end
 end
 
-
 # Then follows a section that describes the boundary conditions
 # for the temperature. The model we choose is called 'box' and
 # allows to set a constant temperature on each of the four sides
@@ -85,7 +82,6 @@ subsection Boundary temperature model
     set Top temperature    = 0
   end
 end
-
 
 # The next parameters then describe on which parts of the
 # boundary we prescribe a zero or nonzero velocity and
@@ -109,7 +105,6 @@ subsection Gravity model
   end
 end
 
-
 subsection Material model
   set Model name = simple
 
@@ -123,14 +118,12 @@ subsection Material model
   end
 end
 
-
 # We also have to specify that we want to use the Boussinesq
 # approximation (assuming the density in the temperature
 # equation to be constant, and incompressibility).
 subsection Formulation
   set Formulation = Boussinesq approximation
 end
-
 
 # The settings above all pertain to the description of the
 # continuous partial differential equations we want to solve.
@@ -143,7 +136,6 @@ subsection Mesh refinement
   set Initial adaptive refinement              = 0
   set Time steps between mesh refinement       = 0
 end
-
 
 # The final part is to specify what ASPECT should do with the
 # solution once computed at the end of every time step. The

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box2.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/convection-box2.prm
@@ -19,7 +19,6 @@ set Output directory                       = output-convection-box2
 set Pressure normalization                 = surface
 set Surface pressure                       = 0
 
-
 # Then come a number of sections that deal with the setup
 # of the problem to solve. The first one deals with the
 # geometry of the domain within which we want to solve.
@@ -36,7 +35,6 @@ subsection Geometry model
     set Y extent = 1
   end
 end
-
 
 # The next section deals with the initial conditions for the
 # temperature. Note that there are no initial conditions for the
@@ -65,7 +63,6 @@ subsection Initial temperature model
   end
 end
 
-
 # Then follows a section that describes the boundary conditions
 # for the temperature. The model we choose is called 'box' and
 # allows to set a constant temperature on each of the four sides
@@ -86,7 +83,6 @@ subsection Boundary temperature model
   end
 end
 
-
 # The next parameters then describe on which parts of the
 # boundary we prescribe a zero or nonzero velocity and
 # on which parts the flow is allowed to be tangential.
@@ -103,11 +99,11 @@ end
 # this cookbook in the manual already.
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 1e4   # = Ra
   end
 end
-
 
 subsection Material model
   set Model name = simple
@@ -122,14 +118,12 @@ subsection Material model
   end
 end
 
-
 # We also have to specify that we want to use the Boussinesq
 # approximation (assuming the density in the temperature
 # equation to be constant, and incompressibility).
 subsection Formulation
   set Formulation = Boussinesq approximation
 end
-
 
 # The settings above all pertain to the description of the
 # continuous partial differential equations we want to solve.
@@ -142,7 +136,6 @@ subsection Mesh refinement
   set Initial adaptive refinement              = 0
   set Time steps between mesh refinement       = 0
 end
-
 
 # The final part is to specify what ASPECT should do with the
 # solution once computed at the end of every time step. The

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
@@ -9,7 +9,6 @@ set Use years in output instead of seconds = true
 set End time                               = 1.00e10
 set Output directory                       = output-tutorial
 
-
 # Then come a number of sections that deal with the setup
 # of the problem to solve. The first one deals with the
 # geometry of the domain within which we want to solve.
@@ -20,12 +19,12 @@ set Output directory                       = output-tutorial
 # model.
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent = 4.2e6
     set Y extent = 3e6
   end
 end
-
 
 # The following section deals with the discretization of
 # this problem, namely the kind of mesh we want to compute
@@ -37,12 +36,12 @@ subsection Mesh refinement
   set Time steps between mesh refinement       = 0
 end
 
-
 # The following two sections describe first the
 # direction (vertical) and magnitude of gravity and the
 # material model (i.e., density, viscosity, etc).
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 9.81
   end
@@ -50,11 +49,11 @@ end
 
 subsection Material model
   set Model name = simple
+
   subsection Simple model
     set Viscosity                     = 5.099e23
   end
 end
-
 
 # The next section deals with the initial conditions for the
 # temperature (there are no initial conditions for the
@@ -68,13 +67,13 @@ end
 # a small perturbation:
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Variable names      = x,y
     set Function constants  = p=-0.01, L=4.2e6, D=3e6, pi=3.1415926536, k=1, T_top=273, T_bottom=3600
     set Function expression = T_top + (T_bottom-T_top)*(1-(y/D) - p*cos(k*pi*x/L)*sin(pi*y/D))
   end
 end
-
 
 # We then also have to prescribe several other parts of the model
 # such as which boundaries actually carry a prescribed boundary
@@ -86,11 +85,11 @@ end
 # subsection Model settings    OLD DEPRECATED
 #   set Fixed temperature boundary indicators   = 2,3 OLD MOVED
 
-  # The next parameters then describe on which parts of the
-  # boundary we prescribe a zero or nonzero velocity and
-  # on which parts the flow is allowed to be tangential.
-  # Here, all four sides of the box allow tangential
-  # unrestricted flow but with a zero normal component:
+# The next parameters then describe on which parts of the
+# boundary we prescribe a zero or nonzero velocity and
+# on which parts the flow is allowed to be tangential.
+# Here, all four sides of the box allow tangential
+# unrestricted flow but with a zero normal component:
 #  set Zero velocity boundary indicators       =             OLD MOVED
 #  set Prescribed velocity boundary indicators =             OLD MOVED
 #  set Tangential velocity boundary indicators = 0,1,2,3     OLD MOVED
@@ -99,11 +98,11 @@ subsection Boundary velocity model
   set Tangential velocity boundary indicators = left, right, bottom, top
 end
 
-  # The final part of this section describes whether we
-  # want to include adiabatic heating (from a small
-  # compressibility of the medium) or from shear friction,
-  # as well as the rate of internal heating. We do not
-  # want to use any of these options here:
+# The final part of this section describes whether we
+# want to include adiabatic heating (from a small
+# compressibility of the medium) or from shear friction,
+# as well as the rate of internal heating. We do not
+# want to use any of these options here:
 #  set Include adiabatic heating               = false      OLD is false
 #  set Include shear heating                   = false      OLD is false
 # end
@@ -120,12 +119,12 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = 2,3
   set Model name = box
+
   subsection Box
     set Bottom temperature = 3600
     set Top temperature    = 273
   end
 end
-
 
 # The final part is to specify what ASPECT should do with the
 # solution once computed at the end of every time step. The
@@ -137,13 +136,22 @@ end
 # a time step crosses time points separated by 1e7 years.
 subsection Postprocess
   set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics , visualization, particles, basic statistics
+
   subsection Visualization
     set Time between graphical output = 1e7
     set Output format = vtu
   end
+
   subsection Particles
-    set Number of particles = 1000
     set Time between data output = 1e7
     set Data output format = vtu
+  end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
   end
 end

--- a/cookbooks/fastscape_eroding_box/fastscape_eroding_box.prm
+++ b/cookbooks/fastscape_eroding_box/fastscape_eroding_box.prm
@@ -6,12 +6,10 @@
 # At the top, we define the number of space dimensions we would like to
 # work in:
 set Dimension                              = 3
-
 set Use years in output instead of seconds = true
 set End time                               = 2.5e5
 set Maximum time step                      = 50000
 set Output directory                       = eroding_box
-
 set Pressure normalization                 = no
 set Surface pressure                       = 0
 
@@ -29,6 +27,7 @@ subsection Geometry model
 
   subsection Initial topography model
     set Model name = function
+
     subsection Function
       set Function expression = if(y>20e3 && y<80e3 && x>32.5e3 && x<92.5e3, 2500, 0)
     end
@@ -56,7 +55,8 @@ end
 
 # Here we setup the top boundary with fastscape.
 subsection Mesh deformation
- set Mesh deformation boundary indicators = top : fastscape
+  set Mesh deformation boundary indicators = top : fastscape
+  set Additional tangential mesh velocity boundary indicators = left, right, front, back
 
   subsection Fastscape
     # As the highest resolution at the surface is 4 in the mesh refinement function, we set this the same.
@@ -112,9 +112,6 @@ subsection Mesh deformation
       set Multi-direction slope exponent = -1
     end
   end
-
-  set Additional tangential mesh velocity boundary indicators = left, right, front, back
-
 end
 
 subsection Gravity model
@@ -139,14 +136,12 @@ subsection Material model
   end
 end
 
-
 # We also have to specify that we want to use the Boussinesq
 # approximation (assuming the density in the temperature
 # equation to be constant, and incompressibility).
 subsection Formulation
   set Formulation = Boussinesq approximation
 end
-
 
 # We set a maximum surface refinement level of 4 using the max/minimum refinement level.
 # This will make it so that the ASPECT surface refinement is the same as what we set
@@ -157,16 +152,16 @@ subsection Mesh refinement
   set Time steps between mesh refinement       = 0
   set Strategy                                 = minimum refinement function, maximum refinement function
 
-    subsection Maximum refinement function
-      set Coordinate system   = cartesian
-      set Variable names      = x,y,z
-      set Function expression = if(z>=21000, 4, 2)
+  subsection Maximum refinement function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,z
+    set Function expression = if(z>=21000, 4, 2)
   end
 
-      subsection Minimum refinement function
-      set Coordinate system   = cartesian
-      set Variable names      = x,y,z
-      set Function expression = if(z>=21000, 4, 2)
+  subsection Minimum refinement function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,z
+    set Function expression = if(z>=21000, 4, 2)
   end
 end
 

--- a/cookbooks/grain_size_ridge/doc/material_model.part.prm
+++ b/cookbooks/grain_size_ridge/doc/material_model.part.prm
@@ -1,5 +1,6 @@
 subsection Material model
   set Model name = grain size
+
   subsection Grain size model
     # Diffusion creep has a prefactor, a temperature dependence defined by the
     # activation energy, a pressure dependence defined by the activation volume

--- a/cookbooks/grain_size_ridge/doc/particles.part.prm
+++ b/cookbooks/grain_size_ridge/doc/particles.part.prm
@@ -1,22 +1,30 @@
 subsection Postprocess
   set List of postprocessors = visualization, composition statistics, velocity statistics, mass flux statistics, particles
 
-  # We use particles to advect the grain size.
   subsection Particles
-    set Interpolation scheme = bilinear least squares
-    set Number of particles = 500000
     set Time between data output = 1e6
-    set List of particle properties = grain size
-    set Load balancing strategy = remove and add particles
-    set Minimum particles per cell = 40
-    set Maximum particles per cell = 640
-    set Integration scheme = rk2
-    set Update ghost particles = true
+  end
+end
 
-    subsection Interpolator
-      subsection Bilinear least squares
-        set  Use linear least squares limiter = true
-      end
+# We use particles to advect the grain size.
+subsection Particles
+  set Interpolation scheme = bilinear least squares
+  set List of particle properties = grain size
+  set Load balancing strategy = remove and add particles
+  set Minimum particles per cell = 40
+  set Maximum particles per cell = 640
+  set Integration scheme = rk2
+  set Update ghost particles = true
+
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true
+    end
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 500000
     end
   end
 end

--- a/cookbooks/grain_size_ridge/grain_size_ridge.prm
+++ b/cookbooks/grain_size_ridge/grain_size_ridge.prm
@@ -50,6 +50,7 @@ end
 # for the cells, we choose more X than Y repetitions.
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent  = 4000000
     set Y extent  = 410000
@@ -99,6 +100,7 @@ end
 # surface).
 subsection Initial temperature model
   set List of model names = adiabatic, function
+
   subsection Adiabatic
     set Age bottom boundary layer   = 0.0
     set Top boundary layer age model = function
@@ -115,12 +117,11 @@ subsection Initial temperature model
   end
 end
 
-
 # The temperature at the boundary is taken from the initial conditions.
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom, right
-
   set List of model names = initial temperature
+
   subsection Initial temperature
     set Minimal temperature = 293
     set Maximal temperature = 1623
@@ -143,6 +144,7 @@ end
 # axis, again to allow for easy deformation there.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function constants  = DeltaC = -29e-4, b = 0, width = 30000, c=397000
     set Function expression = 5e-3 + DeltaC * exp(-((x-b)*(x-b)+(y-c)*(y-c))/(2*width*width))
@@ -156,17 +158,14 @@ subsection Boundary composition model
   set List of model names = initial composition
 end
 
-
 # We use the grain size material model, which implements the equations
 # for grain size evolution.
 subsection Material model
-
   # Because we use the GMG solver, we need to average the viscosity.
   set Material averaging = project to Q1 only viscosity
-
   set Model name = grain size
-  subsection Grain size model
 
+  subsection Grain size model
     # We use typical upper-mantle material properties.
     set Reference density                         = 3300
     set Reference specific heat                   = 1200
@@ -220,6 +219,7 @@ end
 # The gravity points downward and is set to 10.
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 10.0
   end
@@ -258,39 +258,22 @@ end
 subsection Postprocess
   set List of postprocessors = visualization, composition statistics, velocity statistics, mass flux statistics, particles
 
-  # We use particles to advect the grain size.
-  subsection Particles
-    set Interpolation scheme = bilinear least squares
-    set Number of particles = 500000
-    set Time between data output = 1e6
-    set List of particle properties = grain size
-    set Load balancing strategy = remove and add particles
-    set Minimum particles per cell = 40
-    set Maximum particles per cell = 640
-    set Integration scheme = rk2
-    set Update ghost particles = true
-
-    subsection Interpolator
-      subsection Bilinear least squares
-        set  Use linear least squares limiter = true
-      end
-    end
-  end
-
   subsection Visualization
     set List of output variables      = material properties, nonadiabatic temperature, nonadiabatic pressure, strain rate, melt fraction, named additional outputs
     set Point-wise stress and strain  = true
-
-    subsection Material properties
-      set List of material properties = density, viscosity, thermal expansivity
-    end
-
     set Number of grouped files       = 0
     set Interpolate output            = false
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
+    end
   end
 
+  subsection Particles
+    set Time between data output = 1e6
+  end
 end
 
 # Every 10 minutes (600 seconds) we write a restart file that could be used to
@@ -301,4 +284,27 @@ end
 
 subsection Termination criteria
   set Checkpoint on termination = true
+end
+
+# We use particles to advect the grain size.
+subsection Particles
+  set Interpolation scheme = bilinear least squares
+  set List of particle properties = grain size
+  set Load balancing strategy = remove and add particles
+  set Minimum particles per cell = 40
+  set Maximum particles per cell = 640
+  set Integration scheme = rk2
+  set Update ghost particles = true
+
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true
+    end
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 500000
+    end
+  end
 end

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case1_compositions.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case1_compositions.prm
@@ -16,7 +16,6 @@ subsection Compositional fields
   set Names of fields  = BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
 end
 
-
 subsection Initial composition model
   set List of model names = function
 

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case1_materialmodel.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case1_materialmodel.prm
@@ -6,10 +6,10 @@ subsection Material model
   subsection Multicomponent
     set Reference temperature         = 0.0
     set Viscosity averaging scheme    = maximum composition
+
     # BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
     set Viscosities                   = 1.e20, 1.e23, 1.e20, 1.e23, 1.e23, 1.e23, 1.e23, 1.e20
     set Densities                     = 3200.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0
     set Thermal conductivities        = 1
   end
-
 end

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_materialmodel.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_materialmodel.prm
@@ -5,12 +5,9 @@ subsection Material model
     set Reference temperature         = 473.15
     set Densities                     = 3200.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0
     set Thermal expansivities         = 0
-
     set Thermal conductivities        = 183.33,2.5,2.5,2.5,2.5,2.5,2.5,2.5
     set Heat capacities               = 1250.0,750.0,750.0,750.0,750.0,1250.0,1250.0,750.0
-
     set Viscosity averaging scheme    = maximum composition
     set Viscosities                   = 1.e20, 1.e23, 1.e20, 1.e23, 1.e23, 1.e23, 1.e23, 1.e20
   end
-
 end

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_postprocessing.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_postprocessing.prm
@@ -17,5 +17,4 @@ subsection Postprocess
   subsection Composition RMS temperature statistics
     set Names of selected compositional fields = BOC_SP, SHB_SP, thermal_SP
   end
-
 end

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_temperatures.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case2a_temperatures.prm
@@ -6,8 +6,8 @@ set Additional shared libraries            = $ASPECT_SOURCE_DIR/cookbooks/kinema
 # we have inflow through the latter.
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = bottom, top, right
-
   set List of model names = box
+
   subsection Box
     set Bottom temperature = 0
     set Left temperature   = 0

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case2b_materialmodel.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case2b_materialmodel.prm
@@ -22,5 +22,4 @@ subsection Material model
     # feeds into the density and therefore the Stokes equations
     set Thermal expansivities         = 2.5e-5
   end
-
 end

--- a/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
@@ -72,6 +72,7 @@ subsection Material model
   subsection Multicomponent
     set Reference temperature         = 0.0
     set Viscosity averaging scheme    = maximum composition
+
     # BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
     set Viscosities                   = 1.e20, 1.e23, 1.e20, 1.e23, 1.e23, 1.e23, 1.e23, 1.e20
     set Densities                     = 3200.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0
@@ -89,7 +90,6 @@ subsection Compositional fields
   set Number of fields = 7
   set Names of fields  = BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
 end
-
 
 subsection Initial composition model
   set List of model names = function

--- a/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case2a.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case2a.prm
@@ -23,7 +23,6 @@ include kinematically_driven_subduction_2d_case1.prm
 
 set Output directory                       = output-Case2a
 
-
 # We fix temperature on the top and bottom
 # as well as on the right boundary because
 # we have inflow through the latter.
@@ -32,18 +31,17 @@ subsection Boundary temperature model
   set List of model names = initial temperature
 end
 
-
 subsection Material model
   set Model name = multicomponent
 
   subsection Multicomponent
     set Reference temperature         = 473.15
+
     # BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
     set Thermal conductivities        = 183.33,2.5,2.5,2.5,2.5,2.5,2.5,2.5
     set Heat capacities               = 1250.0,750.0,750.0,750.0,750.0,1250.0,1250.0,750.0
     set Thermal expansivities         = 0
   end
-
 end
 
 # The overriding plate (OP) and subducting plate (SP)
@@ -56,9 +54,9 @@ subsection Compositional fields
   set Names of fields  = BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
 end
 
-
 subsection Initial composition model
   set List of model names = function
+
   subsection Function
     set Function constants  = Ax=1475600.0, Az=670000.0, \
                               Bx=1500000.0, Bz=670000.0, \
@@ -77,7 +75,6 @@ subsection Initial composition model
     set Variable names      = x,z
   end
 end
-
 
 # The initial temperature is prescribed through a plugin
 # and uses the plate cooling model for the temperature in both
@@ -107,5 +104,4 @@ subsection Postprocess
   subsection Composition RMS temperature statistics
     set Names of selected compositional fields = BOC_SP, SHB_SP, thermal_SP
   end
-
 end

--- a/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case2b.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case2b.prm
@@ -35,5 +35,4 @@ subsection Material model
     # feeds into the density and therefore the Stokes equations
     set Thermal expansivities         = 2.5e-5
   end
-
 end

--- a/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
+++ b/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
@@ -36,7 +36,6 @@ subsection Nullspace removal
 end
 
 subsection Material model
-
   set Model name = compositing
   set Material averaging = harmonic average only viscosity
 
@@ -48,7 +47,6 @@ subsection Material model
     set Minimum strain rate   = 1e-22
     set Reference strain rate = 1e-15
     set Heat capacities       = background: 1250, 1_mantle: 1250 | 1250 | 1250 , 3_continent: 1250
-
     set Prefactors for dislocation creep          =  background:6.51e-16 ,  1_mantle: 6.51e-16| 8.51e-16 | 6.51e-16  ,  3_continent:6.51e-28
     set Stress exponents for dislocation creep    =  background:1        ,  1_mantle: 3       | 3        | 1         ,  3_continent:       1
     set Activation energies for dislocation creep =  background:540e3    ,  1_mantle: 500e3   | 500e3    | 530e3     ,  3_continent:   540e3
@@ -125,6 +123,7 @@ end
 
 subsection Heating model
   set List of model names = latent heat, adiabatic heating, constant heating, shear heating
+
   subsection Adiabatic heating
     set Use simplified adiabatic heating = true
   end
@@ -189,26 +188,23 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Data output format            = vtu
-    set List of particle properties   = position, velocity, initial composition, pT path, initial position
-    set Number of particles           = 100000
-    set Number of grouped files       = 1
-    set Update ghost particles        = true
-    set Particle generator name       = reference cell
     set Time between data output      = 1e6
     set Data output format            = ascii, vtu
     set Number of grouped files       = 1
     set Write in background thread    = true
+  end
+end
 
-    set Load balancing strategy       = remove and add particles
-    set Minimum particles per cell    = 5
-    set Minimum particles per cell    = 80
+subsection Particles
+  set List of particle properties   = position, velocity, initial composition, pT path, initial position
+  set Update ghost particles        = true
+  set Particle generator name       = reference cell
+  set Load balancing strategy       = remove and add particles
+  set Minimum particles per cell    = 80
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
-
   end
 end

--- a/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
+++ b/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
@@ -21,7 +21,7 @@ subsection Solver parameters
 end
 
 subsection Formulation
-   set Formulation = isentropic compression
+  set Formulation = isentropic compression
 end
 
 subsection Compositional fields
@@ -58,22 +58,18 @@ subsection Material model
     set Activation energies for diffusion creep   =  background:166e3    ,  1_mantle: 150e3   | 155e3    | 150e3     ,  3_continent:   166e3
     set Activation volumes for diffusion creep    =  background:6.34e-7  ,  1_mantle: 6.34e-7 | 14.34e-7 | 12.34e-7  ,  3_continent: 6.34e-7
     set Densities                                 =  background:3300     ,  1_mantle: 3300    | 3500     | 3800      ,  3_continent:    2900
-
     set Grain size                                 =   1
     set Angles of internal friction                =   1.43373998 , 1.43373998  , 30
     set Cohesions                                  =   7e6        , 4e6,1e7
-
     set Phase transition depths                        = 1_mantle: 410000 | 660000
     set Phase transition temperatures                  = 1_mantle:   1700 | 1900
     set Phase transition Clapeyron slopes              = 1_mantle:    3e6 | -2.5e6
     set Phase transition widths                        = 1_mantle: 50000  | 50000
-
     set Use adiabatic pressure in creep viscosity = true
     set Constant viscosity prefactors                   = 1, 1, 1
   end
 
   subsection Latent heat
-
     # The change of density across the phase transition. Together with the
     # Clapeyron slope, this is what determines the entropy change.
     set Phase transition density jumps                 = 273, 341
@@ -116,6 +112,7 @@ end
 
 subsection Geometry model
   set Model name = spherical shell
+
   subsection Spherical shell
     set Inner radius = 3480000
     set Outer radius = 6370000
@@ -123,7 +120,7 @@ subsection Geometry model
 end
 
 subsection Boundary velocity model
-   set Tangential velocity boundary indicators = inner, outer
+  set Tangential velocity boundary indicators = inner, outer
 end
 
 subsection Heating model
@@ -131,6 +128,7 @@ subsection Heating model
   subsection Adiabatic heating
     set Use simplified adiabatic heating = true
   end
+
   subsection Constant heating
     set Radiogenic heating rate = 5.44e-12
   end
@@ -139,6 +137,7 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = outer, inner
   set List of model names = spherical constant
+
   subsection Spherical constant
     set Outer temperature = 300
     set Inner temperature = 3700
@@ -151,28 +150,30 @@ end
 
 subsection Gravity model
   set Model name = radial constant
+
   subsection Radial constant
     set Magnitude = 9.81
-   end
+  end
 end
 
 subsection Mesh refinement
   set Initial global refinement       = 3
   set Initial adaptive refinement     = 4
   set Strategy                        = minimum refinement function, viscosity, velocity
+  set Time steps between mesh refinement = 1
+
   subsection Minimum refinement function
     set Coordinate system = spherical
     set Function expression = if(r>6000e3, 6, if(r>5000e3,5,3))
     set Variable names = r,phi,t
   end
-  set Time steps between mesh refinement = 1
 end
 
 subsection Postprocess
   set List of postprocessors = velocity statistics, temperature statistics, visualization, heat flux statistics, depth average, particles, Stokes residual, basic statistics, mobility statistics
 
   subsection Global statistics
-     set Write statistics for each nonlinear iteration = true
+    set Write statistics for each nonlinear iteration = true
   end
 
   subsection Depth average
@@ -195,8 +196,8 @@ subsection Postprocess
     set Update ghost particles        = true
     set Particle generator name       = reference cell
     set Time between data output      = 1e6
-    set Allow cells without particles = true
-    set Interpolation scheme          = cell average
+    set Data output format            = ascii, vtu
+    set Number of grouped files       = 1
     set Write in background thread    = true
 
     set Load balancing strategy       = remove and add particles

--- a/cookbooks/multicomponent_steinberger/doc/lookup.part.prm
+++ b/cookbooks/multicomponent_steinberger/doc/lookup.part.prm
@@ -6,4 +6,5 @@ subsection Material model
     set Material file names              = pyr_MS95_with_volume_fractions_lo_res.dat, \
                                            morb_G13_with_volume_fractions_lo_res.dat\
   end
+  end
 end

--- a/cookbooks/multicomponent_steinberger/doc/temperature.setup.prm
+++ b/cookbooks/multicomponent_steinberger/doc/temperature.setup.prm
@@ -1,9 +1,11 @@
 subsection Initial temperature model
   set List of model operators = add
   set List of model names = adiabatic, function
+
   subsection Adiabatic
     set Age top boundary layer = 5e7
     set Age bottom boundary layer = 7e8
+
     subsection Function
       set Function constants  = k=-7e-7, c=2.9367
       set Variable names      = x, y

--- a/cookbooks/multicomponent_steinberger/steinberger_thermochemical_plume.prm
+++ b/cookbooks/multicomponent_steinberger/steinberger_thermochemical_plume.prm
@@ -78,9 +78,11 @@ end
 subsection Initial temperature model
   set List of model operators = add
   set List of model names = adiabatic, function
+
   subsection Adiabatic
     set Age top boundary layer = 5e7
     set Age bottom boundary layer = 7e8
+
     subsection Function
       set Function constants  = k=-7e-7, c=2.9367
       set Variable names      = x, y
@@ -124,7 +126,6 @@ subsection Postprocess
       set List of material properties   = viscosity, density, specific heat, thermal conductivity, thermal expansivity, compressibility
     end
   end
-
 end
 
 # other model setup

--- a/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
+++ b/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
@@ -40,19 +40,27 @@ end
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, composition statistics, pressure statistics, material statistics, global statistics, particles
 
-  subsection Particles
-    set Number of particles      = 350000
-    set Time between data output = 0
-    set Data output format       = vtu
-    set List of particle properties = initial composition, velocity
-    set Particle generator name = random uniform
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
-  end
-
   subsection Visualization
     set List of output variables = density, viscosity, strain rate
     set Time between graphical output = 0
     set Interpolate output = false
+  end
+
+  subsection Particles
+    set Time between data output = 0
+    set Data output format       = vtu
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition, velocity
+  set Particle generator name = random uniform
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles      = 350000
+    end
   end
 end

--- a/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
+++ b/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
@@ -21,6 +21,7 @@
 
 set Adiabatic surface temperature              = 1600
 set Nonlinear solver scheme                    = iterated Advection and Stokes
+
 # We choose a low number of iterations and less restrictive nonlinear solver tolerance
 # for model efficiency. During the initial pulse of dehydration (for 3 time steps),
 # solvers do not quite converge to 1e-4, but achieve the convergence criteria for the
@@ -32,6 +33,7 @@ set Max nonlinear iterations                   = 25
 set Nonlinear solver tolerance                 = 1e-4
 set Dimension                                  = 2
 set End time                                   = 2e6
+
 # Set the 'Surface pressure' to 1 GPa to simulate a slab that is at depth.
 set Surface pressure                           = 1e9
 set Maximum time step                          = 1000
@@ -59,7 +61,8 @@ subsection Solver parameters
     set Reaction time step                     = 100
     set Reaction time steps per advection step = 10
   end
-# Set a stricter linear solver tolerance to ensure convergence
+
+  # Set a stricter linear solver tolerance to ensure convergence
   subsection Stokes solver parameters
     set Linear solver tolerance             = 1e-10
     set Number of cheap Stokes solver steps = 1000
@@ -88,6 +91,7 @@ end
 # evolves through the composition boundary conditions specified below.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0; 0; 1; 0; 0; 0
   end
@@ -100,6 +104,7 @@ end
 subsection Boundary composition model
   set Fixed composition boundary indicators         = left
   set List of model names                           = function
+
   subsection Function
     set Function constants  = initial_porosity=0, initial_bound_sediment=0.03, initial_bound_MORB=0.02, initial_bound_gabbro=0.01, \
                               sediment_min=0, sediment_max=5e3, MORB_min=5e3, MORB_max=12e3, gabbro_min=12e3, gabbro_max=20e3, \
@@ -121,6 +126,7 @@ end
 
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent      = 100e3
     set Y extent      = 100e3
@@ -158,6 +164,7 @@ end
 # slab surface.
 subsection Gravity model
   set Model name = function
+
   subsection Function
     set Variable names      = x,y
     set Function constants  = angle=0.7071067811865476
@@ -170,6 +177,7 @@ end
 # outlined below.
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Coordinate system   = cartesian
     set Variable names      = x,y
@@ -184,6 +192,7 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = left
   set List of model names                     = function
+
   subsection Function
     set Coordinate system                     = cartesian
     set Variable names                        = x,y
@@ -191,7 +200,6 @@ subsection Boundary temperature model
     set Function expression                   = if(y<=slab_thickness, Tslab - 200*y/slab_thickness, Tmantle)
   end
 end
-
 
 subsection Material model
   set Model name                                        = reactive fluid transport
@@ -222,6 +230,7 @@ subsection Material model
     set Fluid compressibility                            = 0
     set Fluid reaction time scale for operator splitting = 5e4
     set Fluid-solid reaction scheme                      = tian approximation
+
     # We limit the bound water in the gabbro, MORB, and sediment to their initial
     # values to encourage water to hydrate the overlying mantle. The polynomials defined
     # in Tian et al., 2019 also reach very large values at low P-T conditions, and so limiting
@@ -240,19 +249,17 @@ subsection Material model
     # state and the rheology.
     set Viscosity averaging scheme                      = harmonic
     set Viscous flow law                                = composite
-
     set Prefactors for diffusion creep                  = 4.5e-15
     set Stress exponents for diffusion creep            = 1.0
     set Activation energies for diffusion creep         = 375e3
     set Activation volumes for diffusion creep          = 8.2e-6
-
     set Prefactors for dislocation creep                = 7.4e-15
     set Stress exponents for dislocation creep          = 3.5
     set Activation energies for dislocation creep       = 530e3
     set Activation volumes for dislocation creep        = 14e-6
-
     set Angles of internal friction                     = 0
     set Cohesions                                       = 1e50
+
     # Limit the minimum and maximum viscosity to four orders of
     # magnitude to improve solver convergence behavior.
     set Minimum viscosity                               = 1e19
@@ -266,6 +273,7 @@ end
 # viscous coupling of the mantle wedge with distance from the slab surface.
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = left: function, bottom: function, top: function, right: function
+
   subsection Function
     set Coordinate system   = cartesian
     set Function constants  = basal_v = 0.05, top_v = 0.02, slab_depth = 20e3, ymax = 100e3
@@ -286,14 +294,16 @@ end
 # compaction viscosities and compaction pressures.
 subsection Postprocess
   set List of postprocessors = visualization, composition statistics, velocity statistics
+
   subsection Visualization
     set List of output variables      = density, viscosity, thermal expansivity, melt material properties, melt fraction
-    subsection Melt material properties
-      set List of properties          = fluid density, permeability, fluid viscosity, compaction viscosity
-    end
     set Output format                 = vtu
     set Time between graphical output = 5e4
     set Interpolate output            = true
     set Number of grouped files       = 0
+
+    subsection Melt material properties
+      set List of properties          = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
   end
 end

--- a/cookbooks/tian_parameterization_kinematic_slab/uncoupled-two-phase-tian-parameterization-kinematic-slab.prm
+++ b/cookbooks/tian_parameterization_kinematic_slab/uncoupled-two-phase-tian-parameterization-kinematic-slab.prm
@@ -29,6 +29,7 @@ end
 
 subsection Postprocess
   set List of postprocessors     = visualization, composition statistics, velocity statistics
+
   subsection Visualization
     set List of output variables = density, viscosity, thermal expansivity, melt fraction
   end

--- a/cookbooks/tomography_based_plate_motions/2D_slice_with_faults_and_cratons.prm
+++ b/cookbooks/tomography_based_plate_motions/2D_slice_with_faults_and_cratons.prm
@@ -17,18 +17,17 @@ set Start time                             = 0
 set End time                               = 0
 set Adiabatic surface temperature          = 1573.0
 
-
 # We use matrix-free solver and geometric multigrid preconditioner
 # to reduce memory consumption.
 subsection Solver parameters
   subsection Stokes solver parameters
-   set Linear solver tolerance                         = 1e-4
-   set Stokes solver type                              = block GMG
-   set Number of cheap Stokes solver steps             = 500
-   set GMRES solver restart length                     = 400
-   set Maximum number of expensive Stokes solver steps = 0
-   set Use full A block as preconditioner              = true
-   set Linear solver A block tolerance                 = 1e-2
+    set Linear solver tolerance                         = 1e-4
+    set Stokes solver type                              = block GMG
+    set Number of cheap Stokes solver steps             = 500
+    set GMRES solver restart length                     = 400
+    set Maximum number of expensive Stokes solver steps = 0
+    set Use full A block as preconditioner              = true
+    set Linear solver A block tolerance                 = 1e-2
   end
 end
 
@@ -38,6 +37,7 @@ end
 # uppermost mantle thickness parameter to compute the adiabatic conditions.
 subsection Adiabatic conditions model
   set Model name = reference profile
+
   subsection Reference profile
     subsection Ascii data model
       set Data directory = $ASPECT_SOURCE_DIR/data/1D_reference_profiles/
@@ -46,16 +46,15 @@ subsection Adiabatic conditions model
   end
 end
 
-
 # We use the spherical shell geometry using the real Earth radius values.
 subsection Geometry model
   set Model name = spherical shell
+
   subsection Spherical shell
     set Inner radius  = 3481000
     set Outer radius  = 6371000
   end
 end
-
 
 # We use adaptive refinement to better resolve the plate boundaries and
 # the near-surface heterogeneity
@@ -64,19 +63,18 @@ subsection Mesh refinement
   set Initial global refinement = 4
   set Strategy = minimum refinement function
   set Skip solvers on initial refinement = true
+
   subsection Minimum refinement function
     set Variable names = depth, y
     set Function expression = if (depth < 350000, 5, 4)
   end
 end
 
-
 subsection Compositional fields
   set Number of fields = 6
   set Names of fields = grain_size, Vp, Vs, vs_anomaly, faults, continents
   set Compositional field methods = static, static, static, static, static, static
 end
-
 
 # We use world builder to define the complex geometery of plate boundaries ("faults")
 # and cratons ("continents") in our model.
@@ -94,11 +92,9 @@ subsection Initial composition model
   end
 end
 
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = bottom, top
 end
-
 
 # We set the net rotation of the velocities at the surface to zero.
 # This is useful for comparison with the observed GPS velocities in the no
@@ -107,16 +103,15 @@ subsection Nullspace removal
   set Remove nullspace = net surface rotation
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom
   set List of model names = spherical constant
+
   subsection Spherical constant
     set Inner temperature = 3700
     set Outer temperature = 273
   end
 end
-
 
 # We set initial temperatures purely from an ASCII data file.
 # The only reason we also activate the adiabatic boundary plugin is that it
@@ -140,7 +135,6 @@ subsection Initial temperature model
   end
 end
 
-
 # We do not solve for the temperature field and instead prescribe temperatures
 # in our material model using the initial temperature distribution and
 # temperatures computed from the input tomography data.
@@ -148,16 +142,13 @@ subsection Temperature field
   set Temperature method = prescribed field
 end
 
-
 subsection Heating model
   set List of model names = adiabatic heating, shear heating
 end
 
-
 subsection Gravity model
   set Model name = ascii data
 end
-
 
 # The material model uses diffusion/dislocation creep with prefactors, activation
 # energies and volumes for each major mantle phase chosen to facilitate combined
@@ -170,88 +161,80 @@ subsection Material model
   subsection Tomography based plate motions model
     set Average specific grain boundary energy      = 1.0,1.0,1.0,1.0
     set Use equilibrium grain size                  = false
-
     set Minimum viscosity                           = 1e19
     set Maximum viscosity                           = 1e24
+    set Diffusion activation energy                 = 375000,231000,270000,299000
+    set Diffusion activation volume                 = 6e-6,6e-6,6e-6,2e-6
+    set Diffusion creep exponent                    = 1.0,1.0,1.0,1.0
+    set Diffusion creep grain size exponent         = 3,3,3,3
+    set Diffusion creep prefactor                   = 1.25E-015,6.12E-019,2.94E-017,5.4E-022
+    set Dislocation activation energy               = 530000,530000,530000,530000
+    set Dislocation activation volume               = 1.40E-005,1.70E-005,1.70E-005,0.0
+    set Dislocation creep exponent                  = 3.5,3.5,3.5,3.5
+    set Dislocation creep prefactor                 = 8.33E-015,2.05e-12,2.05e-19,1.e-40 #1e-100, 1e-100, 1e-100, 1e-100
+    set Geometric constant                          = 3,3,3,3
+    set Grain growth activation energy              = 400000,662000,414000,299000
+    set Grain growth activation volume              = 0.0,0.0,0.0,1.5e-6
+    set Grain growth exponent                       = 3,3,4.5,5.0
+    set Grain growth rate constant                  = 1.92e-10,3.02e-4,7.63e-22,5.00E-026
+    set Work fraction for boundary area change      = 0.1,0.1,0.1,0.1
+    set Reference compressibility                   = 4e-12
+    set Reference density                           = 3400
+    set Reference specific heat                     = 1200
+    set Thermal conductivity                        = 4
+    set Thermal expansion coefficient               = 2.0e-5
+    set Maximum temperature dependence of viscosity = 1e6
+    set Phase transition Clapeyron slopes           = 0,0,0
+    set Phase transition depths                     = 410000,520000,660000
+    set Phase transition temperatures               = 1950,1950,1950
+    set Phase transition widths                     = 0,0,0
+    set Reciprocal required strain                  = 10
+    set Recrystallized grain size                   = 0.0,0.0,1e-4
+    set Uppermost mantle thickness                  = 300000
 
-   set Diffusion activation energy                 = 375000,231000,270000,299000
-   set Diffusion activation volume                 = 6e-6,6e-6,6e-6,2e-6
-   set Diffusion creep exponent                    = 1.0,1.0,1.0,1.0
-   set Diffusion creep grain size exponent         = 3,3,3,3
-   set Diffusion creep prefactor                   = 1.25E-015,6.12E-019,2.94E-017,5.4E-022
+    # The following parameters govern whether we want to scale the laterally
+    # averaged viscosity to a reference profile, and the location of that
+    # profile.
+    set Use depth dependent viscosity               = true
 
-   set Dislocation activation energy               = 530000,530000,530000,530000
-   set Dislocation activation volume               = 1.40E-005,1.70E-005,1.70E-005,0.0
-   set Dislocation creep exponent                  = 3.5,3.5,3.5,3.5
-   set Dislocation creep prefactor                 = 8.33E-015,2.05e-12,2.05e-19,1.e-40 #1e-100, 1e-100, 1e-100, 1e-100
+    # This tells us how we want to scale the input Vs anomalies to compute density/temperature
+    # anomalies. By default, the model uses a constant scaling factor, but in this cookbook we use
+    # depth-dependent scaling factors taken from input ascii files.
+    set Use depth dependent density scaling         = true
+    set Use depth dependent temperature scaling     = true
+    set Use faults                                  = true
+    set Use cratons                                 = true
+    set Asthenosphere viscosity                     = 1e20
+    set Fault viscosity                             = 1e19
 
-   set Geometric constant                          = 3,3,3,3
-   set Grain growth activation energy              = 400000,662000,414000,299000
-   set Grain growth activation volume              = 0.0,0.0,0.0,1.5e-6
-   set Grain growth exponent                       = 3,3,4.5,5.0
-   set Grain growth rate constant                  = 1.92e-10,3.02e-4,7.63e-22,5.00E-026
-   set Work fraction for boundary area change      = 0.1,0.1,0.1,0.1
+    subsection Ascii data model
+      set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/viscosity_profiles/
+      set Data file name                            = steinberger_source-1.txt
+    end
 
-   set Reference compressibility                   = 4e-12
-   set Reference density                           = 3400
-   set Reference specific heat                     = 1200
-   set Thermal conductivity                        = 4
-   set Thermal expansion coefficient               = 2.0e-5
+    subsection Density velocity scaling
+      set Data file name                            = rho_vs_scaling.txt
+    end
 
-   set Maximum temperature dependence of viscosity = 1e6
-   set Phase transition Clapeyron slopes           = 0,0,0
-   set Phase transition depths                     = 410000,520000,660000
-   set Phase transition temperatures               = 1950,1950,1950
-   set Phase transition widths                     = 0,0,0
-   set Reciprocal required strain                  = 10
-   set Recrystallized grain size                   = 0.0,0.0,1e-4
+    subsection Temperature velocity scaling
+      set Data file name                            = dT_vs_scaling.txt
+    end
 
-   set Uppermost mantle thickness                  = 300000
+    subsection Thermal expansivity profile
+      set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
+      set Data file name                            = thermal_expansivity_steinberger_calderwood.txt
+    end
 
-# The following parameters govern whether we want to scale the laterally
-# averaged viscosity to a reference profile, and the location of that
-# profile.
-   set Use depth dependent viscosity               = true
-   subsection Ascii data model
-     set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/viscosity_profiles/
-     set Data file name                            = steinberger_source-1.txt
-   end
-
-# This tells us how we want to scale the input Vs anomalies to compute density/temperature
-# anomalies. By default, the model uses a constant scaling factor, but in this cookbook we use
-# depth-dependent scaling factors taken from input ascii files.
-   set Use depth dependent density scaling         = true
-   subsection Density velocity scaling
-     set Data file name                            = rho_vs_scaling.txt
-   end
-   set Use depth dependent temperature scaling     = true
-   subsection Temperature velocity scaling
-     set Data file name                            = dT_vs_scaling.txt
-   end
-
-   set Use faults                                  = true
-   set Use cratons                                 = true
-
-   set Asthenosphere viscosity                     = 1e20
-   set Fault viscosity                             = 1e19
-
-   subsection Thermal expansivity profile
-     set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
-     set Data file name                            = thermal_expansivity_steinberger_calderwood.txt
-   end
-
-   subsection Crustal depths
-     set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
-     set Data file name                            = crustal_structure_2D.txt
-   end
+    subsection Crustal depths
+      set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
+      set Data file name                            = crustal_structure_2D.txt
+    end
   end
 end
-
 
 subsection Formulation
   set Mass conservation = reference density profile
 end
-
 
 subsection Postprocess
   set List of postprocessors         = boundary velocity residual statistics, velocity boundary statistics, visualization, heat flux statistics, depth average

--- a/cookbooks/tomography_based_plate_motions/doc/tomography_based_plate_motions.part.prm
+++ b/cookbooks/tomography_based_plate_motions/doc/tomography_based_plate_motions.part.prm
@@ -27,28 +27,27 @@ subsection Material model
   set Material averaging = harmonic average only viscosity
 
   subsection Tomography based plate motions model
-   set Uppermost mantle thickness                  = 300000
+    set Uppermost mantle thickness                  = 300000
+    set Use depth dependent viscosity               = true
+    set Use depth dependent density scaling         = true
+    set Use depth dependent temperature scaling     = true
+    set Use faults                                  = true
+    set Fault viscosity                             = 1e19
+    set Use cratons                                 = true
+    set Craton viscosity                            = 1e25
+    set Asthenosphere viscosity                     = 1e20
 
-   set Use depth dependent viscosity               = true
-   subsection Ascii data model
-     set Data directory                            = ../../input_data/viscosity_profiles/
-     set Data file name                            = steinberger_source-1.txt
-   end
+    subsection Ascii data model
+      set Data directory                            = ../../input_data/viscosity_profiles/
+      set Data file name                            = steinberger_source-1.txt
+    end
 
-   set Use depth dependent density scaling         = true
-   set Use depth dependent temperature scaling     = true
-   subsection Density velocity scaling
-     set Data file name                            = rho_vs_scaling.txt
-   end
-   subsection Temperature velocity scaling
-     set Data file name                            = dT_vs_scaling.txt
-   end
+    subsection Density velocity scaling
+      set Data file name                            = rho_vs_scaling.txt
+    end
 
-   set Use faults                                  = true
-   set Fault viscosity                             = 1e19
-   set Use cratons                                 = true
-   set Craton viscosity                            = 1e25
-
-   set Asthenosphere viscosity                     = 1e20
+    subsection Temperature velocity scaling
+      set Data file name                            = dT_vs_scaling.txt
+    end
   end
 end

--- a/cookbooks/transform_fault_behn_2007/doc/material.part.prm
+++ b/cookbooks/transform_fault_behn_2007/doc/material.part.prm
@@ -6,7 +6,6 @@ subsection Material model
     set Heat capacities       = 1000
     set Densities             = 3300           # Value from Behn et al., 2007
     set Thermal expansivities = 0              # Thermal buoyancy is ignored in Behn et al., 2007
-
     set Define thermal conductivities = true
     set Thermal conductivities        = 3.5
   end

--- a/cookbooks/transform_fault_behn_2007/doc/temperature.part.prm
+++ b/cookbooks/transform_fault_behn_2007/doc/temperature.part.prm
@@ -19,8 +19,8 @@ end
 # at the bottom.
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom
-
   set List of model names = box
+
   subsection Box
     set Top temperature = 273.15
     set Bottom temperature = 1573.15

--- a/cookbooks/transform_fault_behn_2007/transform_fault_behn_2007.prm
+++ b/cookbooks/transform_fault_behn_2007/transform_fault_behn_2007.prm
@@ -24,7 +24,6 @@ set Surface pressure                       = 0
 # value assumed in the GWB input file, given in the parameter 'potential
 # mantle temperature'.
 set Adiabatic surface temperature          = 1573.15
-
 set Nonlinear solver scheme                = iterated Advection and Stokes
 set Nonlinear solver tolerance             = 1e-5
 set Max nonlinear iterations               = 50
@@ -52,6 +51,7 @@ end
 # of the oceanic plate feature given in the GWB input file.
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent  = 250000
     set Y extent  = 100000
@@ -102,25 +102,21 @@ subsection Initial temperature model
   set List of model names = world builder
 end
 
-
 # We prescribe the surface temperature at the top and the mantle potential temperature
 # at the bottom.
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom
-
   set List of model names = box
+
   subsection Box
     set Top temperature = 273.15
     set Bottom temperature = 1573.15
   end
 end
 
-
 subsection Material model
-
   # Because we use the GMG solver, we need to average the viscosity.
   set Material averaging = project to Q1 only viscosity
-
   set Model name = visco plastic
 
   subsection Visco Plastic
@@ -133,14 +129,11 @@ subsection Material model
     # 1e19 Pa s.
     set Minimum viscosity = 1e18
     set Maximum viscosity = 1e23
-
     set Heat capacities       = 1000
     set Densities             = 3300           # Value from Behn et al., 2007
     set Thermal expansivities = 0              # Thermal buoyancy is ignored in Behn et al., 2007
-
     set Define thermal conductivities = true
     set Thermal conductivities        = 3.5
-
     set Viscous flow law      = diffusion
     set Activation volumes for diffusion creep  = 0
     set Grain size            = 1
@@ -160,6 +153,7 @@ end
 # The gravity points downward and is set to 10.
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 10.0
   end
@@ -190,7 +184,6 @@ subsection Heating model
   set List of model names =
 end
 
-
 # Below, we describe the variables we want to include in the graphical output.
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, mass flux statistics
@@ -198,15 +191,13 @@ subsection Postprocess
   subsection Visualization
     set List of output variables      = material properties, nonadiabatic temperature, strain rate, melt fraction
     set Point-wise stress and strain  = true
-
-    subsection Material properties
-      set List of material properties = density, viscosity, thermal expansivity, thermal conductivity
-    end
-
     set Number of grouped files       = 0
     set Interpolate output            = false
     set Output format                 = vtu
     set Time between graphical output = 1e5
-  end
 
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity, thermal conductivity
+    end
+  end
 end

--- a/doc/modules/changes/20230910_gassmoeller
+++ b/doc/modules/changes/20230910_gassmoeller
@@ -1,0 +1,9 @@
+Changed: The input subsection 'Particles' has been moved
+from the 'Postprocess' subsection into its own subsection
+at the top level. This is to make it more clear that
+particles are not simply a postprocessing feature.
+All included input files have been adjusted and the reformatting
+script has been adjusted. Users will have to apply the reformatting
+script to their input files manually.
+<br>
+(Rene Gassmoeller, 2023/09/10)

--- a/source/particle/generator/ascii_file.cc
+++ b/source/particle/generator/ascii_file.cc
@@ -61,29 +61,25 @@ namespace aspect
       void
       AsciiFile<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Ascii file");
             {
-              prm.enter_subsection("Ascii file");
-              {
-                prm.declare_entry ("Data directory",
-                                   "$ASPECT_SOURCE_DIR/data/particle/generator/ascii/",
-                                   Patterns::DirectoryName (),
-                                   "The name of a directory that contains the particle data. This path "
-                                   "may either be absolute (if starting with a '/') or relative to "
-                                   "the current directory. The path may also include the special "
-                                   "text '$ASPECT_SOURCE_DIR' which will be interpreted as the path "
-                                   "in which the ASPECT source files were located when ASPECT was "
-                                   "compiled. This interpretation allows, for example, to reference "
-                                   "files located in the `data/' subdirectory of ASPECT. ");
-                prm.declare_entry ("Data file name", "particle.dat",
-                                   Patterns::Anything (),
-                                   "The name of the particle file.");
-                prm.leave_subsection();
-              }
+              prm.declare_entry ("Data directory",
+                                 "$ASPECT_SOURCE_DIR/data/particle/generator/ascii/",
+                                 Patterns::DirectoryName (),
+                                 "The name of a directory that contains the particle data. This path "
+                                 "may either be absolute (if starting with a '/') or relative to "
+                                 "the current directory. The path may also include the special "
+                                 "text '$ASPECT_SOURCE_DIR' which will be interpreted as the path "
+                                 "in which the ASPECT source files were located when ASPECT was "
+                                 "compiled. This interpretation allows, for example, to reference "
+                                 "files located in the `data/' subdirectory of ASPECT. ");
+              prm.declare_entry ("Data file name", "particle.dat",
+                                 Patterns::Anything (),
+                                 "The name of the particle file.");
               prm.leave_subsection();
             }
             prm.leave_subsection();
@@ -97,19 +93,15 @@ namespace aspect
       void
       AsciiFile<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Ascii file");
             {
-              prm.enter_subsection("Ascii file");
-              {
-                data_directory = Utilities::expand_ASPECT_SOURCE_DIR(prm.get ("Data directory"));
+              data_directory = Utilities::expand_ASPECT_SOURCE_DIR(prm.get ("Data directory"));
 
-                data_filename    = prm.get ("Data file name");
-              }
-              prm.leave_subsection();
+              data_filename    = prm.get ("Data file name");
             }
             prm.leave_subsection();
           }

--- a/source/particle/generator/ascii_file.cc
+++ b/source/particle/generator/ascii_file.cc
@@ -130,12 +130,12 @@ namespace aspect
                                          "Initial comment lines starting with `#' will be discarded. "
                                          "Note that this plugin always generates as many particles "
                                          "as there are coordinates in the data file, the "
-                                         "``Postprocess/Particles/Number of particles'' parameter "
+                                         "``Particles/Number of particles'' parameter "
                                          "has no effect on this plugin. "
                                          "All of the values that define this generator are read "
-                                         "from a section ``Postprocess/Particles/Generator/Ascii file'' in the "
+                                         "from a section ``Particles/Generator/Ascii file'' in the "
                                          "input file, see "
-                                         "Section~\\ref{parameters:Postprocess/Particles/Generator/Ascii_20file}.")
+                                         "Section~\\ref{parameters:Particles/Generator/Ascii_20file}.")
     }
   }
 }

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -218,13 +218,9 @@ namespace aspect
       create_particle_generator (ParameterHandler &prm)
       {
         std::string name;
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            name = prm.get ("Particle generator name");
-          }
-          prm.leave_subsection ();
+          name = prm.get ("Particle generator name");
         }
         prm.leave_subsection ();
 
@@ -239,20 +235,16 @@ namespace aspect
       declare_parameters (ParameterHandler &prm)
       {
         // declare the entry in the parameter file
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            const std::string pattern_of_names
-              = std::get<dim>(registered_plugins).get_pattern_of_names ();
+          const std::string pattern_of_names
+            = std::get<dim>(registered_plugins).get_pattern_of_names ();
 
-            prm.declare_entry ("Particle generator name", "random uniform",
-                               Patterns::Selection (pattern_of_names),
-                               "Select one of the following models:\n\n"
-                               +
-                               std::get<dim>(registered_plugins).get_description_string());
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Particle generator name", "random uniform",
+                             Patterns::Selection (pattern_of_names),
+                             "Select one of the following models:\n\n"
+                             +
+                             std::get<dim>(registered_plugins).get_description_string());
         }
         prm.leave_subsection ();
 

--- a/source/particle/generator/probability_density_function.cc
+++ b/source/particle/generator/probability_density_function.cc
@@ -49,46 +49,42 @@ namespace aspect
       void
       ProbabilityDensityFunction<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.declare_entry ("Number of particles", "1000",
-                               Patterns::Double (0.),
-                               "Total number of particles to create (not per processor or per element). "
-                               "The number is parsed as a floating point number (so that one can "
-                               "specify, for example, '1e4' particles) but it is interpreted as "
-                               "an integer, of course.");
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Probability density function");
             {
-              prm.enter_subsection("Probability density function");
-              {
-                Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
+              Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
 
-                prm.declare_entry ("Random cell selection", "true",
-                                   Patterns::Bool(),
-                                   "If true, particle numbers per cell are calculated randomly "
-                                   "according to their respective probability density. "
-                                   "This means particle numbers per cell can deviate statistically from "
-                                   "the integral of the probability density. If false, "
-                                   "first determine how many particles each cell should have "
-                                   "based on the integral of the density over each of the cells, "
-                                   "and then once we know how many particles we want on each cell, "
-                                   "choose their locations randomly within each cell.");
+              prm.declare_entry ("Number of particles", "1000",
+                                 Patterns::Double (0.),
+                                 "Total number of particles to create (not per processor or per element). "
+                                 "The number is parsed as a floating point number (so that one can "
+                                 "specify, for example, '1e4' particles) but it is interpreted as "
+                                 "an integer, of course.");
 
-                prm.declare_entry ("Random number seed", "5432",
-                                   Patterns::Integer(0),
-                                   "The seed for the random number generator that controls "
-                                   "the particle generation. Keep constant to generate "
-                                   "identical particle distributions in subsequent model "
-                                   "runs. Change to get a different distribution. In parallel "
-                                   "computations the seed is further modified on each process "
-                                   "to ensure different particle patterns on different "
-                                   "processes. Note that the number of particles per processor "
-                                   "is not affected by the seed.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Random cell selection", "true",
+                                 Patterns::Bool(),
+                                 "If true, particle numbers per cell are calculated randomly "
+                                 "according to their respective probability density. "
+                                 "This means particle numbers per cell can deviate statistically from "
+                                 "the integral of the probability density. If false, "
+                                 "first determine how many particles each cell should have "
+                                 "based on the integral of the density over each of the cells, "
+                                 "and then once we know how many particles we want on each cell, "
+                                 "choose their locations randomly within each cell.");
+
+              prm.declare_entry ("Random number seed", "5432",
+                                 Patterns::Integer(0),
+                                 "The seed for the random number generator that controls "
+                                 "the particle generation. Keep constant to generate "
+                                 "identical particle distributions in subsequent model "
+                                 "runs. Change to get a different distribution. In parallel "
+                                 "computations the seed is further modified on each process "
+                                 "to ensure different particle patterns on different "
+                                 "processes. Note that the number of particles per processor "
+                                 "is not affected by the seed.");
             }
             prm.leave_subsection();
           }
@@ -102,33 +98,28 @@ namespace aspect
       void
       ProbabilityDensityFunction<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Probability density function");
             {
-              prm.enter_subsection("Probability density function");
-              {
-                random_cell_selection = prm.get_bool("Random cell selection");
-                random_number_seed = prm.get_integer("Random number seed");
+              n_particles = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
+              random_cell_selection = prm.get_bool("Random cell selection");
+              random_number_seed = prm.get_integer("Random number seed");
 
-                try
-                  {
-                    function.parse_parameters (prm);
-                  }
-                catch (...)
-                  {
-                    std::cerr << "ERROR: FunctionParser failed to parse\n"
-                              << "\t'Particle.Generator.Probability density function'\n"
-                              << "with expression\n"
-                              << "\t'" << prm.get("Function expression") << "'";
-                    throw;
-                  }
-              }
-              prm.leave_subsection();
+              try
+                {
+                  function.parse_parameters (prm);
+                }
+              catch (...)
+                {
+                  std::cerr << "ERROR: FunctionParser failed to parse\n"
+                            << "\t'Particle.Generator.Probability density function'\n"
+                            << "with expression\n"
+                            << "\t'" << prm.get("Function expression") << "'";
+                  throw;
+                }
             }
             prm.leave_subsection();
           }

--- a/source/particle/generator/random_uniform.cc
+++ b/source/particle/generator/random_uniform.cc
@@ -47,44 +47,40 @@ namespace aspect
       void
       RandomUniform<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.declare_entry ("Number of particles", "1000",
-                               Patterns::Double (0.),
-                               "Total number of particles to create (not per processor or per element). "
-                               "The number is parsed as a floating point number (so that one can "
-                               "specify, for example, '1e4' particles) but it is interpreted as "
-                               "an integer, of course.");
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Probability density function");
             {
-              prm.enter_subsection("Probability density function");
-              {
-                prm.declare_entry ("Random cell selection", "true",
-                                   Patterns::Bool(),
-                                   "If true, particle numbers per cell are calculated randomly "
-                                   "according to their respective probability density. "
-                                   "This means particle numbers per cell can deviate statistically from "
-                                   "the integral of the probability density. If false, "
-                                   "first determine how many particles each cell should have "
-                                   "based on the integral of the density over each of the cells, "
-                                   "and then once we know how many particles we want on each cell, "
-                                   "choose their locations randomly within each cell.");
+              prm.declare_entry ("Number of particles", "1000",
+                                 Patterns::Double (0.),
+                                 "Total number of particles to create (not per processor or per element). "
+                                 "The number is parsed as a floating point number (so that one can "
+                                 "specify, for example, '1e4' particles) but it is interpreted as "
+                                 "an integer, of course.");
 
-                prm.declare_entry ("Random number seed", "5432",
-                                   Patterns::Integer(0),
-                                   "The seed for the random number generator that controls "
-                                   "the particle generation. Keep constant to generate "
-                                   "identical particle distributions in subsequent model "
-                                   "runs. Change to get a different distribution. In parallel "
-                                   "computations the seed is further modified on each process "
-                                   "to ensure different particle patterns on different "
-                                   "processes. Note that the number of particles per processor "
-                                   "is not affected by the seed.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Random cell selection", "true",
+                                 Patterns::Bool(),
+                                 "If true, particle numbers per cell are calculated randomly "
+                                 "according to their respective probability density. "
+                                 "This means particle numbers per cell can deviate statistically from "
+                                 "the integral of the probability density. If false, "
+                                 "first determine how many particles each cell should have "
+                                 "based on the integral of the density over each of the cells, "
+                                 "and then once we know how many particles we want on each cell, "
+                                 "choose their locations randomly within each cell.");
+
+              prm.declare_entry ("Random number seed", "5432",
+                                 Patterns::Integer(0),
+                                 "The seed for the random number generator that controls "
+                                 "the particle generation. Keep constant to generate "
+                                 "identical particle distributions in subsequent model "
+                                 "runs. Change to get a different distribution. In parallel "
+                                 "computations the seed is further modified on each process "
+                                 "to ensure different particle patterns on different "
+                                 "processes. Note that the number of particles per processor "
+                                 "is not affected by the seed.");
             }
             prm.leave_subsection();
           }
@@ -98,20 +94,15 @@ namespace aspect
       void
       RandomUniform<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Probability density function");
             {
-              prm.enter_subsection("Probability density function");
-              {
-                random_cell_selection = prm.get_bool("Random cell selection");
-                random_number_seed = prm.get_integer("Random number seed");
-              }
-              prm.leave_subsection();
+              n_particles = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
+              random_cell_selection = prm.get_bool("Random cell selection");
+              random_number_seed = prm.get_integer("Random number seed");
             }
             prm.leave_subsection();
           }

--- a/source/particle/generator/reference_cell.cc
+++ b/source/particle/generator/reference_cell.cc
@@ -85,24 +85,20 @@ namespace aspect
       void
       ReferenceCell<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Reference cell");
             {
-              prm.enter_subsection("Reference cell");
-              {
-                prm.declare_entry ("Number of particles per cell per direction", "2",
-                                   Patterns::List(Patterns::Integer(1)),
-                                   "List of number of particles to create per cell and spatial dimension. "
-                                   "The size of the list is the number of spatial dimensions. If only "
-                                   "one value is given, then each spatial dimension is set to the same value. "
-                                   "The list of numbers are parsed as a floating point number (so that one can "
-                                   "specify, for example, '1e4' particles) but it is interpreted as "
-                                   "an integer, of course.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Number of particles per cell per direction", "2",
+                                 Patterns::List(Patterns::Integer(1)),
+                                 "List of number of particles to create per cell and spatial dimension. "
+                                 "The size of the list is the number of spatial dimensions. If only "
+                                 "one value is given, then each spatial dimension is set to the same value. "
+                                 "The list of numbers are parsed as a floating point number (so that one can "
+                                 "specify, for example, '1e4' particles) but it is interpreted as "
+                                 "an integer, of course.");
             }
             prm.leave_subsection();
           }
@@ -116,24 +112,20 @@ namespace aspect
       void
       ReferenceCell<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Reference cell");
             {
-              prm.enter_subsection("Reference cell");
-              {
-                const auto n_particles_per_direction = Utilities::possibly_extend_from_1_to_N (
-                                                         Utilities::string_to_int(
-                                                           Utilities::split_string_list(prm.get("Number of particles per cell per direction"))),
-                                                         dim,
-                                                         "Number of particles per cell per direction");
+              const auto n_particles_per_direction = Utilities::possibly_extend_from_1_to_N (
+                                                       Utilities::string_to_int(
+                                                         Utilities::split_string_list(prm.get("Number of particles per cell per direction"))),
+                                                       dim,
+                                                       "Number of particles per cell per direction");
 
-                for (const auto &n_particle_direction: n_particles_per_direction)
-                  number_of_particles.push_back(static_cast<unsigned int> (n_particle_direction));
-              }
-              prm.leave_subsection();
+              for (const auto &n_particle_direction: n_particles_per_direction)
+                number_of_particles.push_back(static_cast<unsigned int> (n_particle_direction));
             }
             prm.leave_subsection();
           }

--- a/source/particle/generator/uniform_box.cc
+++ b/source/particle/generator/uniform_box.cc
@@ -83,41 +83,37 @@ namespace aspect
       void
       UniformBox<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.declare_entry ("Number of particles", "1000",
-                               Patterns::Double (0.),
-                               "Total number of particles to create (not per processor or per element). "
-                               "The number is parsed as a floating point number (so that one can "
-                               "specify, for example, '1e4' particles) but it is interpreted as "
-                               "an integer, of course.");
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Uniform box");
             {
-              prm.enter_subsection("Uniform box");
-              {
-                prm.declare_entry ("Minimum x", "0.",
-                                   Patterns::Double (),
-                                   "Minimum x coordinate for the region of particles.");
-                prm.declare_entry ("Maximum x", "1.",
-                                   Patterns::Double (),
-                                   "Maximum x coordinate for the region of particles.");
-                prm.declare_entry ("Minimum y", "0.",
-                                   Patterns::Double (),
-                                   "Minimum y coordinate for the region of particles.");
-                prm.declare_entry ("Maximum y", "1.",
-                                   Patterns::Double (),
-                                   "Maximum y coordinate for the region of particles.");
-                prm.declare_entry ("Minimum z", "0.",
-                                   Patterns::Double (),
-                                   "Minimum z coordinate for the region of particles.");
-                prm.declare_entry ("Maximum z", "1.",
-                                   Patterns::Double (),
-                                   "Maximum z coordinate for the region of particles.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Number of particles", "1000",
+                                 Patterns::Double (0.),
+                                 "Total number of particles to create (not per processor or per element). "
+                                 "The number is parsed as a floating point number (so that one can "
+                                 "specify, for example, '1e4' particles) but it is interpreted as "
+                                 "an integer, of course.");
+
+              prm.declare_entry ("Minimum x", "0.",
+                                 Patterns::Double (),
+                                 "Minimum x coordinate for the region of particles.");
+              prm.declare_entry ("Maximum x", "1.",
+                                 Patterns::Double (),
+                                 "Maximum x coordinate for the region of particles.");
+              prm.declare_entry ("Minimum y", "0.",
+                                 Patterns::Double (),
+                                 "Minimum y coordinate for the region of particles.");
+              prm.declare_entry ("Maximum y", "1.",
+                                 Patterns::Double (),
+                                 "Maximum y coordinate for the region of particles.");
+              prm.declare_entry ("Minimum z", "0.",
+                                 Patterns::Double (),
+                                 "Minimum z coordinate for the region of particles.");
+              prm.declare_entry ("Maximum z", "1.",
+                                 Patterns::Double (),
+                                 "Maximum z coordinate for the region of particles.");
             }
             prm.leave_subsection();
           }
@@ -131,33 +127,29 @@ namespace aspect
       void
       UniformBox<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Uniform box");
             {
-              prm.enter_subsection("Uniform box");
-              {
-                P_min(0) = prm.get_double ("Minimum x");
-                P_max(0) = prm.get_double ("Maximum x");
-                P_min(1) = prm.get_double ("Minimum y");
-                P_max(1) = prm.get_double ("Maximum y");
+              n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
 
-                AssertThrow(P_min(0) < P_max(0), ExcMessage("Minimum x must be less than maximum x"));
-                AssertThrow(P_min(1) < P_max(1), ExcMessage("Minimum y must be less than maximum y"));
+              P_min(0) = prm.get_double ("Minimum x");
+              P_max(0) = prm.get_double ("Maximum x");
+              P_min(1) = prm.get_double ("Minimum y");
+              P_max(1) = prm.get_double ("Maximum y");
 
-                if (dim == 3)
-                  {
-                    P_min(2) = prm.get_double ("Minimum z");
-                    P_max(2) = prm.get_double ("Maximum z");
+              AssertThrow(P_min(0) < P_max(0), ExcMessage("Minimum x must be less than maximum x"));
+              AssertThrow(P_min(1) < P_max(1), ExcMessage("Minimum y must be less than maximum y"));
 
-                    AssertThrow(P_min(2) < P_max(2), ExcMessage("Minimum z must be less than maximum z"));
-                  }
-              }
-              prm.leave_subsection();
+              if (dim == 3)
+                {
+                  P_min(2) = prm.get_double ("Minimum z");
+                  P_max(2) = prm.get_double ("Maximum z");
+
+                  AssertThrow(P_min(2) < P_max(2), ExcMessage("Minimum z must be less than maximum z"));
+                }
             }
             prm.leave_subsection();
           }

--- a/source/particle/generator/uniform_radial.cc
+++ b/source/particle/generator/uniform_radial.cc
@@ -121,65 +121,61 @@ namespace aspect
       void
       UniformRadial<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            prm.declare_entry ("Number of particles", "1000",
-                               Patterns::Double (0.),
-                               "Total number of particles to create (not per processor or per element). "
-                               "The number is parsed as a floating point number (so that one can "
-                               "specify, for example, '1e4' particles) but it is interpreted as "
-                               "an integer, of course.");
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Uniform radial");
             {
-              prm.enter_subsection("Uniform radial");
-              {
-                prm.declare_entry ("Center x", "0.",
-                                   Patterns::Double (),
-                                   "x coordinate for the center of the spherical region, "
-                                   "where particles are generated.");
-                prm.declare_entry ("Center y", "0.",
-                                   Patterns::Double (),
-                                   "y coordinate for the center of the spherical region, "
-                                   "where particles are generated.");
-                prm.declare_entry ("Center z", "0.",
-                                   Patterns::Double (),
-                                   "z coordinate for the center of the spherical region, "
-                                   "where particles are generated.");
-                prm.declare_entry ("Minimum radius", "0.",
-                                   Patterns::Double (0.),
-                                   "Minimum radial coordinate for the region of particles. "
-                                   "Measured from the center position.");
-                prm.declare_entry ("Maximum radius", "1.",
-                                   Patterns::Double (),
-                                   "Maximum radial coordinate for the region of particles. "
-                                   "Measured from the center position.");
-                prm.declare_entry ("Minimum longitude", "0.",
-                                   Patterns::Double (-180., 360.),
-                                   "Minimum longitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position.");
-                prm.declare_entry ("Maximum longitude", "360.",
-                                   Patterns::Double (-180., 360.),
-                                   "Maximum longitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position.");
-                prm.declare_entry ("Minimum latitude", "0.",
-                                   Patterns::Double (0., 180.),
-                                   "Minimum latitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position, and from "
-                                   "the north pole.");
-                prm.declare_entry ("Maximum latitude", "180.",
-                                   Patterns::Double (0., 180.),
-                                   "Maximum latitude coordinate for the region of particles "
-                                   "in degrees. Measured from the center position, and from "
-                                   "the north pole.");
-                prm.declare_entry ("Radial layers", "1",
-                                   Patterns::Integer(1),
-                                   "The number of radial shells of particles that will be generated "
-                                   "around the central point.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Number of particles", "1000",
+                                 Patterns::Double (0.),
+                                 "Total number of particles to create (not per processor or per element). "
+                                 "The number is parsed as a floating point number (so that one can "
+                                 "specify, for example, '1e4' particles) but it is interpreted as "
+                                 "an integer, of course.");
+
+              prm.declare_entry ("Center x", "0.",
+                                 Patterns::Double (),
+                                 "x coordinate for the center of the spherical region, "
+                                 "where particles are generated.");
+              prm.declare_entry ("Center y", "0.",
+                                 Patterns::Double (),
+                                 "y coordinate for the center of the spherical region, "
+                                 "where particles are generated.");
+              prm.declare_entry ("Center z", "0.",
+                                 Patterns::Double (),
+                                 "z coordinate for the center of the spherical region, "
+                                 "where particles are generated.");
+              prm.declare_entry ("Minimum radius", "0.",
+                                 Patterns::Double (0.),
+                                 "Minimum radial coordinate for the region of particles. "
+                                 "Measured from the center position.");
+              prm.declare_entry ("Maximum radius", "1.",
+                                 Patterns::Double (),
+                                 "Maximum radial coordinate for the region of particles. "
+                                 "Measured from the center position.");
+              prm.declare_entry ("Minimum longitude", "0.",
+                                 Patterns::Double (-180., 360.),
+                                 "Minimum longitude coordinate for the region of particles "
+                                 "in degrees. Measured from the center position.");
+              prm.declare_entry ("Maximum longitude", "360.",
+                                 Patterns::Double (-180., 360.),
+                                 "Maximum longitude coordinate for the region of particles "
+                                 "in degrees. Measured from the center position.");
+              prm.declare_entry ("Minimum latitude", "0.",
+                                 Patterns::Double (0., 180.),
+                                 "Minimum latitude coordinate for the region of particles "
+                                 "in degrees. Measured from the center position, and from "
+                                 "the north pole.");
+              prm.declare_entry ("Maximum latitude", "180.",
+                                 Patterns::Double (0., 180.),
+                                 "Maximum latitude coordinate for the region of particles "
+                                 "in degrees. Measured from the center position, and from "
+                                 "the north pole.");
+              prm.declare_entry ("Radial layers", "1",
+                                 Patterns::Integer(1),
+                                 "The number of radial shells of particles that will be generated "
+                                 "around the central point.");
             }
             prm.leave_subsection();
           }
@@ -193,47 +189,43 @@ namespace aspect
       void
       UniformRadial<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Generator");
           {
-            n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
-
-            prm.enter_subsection("Generator");
+            prm.enter_subsection("Uniform radial");
             {
-              prm.enter_subsection("Uniform radial");
-              {
-                P_center[0] = prm.get_double ("Center x");
-                P_center[1] = prm.get_double ("Center y");
+              n_particles    = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
 
-                P_min[0] = prm.get_double ("Minimum radius");
-                P_max[0] = prm.get_double ("Maximum radius");
-                P_min[1] = prm.get_double ("Minimum longitude") * constants::degree_to_radians;
-                P_max[1] = prm.get_double ("Maximum longitude") * constants::degree_to_radians;
+              P_center[0] = prm.get_double ("Center x");
+              P_center[1] = prm.get_double ("Center y");
 
-                AssertThrow(P_max[1] > P_min[1],
-                            ExcMessage("The maximum longitude you prescribed in the uniform radial"
-                                       "particle generator has to be higher than the minimum longitude."));
-                AssertThrow(P_max[1] - P_min[1] <= 2.0 * numbers::PI,
-                            ExcMessage("The difference between the maximum and minimum longitude you "
-                                       "prescribed in the uniform radial particle generator has to be "
-                                       "less than 360 degrees."));
+              P_min[0] = prm.get_double ("Minimum radius");
+              P_max[0] = prm.get_double ("Maximum radius");
+              P_min[1] = prm.get_double ("Minimum longitude") * constants::degree_to_radians;
+              P_max[1] = prm.get_double ("Maximum longitude") * constants::degree_to_radians;
 
-                if (dim ==3)
-                  {
-                    P_center[2] = prm.get_double ("Center z");
+              AssertThrow(P_max[1] > P_min[1],
+                          ExcMessage("The maximum longitude you prescribed in the uniform radial"
+                                     "particle generator has to be higher than the minimum longitude."));
+              AssertThrow(P_max[1] - P_min[1] <= 2.0 * numbers::PI,
+                          ExcMessage("The difference between the maximum and minimum longitude you "
+                                     "prescribed in the uniform radial particle generator has to be "
+                                     "less than 360 degrees."));
 
-                    P_min[2]    = prm.get_double ("Minimum latitude") * constants::degree_to_radians;
-                    P_max[2]    = prm.get_double ("Maximum latitude") * constants::degree_to_radians;
+              if (dim ==3)
+                {
+                  P_center[2] = prm.get_double ("Center z");
 
-                    AssertThrow(P_max[2] > P_min[2],
-                                ExcMessage("The maximum latitude you prescribed in the uniform radial"
-                                           "particle generator has to be higher than the minimum latitude."));
-                  }
+                  P_min[2]    = prm.get_double ("Minimum latitude") * constants::degree_to_radians;
+                  P_max[2]    = prm.get_double ("Maximum latitude") * constants::degree_to_radians;
 
-                radial_layers   = prm.get_integer("Radial layers");
-              }
-              prm.leave_subsection();
+                  AssertThrow(P_max[2] > P_min[2],
+                              ExcMessage("The maximum latitude you prescribed in the uniform radial"
+                                         "particle generator has to be higher than the minimum latitude."));
+                }
+
+              radial_layers   = prm.get_integer("Radial layers");
             }
             prm.leave_subsection();
           }

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -101,13 +101,9 @@ namespace aspect
       create_particle_integrator (ParameterHandler &prm)
       {
         std::string name;
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            name = prm.get ("Integration scheme");
-          }
-          prm.leave_subsection ();
+          name = prm.get ("Integration scheme");
         }
         prm.leave_subsection ();
 
@@ -122,79 +118,75 @@ namespace aspect
       declare_parameters (ParameterHandler &prm)
       {
         // declare the entry in the parameter file
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            const std::string pattern_of_names
-              = std::get<dim>(registered_plugins).get_pattern_of_names ();
+          const std::string pattern_of_names
+            = std::get<dim>(registered_plugins).get_pattern_of_names ();
 
-            prm.declare_entry ("Integration scheme", "rk2",
-                               Patterns::Selection (pattern_of_names),
-                               "This parameter is used to decide which method to "
-                               "use to solve the equation that describes the position "
-                               "of particles, i.e., $\\frac{d}{dt}\\mathbf x_k(t) = "
-                               "\\mathbf u(\\mathbf x_k(t),t)$, where $k$ is an index "
-                               "that runs over all particles, and $\\mathbf u(\\mathbf x,t)$ "
-                               "is the velocity field that results from the Stokes "
-                               "equations."
-                               "\n\n"
-                               "In practice, the exact velocity $\\mathbf u(\\mathbf x,t)$ "
-                               "is of course not available, but only a numerical "
-                               "approximation $\\mathbf u_h(\\mathbf x,t)$. Furthermore, "
-                               "this approximation is only available at discrete time steps, "
-                               "$\\mathbf u^n(\\mathbf x)=\\mathbf u(\\mathbf x,t^n)$, and "
-                               "these need to be interpolated between time steps if the "
-                               "integrator for the equation above requires an evaluation at "
-                               "time points between the discrete time steps. If we denote this "
-                               "interpolation in time by $\\tilde{\\mathbf u}_h(\\mathbf x,t)$ "
-                               "where $\\tilde{\\mathbf u}_h(\\mathbf x,t^n)="
-                               "\\mathbf u^n(\\mathbf x)$, then the equation the differential "
-                               "equation solver really tries to solve is "
-                               "$\\frac{d}{dt}\\tilde{\\mathbf x}_k(t) = "
-                               " \\tilde{\\mathbf u}_h(\\mathbf x_k(t),t)$."
-                               "\n\n"
-                               "As a consequence of these considerations, if you try to "
-                               "assess convergence properties of an ODE integrator -- for "
-                               "example to verify that the RK4 integrator converges with "
-                               "fourth order --, it is important to recall that the "
-                               "integrator may not solve the equation you think it "
-                               "solves. If, for example, we call the numerical solution "
-                               "of the ODE $\\tilde{\\mathbf x}_{k,h}(t)$, then the "
-                               "error will typically satisfy a relationship like "
-                               "\\["
-                               "  \\| \\tilde{\\mathbf x}_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|"
-                               "  \\le"
-                               "  C(T) \\Delta t^p"
-                               "\\] "
-                               "where $\\Delta t$ is the time step and $p$ the convergence order "
-                               "of the method, and $C(T)$ is a (generally unknown) constant "
-                               "that depends on the end time $T$ at which one compares the "
-                               "solutions. On the other hand, an analytically computed "
-                               "trajectory would likely use the \\textit{exact} velocity, "
-                               "and one may be tempted to compute "
-                               "$\\| \\mathbf x_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|$, "
-                               "but this quantity will, in the best case, only satisfy an "
-                               "estimate of the form "
-                               "\\["
-                               "  \\| \\mathbf x_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|"
-                               "  \\le"
-                               "  C_1(T) \\Delta t^p"
-                               "  + C_2(T) \\| \\mathbf u-\\mathbf u_h \\|"
-                               "  + C_3(T) \\| \\mathbf u_h-\\tilde{\\mathbf u}_h \\|"
-                               "\\] "
-                               "with appropriately chosen norms for the second and third "
-                               "term. These second and third terms typically converge to "
-                               "zero at relatively low rates (compared to the order $p$ of "
-                               "the integrator, which can often be chosen relatively high) "
-                               "in the mesh size $h$ and the time step size $\\\\Delta t$, "
-                               "limiting the overall accuracy of the ODE integrator."
-                               "\n\n"
-                               "Select one of the following models:\n\n"
-                               +
-                               std::get<dim>(registered_plugins).get_description_string());
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Integration scheme", "rk2",
+                             Patterns::Selection (pattern_of_names),
+                             "This parameter is used to decide which method to "
+                             "use to solve the equation that describes the position "
+                             "of particles, i.e., $\\frac{d}{dt}\\mathbf x_k(t) = "
+                             "\\mathbf u(\\mathbf x_k(t),t)$, where $k$ is an index "
+                             "that runs over all particles, and $\\mathbf u(\\mathbf x,t)$ "
+                             "is the velocity field that results from the Stokes "
+                             "equations."
+                             "\n\n"
+                             "In practice, the exact velocity $\\mathbf u(\\mathbf x,t)$ "
+                             "is of course not available, but only a numerical "
+                             "approximation $\\mathbf u_h(\\mathbf x,t)$. Furthermore, "
+                             "this approximation is only available at discrete time steps, "
+                             "$\\mathbf u^n(\\mathbf x)=\\mathbf u(\\mathbf x,t^n)$, and "
+                             "these need to be interpolated between time steps if the "
+                             "integrator for the equation above requires an evaluation at "
+                             "time points between the discrete time steps. If we denote this "
+                             "interpolation in time by $\\tilde{\\mathbf u}_h(\\mathbf x,t)$ "
+                             "where $\\tilde{\\mathbf u}_h(\\mathbf x,t^n)="
+                             "\\mathbf u^n(\\mathbf x)$, then the equation the differential "
+                             "equation solver really tries to solve is "
+                             "$\\frac{d}{dt}\\tilde{\\mathbf x}_k(t) = "
+                             " \\tilde{\\mathbf u}_h(\\mathbf x_k(t),t)$."
+                             "\n\n"
+                             "As a consequence of these considerations, if you try to "
+                             "assess convergence properties of an ODE integrator -- for "
+                             "example to verify that the RK4 integrator converges with "
+                             "fourth order --, it is important to recall that the "
+                             "integrator may not solve the equation you think it "
+                             "solves. If, for example, we call the numerical solution "
+                             "of the ODE $\\tilde{\\mathbf x}_{k,h}(t)$, then the "
+                             "error will typically satisfy a relationship like "
+                             "\\["
+                             "  \\| \\tilde{\\mathbf x}_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|"
+                             "  \\le"
+                             "  C(T) \\Delta t^p"
+                             "\\] "
+                             "where $\\Delta t$ is the time step and $p$ the convergence order "
+                             "of the method, and $C(T)$ is a (generally unknown) constant "
+                             "that depends on the end time $T$ at which one compares the "
+                             "solutions. On the other hand, an analytically computed "
+                             "trajectory would likely use the \\textit{exact} velocity, "
+                             "and one may be tempted to compute "
+                             "$\\| \\mathbf x_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|$, "
+                             "but this quantity will, in the best case, only satisfy an "
+                             "estimate of the form "
+                             "\\["
+                             "  \\| \\mathbf x_k(T) - \\tilde{\\mathbf x}_{k,h}(T) \\|"
+                             "  \\le"
+                             "  C_1(T) \\Delta t^p"
+                             "  + C_2(T) \\| \\mathbf u-\\mathbf u_h \\|"
+                             "  + C_3(T) \\| \\mathbf u_h-\\tilde{\\mathbf u}_h \\|"
+                             "\\] "
+                             "with appropriately chosen norms for the second and third "
+                             "term. These second and third terms typically converge to "
+                             "zero at relatively low rates (compared to the order $p$ of "
+                             "the integrator, which can often be chosen relatively high) "
+                             "in the mesh size $h$ and the time step size $\\\\Delta t$, "
+                             "limiting the overall accuracy of the ODE integrator."
+                             "\n\n"
+                             "Select one of the following models:\n\n"
+                             +
+                             std::get<dim>(registered_plugins).get_description_string());
         }
         prm.leave_subsection ();
 

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -188,23 +188,19 @@ namespace aspect
       void
       RK2<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Integrator");
           {
-            prm.enter_subsection("Integrator");
+            prm.enter_subsection("RK2");
             {
-              prm.enter_subsection("RK2");
-              {
-                prm.declare_entry ("Higher order accurate in time", "true",
-                                   Patterns::Bool(),
-                                   "Whether to correctly evaluate old and current velocity "
-                                   "solution to reach higher-order accuracy in time. If set to "
-                                   "'false' only the old velocity solution is evaluated to "
-                                   "simulate a first order method in time. This is only "
-                                   "recommended for benchmark purposes.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Higher order accurate in time", "true",
+                                 Patterns::Bool(),
+                                 "Whether to correctly evaluate old and current velocity "
+                                 "solution to reach higher-order accuracy in time. If set to "
+                                 "'false' only the old velocity solution is evaluated to "
+                                 "simulate a first order method in time. This is only "
+                                 "recommended for benchmark purposes.");
             }
             prm.leave_subsection();
           }
@@ -218,17 +214,13 @@ namespace aspect
       void
       RK2<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Integrator");
           {
-            prm.enter_subsection("Integrator");
+            prm.enter_subsection("RK2");
             {
-              prm.enter_subsection("RK2");
-              {
-                higher_order_in_time = prm.get_bool("Higher order accurate in time");
-              }
-              prm.leave_subsection();
+              higher_order_in_time = prm.get_bool("Higher order accurate in time");
             }
             prm.leave_subsection();
           }

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -248,31 +248,27 @@ namespace aspect
       void
       BilinearLeastSquares<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Interpolator");
           {
-            prm.enter_subsection("Interpolator");
+            prm.enter_subsection("Bilinear least squares");
             {
-              prm.enter_subsection("Bilinear least squares");
-              {
-                prm.declare_entry("Use linear least squares limiter", "false",
-                                  Patterns::List(Patterns::Bool()),
-                                  "Limit the interpolation of particle properties onto the cell, so that "
-                                  "the value of each property is no smaller than its minimum and no "
-                                  "larger than its maximum on the particles of each cell, and the "
-                                  "average of neighboring cells. If more than one value is given, "
-                                  "it will be treated as a list with one component per particle property.");
-                prm.declare_entry("Use boundary extrapolation", "false",
-                                  Patterns::List(Patterns::Bool()),
-                                  "Extends the range used by 'Use linear least squares limiter' "
-                                  "by linearly interpolating values at cell boundaries from neighboring "
-                                  "cells. If more than one value is given, it will be treated as a list "
-                                  "with one component per particle property. Enabling 'Use boundary "
-                                  "extrapolation' requires enabling 'Use linear least squares "
-                                  "limiter'.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry("Use linear least squares limiter", "false",
+                                Patterns::List(Patterns::Bool()),
+                                "Limit the interpolation of particle properties onto the cell, so that "
+                                "the value of each property is no smaller than its minimum and no "
+                                "larger than its maximum on the particles of each cell, and the "
+                                "average of neighboring cells. If more than one value is given, "
+                                "it will be treated as a list with one component per particle property.");
+              prm.declare_entry("Use boundary extrapolation", "false",
+                                Patterns::List(Patterns::Bool()),
+                                "Extends the range used by 'Use linear least squares limiter' "
+                                "by linearly interpolating values at cell boundaries from neighboring "
+                                "cells. If more than one value is given, it will be treated as a list "
+                                "with one component per particle property. Enabling 'Use boundary "
+                                "extrapolation' requires enabling 'Use linear least squares "
+                                "limiter'.");
             }
             prm.leave_subsection();
           }
@@ -287,73 +283,70 @@ namespace aspect
       BilinearLeastSquares<dim>::parse_parameters (ParameterHandler &prm)
       {
         fallback_interpolator.parse_parameters(prm);
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Interpolator");
           {
-            prm.enter_subsection("Interpolator");
+            prm.enter_subsection("Bilinear least squares");
             {
-              prm.enter_subsection("Bilinear least squares");
-              {
-                const Postprocess::Particles<dim> &particle_postprocessor =
-                  this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
-                const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
-                const unsigned int n_property_components = particle_property_information.n_components();
-                const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
+              const Postprocess::Particles<dim> &particle_postprocessor =
+                this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
+              const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+              const unsigned int n_property_components = particle_property_information.n_components();
+              const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 
-                std::vector<std::string> linear_least_squares_limiter_split = Utilities::split_string_list(prm.get("Use linear least squares limiter"));
-                std::vector<bool> linear_least_squares_limiter_parsed;
-                if (linear_least_squares_limiter_split.size() == 1)
-                  {
-                    linear_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(linear_least_squares_limiter_split[0]));
-                  }
-                else if (linear_least_squares_limiter_split.size() == n_property_components - n_internal_components)
-                  {
-                    for (const auto &component: linear_least_squares_limiter_split)
-                      linear_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
-                  }
-                else
-                  {
-                    AssertThrow(false, ExcMessage("The size of 'Use linear least squares limiter' should either be 1 or the number of particle properties"));
-                  }
-                for (unsigned int i = 0; i < n_internal_components; ++i)
-                  linear_least_squares_limiter_parsed.push_back(false);
-                use_linear_least_squares_limiter = ComponentMask(linear_least_squares_limiter_parsed);
+              std::vector<std::string> linear_least_squares_limiter_split = Utilities::split_string_list(prm.get("Use linear least squares limiter"));
+              std::vector<bool> linear_least_squares_limiter_parsed;
+              if (linear_least_squares_limiter_split.size() == 1)
+                {
+                  linear_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(linear_least_squares_limiter_split[0]));
+                }
+              else if (linear_least_squares_limiter_split.size() == n_property_components - n_internal_components)
+                {
+                  for (const auto &component: linear_least_squares_limiter_split)
+                    linear_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
+                }
+              else
+                {
+                  AssertThrow(false, ExcMessage("The size of 'Use linear least squares limiter' should either be 1 or the number of particle properties"));
+                }
+              for (unsigned int i = 0; i < n_internal_components; ++i)
+                linear_least_squares_limiter_parsed.push_back(false);
+              use_linear_least_squares_limiter = ComponentMask(linear_least_squares_limiter_parsed);
 
 
 
-                const std::vector<std::string> boundary_extrapolation_split = Utilities::split_string_list(prm.get("Use boundary extrapolation"));
-                std::vector<bool> boundary_extrapolation_parsed;
-                if (boundary_extrapolation_split.size() == 1)
-                  {
-                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
-                  }
-                else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
-                  {
-                    for (const auto &component: boundary_extrapolation_split)
-                      boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
-                  }
-                else
-                  {
-                    AssertThrow(false, ExcMessage("The size of 'Use boundary extrapolation' should either be 1 or the number of particle properties"));
-                  }
-                for (unsigned int i = 0; i < n_internal_components; ++i)
-                  boundary_extrapolation_parsed.push_back(false);
-                use_boundary_extrapolation = ComponentMask(boundary_extrapolation_parsed);
-                for (unsigned int property_index = 0; property_index < n_property_components - n_internal_components; ++property_index)
-                  {
-                    AssertThrow(use_linear_least_squares_limiter[property_index] || !use_boundary_extrapolation[property_index],
-                                ExcMessage("'Use boundary extrapolation' must be set with 'Use linear least squares limiter' to be valid."));
-                  }
-              }
-              prm.leave_subsection();
+              const std::vector<std::string> boundary_extrapolation_split = Utilities::split_string_list(prm.get("Use boundary extrapolation"));
+              std::vector<bool> boundary_extrapolation_parsed;
+              if (boundary_extrapolation_split.size() == 1)
+                {
+                  boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
+                }
+              else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
+                {
+                  for (const auto &component: boundary_extrapolation_split)
+                    boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
+                }
+              else
+                {
+                  AssertThrow(false, ExcMessage("The size of 'Use boundary extrapolation' should either be 1 or the number of particle properties"));
+                }
+              for (unsigned int i = 0; i < n_internal_components; ++i)
+                boundary_extrapolation_parsed.push_back(false);
+              use_boundary_extrapolation = ComponentMask(boundary_extrapolation_parsed);
+              for (unsigned int property_index = 0; property_index < n_property_components - n_internal_components; ++property_index)
+                {
+                  AssertThrow(use_linear_least_squares_limiter[property_index] || !use_boundary_extrapolation[property_index],
+                              ExcMessage("'Use boundary extrapolation' must be set with 'Use linear least squares limiter' to be valid."));
+                }
             }
             prm.leave_subsection();
-            const bool limiter_enabled_for_at_least_one_property = (use_linear_least_squares_limiter.n_selected_components() != 0);
-            AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
-                        ExcMessage("If 'Use linear least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
           }
           prm.leave_subsection();
+
+          const bool limiter_enabled_for_at_least_one_property = (use_linear_least_squares_limiter.n_selected_components() != 0);
+          AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
+                      ExcMessage("If 'Use linear least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
         }
         prm.leave_subsection();
       }

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -123,18 +123,14 @@ namespace aspect
       void
       CellAverage<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            prm.declare_entry ("Allow cells without particles", "false",
-                               Patterns::Bool (),
-                               "By default, every cell needs to contain particles to use this interpolator "
-                               "plugin. If this parameter is set to true, cells are allowed to have no particles, "
-                               "In case both the current cell and its neighbors are empty, "
-                               "the interpolator will return 0 for the current cell's properties.");
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Allow cells without particles", "false",
+                             Patterns::Bool (),
+                             "By default, every cell needs to contain particles to use this interpolator "
+                             "plugin. If this parameter is set to true, cells are allowed to have no particles, "
+                             "In case both the current cell and its neighbors are empty, "
+                             "the interpolator will return 0 for the current cell's properties.");
         }
         prm.leave_subsection ();
       }
@@ -145,13 +141,9 @@ namespace aspect
       void
       CellAverage<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-          }
-          prm.leave_subsection ();
+          allow_cells_without_particles = prm.get_bool("Allow cells without particles");
         }
         prm.leave_subsection ();
       }

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -131,18 +131,14 @@ namespace aspect
       void
       HarmonicAverage<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            prm.declare_entry ("Allow cells without particles", "false",
-                               Patterns::Bool (),
-                               "By default, every cell needs to contain particles to use this interpolator "
-                               "plugin. If this parameter is set to true, cells are allowed to have no particles. "
-                               "In case both the current cell and its neighbors are empty, "
-                               "the interpolator will return 0 for the current cell's properties.");
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Allow cells without particles", "false",
+                             Patterns::Bool (),
+                             "By default, every cell needs to contain particles to use this interpolator "
+                             "plugin. If this parameter is set to true, cells are allowed to have no particles. "
+                             "In case both the current cell and its neighbors are empty, "
+                             "the interpolator will return 0 for the current cell's properties.");
         }
         prm.leave_subsection ();
       }
@@ -153,13 +149,9 @@ namespace aspect
       void
       HarmonicAverage<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-          }
-          prm.leave_subsection ();
+          allow_cells_without_particles = prm.get_bool("Allow cells without particles");
         }
         prm.leave_subsection ();
       }

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -61,13 +61,9 @@ namespace aspect
       create_particle_interpolator (ParameterHandler &prm)
       {
         std::string name;
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            name = prm.get ("Interpolation scheme");
-          }
-          prm.leave_subsection ();
+          name = prm.get ("Interpolation scheme");
         }
         prm.leave_subsection ();
 
@@ -82,20 +78,16 @@ namespace aspect
       declare_parameters (ParameterHandler &prm)
       {
         // declare the entry in the parameter file
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            const std::string pattern_of_names
-              = std::get<dim>(registered_plugins).get_pattern_of_names ();
+          const std::string pattern_of_names
+            = std::get<dim>(registered_plugins).get_pattern_of_names ();
 
-            prm.declare_entry ("Interpolation scheme", "cell average",
-                               Patterns::Selection (pattern_of_names),
-                               "Select one of the following models:\n\n"
-                               +
-                               std::get<dim>(registered_plugins).get_description_string());
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Interpolation scheme", "cell average",
+                             Patterns::Selection (pattern_of_names),
+                             "Select one of the following models:\n\n"
+                             +
+                             std::get<dim>(registered_plugins).get_description_string());
         }
         prm.leave_subsection ();
 

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -122,18 +122,14 @@ namespace aspect
       void
       NearestNeighbor<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            prm.declare_entry ("Allow cells without particles", "false",
-                               Patterns::Bool (),
-                               "By default, every cell needs to contain particles to use this interpolator "
-                               "plugin. If this parameter is set to true, cells are allowed to have no particles. "
-                               "In case both the current cell and its neighbors are empty, "
-                               "the interpolator will return 0 for the current cell's properties.");
-          }
-          prm.leave_subsection ();
+          prm.declare_entry ("Allow cells without particles", "false",
+                             Patterns::Bool (),
+                             "By default, every cell needs to contain particles to use this interpolator "
+                             "plugin. If this parameter is set to true, cells are allowed to have no particles. "
+                             "In case both the current cell and its neighbors are empty, "
+                             "the interpolator will return 0 for the current cell's properties.");
         }
         prm.leave_subsection ();
       }
@@ -144,13 +140,9 @@ namespace aspect
       void
       NearestNeighbor<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            allow_cells_without_particles = prm.get_bool("Allow cells without particles");
-          }
-          prm.leave_subsection ();
+          allow_cells_without_particles = prm.get_bool("Allow cells without particles");
         }
         prm.leave_subsection ();
       }

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -527,31 +527,27 @@ namespace aspect
       void
       QuadraticLeastSquares<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Interpolator");
           {
-            prm.enter_subsection("Interpolator");
+            prm.enter_subsection("Quadratic least squares");
             {
-              prm.enter_subsection("Quadratic least squares");
-              {
-                prm.declare_entry("Use quadratic least squares limiter", "true",
-                                  Patterns::List(Patterns::Bool()),
-                                  "Limit the interpolation of particle properties onto the cell, so that "
-                                  "the value of each property is no smaller than its minimum and no "
-                                  "larger than its maximum on the particles of each cell, and the "
-                                  "average of neighboring cells. If more than one value is given, "
-                                  "it will be treated as a list with one component per particle property.");
-                prm.declare_entry("Use boundary extrapolation", "false",
-                                  Patterns::List(Patterns::Bool()),
-                                  "Extends the range used by 'Use quadratic least squares limiter' "
-                                  "by linearly interpolating values at cell boundaries from neighboring "
-                                  "cells. If more than one value is given, it will be treated as a list "
-                                  "with one component per particle property. Enabling 'Use boundary "
-                                  "extrapolation' requires enabling 'Use quadratic least squares "
-                                  "limiter'.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry("Use quadratic least squares limiter", "true",
+                                Patterns::List(Patterns::Bool()),
+                                "Limit the interpolation of particle properties onto the cell, so that "
+                                "the value of each property is no smaller than its minimum and no "
+                                "larger than its maximum on the particles of each cell, and the "
+                                "average of neighboring cells. If more than one value is given, "
+                                "it will be treated as a list with one component per particle property.");
+              prm.declare_entry("Use boundary extrapolation", "false",
+                                Patterns::List(Patterns::Bool()),
+                                "Extends the range used by 'Use quadratic least squares limiter' "
+                                "by linearly interpolating values at cell boundaries from neighboring "
+                                "cells. If more than one value is given, it will be treated as a list "
+                                "with one component per particle property. Enabling 'Use boundary "
+                                "extrapolation' requires enabling 'Use quadratic least squares "
+                                "limiter'.");
             }
             prm.leave_subsection();
           }
@@ -565,75 +561,72 @@ namespace aspect
       QuadraticLeastSquares<dim>::parse_parameters (ParameterHandler &prm)
       {
         fallback_interpolator.parse_parameters(prm);
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Interpolator");
           {
-            prm.enter_subsection("Interpolator");
+            prm.enter_subsection("Quadratic least squares");
             {
-              prm.enter_subsection("Quadratic least squares");
-              {
-                const Postprocess::Particles<dim> &particle_postprocessor =
-                  this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
-                const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
-                const unsigned int n_property_components = particle_property_information.n_components();
-                const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
+              const Postprocess::Particles<dim> &particle_postprocessor =
+                this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
+              const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+              const unsigned int n_property_components = particle_property_information.n_components();
+              const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 
-                const std::vector<std::string> quadratic_least_squares_limiter_split = Utilities::split_string_list(prm.get("Use quadratic least squares limiter"));
-                std::vector<bool> quadratic_least_squares_limiter_parsed;
-                if (quadratic_least_squares_limiter_split.size() == 1)
-                  {
-                    quadratic_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(quadratic_least_squares_limiter_split[0]));
-                  }
-                else if (quadratic_least_squares_limiter_split.size() == n_property_components - n_internal_components)
-                  {
-                    for (const auto &component: quadratic_least_squares_limiter_split)
-                      quadratic_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
-                  }
-                else
-                  {
-                    AssertThrow(false, ExcMessage("The size of 'Use quadratic least squares limiter' should either be 1 or the number of particle properties"));
-                  }
-                for (unsigned int i = 0; i < n_internal_components; ++i)
-                  quadratic_least_squares_limiter_parsed.push_back(false);
-                use_quadratic_least_squares_limiter = ComponentMask(quadratic_least_squares_limiter_parsed);
+              const std::vector<std::string> quadratic_least_squares_limiter_split = Utilities::split_string_list(prm.get("Use quadratic least squares limiter"));
+              std::vector<bool> quadratic_least_squares_limiter_parsed;
+              if (quadratic_least_squares_limiter_split.size() == 1)
+                {
+                  quadratic_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(quadratic_least_squares_limiter_split[0]));
+                }
+              else if (quadratic_least_squares_limiter_split.size() == n_property_components - n_internal_components)
+                {
+                  for (const auto &component: quadratic_least_squares_limiter_split)
+                    quadratic_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
+                }
+              else
+                {
+                  AssertThrow(false, ExcMessage("The size of 'Use quadratic least squares limiter' should either be 1 or the number of particle properties"));
+                }
+              for (unsigned int i = 0; i < n_internal_components; ++i)
+                quadratic_least_squares_limiter_parsed.push_back(false);
+              use_quadratic_least_squares_limiter = ComponentMask(quadratic_least_squares_limiter_parsed);
 
 
-                const std::vector<std::string> boundary_extrapolation_split = Utilities::split_string_list(prm.get("Use boundary extrapolation"));
-                std::vector<bool> boundary_extrapolation_parsed;
-                if (boundary_extrapolation_split.size() == 1)
-                  {
-                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
-                  }
-                else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
-                  {
-                    for (const auto &component: boundary_extrapolation_split)
-                      boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
-                  }
-                else
-                  {
-                    AssertThrow(false, ExcMessage("The size of 'Use boundary extrapolation' should either be 1 or the number of particle properties"));
-                  }
-                for (unsigned int i = 0; i < n_internal_components; ++i)
-                  boundary_extrapolation_parsed.push_back(false);
-                use_boundary_extrapolation = ComponentMask(boundary_extrapolation_parsed);
-                for (unsigned int property_index = 0; property_index < n_property_components - n_internal_components; ++property_index)
-                  {
-                    AssertThrow(use_quadratic_least_squares_limiter[property_index] || !use_boundary_extrapolation[property_index],
-                                ExcMessage("'Use boundary extrapolation' must be set with 'Use quadratic least squares limiter' to be valid."));
-                  }
+              const std::vector<std::string> boundary_extrapolation_split = Utilities::split_string_list(prm.get("Use boundary extrapolation"));
+              std::vector<bool> boundary_extrapolation_parsed;
+              if (boundary_extrapolation_split.size() == 1)
+                {
+                  boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
+                }
+              else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
+                {
+                  for (const auto &component: boundary_extrapolation_split)
+                    boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
+                }
+              else
+                {
+                  AssertThrow(false, ExcMessage("The size of 'Use boundary extrapolation' should either be 1 or the number of particle properties"));
+                }
+              for (unsigned int i = 0; i < n_internal_components; ++i)
+                boundary_extrapolation_parsed.push_back(false);
+              use_boundary_extrapolation = ComponentMask(boundary_extrapolation_parsed);
+              for (unsigned int property_index = 0; property_index < n_property_components - n_internal_components; ++property_index)
+                {
+                  AssertThrow(use_quadratic_least_squares_limiter[property_index] || !use_boundary_extrapolation[property_index],
+                              ExcMessage("'Use boundary extrapolation' must be set with 'Use quadratic least squares limiter' to be valid."));
+                }
 
-              }
-              prm.leave_subsection();
             }
             prm.leave_subsection();
-            // In general n_selected_components() requests an argument of the ComponentMask's size since it could be initialized to be entirely true without a size.
-            // Here it is given a size equal to n_property_components, so that argument is not necessary.
-            const bool limiter_enabled_for_at_least_one_property = (use_quadratic_least_squares_limiter.n_selected_components() != 0);
-            AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
-                        ExcMessage("If 'Use quadratic least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
           }
           prm.leave_subsection();
+
+          // In general n_selected_components() requests an argument of the ComponentMask's size since it could be initialized to be entirely true without a size.
+          // Here it is given a size equal to n_property_components, so that argument is not necessary.
+          const bool limiter_enabled_for_at_least_one_property = (use_quadratic_least_squares_limiter.n_selected_components() != 0);
+          AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
+                      ExcMessage("If 'Use quadratic least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
         }
         prm.leave_subsection();
       }

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -229,26 +229,22 @@ namespace aspect
       void
       CpoBinghamAverage<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("CPO Bingham Average");
           {
-            prm.enter_subsection("CPO Bingham Average");
-            {
-              prm.declare_entry ("Random number seed", "1",
-                                 Patterns::Integer (0),
-                                 "The seed used to generate random numbers. This will make sure that "
-                                 "results are reproducible as long as the problem is run with the "
-                                 "same amount of MPI processes. It is implemented as final seed = "
-                                 "Random number seed + MPI Rank. ");
+            prm.declare_entry ("Random number seed", "1",
+                               Patterns::Integer (0),
+                               "The seed used to generate random numbers. This will make sure that "
+                               "results are reproducible as long as the problem is run with the "
+                               "same amount of MPI processes. It is implemented as final seed = "
+                               "Random number seed + MPI Rank. ");
 
-              prm.declare_entry ("Number of samples", "0",
-                                 Patterns::Double(0),
-                                 "This determines how many samples are taken when using the random "
-                                 "draw volume averaging. Setting it to zero means that the number of "
-                                 "samples is set to be equal to the number of grains.");
-            }
-            prm.leave_subsection ();
+            prm.declare_entry ("Number of samples", "0",
+                               Patterns::Double(0),
+                               "This determines how many samples are taken when using the random "
+                               "draw volume averaging. Setting it to zero means that the number of "
+                               "samples is set to be equal to the number of grains.");
           }
           prm.leave_subsection ();
         }
@@ -262,24 +258,20 @@ namespace aspect
       CpoBinghamAverage<dim>::parse_parameters (ParameterHandler &prm)
       {
 
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("CPO Bingham Average");
           {
-            prm.enter_subsection("CPO Bingham Average");
-            {
-              // Get a pointer to the CPO particle property.
-              cpo_particle_property = std::make_unique<const Particle::Property::CrystalPreferredOrientation<dim>> (
-                                        this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>());
+            // Get a pointer to the CPO particle property.
+            cpo_particle_property = std::make_unique<const Particle::Property::CrystalPreferredOrientation<dim>> (
+                                      this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>());
 
-              random_number_seed = prm.get_integer ("Random number seed");
-              n_grains = cpo_particle_property->get_number_of_grains();
-              n_minerals = cpo_particle_property->get_number_of_minerals();
-              n_samples = prm.get_integer("Number of samples");
-              if (n_samples == 0)
-                n_samples = n_grains;
-            }
-            prm.leave_subsection ();
+            random_number_seed = prm.get_integer ("Random number seed");
+            n_grains = cpo_particle_property->get_number_of_grains();
+            n_minerals = cpo_particle_property->get_number_of_minerals();
+            n_samples = prm.get_integer("Number of samples");
+            if (n_samples == 0)
+              n_samples = n_grains;
           }
           prm.leave_subsection ();
         }

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -229,22 +229,18 @@ namespace aspect
       void
       CpoElasticTensor<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Crystal Preferred Orientation");
           {
-            prm.enter_subsection("Crystal Preferred Orientation");
+            n_grains = prm.get_integer("Number of grains per particle");
+            prm.enter_subsection("Initial grains");
             {
-              n_grains = prm.get_integer("Number of grains per particle");
-              prm.enter_subsection("Initial grains");
-              {
-                n_minerals = dealii::Utilities::split_string_list(prm.get("Minerals")).size();
-              }
-              prm.leave_subsection();
+              n_minerals = dealii::Utilities::split_string_list(prm.get("Minerals")).size();
             }
             prm.leave_subsection();
           }
-          prm.leave_subsection ();
+          prm.leave_subsection();
         }
         prm.leave_subsection ();
       }

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -1020,104 +1020,100 @@ namespace aspect
       void
       CrystalPreferredOrientation<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Crystal Preferred Orientation");
           {
-            prm.enter_subsection("Crystal Preferred Orientation");
+            prm.declare_entry ("Random number seed", "1",
+                               Patterns::Integer (0),
+                               "The seed used to generate random numbers. This will make sure that "
+                               "results are reproducible as long as the problem is run with the "
+                               "same number of MPI processes. It is implemented as final seed = "
+                               "user seed + MPI Rank. ");
+
+            prm.declare_entry ("Number of grains per particle", "50",
+                               Patterns::Integer (1),
+                               "The number of grains of each different mineral "
+                               "each particle contains.");
+
+            prm.declare_entry ("Property advection method", "Backward Euler",
+                               Patterns::Anything(),
+                               "Options: Forward Euler, Backward Euler");
+
+            prm.declare_entry ("Property advection tolerance", "1e-10",
+                               Patterns::Double(0),
+                               "The Backward Euler property advection method involve internal iterations. "
+                               "This option allows for setting a tolerance. When the norm of tensor new - tensor old is "
+                               "smaller than this tolerance, the iteration is stopped.");
+
+            prm.declare_entry ("Property advection max iterations", "100",
+                               Patterns::Integer(0),
+                               "The Backward Euler property advection method involve internal iterations. "
+                               "This option allows for setting the maximum number of iterations. Note that when the iteration "
+                               "is ended by the max iteration amount an assert is thrown.");
+
+            prm.declare_entry ("CPO derivatives algorithm", "Spin tensor",
+                               Patterns::List(Patterns::Anything()),
+                               "Options: Spin tensor");
+
+            prm.enter_subsection("Initial grains");
             {
-              prm.declare_entry ("Random number seed", "1",
-                                 Patterns::Integer (0),
-                                 "The seed used to generate random numbers. This will make sure that "
-                                 "results are reproducible as long as the problem is run with the "
-                                 "same number of MPI processes. It is implemented as final seed = "
-                                 "user seed + MPI Rank. ");
+              prm.declare_entry("Model name","Uniform grains and random uniform rotations",
+                                Patterns::Anything(),
+                                "The model used to initialize the CPO for all particles. "
+                                "Currently 'Uniform grains and random uniform rotations' and 'World Builder' are the only valid option.");
 
-              prm.declare_entry ("Number of grains per particle", "50",
-                                 Patterns::Integer (1),
-                                 "The number of grains of each different mineral "
-                                 "each particle contains.");
-
-              prm.declare_entry ("Property advection method", "Backward Euler",
-                                 Patterns::Anything(),
-                                 "Options: Forward Euler, Backward Euler");
-
-              prm.declare_entry ("Property advection tolerance", "1e-10",
-                                 Patterns::Double(0),
-                                 "The Backward Euler property advection method involve internal iterations. "
-                                 "This option allows for setting a tolerance. When the norm of tensor new - tensor old is "
-                                 "smaller than this tolerance, the iteration is stopped.");
-
-              prm.declare_entry ("Property advection max iterations", "100",
-                                 Patterns::Integer(0),
-                                 "The Backward Euler property advection method involve internal iterations. "
-                                 "This option allows for setting the maximum number of iterations. Note that when the iteration "
-                                 "is ended by the max iteration amount an assert is thrown.");
-
-              prm.declare_entry ("CPO derivatives algorithm", "Spin tensor",
+              prm.declare_entry ("Minerals", "Olivine: Karato 2008, Enstatite",
                                  Patterns::List(Patterns::Anything()),
-                                 "Options: Spin tensor");
-
-              prm.enter_subsection("Initial grains");
-              {
-                prm.declare_entry("Model name","Uniform grains and random uniform rotations",
-                                  Patterns::Anything(),
-                                  "The model used to initialize the CPO for all particles. "
-                                  "Currently 'Uniform grains and random uniform rotations' and 'World Builder' are the only valid option.");
-
-                prm.declare_entry ("Minerals", "Olivine: Karato 2008, Enstatite",
-                                   Patterns::List(Patterns::Anything()),
-                                   "This determines what minerals and fabrics or fabric selectors are used used for the LPO/CPO calculation. "
-                                   "The options are Olivine: Passive, A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric, "
-                                   "Olivine: E-fabric, Olivine: Karato 2008 or Enstatite. Passive sets all RRSS entries to the maximum. The "
-                                   "Karato 2008 selector selects a fabric based on stress and water content as defined in "
-                                   "figure 4 of the Karato 2008 review paper (doi: 10.1146/annurev.earth.36.031207.124120).");
+                                 "This determines what minerals and fabrics or fabric selectors are used used for the LPO/CPO calculation. "
+                                 "The options are Olivine: Passive, A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric, "
+                                 "Olivine: E-fabric, Olivine: Karato 2008 or Enstatite. Passive sets all RRSS entries to the maximum. The "
+                                 "Karato 2008 selector selects a fabric based on stress and water content as defined in "
+                                 "figure 4 of the Karato 2008 review paper (doi: 10.1146/annurev.earth.36.031207.124120).");
 
 
-                prm.declare_entry ("Volume fractions minerals", "0.7, 0.3",
-                                   Patterns::List(Patterns::Double(0)),
-                                   "The volume fractions for the different minerals. "
-                                   "There need to be the same number of values as there are minerals."
-                                   "Note that the currently implemented scheme is incompressible and "
-                                   "does not allow chemical interaction or the formation of new phases");
-              }
-              prm.leave_subsection ();
-
-              prm.enter_subsection("D-Rex 2004");
-              {
-
-                prm.declare_entry ("Mobility", "50",
-                                   Patterns::Double(0),
-                                   "The dimensionless intrinsic grain boundary mobility for both olivine and enstatite.");
-
-                prm.declare_entry ("Volume fractions minerals", "0.5, 0.5",
-                                   Patterns::List(Patterns::Double(0)),
-                                   "The volume fraction for the different minerals. "
-                                   "There need to be the same amount of values as there are minerals");
-
-                prm.declare_entry ("Stress exponents", "3.5",
-                                   Patterns::Double(0),
-                                   "This is the power law exponent that characterizes the rheology of the "
-                                   "slip systems. It is used in equation 11 of Kaminski et al., 2004.");
-
-                prm.declare_entry ("Exponents p", "1.5",
-                                   Patterns::Double(0),
-                                   "This is exponent p as defined in equation 11 of Kaminski et al., 2004. ");
-
-                prm.declare_entry ("Nucleation efficiency", "5",
-                                   Patterns::Double(0),
-                                   "This is the dimensionless nucleation rate as defined in equation 8 of "
-                                   "Kaminski et al., 2004. ");
-
-                prm.declare_entry ("Threshold GBS", "0.3",
-                                   Patterns::Double(0),
-                                   "The Dimensionless Grain Boundary Sliding (GBS) threshold. "
-                                   "This is a grain size threshold below which grain deform by GBS and "
-                                   "become strain-free grains.");
-              }
-              prm.leave_subsection();
+              prm.declare_entry ("Volume fractions minerals", "0.7, 0.3",
+                                 Patterns::List(Patterns::Double(0)),
+                                 "The volume fractions for the different minerals. "
+                                 "There need to be the same number of values as there are minerals."
+                                 "Note that the currently implemented scheme is incompressible and "
+                                 "does not allow chemical interaction or the formation of new phases");
             }
             prm.leave_subsection ();
+
+            prm.enter_subsection("D-Rex 2004");
+            {
+
+              prm.declare_entry ("Mobility", "50",
+                                 Patterns::Double(0),
+                                 "The dimensionless intrinsic grain boundary mobility for both olivine and enstatite.");
+
+              prm.declare_entry ("Volume fractions minerals", "0.5, 0.5",
+                                 Patterns::List(Patterns::Double(0)),
+                                 "The volume fraction for the different minerals. "
+                                 "There need to be the same amount of values as there are minerals");
+
+              prm.declare_entry ("Stress exponents", "3.5",
+                                 Patterns::Double(0),
+                                 "This is the power law exponent that characterizes the rheology of the "
+                                 "slip systems. It is used in equation 11 of Kaminski et al., 2004.");
+
+              prm.declare_entry ("Exponents p", "1.5",
+                                 Patterns::Double(0),
+                                 "This is exponent p as defined in equation 11 of Kaminski et al., 2004. ");
+
+              prm.declare_entry ("Nucleation efficiency", "5",
+                                 Patterns::Double(0),
+                                 "This is the dimensionless nucleation rate as defined in equation 8 of "
+                                 "Kaminski et al., 2004. ");
+
+              prm.declare_entry ("Threshold GBS", "0.3",
+                                 Patterns::Double(0),
+                                 "The Dimensionless Grain Boundary Sliding (GBS) threshold. "
+                                 "This is a grain size threshold below which grain deform by GBS and "
+                                 "become strain-free grains.");
+            }
+            prm.leave_subsection();
           }
           prm.leave_subsection ();
         }
@@ -1134,139 +1130,135 @@ namespace aspect
                                          "2d computations will work when this assert is removed, but you will need to make sure that the "
                                          "correct 3d strain-rate and velocity gradient tensors are provided to the algorithm."));
 
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Crystal Preferred Orientation");
           {
-            prm.enter_subsection("Crystal Preferred Orientation");
+            random_number_seed = prm.get_integer ("Random number seed");
+            n_grains = prm.get_integer("Number of grains per particle");
+
+            property_advection_tolerance = prm.get_double("Property advection tolerance");
+            property_advection_max_iterations = prm.get_integer ("Property advection max iterations");
+
+            const std::string temp_cpo_derivative_algorithm = prm.get("CPO derivatives algorithm");
+
+            if (temp_cpo_derivative_algorithm == "Spin tensor")
+              {
+                cpo_derivative_algorithm = CPODerivativeAlgorithm::spin_tensor;
+              }
+            else if (temp_cpo_derivative_algorithm ==  "D-Rex 2004")
+              {
+                cpo_derivative_algorithm = CPODerivativeAlgorithm::drex_2004;
+              }
+            else
+              {
+                AssertThrow(false,
+                            ExcMessage("The CPO derivatives algorithm needs to be one of the following: "
+                                       "Spin tensor, D-Rex 2004."));
+              }
+
+            const std::string temp_advection_method = prm.get("Property advection method");
+            if (temp_advection_method == "Forward Euler")
+              {
+                advection_method = AdvectionMethod::forward_euler;
+              }
+            else if (temp_advection_method == "Backward Euler")
+              {
+                advection_method = AdvectionMethod::backward_euler;
+              }
+            else
+              {
+                AssertThrow(false, ExcMessage("particle property advection method not found: \"" + temp_advection_method + "\""));
+              }
+
+            prm.enter_subsection("Initial grains");
             {
-              random_number_seed = prm.get_integer ("Random number seed");
-              n_grains = prm.get_integer("Number of grains per particle");
-
-              property_advection_tolerance = prm.get_double("Property advection tolerance");
-              property_advection_max_iterations = prm.get_integer ("Property advection max iterations");
-
-              const std::string temp_cpo_derivative_algorithm = prm.get("CPO derivatives algorithm");
-
-              if (temp_cpo_derivative_algorithm == "Spin tensor")
+              const std::string model_name = prm.get("Model name");
+              if (model_name == "Uniform grains and random uniform rotations")
                 {
-                  cpo_derivative_algorithm = CPODerivativeAlgorithm::spin_tensor;
+                  initial_grains_model = CPOInitialGrainsModel::uniform_grains_and_random_uniform_rotations;
                 }
-              else if (temp_cpo_derivative_algorithm ==  "D-Rex 2004")
+              else if (model_name == "World Builder")
                 {
-                  cpo_derivative_algorithm = CPODerivativeAlgorithm::drex_2004;
+                  initial_grains_model = CPOInitialGrainsModel::world_builder;
                 }
               else
                 {
                   AssertThrow(false,
-                              ExcMessage("The CPO derivatives algorithm needs to be one of the following: "
-                                         "Spin tensor, D-Rex 2004."));
+                              ExcMessage("No model named " + model_name + "for CPO particle property initialization. "
+                                         + "Only the model \"Uniform grains and random uniform rotations\"  and "
+                                         "\"World Builder\" are available."));
                 }
 
-              const std::string temp_advection_method = prm.get("Property advection method");
-              if (temp_advection_method == "Forward Euler")
+              const std::vector<std::string> temp_deformation_type_selector = dealii::Utilities::split_string_list(prm.get("Minerals"));
+              n_minerals = temp_deformation_type_selector.size();
+              deformation_type_selector.resize(n_minerals);
+
+              for (size_t mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
                 {
-                  advection_method = AdvectionMethod::forward_euler;
+                  if (temp_deformation_type_selector[mineral_i] == "Passive")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::passive;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] == "Olivine: Karato 2008")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_karato_2008;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: A-fabric")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_a_fabric;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: B-fabric")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_b_fabric;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: C-fabric")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_c_fabric;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: D-fabric")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_d_fabric;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: E-fabric")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_e_fabric;
+                    }
+                  else if (temp_deformation_type_selector[mineral_i] ==  "Enstatite")
+                    {
+                      deformation_type_selector[mineral_i] = DeformationTypeSelector::enstatite;
+                    }
+                  else
+                    {
+                      AssertThrow(false,
+                                  ExcMessage("The fabric needs to be assigned one of the following comma-delimited values: Olivine: Karato 2008, "
+                                             "Olivine: A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric,"
+                                             "Olivine: E-fabric, Enstatite, Passive."));
+                    }
                 }
-              else if (temp_advection_method == "Backward Euler")
+
+              volume_fractions_minerals = Utilities::string_to_double(dealii::Utilities::split_string_list(prm.get("Volume fractions minerals")));
+              double volume_fractions_minerals_sum = 0;
+              for (auto fraction : volume_fractions_minerals)
                 {
-                  advection_method = AdvectionMethod::backward_euler;
-                }
-              else
-                {
-                  AssertThrow(false, ExcMessage("particle property advection method not found: \"" + temp_advection_method + "\""));
+                  volume_fractions_minerals_sum += fraction;
                 }
 
-              prm.enter_subsection("Initial grains");
-              {
-                const std::string model_name = prm.get("Model name");
-                if (model_name == "Uniform grains and random uniform rotations")
-                  {
-                    initial_grains_model = CPOInitialGrainsModel::uniform_grains_and_random_uniform_rotations;
-                  }
-                else if (model_name == "World Builder")
-                  {
-                    initial_grains_model = CPOInitialGrainsModel::world_builder;
-                  }
-                else
-                  {
-                    AssertThrow(false,
-                                ExcMessage("No model named " + model_name + "for CPO particle property initialization. "
-                                           + "Only the model \"Uniform grains and random uniform rotations\"  and "
-                                           "\"World Builder\" are available."));
-                  }
-
-                const std::vector<std::string> temp_deformation_type_selector = dealii::Utilities::split_string_list(prm.get("Minerals"));
-                n_minerals = temp_deformation_type_selector.size();
-                deformation_type_selector.resize(n_minerals);
-
-                for (size_t mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
-                  {
-                    if (temp_deformation_type_selector[mineral_i] == "Passive")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::passive;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] == "Olivine: Karato 2008")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_karato_2008;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: A-fabric")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_a_fabric;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: B-fabric")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_b_fabric;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: C-fabric")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_c_fabric;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: D-fabric")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_d_fabric;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Olivine: E-fabric")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::olivine_e_fabric;
-                      }
-                    else if (temp_deformation_type_selector[mineral_i] ==  "Enstatite")
-                      {
-                        deformation_type_selector[mineral_i] = DeformationTypeSelector::enstatite;
-                      }
-                    else
-                      {
-                        AssertThrow(false,
-                                    ExcMessage("The fabric needs to be assigned one of the following comma-delimited values: Olivine: Karato 2008, "
-                                               "Olivine: A-fabric, Olivine: B-fabric, Olivine: C-fabric, Olivine: D-fabric,"
-                                               "Olivine: E-fabric, Enstatite, Passive."));
-                      }
-                  }
-
-                volume_fractions_minerals = Utilities::string_to_double(dealii::Utilities::split_string_list(prm.get("Volume fractions minerals")));
-                double volume_fractions_minerals_sum = 0;
-                for (auto fraction : volume_fractions_minerals)
-                  {
-                    volume_fractions_minerals_sum += fraction;
-                  }
-
-                AssertThrow(abs(volume_fractions_minerals_sum-1.0) < 2.0 * std::numeric_limits<double>::epsilon(),
-                            ExcMessage("The sum of the CPO volume fractions should be one."));
-              }
-              prm.leave_subsection();
-
-              prm.enter_subsection("D-Rex 2004");
-              {
-                mobility = prm.get_double("Mobility");
-                volume_fractions_minerals = Utilities::string_to_double(dealii::Utilities::split_string_list(prm.get("Volume fractions minerals")));
-                stress_exponent = prm.get_double("Stress exponents");
-                exponent_p = prm.get_double("Exponents p");
-                nucleation_efficiency = prm.get_double("Nucleation efficiency");
-                threshold_GBS = prm.get_double("Threshold GBS");
-              }
-              prm.leave_subsection();
+              AssertThrow(abs(volume_fractions_minerals_sum-1.0) < 2.0 * std::numeric_limits<double>::epsilon(),
+                          ExcMessage("The sum of the CPO volume fractions should be one."));
             }
-            prm.leave_subsection ();
+            prm.leave_subsection();
+
+            prm.enter_subsection("D-Rex 2004");
+            {
+              mobility = prm.get_double("Mobility");
+              volume_fractions_minerals = Utilities::string_to_double(dealii::Utilities::split_string_list(prm.get("Volume fractions minerals")));
+              stress_exponent = prm.get_double("Stress exponents");
+              exponent_p = prm.get_double("Exponents p");
+              nucleation_efficiency = prm.get_double("Nucleation efficiency");
+              threshold_GBS = prm.get_double("Threshold GBS");
+            }
+            prm.leave_subsection();
           }
           prm.leave_subsection ();
         }

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -86,7 +86,7 @@ namespace aspect
           catch (...)
             {
               std::cerr << "ERROR: FunctionParser failed to parse\n"
-                        << "\t'Postprocess.Particles.Function'\n"
+                        << "\t'Particles.Function'\n"
                         << "with expression\n"
                         << "\t'" << prm.get("Function expression") << "'";
               throw;

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -54,19 +54,15 @@ namespace aspect
       void
       Function<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Function");
           {
-            prm.enter_subsection("Function");
-            {
-              prm.declare_entry ("Number of components", "1",
-                                 Patterns::Integer (0),
-                                 "The number of function components where each component is described "
-                                 "by a function expression delimited by a ';'.");
-              Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
-            }
-            prm.leave_subsection();
+            prm.declare_entry ("Number of components", "1",
+                               Patterns::Integer (0),
+                               "The number of function components where each component is described "
+                               "by a function expression delimited by a ';'.");
+            Functions::ParsedFunction<dim>::declare_parameters (prm, 1);
           }
           prm.leave_subsection();
         }
@@ -78,27 +74,23 @@ namespace aspect
       void
       Function<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            prm.enter_subsection("Function");
-            n_components = prm.get_integer ("Number of components");
-            try
-              {
-                function = std::make_unique<Functions::ParsedFunction<dim>>(n_components);
-                function->parse_parameters (prm);
-              }
-            catch (...)
-              {
-                std::cerr << "ERROR: FunctionParser failed to parse\n"
-                          << "\t'Postprocess.Particles.Function'\n"
-                          << "with expression\n"
-                          << "\t'" << prm.get("Function expression") << "'";
-                throw;
-              }
-            prm.leave_subsection();
-          }
+          prm.enter_subsection("Function");
+          n_components = prm.get_integer ("Number of components");
+          try
+            {
+              function = std::make_unique<Functions::ParsedFunction<dim>>(n_components);
+              function->parse_parameters (prm);
+            }
+          catch (...)
+            {
+              std::cerr << "ERROR: FunctionParser failed to parse\n"
+                        << "\t'Postprocess.Particles.Function'\n"
+                        << "with expression\n"
+                        << "\t'" << prm.get("Function expression") << "'";
+              throw;
+            }
           prm.leave_subsection();
         }
         prm.leave_subsection();

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -697,7 +697,7 @@ namespace aspect
           plugin_names = Utilities::split_string_list(prm.get("List of particle properties"));
           AssertThrow(Utilities::has_unique_entries(plugin_names),
                       ExcMessage("The list of strings for the parameter "
-                                 "'Postprocess/Particles/List of particle properties' contains entries more than once. "
+                                 "'Particles/List of particle properties' contains entries more than once. "
                                  "This is not allowed. Please check your parameter file."));
 
           // see if 'all' was selected (or is part of the list). if so

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -267,24 +267,20 @@ namespace aspect
       IntegratorProperties<dim>::parse_parameters (ParameterHandler &prm)
       {
         std::string name;
-        prm.enter_subsection ("Postprocess");
+        prm.enter_subsection ("Particles");
         {
-          prm.enter_subsection ("Particles");
-          {
-            name = prm.get ("Integration scheme");
+          name = prm.get ("Integration scheme");
 
-            if (name == "rk2")
-              n_integrator_properties = Particle::Integrator::RK2<dim>::n_integrator_properties;
-            else if (name == "rk4")
-              n_integrator_properties = Particle::Integrator::RK4<dim>::n_integrator_properties;
-            else if (name == "euler")
-              n_integrator_properties = Particle::Integrator::Euler<dim>::n_integrator_properties;
-            else
-              AssertThrow(false,
-                          ExcMessage("Unknown integrator scheme. The particle property 'Integrator properties' "
-                                     "does not know how many particle properties to store for this integration scheme."));
-          }
-          prm.leave_subsection ();
+          if (name == "rk2")
+            n_integrator_properties = Particle::Integrator::RK2<dim>::n_integrator_properties;
+          else if (name == "rk4")
+            n_integrator_properties = Particle::Integrator::RK4<dim>::n_integrator_properties;
+          else if (name == "euler")
+            n_integrator_properties = Particle::Integrator::Euler<dim>::n_integrator_properties;
+          else
+            AssertThrow(false,
+                        ExcMessage("Unknown integrator scheme. The particle property 'Integrator properties' "
+                                   "does not know how many particle properties to store for this integration scheme."));
         }
         prm.leave_subsection ();
       }
@@ -663,25 +659,21 @@ namespace aspect
       void
       Manager<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            // finally also construct a string for Patterns::MultipleSelection that
-            // contains the names of all registered particle properties
-            const std::string pattern_of_names
-              = std::get<dim>(registered_plugins).get_pattern_of_names ();
-            prm.declare_entry("List of particle properties",
-                              "",
-                              Patterns::MultipleSelection(pattern_of_names),
-                              "A comma separated list of particle properties that should be tracked. "
-                              "By default none is selected, which means only position, velocity "
-                              "and id of the particles are output. \n\n"
-                              "The following properties are available:\n\n"
-                              +
-                              std::get<dim>(registered_plugins).get_description_string());
-          }
-          prm.leave_subsection();
+          // finally also construct a string for Patterns::MultipleSelection that
+          // contains the names of all registered particle properties
+          const std::string pattern_of_names
+            = std::get<dim>(registered_plugins).get_pattern_of_names ();
+          prm.declare_entry("List of particle properties",
+                            "",
+                            Patterns::MultipleSelection(pattern_of_names),
+                            "A comma separated list of particle properties that should be tracked. "
+                            "By default none is selected, which means only position, velocity "
+                            "and id of the particles are output. \n\n"
+                            "The following properties are available:\n\n"
+                            +
+                            std::get<dim>(registered_plugins).get_description_string());
         }
         prm.leave_subsection();
 
@@ -699,31 +691,27 @@ namespace aspect
         Assert (std::get<dim>(registered_plugins).plugins != nullptr,
                 ExcMessage ("No postprocessors registered!?"));
 
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
-          {
-            // now also see which derived quantities we are to compute
-            plugin_names = Utilities::split_string_list(prm.get("List of particle properties"));
-            AssertThrow(Utilities::has_unique_entries(plugin_names),
-                        ExcMessage("The list of strings for the parameter "
-                                   "'Postprocess/Particles/List of particle properties' contains entries more than once. "
-                                   "This is not allowed. Please check your parameter file."));
+          // now also see which derived quantities we are to compute
+          plugin_names = Utilities::split_string_list(prm.get("List of particle properties"));
+          AssertThrow(Utilities::has_unique_entries(plugin_names),
+                      ExcMessage("The list of strings for the parameter "
+                                 "'Postprocess/Particles/List of particle properties' contains entries more than once. "
+                                 "This is not allowed. Please check your parameter file."));
 
-            // see if 'all' was selected (or is part of the list). if so
-            // simply replace the list with one that contains all names
-            if (std::find (plugin_names.begin(),
-                           plugin_names.end(),
-                           "all") != plugin_names.end())
-              {
-                plugin_names.clear();
-                for (typename std::list<typename aspect::internal::Plugins::PluginList<aspect::Particle::Property::Interface<dim>>::PluginInfo>::const_iterator
-                     p = std::get<dim>(registered_plugins).plugins->begin();
-                     p != std::get<dim>(registered_plugins).plugins->end(); ++p)
-                  plugin_names.push_back (std::get<0>(*p));
-              }
-          }
-          prm.leave_subsection();
+          // see if 'all' was selected (or is part of the list). if so
+          // simply replace the list with one that contains all names
+          if (std::find (plugin_names.begin(),
+                         plugin_names.end(),
+                         "all") != plugin_names.end())
+            {
+              plugin_names.clear();
+              for (typename std::list<typename aspect::internal::Plugins::PluginList<aspect::Particle::Property::Interface<dim>>::PluginInfo>::const_iterator
+                   p = std::get<dim>(registered_plugins).plugins->begin();
+                   p != std::get<dim>(registered_plugins).plugins->end(); ++p)
+                plugin_names.push_back (std::get<0>(*p));
+            }
         }
         prm.leave_subsection();
 

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -81,19 +81,15 @@ namespace aspect
       void
       MeltParticle<dim>::declare_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Melt particle");
           {
-            prm.enter_subsection("Melt particle");
-            {
-              prm.declare_entry ("Threshold for melt presence", "1e-3",
-                                 Patterns::Double (0., 1.),
-                                 "The minimum porosity that has to be present at the position of a particle "
-                                 "for it to be considered a melt particle (in the sense that the melt presence "
-                                 "property is set to 1).");
-            }
-            prm.leave_subsection();
+            prm.declare_entry ("Threshold for melt presence", "1e-3",
+                               Patterns::Double (0., 1.),
+                               "The minimum porosity that has to be present at the position of a particle "
+                               "for it to be considered a melt particle (in the sense that the melt presence "
+                               "property is set to 1).");
           }
           prm.leave_subsection();
         }
@@ -105,15 +101,11 @@ namespace aspect
       void
       MeltParticle<dim>::parse_parameters (ParameterHandler &prm)
       {
-        prm.enter_subsection("Postprocess");
+        prm.enter_subsection("Particles");
         {
-          prm.enter_subsection("Particles");
+          prm.enter_subsection("Melt particle");
           {
-            prm.enter_subsection("Melt particle");
-            {
-              threshold_for_melt_presence = prm.get_double ("Threshold for melt presence");
-            }
-            prm.leave_subsection();
+            threshold_for_melt_presence = prm.get_double ("Threshold for melt presence");
           }
           prm.leave_subsection();
         }

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1281,7 +1281,7 @@ namespace aspect
         const std::vector<std::string> strategies = Utilities::split_string_list(prm.get ("Load balancing strategy"));
         AssertThrow(Utilities::has_unique_entries(strategies),
                     ExcMessage("The list of strings for the parameter "
-                               "'Postprocess/Particles/Load balancing strategy' contains entries more than once. "
+                               "'Particles/Load balancing strategy' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         particle_load_balancing = ParticleLoadBalancing::no_balancing;

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1184,61 +1184,57 @@ namespace aspect
     void
     World<dim>::declare_parameters (ParameterHandler &prm)
     {
-      prm.enter_subsection("Postprocess");
+      prm.enter_subsection("Particles");
       {
-        prm.enter_subsection("Particles");
-        {
-          prm.declare_entry ("Load balancing strategy", "repartition",
-                             Patterns::MultipleSelection ("none|remove particles|add particles|"
-                                                          "remove and add particles|repartition"),
-                             "Strategy that is used to balance the computational "
-                             "load across processors for adaptive meshes.");
-          prm.declare_entry ("Minimum particles per cell", "0",
-                             Patterns::Integer (0),
-                             "Lower limit for particle number per cell. This limit is "
-                             "useful for adaptive meshes to prevent fine cells from being empty "
-                             "of particles. It will be checked and enforced after mesh "
-                             "refinement and after particle movement. "
-                             "If there are "
-                             "\\texttt{n\\_number\\_of\\_particles} $<$ \\texttt{min\\_particles\\_per\\_cell} "
-                             "particles in one cell then "
-                             "\\texttt{min\\_particles\\_per\\_cell} - \\texttt{n\\_number\\_of\\_particles} "
-                             "particles are generated and randomly placed in "
-                             "this cell. If the particles carry properties the "
-                             "individual property plugins control how the "
-                             "properties of the new particles are initialized.");
-          prm.declare_entry ("Maximum particles per cell", "100",
-                             Patterns::Integer (0),
-                             "Upper limit for particle number per cell. This limit is "
-                             "useful for adaptive meshes to prevent coarse cells from slowing down "
-                             "the whole model. It will be checked and enforced after mesh "
-                             "refinement, after MPI transfer of particles and after particle "
-                             "movement. If there are "
-                             "\\texttt{n\\_number\\_of\\_particles} $>$ \\texttt{max\\_particles\\_per\\_cell} "
-                             "particles in one cell then "
-                             "\\texttt{n\\_number\\_of\\_particles} - \\texttt{max\\_particles\\_per\\_cell} "
-                             "particles in this cell are randomly chosen and destroyed.");
-          prm.declare_entry ("Particle weight", "10",
-                             Patterns::Integer (0),
-                             "Weight that is associated with the computational load of "
-                             "a single particle. The sum of particle weights will be added "
-                             "to the sum of cell weights to determine the partitioning of "
-                             "the mesh if the `repartition' particle load balancing strategy "
-                             "is selected. The optimal weight depends on the used "
-                             "integrator and particle properties. In general for a more "
-                             "expensive integrator and more expensive properties a larger "
-                             "particle weight is recommended. Before adding the weights "
-                             "of particles, each cell already carries a weight of 1000 to "
-                             "account for the cost of field-based computations.");
-          prm.declare_entry ("Update ghost particles", "false",
-                             Patterns::Bool (),
-                             "Some particle interpolation algorithms require knowledge "
-                             "about particles in neighboring cells. To allow this, "
-                             "particles in ghost cells need to be exchanged between the "
-                             "processes neighboring this cell. This parameter determines "
-                             "whether this transport is happening.");
-        }
-        prm.leave_subsection ();
+        prm.declare_entry ("Load balancing strategy", "repartition",
+                           Patterns::MultipleSelection ("none|remove particles|add particles|"
+                                                        "remove and add particles|repartition"),
+                           "Strategy that is used to balance the computational "
+                           "load across processors for adaptive meshes.");
+        prm.declare_entry ("Minimum particles per cell", "0",
+                           Patterns::Integer (0),
+                           "Lower limit for particle number per cell. This limit is "
+                           "useful for adaptive meshes to prevent fine cells from being empty "
+                           "of particles. It will be checked and enforced after mesh "
+                           "refinement and after particle movement. "
+                           "If there are "
+                           "\\texttt{n\\_number\\_of\\_particles} $<$ \\texttt{min\\_particles\\_per\\_cell} "
+                           "particles in one cell then "
+                           "\\texttt{min\\_particles\\_per\\_cell} - \\texttt{n\\_number\\_of\\_particles} "
+                           "particles are generated and randomly placed in "
+                           "this cell. If the particles carry properties the "
+                           "individual property plugins control how the "
+                           "properties of the new particles are initialized.");
+        prm.declare_entry ("Maximum particles per cell", "100",
+                           Patterns::Integer (0),
+                           "Upper limit for particle number per cell. This limit is "
+                           "useful for adaptive meshes to prevent coarse cells from slowing down "
+                           "the whole model. It will be checked and enforced after mesh "
+                           "refinement, after MPI transfer of particles and after particle "
+                           "movement. If there are "
+                           "\\texttt{n\\_number\\_of\\_particles} $>$ \\texttt{max\\_particles\\_per\\_cell} "
+                           "particles in one cell then "
+                           "\\texttt{n\\_number\\_of\\_particles} - \\texttt{max\\_particles\\_per\\_cell} "
+                           "particles in this cell are randomly chosen and destroyed.");
+        prm.declare_entry ("Particle weight", "10",
+                           Patterns::Integer (0),
+                           "Weight that is associated with the computational load of "
+                           "a single particle. The sum of particle weights will be added "
+                           "to the sum of cell weights to determine the partitioning of "
+                           "the mesh if the `repartition' particle load balancing strategy "
+                           "is selected. The optimal weight depends on the used "
+                           "integrator and particle properties. In general for a more "
+                           "expensive integrator and more expensive properties a larger "
+                           "particle weight is recommended. Before adding the weights "
+                           "of particles, each cell already carries a weight of 1000 to "
+                           "account for the cost of field-based computations.");
+        prm.declare_entry ("Update ghost particles", "false",
+                           Patterns::Bool (),
+                           "Some particle interpolation algorithms require knowledge "
+                           "about particles in neighboring cells. To allow this, "
+                           "particles in ghost cells need to be exchanged between the "
+                           "processes neighboring this cell. This parameter determines "
+                           "whether this transport is happening.");
       }
       prm.leave_subsection ();
 
@@ -1269,56 +1265,52 @@ namespace aspect
                              "diameter in one time step and therefore skip the layer "
                              "of ghost cells around the local subdomain."));
 
-      prm.enter_subsection("Postprocess");
+      prm.enter_subsection("Particles");
       {
-        prm.enter_subsection("Particles");
-        {
-          min_particles_per_cell = prm.get_integer("Minimum particles per cell");
-          max_particles_per_cell = prm.get_integer("Maximum particles per cell");
+        min_particles_per_cell = prm.get_integer("Minimum particles per cell");
+        max_particles_per_cell = prm.get_integer("Maximum particles per cell");
 
-          AssertThrow(min_particles_per_cell <= max_particles_per_cell,
-                      ExcMessage("Please select a 'Minimum particles per cell' parameter "
-                                 "that is smaller than or equal to the 'Maximum particles per cell' parameter."));
+        AssertThrow(min_particles_per_cell <= max_particles_per_cell,
+                    ExcMessage("Please select a 'Minimum particles per cell' parameter "
+                               "that is smaller than or equal to the 'Maximum particles per cell' parameter."));
 
-          particle_weight = prm.get_integer("Particle weight");
+        particle_weight = prm.get_integer("Particle weight");
 
-          update_ghost_particles = prm.get_bool("Update ghost particles");
+        update_ghost_particles = prm.get_bool("Update ghost particles");
 
-          const std::vector<std::string> strategies = Utilities::split_string_list(prm.get ("Load balancing strategy"));
-          AssertThrow(Utilities::has_unique_entries(strategies),
-                      ExcMessage("The list of strings for the parameter "
-                                 "'Postprocess/Particles/Load balancing strategy' contains entries more than once. "
-                                 "This is not allowed. Please check your parameter file."));
+        const std::vector<std::string> strategies = Utilities::split_string_list(prm.get ("Load balancing strategy"));
+        AssertThrow(Utilities::has_unique_entries(strategies),
+                    ExcMessage("The list of strings for the parameter "
+                               "'Postprocess/Particles/Load balancing strategy' contains entries more than once. "
+                               "This is not allowed. Please check your parameter file."));
 
-          particle_load_balancing = ParticleLoadBalancing::no_balancing;
+        particle_load_balancing = ParticleLoadBalancing::no_balancing;
 
-          for (std::vector<std::string>::const_iterator strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
-            {
-              if (*strategy == "remove particles")
-                particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::remove_particles);
-              else if (*strategy == "add particles")
-                particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::add_particles);
-              else if (*strategy == "remove and add particles")
-                particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::remove_and_add_particles);
-              else if (*strategy == "repartition")
-                particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::repartition);
-              else if (*strategy == "none")
-                {
-                  particle_load_balancing = ParticleLoadBalancing::no_balancing;
-                  AssertThrow(strategies.size() == 1,
-                              ExcMessage("The particle load balancing strategy `none' is not compatible "
-                                         "with any other strategy, yet it seems another is selected as well. "
-                                         "Please check the parameter file."));
-                }
-              else
-                AssertThrow(false,
-                            ExcMessage("The 'Load balancing strategy' parameter contains an unknown value: <" + *strategy
-                                       + ">. This value does not correspond to any known load balancing strategy. Possible values "
-                                       "are listed in the corresponding manual subsection."));
-            }
+        for (std::vector<std::string>::const_iterator strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
+          {
+            if (*strategy == "remove particles")
+              particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::remove_particles);
+            else if (*strategy == "add particles")
+              particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::add_particles);
+            else if (*strategy == "remove and add particles")
+              particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::remove_and_add_particles);
+            else if (*strategy == "repartition")
+              particle_load_balancing = typename ParticleLoadBalancing::Kind(particle_load_balancing | ParticleLoadBalancing::repartition);
+            else if (*strategy == "none")
+              {
+                particle_load_balancing = ParticleLoadBalancing::no_balancing;
+                AssertThrow(strategies.size() == 1,
+                            ExcMessage("The particle load balancing strategy `none' is not compatible "
+                                       "with any other strategy, yet it seems another is selected as well. "
+                                       "Please check the parameter file."));
+              }
+            else
+              AssertThrow(false,
+                          ExcMessage("The 'Load balancing strategy' parameter contains an unknown value: <" + *strategy
+                                     + ">. This value does not correspond to any known load balancing strategy. Possible values "
+                                     "are listed in the corresponding manual subsection."));
+          }
 
-        }
-        prm.leave_subsection ();
       }
       prm.leave_subsection ();
 

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -695,22 +695,24 @@ namespace aspect
         end_time *= year_in_seconds;
 
       unsigned int n_minerals;
-      prm.enter_subsection("Postprocess");
+
+      prm.enter_subsection("Particles");
       {
-        prm.enter_subsection("Particles");
+        prm.enter_subsection("Crystal Preferred Orientation");
         {
-          prm.enter_subsection("Crystal Preferred Orientation");
+          prm.enter_subsection("Initial grains");
           {
-            prm.enter_subsection("Initial grains");
-            {
-              // Static variable of CPO has not been initialize yet, so we need to get it directly.
-              n_minerals = dealii::Utilities::split_string_list(prm.get("Minerals")).size();
-            }
-            prm.leave_subsection();
+            // Static variable of CPO has not been initialize yet, so we need to get it directly.
+            n_minerals = dealii::Utilities::split_string_list(prm.get("Minerals")).size();
           }
-          prm.leave_subsection ();
+          prm.leave_subsection();
         }
         prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+
+      prm.enter_subsection("Postprocess");
+      {
         prm.enter_subsection("Crystal Preferred Orientation");
         {
           output_interval = prm.get_double ("Time between data output");

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -674,7 +674,7 @@ namespace aspect
           output_formats   = Utilities::split_string_list(prm.get ("Data output format"));
           AssertThrow(Utilities::has_unique_entries(output_formats),
                       ExcMessage("The list of strings for the parameter "
-                                 "'Particles/Data output format' contains entries more than once. "
+                                 "'Postprocess/Particles/Data output format' contains entries more than once. "
                                  "This is not allowed. Please check your parameter file."));
 
           AssertThrow ((std::find (output_formats.begin(),

--- a/tests/airy_isostasy_initial_topo_lithostatic_pressure.prm
+++ b/tests/airy_isostasy_initial_topo_lithostatic_pressure.prm
@@ -11,6 +11,7 @@
 include $ASPECT_SOURCE_DIR/tests/airy_isostasy.prm
 
 set Dimension = 2
+
 # The point_is_in_domain function is only called in
 # timestep 0, so we do not need to run the test further.
 set End time                               = 0

--- a/tests/annulus_transient.prm
+++ b/tests/annulus_transient.prm
@@ -66,14 +66,6 @@ subsection Postprocess
 
   subsection Particles
     set Time between data output = 2.6
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set List of particle properties = particle density
-    set Update ghost particles = true
-    set Particle generator name = random uniform
-    set Number of particles = 49152
-    set Load balancing strategy = add particles
-    set Minimum particles per cell = 12
   end
 end
 
@@ -84,5 +76,21 @@ subsection Solver parameters
     set Stokes solver type = block GMG
     set Krylov method for cheap solver steps = IDR(s)
     set IDR(s) parameter = 4
+  end
+end
+
+subsection Particles
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set List of particle properties = particle density
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+  set Load balancing strategy = add particles
+  set Minimum particles per cell = 12
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 49152
+    end
   end
 end

--- a/tests/box_surface_base_variables.prm
+++ b/tests/box_surface_base_variables.prm
@@ -12,7 +12,6 @@ set Surface pressure                       = 0
 set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
-
 subsection Gravity model
   set Model name = vertical
 
@@ -20,7 +19,6 @@ subsection Gravity model
     set Magnitude = 10
   end
 end
-
 
 # We take a box geometry and increase the repetitions
 # of the coarse mesh to capture the initial topography.
@@ -35,9 +33,11 @@ subsection Geometry model
     set Y repetitions = 1
     set Z repetitions = 1
   end
-# We specify the name and directory of the ascii data file
+
+  # We specify the name and directory of the ascii data file
   subsection Initial topography model
     set Model name = ascii data
+
     subsection Ascii data model
       set Data directory = $ASPECT_SOURCE_DIR/data/geometry-model/initial-topography-model/ascii-data/test/
       set Data file name = box_3d_top.0.txt
@@ -47,13 +47,20 @@ end
 
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 1613.0
   end
 end
 
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
+
 subsection Boundary temperature model
   set List of model names = function
+  set Fixed temperature boundary indicators   = 5
+
   subsection Function
     set Function expression = 1613.0
   end
@@ -61,6 +68,7 @@ end
 
 subsection Material model
   set Model name = simple
+
   subsection Simple model
     set Reference density = 3340
     set Reference specific heat = 1200
@@ -69,23 +77,14 @@ subsection Material model
   end
 end
 
-
 subsection Mesh refinement
   set Initial adaptive refinement        = 1
   set Initial global refinement          = 1
   set Strategy                           = minimum refinement function
+
   subsection Minimum refinement function
-     set Function expression             = if(x<400000, 2,1)
+    set Function expression             = if(x<400000, 2,1)
   end
-end
-
-
-# The parameters below this comment were created by the update script
-# as replacement for the old 'Model settings' subsection. They can be
-# safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 5
 end
 
 subsection Boundary velocity model
@@ -96,6 +95,7 @@ end
 # The topography statistics should not exceed these bounds.
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography
+
   subsection Visualization
     set Interpolate output = false
     set List of output variables = boundary indicators, depth

--- a/tests/checkpoint_03_particles.prm
+++ b/tests/checkpoint_03_particles.prm
@@ -66,15 +66,8 @@ subsection Postprocess
   set List of postprocessors = composition statistics, temperature statistics, velocity statistics, particles
 
   subsection Particles
-    set Number of particles = 1000
-    set List of particle properties = function, initial position, position, velocity
-    set Data output format = ascii
     set Time between data output = 0
-
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+    set Data output format = ascii
   end
 end
 
@@ -85,5 +78,20 @@ end
 subsection Solver parameters
   subsection Stokes solver parameters
     set Use direct solver for Stokes system = true
+  end
+end
+
+subsection Particles
+  set List of particle properties = function, initial position, position, velocity
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
   end
 end

--- a/tests/checkpoint_04_particles_no_output.prm
+++ b/tests/checkpoint_04_particles_no_output.prm
@@ -66,15 +66,8 @@ subsection Postprocess
   set List of postprocessors = composition statistics, temperature statistics, velocity statistics, particles
 
   subsection Particles
-    set Number of particles = 1000
-    set List of particle properties = function, initial position, position, velocity
-    set Data output format = none
     set Time between data output = 0
-
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+    set Data output format = none
   end
 end
 
@@ -85,5 +78,20 @@ end
 subsection Solver parameters
   subsection Stokes solver parameters
     set Use direct solver for Stokes system = true
+  end
+end
+
+subsection Particles
+  set List of particle properties = function, initial position, position, velocity
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
   end
 end

--- a/tests/composition_passive_particles.prm
+++ b/tests/composition_passive_particles.prm
@@ -78,7 +78,6 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 0.1
     set Data output format = vtu
   end
@@ -100,5 +99,13 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
+    end
   end
 end

--- a/tests/cookbook_mantle_convection_annulus.prm
+++ b/tests/cookbook_mantle_convection_annulus.prm
@@ -3,15 +3,14 @@
 include $ASPECT_SOURCE_DIR/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
 
 set World builder file                     = $ASPECT_SOURCE_DIR/cookbooks/mantle_convection_with_continents_in_annulus/world.wb
-
 set Output directory                       = cookbook_mantle_convection_annulus
-
 set End time                               = 0
 
 subsection Mesh refinement
   set Initial global refinement       = 1
   set Initial adaptive refinement     = 0
   set Strategy                        = minimum refinement function, viscosity, velocity
+
   subsection Minimum refinement function
     set Coordinate system = spherical
     set Function expression = if(r>6000e3, 6, if(r>5000e3,5,3))
@@ -20,14 +19,18 @@ subsection Mesh refinement
 end
 
 subsection Postprocess
-  subsection Particles
-    set Number of particles           = 123
-    subsection Generator
-      subsection Uniform radial
-         set Minimum radius = 3580000
-         set Maximum radius = 6270000
-         set Radial layers  = 50
-      end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Uniform radial
+      set Minimum radius = 3580000
+      set Maximum radius = 6270000
+      set Radial layers  = 50
+    end
+
+    subsection Probability density function
+      set Number of particles           = 123
     end
   end
 end

--- a/tests/coupled_two_phase_tian_parameterization_kinematic_slab.prm
+++ b/tests/coupled_two_phase_tian_parameterization_kinematic_slab.prm
@@ -3,12 +3,14 @@
 # compaction viscosity.
 
 include $ASPECT_SOURCE_DIR/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
+
 set Adiabatic surface temperature              = 1600
 set Nonlinear solver scheme                    = single Advection, single Stokes
 set End time                                   = 2000
 
 subsection Mesh refinement
   set Initial global refinement = 1
+
   subsection Minimum refinement function
     set Function expression = 1
   end
@@ -19,6 +21,7 @@ end
 subsection Boundary composition model
   set Fixed composition boundary indicators         = left
   set List of model names                           = function
+
   subsection Function
     set Function constants  = initial_porosity=0, initial_bound_sed=0.03, initial_bound_MORB=0.02, initial_bound_gabbro=0.01, \
                               sediment_min=0, sediment_max=5e3, MORB_min=5e3, MORB_max=12e3, gabbro_min=12e3, gabbro_max=20e3, \
@@ -44,11 +47,13 @@ end
 
 subsection Postprocess
   set List of postprocessors          = composition statistics, visualization
+
   subsection Visualization
+    set Output format                 = gnuplot
+    set Time between graphical output = 2000
+
     subsection Melt material properties
       set List of properties          = compaction viscosity
     end
-    set Output format                 = gnuplot
-    set Time between graphical output = 2000
-    end
+  end
 end

--- a/tests/cpo_simple_shearbox.prm
+++ b/tests/cpo_simple_shearbox.prm
@@ -7,11 +7,10 @@ set End time                 = 2e6
 set Use years in output instead of seconds = false
 set Maximum time step = 1e3
 
-
 subsection Compositional fields
   set Number of fields = 1
   set Names of fields = water
- set Compositional field methods = static
+  set Compositional field methods = static
 end
 
 subsection Initial composition model
@@ -25,6 +24,7 @@ end
 
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 10
   end
@@ -32,6 +32,7 @@ end
 
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent = 1
     set Y extent = 1
@@ -64,16 +65,14 @@ subsection Boundary temperature model
   end
 end
 
-
 subsection Prescribed Stokes solution
   set Model name = function
+
   subsection Velocity function
     set Variable names = x,y,z,t
     set Function expression = z*1e-5;0;0 ## Annotation set velocity condition
   end
-
 end
-
 
 subsection Material model
   set Model name = visco plastic
@@ -93,47 +92,11 @@ end
 subsection Postprocess
   set List of postprocessors = visualization, particles, crystal preferred orientation
 
-   subsection Visualization
+  subsection Visualization
     set Time between graphical output = 1e6
     set List of output variables = viscosity, strain rate, stress, density
   end
 
-
-  subsection Particles
-    set Time between data output = 1e6
-    set Data output format       = gnuplot
-    set List of particle properties = integrated strain invariant, crystal preferred orientation, cpo bingham average, cpo elastic tensor, elastic tensor decomposition
-    set Exclude output properties = a_cosine_matrix, volume fraction
-    set Particle generator name = ascii file
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/data/particle/property/
-        set Data file name = particle_one.dat
-      end
-    end
-    subsection Crystal Preferred Orientation
-      subsection Initial grains
-        set Minerals = Olivine: A-fabric , Enstatite
-        set Volume fractions minerals =1.0,0.0
-      end
-      set Random number seed = 301
-      set Number of grains per particle = 5
-      set Property advection method = Backward Euler ## Annotation Property advection method
-      set Property advection tolerance = 1e-15
-      set CPO derivatives algorithm = D-Rex 2004
-      subsection D-Rex 2004
-        set Mobility = 125
-        set Stress exponents = 3.5
-        set Exponents p = 1.5
-        set Nucleation efficiency = 5
-        set Threshold GBS = 0.3
-
-      end
-    end
-    subsection CPO Bingham Average
-      set Random number seed = 200
-    end
-  end
   subsection Crystal Preferred Orientation
     set Time between data output = 1e6
     set Write in background thread = true
@@ -141,8 +104,51 @@ subsection Postprocess
     set Write out raw cpo data = mineral 0: volume fraction, mineral 0: Euler angles, mineral 1: volume fraction, mineral 1: Euler angles
     set Write out draw volume weighted cpo data = mineral 0: volume fraction, mineral 0: Euler angles, mineral 1: volume fraction, mineral 1: Euler angles
   end
+
+  subsection Particles
+    set Time between data output = 1e6
+    set Data output format       = gnuplot
+    set Exclude output properties = a_cosine_matrix, volume fraction
+  end
 end
 
 subsection Solver parameters
-   set Temperature solver tolerance = 1e-10
+  set Temperature solver tolerance = 1e-10
+end
+
+subsection Particles
+  set List of particle properties = integrated strain invariant, crystal preferred orientation, cpo bingham average, cpo elastic tensor, elastic tensor decomposition
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/data/particle/property/
+      set Data file name = particle_one.dat
+    end
+  end
+
+  subsection Crystal Preferred Orientation
+    set Random number seed = 301
+    set Number of grains per particle = 5
+    set Property advection method = Backward Euler ## Annotation Property advection method
+    set Property advection tolerance = 1e-15
+    set CPO derivatives algorithm = D-Rex 2004
+
+    subsection Initial grains
+      set Minerals = Olivine: A-fabric , Enstatite
+      set Volume fractions minerals = 1.0,0.0
+    end
+
+    subsection D-Rex 2004
+      set Mobility = 125
+      set Stress exponents = 3.5
+      set Exponents p = 1.5
+      set Nucleation efficiency = 5
+      set Threshold GBS = 0.3
+    end
+  end
+
+  subsection CPO Bingham Average
+    set Random number seed = 200
+  end
 end

--- a/tests/depth_dependent_additional_outputs.prm
+++ b/tests/depth_dependent_additional_outputs.prm
@@ -13,10 +13,10 @@ set End time = 0
 subsection Material model
   set Model name = depth dependent
 
-   subsection Depth dependent model
-     set Base model = grain size
-     set Reference viscosity = 1e22
-   end
+  subsection Depth dependent model
+    set Base model = grain size
+    set Reference viscosity = 1e22
+  end
 end
 
 subsection Mesh refinement

--- a/tests/entropy_initial_lookup.prm
+++ b/tests/entropy_initial_lookup.prm
@@ -3,15 +3,14 @@
 
 set Dimension                              = 2
 set Use years in output instead of seconds = true
-
 set End time                               = 0
 set Nonlinear solver scheme                = iterated Advection and Stokes
-
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600.0
 
 subsection Formulation
   set Mass conservation = projected density field
 end
-
 
 subsection Geometry model
   set Model name = box
@@ -23,7 +22,6 @@ subsection Geometry model
   end
 end
 
-
 subsection Initial temperature model
   # A constant initial temperature is assigned
   # There is a decreasing in the entropy with increasing pressure.
@@ -33,9 +31,6 @@ subsection Initial temperature model
     set Function expression = 1600.0
   end
 end
-
-set Surface pressure                       = 0
-set Adiabatic surface temperature          = 1600.0
 
 subsection Adiabatic conditions model
   # The 'ascii data' option does not need the additional
@@ -55,13 +50,11 @@ subsection Adiabatic conditions model
   end
 end
 
-
 # We prescribe temperatures according to the data table.
 # This output is computed in the material model.
 subsection Temperature field
   set Temperature method = prescribed field with diffusion
 end
-
 
 # We solve the entropy equation for the compositional field with name
 # 'entropy'. Temperature and density are then computed based on entropy and
@@ -73,23 +66,21 @@ subsection Compositional fields
   set Compositional field methods = field, prescribed field
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = top
   set List of model names = initial temperature
 end
-
 
 # Prescribing downward flow through a vertical pipe with
 # tangential side boundaries.
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = top:function
   set Tangential velocity boundary indicators = left, right
+
   subsection Function
     set Function expression = 0; -0.01
   end
 end
-
 
 subsection Gravity model
   set Model name = vertical
@@ -99,17 +90,16 @@ subsection Gravity model
   end
 end
 
-
 # We look up the values of entropies from another look-up table.
 # This table looks up the value of entropy from a pair of temperature and pressure.
 subsection Initial composition model
   set List of model names = entropy table lookup
+
   subsection Entropy table lookup
     set Data directory = $ASPECT_SOURCE_DIR/data/material-model/entropy-table/pyrtable/
     set Material file name = material_table_temperature_pressure.txt
   end
 end
-
 
 # We use a data table for orthopyroxene computed using the thermodynamic
 # modeling software Perple_X.
@@ -125,23 +115,22 @@ subsection Material model
   end
 end
 
-
 subsection Mesh refinement
   set Initial global refinement                = 0
   set Initial adaptive refinement              = 0
   set Time steps between mesh refinement       = 0
 end
 
-
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, temperature statistics, mass flux statistics, composition statistics
 
   subsection Visualization
-     set Time between graphical output = 1e6
-     set List of output variables      = material properties, adiabat, nonadiabatic pressure, nonadiabatic temperature
-     set Output format = gnuplot
-     subsection Material properties
-       set List of material properties = density,thermal expansivity,specific heat,viscosity, compressibility
-     end
+    set Time between graphical output = 1e6
+    set List of output variables      = material properties, adiabat, nonadiabatic pressure, nonadiabatic temperature
+    set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = density,thermal expansivity,specific heat,viscosity, compressibility
+    end
   end
 end

--- a/tests/entropy_initial_lookup_wb.prm
+++ b/tests/entropy_initial_lookup_wb.prm
@@ -14,12 +14,11 @@ set Resume computation = false
 set Nonlinear solver scheme                = iterated Advection and Stokes
 set World builder file = $ASPECT_SOURCE_DIR/tests/entropy_initial_lookup_wb.wb
 
-
 subsection Discretization
-    set Composition polynomial degree = 2
-    set Stokes velocity polynomial degree = 2
-    set Temperature polynomial degree = 2
-    set Use discontinuous composition discretization = false
+  set Composition polynomial degree = 2
+  set Stokes velocity polynomial degree = 2
+  set Temperature polynomial degree = 2
+  set Use discontinuous composition discretization = false
 end
 
 subsection Formulation
@@ -29,64 +28,64 @@ end
 # Geometry:
 #   The mesh is a 2-D chunk that spans 171.5 degree in longitude
 subsection Geometry model
-    set Model name = chunk
-    subsection Chunk
-        set Chunk inner radius = 3.481e6
-        set Chunk outer radius = 6.371e6
-        set Chunk maximum longitude = 1.7150e+02
-        set Chunk minimum longitude = 0.0
-        set Longitude repetitions = 6
-    end
-end
+  set Model name = chunk
 
+  subsection Chunk
+    set Chunk inner radius = 3.481e6
+    set Chunk outer radius = 6.371e6
+    set Chunk maximum longitude = 1.7150e+02
+    set Chunk minimum longitude = 0.0
+    set Longitude repetitions = 6
+  end
+end
 
 # Mesh refinement:
 #   We combine the strategies of the isosurfaces with the viscosity.
 #   In this way, we can refine the level of the refinement in the
 #   slab core controlled by the colder temperature in the slab.
 subsection Mesh refinement
-    set Initial global refinement = 3
-    set Initial adaptive refinement = 3
-    set Minimum refinement level = 3
-    set Strategy = isosurfaces, minimum refinement function, viscosity
-    set Time steps between mesh refinement = 10
-    set Refinement fraction = 0.2
-    set Coarsening fraction = 0.2
-    set Run postprocessors on initial refinement = true
-    set Skip solvers on initial refinement = true
-    subsection Isosurfaces
-        set Isosurfaces = max, max, Temperature: 270.0 | 1173.0
-    end
-    subsection Minimum refinement function
-        set Coordinate system = spherical
-        set Variable names = r,phi,t
-        set Function constants = Ro=6.3710e+06, UM=670e3, DD=100e3
-        set Function expression = ((Ro-r<UM)? \
+  set Initial global refinement = 3
+  set Initial adaptive refinement = 3
+  set Minimum refinement level = 3
+  set Strategy = isosurfaces, minimum refinement function, viscosity
+  set Time steps between mesh refinement = 10
+  set Refinement fraction = 0.2
+  set Coarsening fraction = 0.2
+  set Run postprocessors on initial refinement = true
+  set Skip solvers on initial refinement = true
+
+  subsection Isosurfaces
+    set Isosurfaces = max, max, Temperature: 270.0 | 1173.0
+  end
+
+  subsection Minimum refinement function
+    set Coordinate system = spherical
+    set Variable names = r,phi,t
+    set Function constants = Ro=6.3710e+06, UM=670e3, DD=100e3
+    set Function expression = ((Ro-r<UM)? \
                                    ((Ro-r<DD)? 5: 3): 0.0)
-    end
+  end
 end
 
-
 subsection Boundary velocity model
-    set Tangential velocity boundary indicators = 0, 1, 2, 3
+  set Tangential velocity boundary indicators = 0, 1, 2, 3
 end
 
 # Initial temperature:
 # A slab structure is configured by the WorldBuilder
 subsection Initial temperature model
-    set List of model names = world builder
+  set List of model names = world builder
 end
-
 
 subsection Boundary temperature model
-    set Fixed temperature boundary indicators = bottom, top
-    set List of model names = spherical constant
-    subsection Spherical constant
-        set Inner temperature = 3500
-        set Outer temperature = 273
-    end
-end
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = spherical constant
 
+  subsection Spherical constant
+    set Inner temperature = 3500
+    set Outer temperature = 273
+  end
+end
 
 # We solve the entropy equation for the compositional field with name
 # 'entropy'. Temperature and density are then computed based on entropy and
@@ -98,17 +97,16 @@ subsection Compositional fields
   set Compositional field methods = field, prescribed field
 end
 
-
 # We look up the values of entropies from another look-up table.
 # This table looks up the value of entropy from a pair of temperature and pressure.
 subsection Initial composition model
   set List of model names = entropy table lookup
+
   subsection Entropy table lookup
     set Data directory = $ASPECT_SOURCE_DIR/data/material-model/entropy-table/pyrtable/
     set Material file name = material_table_temperature_pressure.txt
   end
 end
-
 
 # We use a data table for pyrolite computed using the thermodynamic
 # modeling software Perple_X.
@@ -124,20 +122,20 @@ subsection Material model
   end
 end
 
-
 subsection Gravity model
-    set Model name = ascii data
+  set Model name = ascii data
 end
-
 
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, temperature statistics, mass flux statistics, composition statistics
+
   subsection Visualization
-     set Time between graphical output = 1e6
-     set List of output variables      = material properties, adiabat, nonadiabatic pressure, nonadiabatic temperature
-     set Output format = gnuplot
-     subsection Material properties
-       set List of material properties = density,thermal expansivity,specific heat,viscosity, compressibility
-     end
+    set Time between graphical output = 1e6
+    set List of output variables      = material properties, adiabat, nonadiabatic pressure, nonadiabatic temperature
+    set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = density,thermal expansivity,specific heat,viscosity, compressibility
+    end
   end
 end

--- a/tests/entropy_read_multi_table.prm
+++ b/tests/entropy_read_multi_table.prm
@@ -24,7 +24,6 @@ subsection Geometry model
   end
 end
 
-
 subsection Adiabatic conditions model
   # 'compute entropy profile' computes arbitrary adiabats
   # internally, based on the data table.
@@ -52,7 +51,6 @@ subsection Compositional fields
   set Compositional field methods = field, field, field, prescribed field
 end
 
-
 # Prescribing closed boundaries.
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = top, left, right, bottom
@@ -77,8 +75,7 @@ subsection Initial composition model
   subsection Function
     # Entropy equivalent to T=1560.29 K according to table
     set Function expression = 0.2; 2500; 2500; 0.0
-
-    end
+  end
 end
 
 # We use a data table for orthopyroxene computed using the thermodynamic
@@ -110,11 +107,10 @@ subsection Postprocess
   subsection Visualization
     set Time between graphical output = 1e8
     set List of output variables      = material properties, adiabat, nonadiabatic pressure, nonadiabatic temperature
+    set Output format = gnuplot
 
     subsection Material properties
       set List of material properties = density,thermal expansivity,specific heat,viscosity, compressibility
     end
-
-    set Output format = gnuplot
   end
 end

--- a/tests/gmg_velocity_boundary_2d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_flux.prm
@@ -60,11 +60,11 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = constant
+
   subsection Constant
     set Boundary indicator to temperature mappings = bottom: 1673, top: 273
   end
 end
-
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_2d_box_no_normal_flux.prm
@@ -59,11 +59,11 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = constant
+
   subsection Constant
     set Boundary indicator to temperature mappings = bottom: 1673, top: 273
   end
 end
-
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_3d_box_no_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_flux.prm
@@ -63,11 +63,11 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = constant
+
   subsection Constant
     set Boundary indicator to temperature mappings = bottom: 1673, top: 273
   end
 end
-
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
+++ b/tests/gmg_velocity_boundary_3d_box_no_normal_flux.prm
@@ -62,11 +62,11 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = constant
+
   subsection Constant
     set Boundary indicator to temperature mappings = bottom: 1673, top: 273
   end
 end
-
 
 subsection Material model
   set Material averaging = harmonic average

--- a/tests/grain_size_averaging.prm
+++ b/tests/grain_size_averaging.prm
@@ -4,6 +4,7 @@
 
 include $ASPECT_SOURCE_DIR/tests/grain_size_growth.prm
 
+
 subsection Material model
   set Material averaging = geometric average only viscosity
 end

--- a/tests/grain_size_crossed_transition.prm
+++ b/tests/grain_size_crossed_transition.prm
@@ -103,7 +103,6 @@ subsection Material model
     set Geometric constant                   = 3, 3
     set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain           = 10
-
     set Phase transition depths              = 50000
     set Phase transition Clapeyron slopes    = 1e6
     set Phase transition temperatures        = 1600
@@ -142,21 +141,25 @@ end
 
 subsection Postprocess
   set List of postprocessors = visualization, composition statistics, particles
+
   subsection Visualization
     set List of output variables  = material properties
     set Time between graphical output = 0
   end
 
   subsection Particles
-    set List of particle properties = grain size
-    set Number of particles = 10000
     set Time between data output = 0
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Function expression = sin(y/100000*pi)
-      end
+subsection Particles
+  set List of particle properties = grain size
+  set Particle generator name = probability density function
+
+  subsection Generator
+    subsection Probability density function
+      set Function expression = sin(y/100000*pi)
+      set Number of particles = 10000
     end
   end
 end

--- a/tests/grain_size_growth_one_cell_particles.prm
+++ b/tests/grain_size_growth_one_cell_particles.prm
@@ -2,6 +2,7 @@
 
 include $ASPECT_SOURCE_DIR/tests/grain_size_growth_one_cell.prm
 
+
 ############### Global parameters
 
 set Dimension                              = 2
@@ -21,14 +22,22 @@ end
 subsection Postprocess
   set List of postprocessors = composition statistics, velocity statistics, particles
 
-  # We use particles to advect the grain size.
   subsection Particles
-    set Interpolation scheme = cell average
-    set Number of particles = 50000
     set Time between data output = 1e6
-    set List of particle properties = grain size
-    set Load balancing strategy = none
-    set Integration scheme = rk2
-    set Update ghost particles = true
+  end
+end
+
+# We use particles to advect the grain size.
+subsection Particles
+  set Interpolation scheme = cell average
+  set List of particle properties = grain size
+  set Load balancing strategy = none
+  set Integration scheme = rk2
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 50000
+    end
   end
 end

--- a/tests/grain_size_growth_particles.prm
+++ b/tests/grain_size_growth_particles.prm
@@ -32,10 +32,18 @@ subsection Postprocess
   set List of postprocessors = composition statistics,temperature statistics, velocity statistics, particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 0
     set Data output format = gnuplot
-    set List of particle properties = grain size
-    set Integration scheme = rk2
+  end
+end
+
+subsection Particles
+  set List of particle properties = grain size
+  set Integration scheme = rk2
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
+    end
   end
 end

--- a/tests/grain_size_phase_function.prm
+++ b/tests/grain_size_phase_function.prm
@@ -89,7 +89,6 @@ subsection Material model
     set Geometric constant                   = 3, 3, 3, 3
     set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain           = 10
-
     set Phase transition depths              = background:20000|50000|65000
     set Phase transition Clapeyron slopes    = background:1e6|-5e5|2.5e5
     set Phase transition temperatures        = background:1600|1600|1600
@@ -122,14 +121,23 @@ end
 
 subsection Postprocess
   set List of postprocessors = visualization, composition statistics, particles, material statistics
+
   subsection Visualization
     set List of output variables  = material properties
     set Time between graphical output = 0
   end
 
   subsection Particles
-    set List of particle properties = grain size
-    set Number of particles = 10000
     set Time between data output = 0
+  end
+end
+
+subsection Particles
+  set List of particle properties = grain size
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10000
+    end
   end
 end

--- a/tests/grain_size_ridge_traction.prm
+++ b/tests/grain_size_ridge_traction.prm
@@ -10,7 +10,6 @@ include $ASPECT_SOURCE_DIR/cookbooks/grain_size_ridge/grain_size_ridge.prm
 set End time                    = 100
 set Maximum time step           = 50
 
-
 # Refine the mesh within the lithosphere.
 subsection Mesh refinement
   set Initial global refinement = 5
@@ -19,11 +18,11 @@ subsection Mesh refinement
   set Time steps between mesh refinement = 0
 end
 
-
 # Make the model domain smaller so we can resolve the
 # lithosphere well even in a small test case.
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent  = 410000
     set Y extent  = 200000
@@ -31,7 +30,6 @@ subsection Geometry model
     set Y repetitions = 1
   end
 end
-
 
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = left, top
@@ -42,7 +40,6 @@ subsection Boundary velocity model
     set Function expression = 0; 0
   end
 end
-
 
 # Prescribe traction instead of velocity to avoid sigularity
 # in the top left corner.
@@ -55,11 +52,11 @@ subsection Boundary traction model
   end
 end
 
-
 # Larger conductivity to make up for the smaller model domain.
 # Fast grain size change.
 subsection Material model
   set Material averaging = harmonic average only viscosity
+
   subsection Grain size model
     set Thermal conductivity  = 20
     set Maximum viscosity     = 1e23
@@ -67,11 +64,11 @@ subsection Material model
   end
 end
 
-
 # Leave a gap of low viscosity in the corner to make the problem
 # more well-posed.
 subsection Initial temperature model
   set List of model names = adiabatic
+
   subsection Adiabatic
     set Age bottom boundary layer   = 0.0
     set Top boundary layer age model = function
@@ -82,32 +79,34 @@ subsection Initial temperature model
   end
 end
 
-
 # Make the initial grain size constant everywhere.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 5e-3
     set Variable names      = x,y
   end
 end
 
-
 subsection Postprocess
   set List of postprocessors = composition statistics, velocity statistics, mass flux statistics, particles
 
   subsection Particles
-    set Number of particles = 20000
-    set Minimum particles per cell = 5
-    set Maximum particles per cell = 80
     set Time between data output = 0
-    set Particle generator name = probability density function
     set Data output format = gnuplot
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Function expression = 20000*20000+y*y
-      end
+subsection Particles
+  set Minimum particles per cell = 5
+  set Maximum particles per cell = 80
+  set Particle generator name = probability density function
+
+  subsection Generator
+    subsection Probability density function
+      set Function expression = 20000*20000+y*y
+      set Number of particles = 20000
     end
   end
 end

--- a/tests/grain_size_yield.prm
+++ b/tests/grain_size_yield.prm
@@ -1,5 +1,6 @@
 include $ASPECT_SOURCE_DIR/tests/visco_plastic_yield.prm
 
+
 # Global parameters
 set Dimension                              = 2
 set Adiabatic surface temperature          = 273
@@ -33,7 +34,6 @@ subsection Material model
     set Dislocation creep exponent           = 1
     set Dislocation activation energy        = 0
     set Dislocation activation volume        = 0
-
     set Use Drucker-Prager rheology          = true
     set Cohesions                            = 1e6
     set Angles of internal friction          = 0

--- a/tests/gravity_model_cartesian.prm
+++ b/tests/gravity_model_cartesian.prm
@@ -61,6 +61,7 @@ end
 
 subsection Gravity model
   set Model name = function
+
   subsection Function
     set Coordinate system = cartesian
     set Variable names = x,y

--- a/tests/gravity_model_depth.prm
+++ b/tests/gravity_model_depth.prm
@@ -51,6 +51,7 @@ end
 
 subsection Gravity model
   set Model name = function
+
   subsection Function
     set Coordinate system = depth
     set Variable names = z,x

--- a/tests/gravity_model_spherical.prm
+++ b/tests/gravity_model_spherical.prm
@@ -61,6 +61,7 @@ end
 
 subsection Gravity model
   set Model name = function
+
   subsection Function
     set Coordinate system = spherical
     set Variable names = r,phi

--- a/tests/gs_drucker_prager.prm
+++ b/tests/gs_drucker_prager.prm
@@ -69,7 +69,6 @@ subsection Initial composition model
   end
 end
 
-
 subsection Initial temperature model
   set Model name = function
 
@@ -77,7 +76,6 @@ subsection Initial temperature model
     set Function expression = 1600
   end
 end
-
 
 subsection Material model
   set Model name = grain size
@@ -108,7 +106,6 @@ subsection Material model
     set Dislocation creep exponent           = 1
     set Dislocation activation energy        = 0
     set Dislocation activation volume        = 0
-
     set Use Drucker-Prager rheology          = true
     set Cohesions                            = 5.77350269e7
     set Angles of internal friction          = 30
@@ -126,9 +123,9 @@ end
 subsection Postprocess
   set List of postprocessors = visualization, material statistics
 
-    subsection Visualization
-      set Output format = gnuplot
-      set List of output variables  = material properties, named additional outputs, strain rate, shear stress
-      set Time between graphical output = 0
+  subsection Visualization
+    set Output format = gnuplot
+    set List of output variables  = material properties, named additional outputs, strain rate, shear stress
+    set Time between graphical output = 0
   end
 end

--- a/tests/gs_drucker_prager_extension.prm
+++ b/tests/gs_drucker_prager_extension.prm
@@ -10,7 +10,6 @@ set Use years in output instead of seconds = false
 set Nonlinear solver tolerance             = 1e-7
 set Adiabatic surface temperature          = 1600
 
-
 subsection Compositional fields
   set Number of fields = 1
   set Names of fields   = grain_size
@@ -27,7 +26,6 @@ subsection Initial composition model
   end
 end
 
-
 subsection Initial temperature model
   set Model name = function
 
@@ -35,7 +33,6 @@ subsection Initial temperature model
     set Function expression = 1600
   end
 end
-
 
 subsection Material model
   set Model name = grain size
@@ -66,25 +63,31 @@ subsection Material model
     set Dislocation creep exponent           = 1
     set Dislocation activation energy        = 0
     set Dislocation activation volume        = 0
-
     set Use Drucker-Prager rheology          = true
     set Cohesions                            = 4e7
     set Angles of internal friction          = 15
   end
 end
 
-
-
 subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles, material statistics
-    subsection Visualization
+
+  subsection Visualization
     set List of output variables  = material properties, named additional outputs, strain rate
     set Time between graphical output = 0
   end
 
   subsection Particles
-    set List of particle properties = grain size
-    set Number of particles = 10000
     set Time between data output = 0
+  end
+end
+
+subsection Particles
+  set List of particle properties = grain size
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10000
+    end
   end
 end

--- a/tests/gs_drucker_prager_extension_adiabatic.prm
+++ b/tests/gs_drucker_prager_extension_adiabatic.prm
@@ -8,7 +8,6 @@ set Use years in output instead of seconds = false
 set Nonlinear solver tolerance             = 1e-7
 set Adiabatic surface temperature          = 1600
 
-
 subsection Compositional fields
   set Number of fields = 1
   set Names of fields   = grain_size
@@ -25,7 +24,6 @@ subsection Initial composition model
   end
 end
 
-
 subsection Initial temperature model
   set Model name = function
 
@@ -33,7 +31,6 @@ subsection Initial temperature model
     set Function expression = 1600
   end
 end
-
 
 subsection Material model
   set Model name = grain size
@@ -64,7 +61,6 @@ subsection Material model
     set Dislocation creep exponent           = 1
     set Dislocation activation energy        = 0
     set Dislocation activation volume        = 0
-
     set Use Drucker-Prager rheology          = true
     set Cohesions                            = 4e7
     set Angles of internal friction          = 15
@@ -72,18 +68,25 @@ subsection Material model
   end
 end
 
-
-
 subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles, material statistics
-    subsection Visualization
+
+  subsection Visualization
     set List of output variables  = material properties, named additional outputs, strain rate
     set Time between graphical output = 0
   end
 
   subsection Particles
-    set List of particle properties = grain size
-    set Number of particles = 10000
     set Time between data output = 0
+  end
+end
+
+subsection Particles
+  set List of particle properties = grain size
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10000
+    end
   end
 end

--- a/tests/heating_function_depth.prm
+++ b/tests/heating_function_depth.prm
@@ -5,6 +5,7 @@ set Dimension                              = 2
 
 include $ASPECT_SOURCE_DIR/tests/heating_function.prm
 
+
 subsection Heating model
   set List of model names = function
 

--- a/tests/heating_function_spherical.prm
+++ b/tests/heating_function_spherical.prm
@@ -5,6 +5,7 @@ set Dimension                              = 2
 
 include $ASPECT_SOURCE_DIR/tests/heating_function.prm
 
+
 subsection Heating model
   set List of model names = function
 

--- a/tests/hk04_olivine_composite_hydration_prefactor.prm
+++ b/tests/hk04_olivine_composite_hydration_prefactor.prm
@@ -57,6 +57,7 @@ end
 
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0.01
   end
@@ -91,6 +92,7 @@ end
 # Initial temperature conditions
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 1173
   end
@@ -105,21 +107,18 @@ subsection Material model
     # the stress exponent, so we input r/n=0.34285714285714286.
     set Reference strain rate                          = 1e-17
     set Minimum strain rate                            = 1e-17
-
     set Viscous flow law                               = composite
     set Prefactors for dislocation creep               = 1.0095317511683098e-25
     set Stress exponents for dislocation creep         = 3.5
     set Activation energies for dislocation creep      = 520e3
     set Activation volumes for dislocation creep       = 22e-6
     set Water fugacity exponents for dislocation creep = 0.34285714285714286
-
     set Prefactors for diffusion creep                 = 1.5773933612004842e-21
     set Stress exponents for diffusion creep           = 1.0
     set Activation energies for diffusion creep        = 375e3
     set Activation volumes for diffusion creep         = 10e-6
     set Grain size                                     = 1e-3
     set Water fugacity exponents for diffusion creep   = 0.7
-
     set Viscosity prefactor scheme                     = HK04 olivine hydration
   end
 end
@@ -136,6 +135,7 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = material statistics, visualization
+
   subsection Visualization
     set Interpolate output       = false
     set List of output variables = material properties

--- a/tests/hk04_olivine_composite_hydration_prefactor_cutoff.prm
+++ b/tests/hk04_olivine_composite_hydration_prefactor_cutoff.prm
@@ -12,9 +12,11 @@
 
 include $ASPECT_SOURCE_DIR/tests/hk04_olivine_composite_hydration_prefactor.prm
 
+
 # Set the bound water everywhere in the model to be 0.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0.0
   end

--- a/tests/hk04_olivine_diffusion_hydration_prefactor.prm
+++ b/tests/hk04_olivine_diffusion_hydration_prefactor.prm
@@ -50,6 +50,7 @@ end
 
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = if(y<=50e3, 1.0, 0.0); 0.01
   end
@@ -84,6 +85,7 @@ end
 # Initial temperature conditions
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 1673
   end
@@ -120,6 +122,7 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = material statistics, visualization
+
   subsection Visualization
     set Interpolate output       = false
     set List of output variables = material properties

--- a/tests/hk04_olivine_dislocation_hydration_prefactor.prm
+++ b/tests/hk04_olivine_dislocation_hydration_prefactor.prm
@@ -45,6 +45,7 @@ end
 
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0.01
   end
@@ -79,6 +80,7 @@ end
 # Initial temperature conditions
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 1173
   end
@@ -95,7 +97,6 @@ subsection Material model
     # where n is the stress exponent and thus we input 1.2/3.5 = 0.34285714285714286
     set Reference strain rate                          = 1e-13
     set Minimum strain rate                            = 1e-13
-
     set Viscous flow law                               = dislocation
     set Prefactors for dislocation creep               = 1.0095317511683098e-25
     set Stress exponents for dislocation creep         = 3.5
@@ -118,6 +119,7 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = material statistics, visualization
+
   subsection Visualization
     set Interpolate output       = false
     set List of output variables = material properties

--- a/tests/iterated_advection_and_stokes_DG.prm
+++ b/tests/iterated_advection_and_stokes_DG.prm
@@ -24,6 +24,7 @@ set Use years in output instead of seconds = true
 subsection Discretization
   set Stokes velocity polynomial degree = 2
   set Use discontinuous composition discretization = true
+
   subsection Stabilization parameters
     set Use limiter for discontinuous composition solution = false
     set beta  = 0.5

--- a/tests/iterated_advection_and_stokes_DG_limiter.prm
+++ b/tests/iterated_advection_and_stokes_DG_limiter.prm
@@ -26,8 +26,10 @@ set Use years in output instead of seconds = true
 subsection Discretization
   set Stokes velocity polynomial degree = 2
   set Use discontinuous composition discretization = true
+
   subsection Stabilization parameters
     set Use limiter for discontinuous composition solution = true
+
     # porosity will not exceed 0.21 during set model time.
     # test will have to stay between 0 and 1.
     set Global composition maximum =  1.0, 1.0

--- a/tests/kaus_rayleigh_taylor_instability.prm
+++ b/tests/kaus_rayleigh_taylor_instability.prm
@@ -7,6 +7,7 @@
 # for the development of surface topography.
 include $ASPECT_SOURCE_DIR/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
 
+
 ############### Global parameters
 set Dimension                              = 2
 set Start time                             = 0
@@ -21,7 +22,6 @@ subsection Mesh refinement
   set Time steps between mesh refinement = 0
 end
 
-
 ############### Parameters describing what to do with the solution
 # We monitor the topography over time.
 subsection Postprocess
@@ -33,6 +33,7 @@ subsection Postprocess
     set Output mesh velocity          = true
     set Output format = gnuplot
   end
+
   subsection Topography
     set Output to file           = true
     set Time between text output = 0

--- a/tests/kinematically_driven_subduction_2d_case2a.prm
+++ b/tests/kinematically_driven_subduction_2d_case2a.prm
@@ -3,6 +3,17 @@
 
 set End time                               = 1.e5
 
+# Copy of the cookbooks instead of includes because we
+# cannot include a prm that includes another prm as
+# $ASPECT_SOURCE_DIR is not expanded the second time.
+set Start time                             = 0
+set CFL number                             = 0.5
+set Use years in output instead of seconds = true
+
+# Linear solver
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Adiabatic surface temperature          = 0
+
 subsection Mesh refinement
   set Initial adaptive refinement              = 1
   set Initial global refinement                = 4
@@ -24,17 +35,6 @@ subsection Mesh refinement
     set Function expression = if(x<crust,8,if(x<L,7,if(x<vel,6,4)))
   end
 end
-
-# Copy of the cookbooks instead of includes because we
-# cannot include a prm that includes another prm as
-# $ASPECT_SOURCE_DIR is not expanded the second time.
-set Start time                             = 0
-set CFL number                             = 0.5
-set Use years in output instead of seconds = true
-
-# Linear solver
-set Nonlinear solver scheme                = single Advection, single Stokes
-set Adiabatic surface temperature          = 0
 
 # We fix composition on the right boundary,
 # because we have inflow there.
@@ -93,12 +93,10 @@ subsection Solver parameters
   end
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = bottom, top, right
   set List of model names = initial temperature
 end
-
 
 subsection Material model
   set Model name = multicomponent
@@ -108,14 +106,11 @@ subsection Material model
     set Reference temperature         = 473.15
     set Densities                     = 3200.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0,3250.0
     set Thermal expansivities         = 0
-
     set Thermal conductivities        = 183.33,2.5,2.5,2.5,2.5,2.5,2.5,2.5
     set Heat capacities               = 1250.0,750.0,750.0,750.0,750.0,1250.0,1250.0,750.0
-
     set Viscosity averaging scheme    = maximum composition
     set Viscosities                   = 1.e20, 1.e23, 1.e20, 1.e23, 1.e23, 1.e23, 1.e23, 1.e20
   end
-
 end
 
 # The overriding plate (OP) and subducting plate (SP)
@@ -128,9 +123,9 @@ subsection Compositional fields
   set Names of fields  = BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
 end
 
-
 subsection Initial composition model
   set List of model names = function
+
   subsection Function
     set Function constants  = Ax=1475600.0, Az=670000.0, \
                               Bx=1500000.0, Bz=670000.0, \
@@ -149,7 +144,6 @@ subsection Initial composition model
     set Variable names      = x,z
   end
 end
-
 
 # The initial temperature is prescribed through a plugin
 # and uses the plate cooling model for the temperature in both
@@ -179,5 +173,4 @@ subsection Postprocess
   subsection Composition RMS temperature statistics
     set Names of selected compositional fields = BOC_SP, SHB_SP, thermal_SP
   end
-
 end

--- a/tests/kinematically_driven_subduction_2d_case2b.prm
+++ b/tests/kinematically_driven_subduction_2d_case2b.prm
@@ -5,6 +5,17 @@
 set Dimension                              = 2
 set End time                               = 1.e5
 
+# Copy of the cookbooks instead of includes because we
+# cannot include a prm that includes another prm as
+# $ASPECT_SOURCE_DIR is not expanded the second time.
+set Start time                             = 0
+set CFL number                             = 0.5
+set Use years in output instead of seconds = true
+
+# Linear solver
+set Nonlinear solver scheme                = single Advection, single Stokes
+set Adiabatic surface temperature          = 0
+
 subsection Mesh refinement
   set Initial adaptive refinement              = 1
   set Initial global refinement                = 4
@@ -26,17 +37,6 @@ subsection Mesh refinement
     set Function expression = if(x<crust,8,if(x<L,7,if(x<vel,6,4)))
   end
 end
-
-# Copy of the cookbooks instead of includes because we
-# cannot include a prm that includes another prm as
-# $ASPECT_SOURCE_DIR is not expanded the second time.
-set Start time                             = 0
-set CFL number                             = 0.5
-set Use years in output instead of seconds = true
-
-# Linear solver
-set Nonlinear solver scheme                = single Advection, single Stokes
-set Adiabatic surface temperature          = 0
 
 # We fix composition on the right boundary,
 # because we have inflow there.
@@ -95,12 +95,10 @@ subsection Solver parameters
   end
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = bottom, top, right
   set List of model names = initial temperature
 end
-
 
 # The overriding plate (OP) and subducting plate (SP)
 # are each divided into three different layers:
@@ -112,9 +110,9 @@ subsection Compositional fields
   set Names of fields  = BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
 end
 
-
 subsection Initial composition model
   set List of model names = function
+
   subsection Function
     set Function constants  = Ax=1475600.0, Az=670000.0, \
                               Bx=1500000.0, Bz=670000.0, \
@@ -133,7 +131,6 @@ subsection Initial composition model
     set Variable names      = x,z
   end
 end
-
 
 # The initial temperature is prescribed through a plugin
 # and uses the plate cooling model for the temperature in both
@@ -163,7 +160,6 @@ subsection Postprocess
   subsection Composition RMS temperature statistics
     set Names of selected compositional fields = BOC_SP, SHB_SP, thermal_SP
   end
-
 end
 
 subsection Material model
@@ -184,18 +180,16 @@ subsection Material model
     # 3200 * (1 - 2.5e-5 * (1355 - 1573.15)) = rho_0_2 * (1 - 2.5e-5 * (1355 - 473.15))
     # rho_0_2 = 3290.66.
     set Reference temperature         = 473.15
+
     # BOC_OP, BOC_SP, SHB_OP, SHB_SP, thermal_OP, thermal_SP, WZ
     set Densities                     = 3290.66,3000.0,3000.0,3250.0,3250.0,3290.66,3290.66,3200.0
 
     # Compared to Case 2a, thermal expansivity is no longer zero and therefore temperature
     # feeds into the density and therefore the Stokes equations
     set Thermal expansivities         = 2.5e-5
-
     set Thermal conductivities        = 183.33,2.5,2.5,2.5,2.5,2.5,2.5,2.5
     set Heat capacities               = 1250.0,750.0,750.0,750.0,750.0,1250.0,1250.0,750.0
-
     set Viscosity averaging scheme    = maximum composition
     set Viscosities                   = 1.e20, 1.e23, 1.e20, 1.e23, 1.e23, 1.e23, 1.e23, 1.e20
   end
-
 end

--- a/tests/matrix_nonzeros_2.prm
+++ b/tests/matrix_nonzeros_2.prm
@@ -82,11 +82,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 70
     set Data output format = none
-    set List of particle properties = initial composition
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/matrix_nonzeros_3.prm
+++ b/tests/matrix_nonzeros_3.prm
@@ -88,11 +88,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 70
     set Data output format = none
-    set List of particle properties = initial composition
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/melt_track.prm
+++ b/tests/melt_track.prm
@@ -135,20 +135,6 @@ end
 subsection Postprocess
   set List of postprocessors = particles,visualization,composition statistics,velocity statistics,solitary wave statistics
 
-  subsection Particles
-    set Particle generator name       = ascii file
-    set List of particle properties   = melt particle
-    set Time between data output      = 0
-    set Number of particles           = 10
-    set Data output format = gnuplot
-
-    subsection Generator
-      subsection Ascii file
-        set Data file name            = melt_track.txt
-      end
-    end
-  end
-
   subsection Visualization
     set Interpolate output = false
     set List of output variables      = density, viscosity, thermal expansivity, melt material properties
@@ -173,6 +159,11 @@ subsection Postprocess
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
     end
   end
+
+  subsection Particles
+    set Time between data output      = 0
+    set Data output format = gnuplot
+  end
 end
 
 subsection Solver parameters
@@ -183,5 +174,16 @@ subsection Solver parameters
     set Linear solver tolerance = 1e-10
     set Use direct solver for Stokes system = false
     set Number of cheap Stokes solver steps = 0
+  end
+end
+
+subsection Particles
+  set Particle generator name       = ascii file
+  set List of particle properties   = melt particle
+
+  subsection Generator
+    subsection Ascii file
+      set Data file name            = melt_track.txt
+    end
   end
 end

--- a/tests/mesh_deformation_gmg_2d_spherical_shell.prm
+++ b/tests/mesh_deformation_gmg_2d_spherical_shell.prm
@@ -10,7 +10,6 @@ set Use years in output instead of seconds = true
 set Nonlinear solver scheme                = iterated Advection and Stokes
 set Max nonlinear iterations               = 1
 
-
 subsection Gravity model
   set Model name = radial constant
 
@@ -19,18 +18,16 @@ subsection Gravity model
   end
 end
 
-
 subsection Solver parameters
   subsection Stokes solver parameters
-   set Linear solver tolerance                         = 1e-1
-   set Stokes solver type                              = block GMG
-   set Number of cheap Stokes solver steps             = 5000
-   set GMRES solver restart length                     = 1000
-   set Maximum number of expensive Stokes solver steps = 0
-   set Use full A block as preconditioner              = true
+    set Linear solver tolerance                         = 1e-1
+    set Stokes solver type                              = block GMG
+    set Number of cheap Stokes solver steps             = 5000
+    set GMRES solver restart length                     = 1000
+    set Maximum number of expensive Stokes solver steps = 0
+    set Use full A block as preconditioner              = true
   end
 end
-
 
 subsection Geometry model
   set Model name = spherical shell
@@ -41,25 +38,24 @@ subsection Geometry model
   end
 end
 
-
 subsection Mesh deformation
   set Mesh deformation boundary indicators = top: ascii data
+
   subsection Ascii data model
     set Data directory = $ASPECT_SOURCE_DIR/data/mesh-deformation/ascii-data/
     set Data file name = spherical_shell_2d.txt
   end
 end
 
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom
   set List of model names = spherical constant
+
   subsection Spherical constant
     set Inner temperature = 3700
     set Outer temperature = 273
   end
 end
-
 
 subsection Material model
   set Model name = simple
@@ -73,22 +69,20 @@ subsection Material model
   end
 end
 
-
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
   set Initial global refinement          = 2
 end
 
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators       = bottom, top
 end
-
 
 # The minimum and maximum topography in the ascii file is 3km and 400 km, respectively.
 # The topography statistics should be within these bounds.
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography
+
   subsection Topography
     set Output to file = true
     set Time between text output = 0

--- a/tests/mesh_deformation_particles.prm
+++ b/tests/mesh_deformation_particles.prm
@@ -62,21 +62,24 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
-    set Minimum particles per cell = 1
-    set Maximum particles per cell = 1
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = initial position, position, reference position
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.5
-        set Maximum x = 1
-        set Minimum y = 0.5
-        set Maximum y = 1
-      end
+subsection Particles
+  set Minimum particles per cell = 1
+  set Maximum particles per cell = 1
+  set List of particle properties = initial position, position, reference position
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.5
+      set Maximum x = 1
+      set Minimum y = 0.5
+      set Maximum y = 1
+      set Number of particles = 1
     end
   end
 end

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles.prm
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles.prm
@@ -17,14 +17,22 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 512
     set Time between data output = 1
     set Data output format = gnuplot
-    set List of particle properties = initial position, position
-    set Interpolation scheme = nearest neighbor
-    set Particle generator name = random uniform
-    set Minimum particles per cell = 2
-    set Maximum particles per cell = 2
-    set Load balancing strategy = remove and add particles
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, position
+  set Interpolation scheme = nearest neighbor
+  set Particle generator name = random uniform
+  set Minimum particles per cell = 2
+  set Maximum particles per cell = 2
+  set Load balancing strategy = remove and add particles
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 512
+    end
   end
 end

--- a/tests/original_prm/original.prm
+++ b/tests/original_prm/original.prm
@@ -10,3 +10,4 @@ include $ASPECT_SOURCE_DIR/tests/no_flow.prm
 # directory below this line:
 
 set Output directory = output-original_prm
+

--- a/tests/original_prm/original.prm
+++ b/tests/original_prm/original.prm
@@ -10,4 +10,3 @@ include $ASPECT_SOURCE_DIR/tests/no_flow.prm
 # directory below this line:
 
 set Output directory = output-original_prm
-

--- a/tests/particle_count_statistics.prm
+++ b/tests/particle_count_statistics.prm
@@ -69,16 +69,23 @@ subsection Postprocess
     set Time between graphical output = 100
   end
 
-  subsection Particles
-    set Number of particles = 1000
-    set Time between data output = 1
-    set Data output format = none
-  end
-
   subsection Visualization
     set Interpolate output = false
     set Number of grouped files       = 0
     set Output format                 = gnuplot
     set Time between graphical output = 100
+  end
+
+  subsection Particles
+    set Time between data output = 1
+    set Data output format = none
+  end
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
   end
 end

--- a/tests/particle_exclude_all_properties.prm
+++ b/tests/particle_exclude_all_properties.prm
@@ -81,10 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = gnuplot
-    set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
     set Exclude output properties = initial C_9,all
   end
 end
@@ -105,5 +103,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_exclude_one_property.prm
+++ b/tests/particle_exclude_one_property.prm
@@ -81,10 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = gnuplot
-    set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
     set Exclude output properties = initial C_9
   end
 end
@@ -105,5 +103,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_exclude_one_property_vtu.prm
+++ b/tests/particle_exclude_one_property_vtu.prm
@@ -81,10 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = vtu
-    set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
     set Exclude output properties = initial C_9
   end
 end
@@ -105,5 +103,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_exclude_three_properties_vtu.prm
+++ b/tests/particle_exclude_three_properties_vtu.prm
@@ -81,10 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = vtu
-    set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
     set Exclude output properties = initial C_2, initial C_4, initial C_9
   end
 end
@@ -105,5 +103,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_exclude_two_properties_vtu.prm
+++ b/tests/particle_exclude_two_properties_vtu.prm
@@ -81,10 +81,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = vtu
-    set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
     set Exclude output properties = initial C_2, initial C_9
   end
 end
@@ -105,5 +103,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_fast_evaluate_many_compositions.prm
+++ b/tests/particle_fast_evaluate_many_compositions.prm
@@ -93,16 +93,24 @@ end
 subsection Postprocess
   set List of postprocessors = particles,visualization,composition statistics,velocity statistics
 
-  subsection Particles
-    set List of particle properties   = composition
-    set Time between data output      = 0
-    set Number of particles           = 10
-    set Data output format            = gnuplot
-  end
-
   subsection Visualization
     set Interpolate output = false
     set Number of grouped files       = 0
     set Time between graphical output = 5e5
+  end
+
+  subsection Particles
+    set Time between data output      = 0
+    set Data output format            = gnuplot
+  end
+end
+
+subsection Particles
+  set List of particle properties   = composition
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles           = 10
+    end
   end
 end

--- a/tests/particle_fast_evaluate_multiple_compositions.prm
+++ b/tests/particle_fast_evaluate_multiple_compositions.prm
@@ -93,16 +93,24 @@ end
 subsection Postprocess
   set List of postprocessors = particles,visualization,composition statistics,velocity statistics
 
-  subsection Particles
-    set List of particle properties   = composition
-    set Time between data output      = 0
-    set Number of particles           = 10
-    set Data output format            = gnuplot
-  end
-
   subsection Visualization
     set Interpolate output = false
     set Number of grouped files       = 0
     set Time between graphical output = 5e5
+  end
+
+  subsection Particles
+    set Time between data output      = 0
+    set Data output format            = gnuplot
+  end
+end
+
+subsection Particles
+  set List of particle properties   = composition
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles           = 10
+    end
   end
 end

--- a/tests/particle_free_surface.prm
+++ b/tests/particle_free_surface.prm
@@ -88,24 +88,27 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = uniform box
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_generator_ascii.prm
+++ b/tests/particle_generator_ascii.prm
@@ -89,15 +89,20 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = ascii file
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
   end
 end

--- a/tests/particle_generator_box.prm
+++ b/tests/particle_generator_box.prm
@@ -87,24 +87,27 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = uniform box
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_generator_box_3d.prm
+++ b/tests/particle_generator_box_3d.prm
@@ -89,27 +89,30 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 30
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = uniform box
-    set Integration scheme = euler
+  end
+end
 
-    subsection Function
-      set Variable names      = x,y,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = uniform box
+  set Integration scheme = euler
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.55
-        set Minimum y = 0.2
-        set Maximum y = 0.3
-        set Minimum z = 0.1
-        set Maximum z = 0.4
-      end
+  subsection Function
+    set Variable names      = x,y,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.55
+      set Minimum y = 0.2
+      set Maximum y = 0.3
+      set Minimum z = 0.1
+      set Maximum z = 0.4
+      set Number of particles = 30
     end
   end
 end

--- a/tests/particle_generator_quadrature_points.prm
+++ b/tests/particle_generator_quadrature_points.prm
@@ -89,15 +89,20 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 144
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = quadrature points
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = quadrature points
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
   end
 end

--- a/tests/particle_generator_radial.prm
+++ b/tests/particle_generator_radial.prm
@@ -87,27 +87,30 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = uniform radial
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = uniform radial
 
-    subsection Generator
-      subsection Uniform radial
-        set Minimum radius = 0.05
-        set Maximum radius = 0.15
-        set Minimum longitude = 0.0
-        set Maximum longitude = 270.0
-        set Center x = 0.4
-        set Center y = 0.2
-        set Radial layers = 2
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Uniform radial
+      set Minimum radius = 0.05
+      set Maximum radius = 0.15
+      set Minimum longitude = 0.0
+      set Maximum longitude = 270.0
+      set Center x = 0.4
+      set Center y = 0.2
+      set Radial layers = 2
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_generator_random_uniform.prm
+++ b/tests/particle_generator_random_uniform.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 256
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = true
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = true
+      set Number of particles = 256
     end
   end
 end

--- a/tests/particle_generator_random_uniform_3mpi_1particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_1particle.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = true
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = true
+      set Number of particles = 1
     end
   end
 end

--- a/tests/particle_generator_random_uniform_3mpi_2particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_2particle.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 2
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = true
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = true
+      set Number of particles = 2
     end
   end
 end

--- a/tests/particle_generator_random_uniform_3mpi_3particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_3particle.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 3
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = true
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = true
+      set Number of particles = 3
     end
   end
 end

--- a/tests/particle_generator_random_uniform_3mpi_4particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_4particle.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 4
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = true
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = true
+      set Number of particles = 4
     end
   end
 end

--- a/tests/particle_generator_random_uniform_deterministic_cell.prm
+++ b/tests/particle_generator_random_uniform_deterministic_cell.prm
@@ -87,21 +87,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 256
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = false
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = false
+      set Number of particles = 256
     end
   end
 end

--- a/tests/particle_generator_random_uniform_empty_rank.prm
+++ b/tests/particle_generator_random_uniform_empty_rank.prm
@@ -86,21 +86,24 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = random uniform
 
-    subsection Generator
-      subsection Probability density function
-        set Random cell selection = false
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Random cell selection = false
+      set Number of particles = 1
     end
   end
 end

--- a/tests/particle_generator_reference_cell.prm
+++ b/tests/particle_generator_reference_cell.prm
@@ -89,21 +89,23 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 256
     set Time between data output = 0
     set Data output format = ascii
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
   end
 end

--- a/tests/particle_handler_copy.prm
+++ b/tests/particle_handler_copy.prm
@@ -75,19 +75,22 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = velocity
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+subsection Particles
+  set List of particle properties = velocity
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_initial_adaptive_output.prm
+++ b/tests/particle_initial_adaptive_output.prm
@@ -87,18 +87,21 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = ascii
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+subsection Particles
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_initial_adaptive_refinement.prm
+++ b/tests/particle_initial_adaptive_refinement.prm
@@ -87,18 +87,21 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = none
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+subsection Particles
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_integrator_euler.prm
+++ b/tests/particle_integrator_euler.prm
@@ -87,15 +87,23 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
-    set Integration scheme = euler
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Integration scheme = euler
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_integrator_rk2_first_order_time.prm
+++ b/tests/particle_integrator_rk2_first_order_time.prm
@@ -12,12 +12,15 @@ include $ASPECT_SOURCE_DIR/tests/particle_integrator_euler.prm
 subsection Postprocess
   subsection Particles
     set Data output format = gnuplot
-    set Integration scheme = rk2
+  end
+end
 
-    subsection Integrator
-      subsection RK2
-        set Higher order accurate in time = false
-      end
+subsection Particles
+  set Integration scheme = rk2
+
+  subsection Integrator
+    subsection RK2
+      set Higher order accurate in time = false
     end
   end
 end

--- a/tests/particle_integrator_rk4.prm
+++ b/tests/particle_integrator_rk4.prm
@@ -87,15 +87,23 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
-    set Integration scheme = rk4
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Integration scheme = rk4
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_interpolator_bilinear_3d.prm
+++ b/tests/particle_interpolator_bilinear_3d.prm
@@ -80,24 +80,7 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 4096
     set Data output format       = none
-    set List of particle properties = initial composition
-    set Interpolation scheme = bilinear least squares
-    set Update ghost particles   = true
-    set Particle generator name = reference cell
-
-    subsection Interpolator
-      subsection Bilinear least squares
-        set Use linear least squares limiter = true
-      end
-    end
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 2
-      end
-    end
   end
 end
 
@@ -112,5 +95,24 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y,z
     set Function expression = if(y<0.2*x, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = bilinear least squares
+  set Update ghost particles   = true
+  set Particle generator name = reference cell
+
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true
+    end
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 2
+    end
   end
 end

--- a/tests/particle_interpolator_bilinear_3d_add_particles.prm
+++ b/tests/particle_interpolator_bilinear_3d_add_particles.prm
@@ -79,20 +79,7 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 4096
     set Data output format       = vtu #none
-    set List of particle properties = initial composition
-    set Interpolation scheme = bilinear least squares
-    set Update ghost particles   = true
-    set Load balancing strategy = add particles, repartition
-    set Minimum particles per cell = 4
-    set Particle generator name = reference cell
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 1
-      end
-    end
   end
 end
 
@@ -107,5 +94,20 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y,z
     set Function expression = if(y<0.2*x, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = bilinear least squares
+  set Update ghost particles   = true
+  set Load balancing strategy = add particles, repartition
+  set Minimum particles per cell = 4
+  set Particle generator name = reference cell
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 1
+    end
   end
 end

--- a/tests/particle_interpolator_bilinear_add_particles.prm
+++ b/tests/particle_interpolator_bilinear_add_particles.prm
@@ -81,36 +81,38 @@ subsection Postprocess
   set List of postprocessors = particles, SolKzPostprocessor
 
   subsection Particles
-    set Number of particles = 16384
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set Minimum particles per cell = 50
-    set Maximum particles per cell = 16384
-    set Load balancing strategy = remove and add particles
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, z
-      set Function constants  = pi=3.1415926, eta_b=1e6
-      set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set Minimum particles per cell = 50
+  set Maximum particles per cell = 16384
+  set Load balancing strategy = remove and add particles
+  set Update ghost particles = true
+  set Particle generator name = reference cell
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, z
+    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 7
     end
+  end
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 7
-      end
-    end
-
-    subsection Interpolator
-      subsection Bilinear least squares
-        set Use linear least squares limiter = true, true
-        set Use boundary extrapolation = true, true
-      end
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true, true
+      set Use boundary extrapolation = true, true
     end
   end
 end

--- a/tests/particle_interpolator_bilinear_least_squares_solkz.prm
+++ b/tests/particle_interpolator_bilinear_least_squares_solkz.prm
@@ -81,33 +81,35 @@ subsection Postprocess
   set List of postprocessors = particles, SolKzPostprocessor, composition statistics
 
   subsection Particles
-    set Number of particles = 16384
     set Time between data output = 0
     set Data output format = vtu
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = bilinear least squares
-    set Maximum particles per cell = 16384
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, z
-      set Function constants  = pi=3.1415926, eta_b=1e6
-      set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = bilinear least squares
+  set Maximum particles per cell = 16384
+  set Update ghost particles = true
+  set Particle generator name = reference cell
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, z
+    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
+  end
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
-    end
-
-    subsection Interpolator
-      subsection Bilinear least squares
-        set Use linear least squares limiter = true
-      end
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true
     end
   end
 end

--- a/tests/particle_interpolator_bilinear_limiter.prm
+++ b/tests/particle_interpolator_bilinear_limiter.prm
@@ -75,22 +75,6 @@ subsection Postprocess
   subsection Particles
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = velocity, initial composition, initial position #, integrated strain
-    set Interpolation scheme = bilinear least squares
-    set Update ghost particles = true
-    set Particle generator name = reference cell
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 3
-      end
-    end
-
-    subsection Interpolator
-      subsection Bilinear least squares
-        set Use linear least squares limiter = true
-      end
-    end
   end
 end
 
@@ -113,5 +97,24 @@ subsection Initial composition model
     set Variable names      = x,y
     set Function constants  = r=0.123456789, xc=0.5, yc=0.6
     set Function expression = if(sqrt((x-xc)*(x-xc)+(y-yc)*(y-yc)) < r, 1, 0) ; if (y>0.75,1,0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = velocity, initial composition, initial position #, integrated strain
+  set Interpolation scheme = bilinear least squares
+  set Update ghost particles = true
+  set Particle generator name = reference cell
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 3
+    end
+  end
+
+  subsection Interpolator
+    subsection Bilinear least squares
+      set Use linear least squares limiter = true
+    end
   end
 end

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -99,24 +99,27 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 100000
     set Time between data output = 70
     set Data output format = none
-    set List of particle properties = velocity, function, initial composition
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
+subsection Particles
+  set List of particle properties = velocity, function, initial composition
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+
+  subsection Generator
+    subsection Probability density function
       set Variable names      = x,z
-      set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
-    end
-
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+      set Function expression = x*x*z
+      set Number of particles = 100000
     end
   end
 end

--- a/tests/particle_interpolator_cell_average_2.prm
+++ b/tests/particle_interpolator_cell_average_2.prm
@@ -82,11 +82,8 @@ subsection Postprocess
   set List of postprocessors = particles, velocity statistics, composition statistics, temperature statistics
 
   subsection Particles
-    set Number of particles        = 20000
     set Time between data output = 0.03
     set Data output format       = none
-    set List of particle properties = initial composition
-    set Update ghost particles   = true
   end
 end
 
@@ -107,5 +104,16 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Update ghost particles   = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 20000
+    end
   end
 end

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -73,20 +73,28 @@ subsection Postprocess
   set List of postprocessors = particles, particle count statistics
 
   subsection Particles
-    set Number of particles = 2500
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = initial composition, initial position
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
-    set Particle generator name = random uniform
-    set Minimum particles per cell = 2
-    set Maximum particles per cell = 100
-    set Load balancing strategy = remove and add particles
   end
 end
 
 subsection Termination criteria
   set Termination criteria = end step
   set End step = 3
+end
+
+subsection Particles
+  set List of particle properties = initial composition, initial position
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+  set Minimum particles per cell = 2
+  set Maximum particles per cell = 100
+  set Load balancing strategy = remove and add particles
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 2500
+    end
+  end
 end

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -81,14 +81,22 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 400
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = initial composition
-    set Particle generator name = random uniform
-    set Minimum particles per cell = 2
-    set Maximum particles per cell = 100
-    set Load balancing strategy = none
-    set Update ghost particles = true
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Particle generator name = random uniform
+  set Minimum particles per cell = 2
+  set Maximum particles per cell = 100
+  set Load balancing strategy = none
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 400
+    end
   end
 end

--- a/tests/particle_interpolator_harmonic_average_solkz.prm
+++ b/tests/particle_interpolator_harmonic_average_solkz.prm
@@ -89,29 +89,31 @@ subsection Postprocess
   set List of postprocessors = particles, SolKzPostprocessor
 
   subsection Particles
-    set Number of particles = 4096
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = harmonic average
-    set Maximum particles per cell = 4096
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    # The initial condition is adapted from the original solkz benchmark by adding a constant
-    # value of 1 to keep all properties positive (which is necessary for harmonic averaging)
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, z
-      set Function constants  = pi=3.1415926, eta_b=1e6
-      set Function expression = 1 - sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
-    end
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = harmonic average
+  set Maximum particles per cell = 4096
+  set Update ghost particles = true
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 4
-      end
+  # The initial condition is adapted from the original solkz benchmark by adding a constant
+  # value of 1 to keep all properties positive (which is necessary for harmonic averaging)
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, z
+    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function expression = 1 - sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
     end
   end
 end

--- a/tests/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particle_interpolator_nearest_neighbor.prm
@@ -100,22 +100,28 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1000
     set Time between data output = 1
     set Data output format = none
-    set List of particle properties = initial composition
-    set Interpolation scheme = nearest neighbor
-    set Update ghost particles = true
-    set Maximum particles per cell = 10
-    set Minimum particles per cell = 10
-    set Particle generator name = uniform box
-    set Load balancing strategy = add particles
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = 1 #x*x*z
-      end
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = nearest neighbor
+  set Update ghost particles = true
+  set Maximum particles per cell = 10
+  set Minimum particles per cell = 10
+  set Particle generator name = uniform box
+  set Load balancing strategy = add particles
+
+  subsection Generator
+    subsection Probability density function
+      set Variable names      = x,z
+      set Function expression = 1 #x*x*z
+    end
+
+    subsection Uniform box
+      set Number of particles = 1000
     end
   end
 end

--- a/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
@@ -86,32 +86,35 @@ subsection Postprocess
   subsection Particles
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = quadratic least squares
-    set Minimum particles per cell = 10
-    set Maximum particles per cell = 16384
-    set Load balancing strategy = remove and add particles
-    set Update ghost particles = false
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Number of components = 2
-      set Variable names      = x, z
-      set Function constants  = pi=3.1415926, eta_b=1e6
-      set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+subsection Particles
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = quadratic least squares
+  set Minimum particles per cell = 10
+  set Maximum particles per cell = 16384
+  set Load balancing strategy = remove and add particles
+  set Update ghost particles = false
+  set Particle generator name = reference cell
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x, z
+    set Function constants  = pi=3.1415926, eta_b=1e6
+    set Function expression =  -1 * sin(2*z) * cos(3*pi*x); exp(log(eta_b)*z)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 3
     end
+  end
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 3
-      end
-    end
-
-    subsection Interpolator
-      subsection Quadratic least squares
-        set Use quadratic least squares limiter = false
-      end
+  subsection Interpolator
+    subsection Quadratic least squares
+      set Use quadratic least squares limiter = false
     end
   end
 end

--- a/tests/particle_interpolator_quadratic_least_squares_2d_limiter.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_limiter.prm
@@ -12,16 +12,17 @@ set Additional shared libraries            = ./libparticle_interpolator_quadrati
 ############### Parameters describing what to do with the solution
 
 subsection Postprocess
-  subsection Particles
-    set Update ghost particles = true
-    set Load balancing strategy = none
-    set Minimum particles per cell = 7
+end
 
-    subsection Interpolator
-      subsection Quadratic least squares
-        set Use quadratic least squares limiter = true
-        set Use boundary extrapolation = true
-      end
+subsection Particles
+  set Update ghost particles = true
+  set Load balancing strategy = none
+  set Minimum particles per cell = 7
+
+  subsection Interpolator
+    subsection Quadratic least squares
+      set Use quadratic least squares limiter = true
+      set Use boundary extrapolation = true
     end
   end
 end

--- a/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
@@ -21,16 +21,21 @@ end
 
 subsection Postprocess
   set List of postprocessors = visualization, particles, composition statistics
+end
 
-  subsection Particles
-    set Number of particles = 10000
-    set Interpolation scheme = quadratic least squares
-    set Update ghost particles = true
+subsection Particles
+  set Interpolation scheme = quadratic least squares
+  set Update ghost particles = true
 
-    subsection Interpolator
-      subsection Quadratic least squares
-        set Use quadratic least squares limiter = true
-      end
+  subsection Interpolator
+    subsection Quadratic least squares
+      set Use quadratic least squares limiter = true
+    end
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10000
     end
   end
 end

--- a/tests/particle_interpolator_quadratic_least_squares_3d.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_3d.prm
@@ -81,23 +81,6 @@ subsection Postprocess
 
   subsection Particles
     set Data output format       = none
-    set List of particle properties = initial composition
-    set Interpolation scheme = quadratic least squares
-    set Update ghost particles   = true
-    set Particle generator name = reference cell
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 3
-      end
-    end
-
-    subsection Interpolator
-      subsection Quadratic least squares
-        set Use quadratic least squares limiter = true
-        set Use boundary extrapolation = false
-      end
-    end
   end
 end
 
@@ -112,5 +95,25 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y,z
     set Function expression = if(y<0.2*x, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Interpolation scheme = quadratic least squares
+  set Update ghost particles   = true
+  set Particle generator name = reference cell
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 3
+    end
+  end
+
+  subsection Interpolator
+    subsection Quadratic least squares
+      set Use quadratic least squares limiter = true
+      set Use boundary extrapolation = false
+    end
   end
 end

--- a/tests/particle_interpolator_time_dependence.prm
+++ b/tests/particle_interpolator_time_dependence.prm
@@ -78,11 +78,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 20000
     set Time between data output = 0.03
     set Data output format       = none
-    set List of particle properties = initial composition
-    set Update ghost particles   = true
   end
 end
 
@@ -97,5 +94,16 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2*x, 1, 0) ; if(y>0.8, 1, 0)
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+  set Update ghost particles   = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 20000
+    end
   end
 end

--- a/tests/particle_linear_accelerated_flow_rk2.prm
+++ b/tests/particle_linear_accelerated_flow_rk2.prm
@@ -65,19 +65,22 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 1
     set Data output format = ascii
-    set Particle generator name = uniform box
-    set Integration scheme = rk2
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.0
-        set Maximum x = 0.1
-        set Minimum y = 0.5
-        set Maximum y = 0.55
-      end
+subsection Particles
+  set Particle generator name = uniform box
+  set Integration scheme = rk2
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.0
+      set Maximum x = 0.1
+      set Minimum y = 0.5
+      set Maximum y = 0.55
+      set Number of particles = 1
     end
   end
 end

--- a/tests/particle_load_balancing_none.prm
+++ b/tests/particle_load_balancing_none.prm
@@ -89,10 +89,18 @@ subsection Postprocess
   set List of postprocessors = particles, particle count statistics, load balance statistics
 
   subsection Particles
-    set Number of particles = 1000
     set Time between data output = 100
-    set Load balancing strategy = none
     set Data output format = none
-    set Integration scheme = euler
+  end
+end
+
+subsection Particles
+  set Load balancing strategy = none
+  set Integration scheme = euler
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1000
+    end
   end
 end

--- a/tests/particle_load_balancing_refinement.prm
+++ b/tests/particle_load_balancing_refinement.prm
@@ -85,18 +85,21 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 100
-    set Load balancing strategy = none
     set Data output format = ascii
-    set Integration scheme = euler
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+subsection Particles
+  set Load balancing strategy = none
+  set Integration scheme = euler
+  set Particle generator name = probability density function
+
+  subsection Generator
+    subsection Probability density function
+      set Variable names      = x,z
+      set Function expression = x*x*z
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_load_balancing_refinement_02.prm
+++ b/tests/particle_load_balancing_refinement_02.prm
@@ -85,18 +85,21 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 100
-    set Load balancing strategy = none
     set Data output format = ascii
-    set Integration scheme = euler
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+subsection Particles
+  set Load balancing strategy = none
+  set Integration scheme = euler
+  set Particle generator name = probability density function
+
+  subsection Generator
+    subsection Probability density function
+      set Variable names      = x,z
+      set Function expression = x*x*z
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_load_balancing_removal.prm
+++ b/tests/particle_load_balancing_removal.prm
@@ -85,11 +85,19 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 100
-    set Load balancing strategy = remove particles
-    set Maximum particles per cell = 10
     set Data output format = ascii
-    set Integration scheme = euler
+  end
+end
+
+subsection Particles
+  set Load balancing strategy = remove particles
+  set Maximum particles per cell = 10
+  set Integration scheme = euler
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/particle_load_balancing_removal_addition.prm
+++ b/tests/particle_load_balancing_removal_addition.prm
@@ -87,12 +87,20 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 100
-    set Load balancing strategy = remove and add particles
-    set Maximum particles per cell = 10
-    set Minimum particles per cell = 5
     set Data output format = ascii
-    set Integration scheme = euler
+  end
+end
+
+subsection Particles
+  set Load balancing strategy = remove and add particles
+  set Maximum particles per cell = 10
+  set Minimum particles per cell = 5
+  set Integration scheme = euler
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -86,14 +86,22 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 500
-    set Load balancing strategy = remove and add particles
-    set List of particle properties = initial position, position
-    set Maximum particles per cell = 10
-    set Minimum particles per cell = 5
     set Data output format = ascii
-    set Integration scheme = euler
-    set Update ghost particles = true
+  end
+end
+
+subsection Particles
+  set Load balancing strategy = remove and add particles
+  set List of particle properties = initial position, position
+  set Maximum particles per cell = 10
+  set Minimum particles per cell = 5
+  set Integration scheme = euler
+  set Update ghost particles = true
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/particle_load_balancing_repartition.prm
+++ b/tests/particle_load_balancing_repartition.prm
@@ -11,8 +11,9 @@ include $ASPECT_SOURCE_DIR/tests/particle_load_balancing_none.prm
 set Dimension                              = 2
 
 subsection Postprocess
-  subsection Particles
-    set Load balancing strategy = repartition
-    set Particle weight = 10
-  end
+end
+
+subsection Particles
+  set Load balancing strategy = repartition
+  set Particle weight = 10
 end

--- a/tests/particle_load_balancing_repartition_1000.prm
+++ b/tests/particle_load_balancing_repartition_1000.prm
@@ -12,8 +12,9 @@ include $ASPECT_SOURCE_DIR/tests/particle_load_balancing_none.prm
 set Dimension                              = 2
 
 subsection Postprocess
-  subsection Particles
-    set Load balancing strategy = repartition
-    set Particle weight = 1000
-  end
+end
+
+subsection Particles
+  set Load balancing strategy = repartition
+  set Particle weight = 1000
 end

--- a/tests/particle_melt_advection.prm
+++ b/tests/particle_melt_advection.prm
@@ -117,19 +117,6 @@ end
 subsection Postprocess
   set List of postprocessors = visualization,composition statistics,velocity statistics, temperature statistics, depth average, particles
 
-  subsection Particles
-    set Particle generator name       = reference cell
-    set List of particle properties   = melt particle
-    set Time between data output      = 0
-    set Data output format            = ascii
-
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 1
-      end
-    end
-  end
-
   subsection Visualization
     set List of output variables      = material properties, nonadiabatic temperature, melt fraction, strain rate, melt material properties
     set Number of grouped files       = 0
@@ -150,6 +137,11 @@ subsection Postprocess
     set Number of zones = 12
     set Time between graphical output = 6e5
   end
+
+  subsection Particles
+    set Time between data output      = 0
+    set Data output format            = ascii
+  end
 end
 
 subsection Checkpointing
@@ -159,5 +151,16 @@ end
 subsection Solver parameters
   subsection Stokes solver parameters
     set Use direct solver for Stokes system = false
+  end
+end
+
+subsection Particles
+  set Particle generator name       = reference cell
+  set List of particle properties   = melt particle
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 1
+    end
   end
 end

--- a/tests/particle_output_gnuplot.prm
+++ b/tests/particle_output_gnuplot.prm
@@ -85,15 +85,23 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = gnuplot
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_output_hdf5.prm
+++ b/tests/particle_output_hdf5.prm
@@ -85,15 +85,23 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = hdf5
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_output_multiple_formats.prm
+++ b/tests/particle_output_multiple_formats.prm
@@ -84,15 +84,23 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = gnuplot, vtu
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_output_none.prm
+++ b/tests/particle_output_none.prm
@@ -88,14 +88,22 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 30
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = function, initial composition, initial position
+  end
+end
 
-    subsection Function
-      set Variable names      = x,y,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+
+  subsection Function
+    set Variable names      = x,y,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 30
     end
   end
 end

--- a/tests/particle_output_vtu.prm
+++ b/tests/particle_output_vtu.prm
@@ -85,15 +85,23 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_output_vtu_group.prm
+++ b/tests/particle_output_vtu_group.prm
@@ -87,16 +87,24 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
     set Number of grouped files = 1
-    set List of particle properties = function, initial composition, initial position
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_output_vtu_temp.prm
+++ b/tests/particle_output_vtu_temp.prm
@@ -86,16 +86,24 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
     set Temporary output location = /tmp
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_periodic_boundaries.prm
+++ b/tests/particle_periodic_boundaries.prm
@@ -93,14 +93,22 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_periodic_boundaries_dc.prm
+++ b/tests/particle_periodic_boundaries_dc.prm
@@ -22,9 +22,14 @@ end
 
 subsection Postprocess
   set List of postprocessors = visualization, particles, composition statistics
+end
 
-  subsection Particles
-    set Interpolation scheme = bilinear least squares
-    set Number of particles = 10000
+subsection Particles
+  set Interpolation scheme = bilinear least squares
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10000
+    end
   end
 end

--- a/tests/particle_periodic_boundaries_rk4.prm
+++ b/tests/particle_periodic_boundaries_rk4.prm
@@ -92,14 +92,22 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 200
     set Data output format = gnuplot
-    set List of particle properties = function, initial composition, initial position
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_periodic_quarter_shell.prm
+++ b/tests/particle_periodic_quarter_shell.prm
@@ -93,17 +93,20 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles, visualization
 
   subsection Particles
-    set Number of particles = 50
     set Time between data output = 5
     set Data output format = gnuplot
-    set Integration scheme = euler
-    set Particle generator name = probability density function
-    set List of particle properties = function, initial composition, initial position
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Function expression = (y < 0.1) ? 1.0 : ((x < 0.1) ? 1.0 : 0.0)
-      end
+subsection Particles
+  set Integration scheme = euler
+  set Particle generator name = probability density function
+  set List of particle properties = function, initial composition, initial position
+
+  subsection Generator
+    subsection Probability density function
+      set Function expression = (y < 0.1) ? 1.0 : ((x < 0.1) ? 1.0 : 0.0)
+      set Number of particles = 50
     end
   end
 end

--- a/tests/particle_periodic_quarter_shell_2.prm
+++ b/tests/particle_periodic_quarter_shell_2.prm
@@ -97,23 +97,26 @@ subsection Postprocess
   set List of postprocessors = particle count statistics, particles, visualization
 
   subsection Particles
-    set Number of particles = 50
     set Time between data output = 0
     set Data output format = gnuplot
-    set Particle generator name = uniform radial
-    set List of particle properties = function, position, reference position, initial position
-    set Integration scheme = rk2
+  end
+end
 
-    subsection Generator
-      subsection Uniform radial
-        set Maximum latitude = 180
-        set Maximum longitude = 89.999
-        set Maximum radius = 0.9999
-        set Minimum latitude = 0.
-        set Minimum longitude = 89
-        set Minimum radius = 0.5001
-        set Radial layers = 10
-      end
+subsection Particles
+  set Particle generator name = uniform radial
+  set List of particle properties = function, position, reference position, initial position
+  set Integration scheme = rk2
+
+  subsection Generator
+    subsection Uniform radial
+      set Maximum latitude = 180
+      set Maximum longitude = 89.999
+      set Maximum radius = 0.9999
+      set Minimum latitude = 0.
+      set Minimum longitude = 89
+      set Minimum radius = 0.5001
+      set Radial layers = 10
+      set Number of particles = 50
     end
   end
 end

--- a/tests/particle_property_composition.prm
+++ b/tests/particle_property_composition.prm
@@ -135,19 +135,6 @@ end
 subsection Postprocess
   set List of postprocessors = particles,visualization,composition statistics,velocity statistics,solitary wave statistics
 
-  subsection Particles
-    set Particle generator name       = ascii file
-    set List of particle properties   = composition
-    set Time between data output      = 0
-    set Number of particles           = 10
-
-    subsection Generator
-      subsection Ascii file
-        set Data file name            = particle_property_composition.txt
-      end
-    end
-  end
-
   subsection Visualization
     set Interpolate output = false
     set List of output variables      = density, viscosity, thermal expansivity, melt material properties
@@ -172,6 +159,10 @@ subsection Postprocess
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
     end
   end
+
+  subsection Particles
+    set Time between data output      = 0
+  end
 end
 
 subsection Solver parameters
@@ -182,5 +173,16 @@ subsection Solver parameters
     set Linear solver tolerance = 1e-10
     set Use direct solver for Stokes system = false
     set Number of cheap Stokes solver steps = 0
+  end
+end
+
+subsection Particles
+  set Particle generator name       = ascii file
+  set List of particle properties   = composition
+
+  subsection Generator
+    subsection Ascii file
+      set Data file name            = particle_property_composition.txt
+    end
   end
 end

--- a/tests/particle_property_function.prm
+++ b/tests/particle_property_function.prm
@@ -89,22 +89,25 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = velocity,function, initial composition, initial position
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Function
+subsection Particles
+  set List of particle properties = velocity,function, initial composition, initial position
+  set Particle generator name = probability density function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
       set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
-    end
-
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+      set Function expression = x*x*z
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -90,9 +90,17 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = initial composition
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial composition
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
+    end
   end
 end

--- a/tests/particle_property_initial_composition_boundary.prm
+++ b/tests/particle_property_initial_composition_boundary.prm
@@ -87,12 +87,17 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 1000
-    set Particle generator name = reference cell
     set Time between data output = 0
     set Data output format = gnuplot
-    set List of particle properties = initial composition
-    set Load balancing strategy = add particles
-    set Minimum particles per cell = 40
+  end
+end
+
+subsection Particles
+  set Particle generator name = reference cell
+  set List of particle properties = initial composition
+  set Load balancing strategy = add particles
+  set Minimum particles per cell = 40
+
+  subsection Generator
   end
 end

--- a/tests/particle_property_integrated_strain_invariant.prm
+++ b/tests/particle_property_integrated_strain_invariant.prm
@@ -89,16 +89,24 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 100
     set Time between data output = 1
     set Data output format = ascii
-    set List of particle properties = integrated strain invariant
-    set Particle generator name = random uniform
   end
 end
 
 subsection Solver parameters
   subsection Stokes solver parameters
     set Number of cheap Stokes solver steps = 0
+  end
+end
+
+subsection Particles
+  set List of particle properties = integrated strain invariant
+  set Particle generator name = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 100
+    end
   end
 end

--- a/tests/particle_property_integrated_strain_pure_shear.prm
+++ b/tests/particle_property_integrated_strain_pure_shear.prm
@@ -75,10 +75,18 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 1.0
     set Data output format = ascii
-    set List of particle properties = integrated strain
-    set Particle generator name = random uniform
+  end
+end
+
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
+    end
   end
 end

--- a/tests/particle_property_integrated_strain_simple_shear.prm
+++ b/tests/particle_property_integrated_strain_simple_shear.prm
@@ -74,10 +74,18 @@ subsection Postprocess
   set List of postprocessors = particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 1
     set Data output format = ascii
-    set List of particle properties = integrated strain
-    set Particle generator name = random uniform
+  end
+end
+
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
+    end
   end
 end

--- a/tests/particle_property_multiple_functions.prm
+++ b/tests/particle_property_multiple_functions.prm
@@ -90,23 +90,26 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = velocity, function, initial composition, initial position
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Function
-      set Number of components = 2
+subsection Particles
+  set List of particle properties = velocity, function, initial composition, initial position
+  set Particle generator name = probability density function
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 ); 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+
+  subsection Generator
+    subsection Probability density function
       set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 ); 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
-    end
-
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+      set Function expression = x*x*z
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -92,24 +92,27 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 1024
     set Time between data output = 70
     set Data output format = none
-    set List of particle properties = velocity, function, initial composition
-    set Update ghost particles = true
-    set Particle generator name = random uniform
+  end
+end
 
-    subsection Function
-      set Number of components = 2
+subsection Particles
+  set List of particle properties = velocity, function, initial composition
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Number of components = 2
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 ); 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+
+  subsection Generator
+    subsection Probability density function
       set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 ); 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
-    end
-
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+      set Function expression = x*x*z
+      set Number of particles = 1024
     end
   end
 end

--- a/tests/particle_property_post_initialize_function.prm
+++ b/tests/particle_property_post_initialize_function.prm
@@ -75,10 +75,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 100
     set Time between data output = 0.1
     set Data output format       = vtu
-    set List of particle properties = initial position, initial composition, PostInitializeParticleProperty, velocity
     set Exclude output properties = initial C_2, initial C_9
   end
 end
@@ -93,5 +91,15 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = 0.1; 0.2; 0.3 ; 0.4; 0.5;0.6;0.7;0.8;0.9;0.95
+  end
+end
+
+subsection Particles
+  set List of particle properties = initial position, initial composition, PostInitializeParticleProperty, velocity
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles        = 100
+    end
   end
 end

--- a/tests/particle_timing_information.prm
+++ b/tests/particle_timing_information.prm
@@ -89,18 +89,21 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = ascii
-    set Particle generator name = uniform box
+  end
+end
 
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.3
-        set Maximum x = 0.5
-        set Minimum y = 0.1
-        set Maximum y = 0.3
-      end
+subsection Particles
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.3
+      set Maximum x = 0.5
+      set Minimum y = 0.1
+      set Maximum y = 0.3
+      set Number of particles = 10
     end
   end
 end

--- a/tests/particle_visualization_particle_count.prm
+++ b/tests/particle_visualization_particle_count.prm
@@ -92,16 +92,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 30
     set Time between data output = 70
     set Data output format = none
-    set Particle generator name = probability density function
+  end
+end
 
-    subsection Generator
-      subsection Probability density function
-        set Variable names      = x,z
-        set Function expression = x*x*z
-      end
+subsection Particles
+  set Particle generator name = probability density function
+
+  subsection Generator
+    subsection Probability density function
+      set Variable names      = x,z
+      set Function expression = x*x*z
+      set Number of particles = 30
     end
   end
 end

--- a/tests/particles_with_AMR_on.prm
+++ b/tests/particles_with_AMR_on.prm
@@ -97,26 +97,28 @@ subsection Postprocess
   set List of postprocessors = particles, velocity statistics, composition statistics
 
   subsection Particles
-    set Number of particles = 120000
-    set Load balancing strategy = remove and add particles
-    set Minimum particles per cell = 9
-    set Maximum particles per cell = 36
     set Data output format = none
-    set List of particle properties = function
-    set Integration scheme = rk2
-    set Interpolation scheme = cell average
-    set Update ghost particles = true
-    set Particle generator name = reference cell
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if(((x>187.5e3)&&(x<312.5e3)&&(z>312.5e3)&&(z<437.5e3)), 1, 0)
-    end
+subsection Particles
+  set Load balancing strategy = remove and add particles
+  set Minimum particles per cell = 9
+  set Maximum particles per cell = 36
+  set List of particle properties = function
+  set Integration scheme = rk2
+  set Interpolation scheme = cell average
+  set Update ghost particles = true
+  set Particle generator name = reference cell
 
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 8
-      end
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if(((x>187.5e3)&&(x<312.5e3)&&(z>312.5e3)&&(z<437.5e3)), 1, 0)
+  end
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 8
     end
   end
 end

--- a/tests/periodic_box_gmg.prm
+++ b/tests/periodic_box_gmg.prm
@@ -77,6 +77,7 @@ subsection Solver parameters
     set Linear solver tolerance = 1e-8
     set Number of cheap Stokes solver steps = 100
   end
+
   subsection Matrix Free
     set Output details = true
   end
@@ -100,19 +101,16 @@ subsection Mesh refinement
   set Additional refinement times        =
   set Initial adaptive refinement        = 2
   set Initial global refinement          = 5                       # default: 2
- set Minimum refinement level                            = 5
-
+  set Minimum refinement level                            = 5
   set Refinement fraction                = 0.3
   set Coarsening fraction                = 0.03
   set Strategy                           = thermal energy density#, equal periodic refinement
   set Time steps between mesh refinement = 5
 end
 
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = bottom, top
 end
-
 
 subsection Postprocess
   set List of postprocessors = visualization

--- a/tests/prescribed_viscosity_additional_outputs.prm
+++ b/tests/prescribed_viscosity_additional_outputs.prm
@@ -13,7 +13,7 @@ set End time = 0
 subsection Material model
   set Model name = prescribed viscosity
 
-   subsection Prescribed viscosity
+  subsection Prescribed viscosity
     set Base model = grain size
 
     subsection Indicator function
@@ -24,7 +24,7 @@ subsection Material model
     subsection Viscosity function
       set Function expression = 1e22
     end
-   end
+  end
 end
 
 subsection Mesh refinement

--- a/tests/prescribed_viscosity_happy.prm
+++ b/tests/prescribed_viscosity_happy.prm
@@ -22,13 +22,13 @@ subsection Mesh refinement
   set Skip solvers on initial refinement = true
 end
 
-
 subsection Material model
   set Model name = prescribed viscosity
   set Material averaging = geometric average only viscosity
 
   subsection Prescribed viscosity
     set Base model = simple
+
     subsection Indicator function
       set Variable names = x,y,t
 
@@ -53,15 +53,13 @@ subsection Material model
   end
 end
 
-
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 9.81
   end
 end
-
-
 
 subsection Postprocess
   set List of postprocessors = visualization

--- a/tests/principal_deviatoric_stress.prm
+++ b/tests/principal_deviatoric_stress.prm
@@ -99,17 +99,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
-        set Data file name = simple_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
+      set Data file name = simple_shear_particle.dat
     end
   end
 end

--- a/tests/prmbackslash.prm
+++ b/tests/prmbackslash.prm
@@ -1,31 +1,25 @@
-# a test that tests \
-#
-\
+# a test that tests #
 
 set Dimension = 2
 set CFL number                             = 1.0
-set End \
-time                               = \
+set End time                               = \
 1e7
 set Start time                             = 0
 set Adiabatic surface temperature          = 0
 set Surface pressure                       = 0
 set Use years in output instead of seconds = false
 set Nonlinear solver scheme                = single Advection, single Stokes
-
+set Maximum time step                      = 42
 
 # \ test
-# \
-bla
+# bla
 
 
 subsection Gravity model
   set Model name = vertical
 end
 
-
-subsection Geometry \
-model
+subsection Geometry model
   set Model name = box
 
   subsection Box
@@ -35,11 +29,9 @@ model
   end
 end
 
-
 subsection Initial temperature model
   set Model name = perturbed box
 end
-
 
 subsection Material model
   set Model name = simple
@@ -54,22 +46,18 @@ subsection Material model
   end
 end
 
-
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
   set Initial global refinement          = 5
 end
 
-
 # The parameters below this comment were created by the update script
 # as replacement for the old 'Model settings' subsection. They can be
 # safely merged with any existing subsections with the same name.
 
-subsection Boundary velocity model
-  set Tangential velocity boundary indicators = 1
-end
 
 subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 1
   set Zero velocity boundary indicators       = 0, 2, 3
 end
 
@@ -81,7 +69,4 @@ subsection Termination criteria
   set Checkpoint on termination = true
   set Termination criteria      = end step
   set End step                  = 5
-
 end
-
-set Maximum time step                      = 42

--- a/tests/prmbackslash_2.prm
+++ b/tests/prmbackslash_2.prm
@@ -1,94 +1,156 @@
-# Based on the sol_cx_2.prm test input, split every input file after 20
-# characters with a backslash. In some cases, split it more than once.
-# The output should still be the same.
+# Based on the sol_c\
+x_2.prm test input, split\
+ every input file after 20
+# characters with a \
+backslash. In some cases,\
+ split it more than once.
+# The output should \
+still be the same.
 
 
 set Dimension = 2
-set CFL number                        = \
+
+set CFL number      \
+                       = \
 1.0
-set End time                        = \
+set End time        \
+                       = \
 0
-set Resume computation                     = \
+
+
+set Resume computati\
+on                     = \
 false
-set Start time                        = \
+set Start time      \
+                       = \
 0
-set Adiabatic surface temperature          = \
+set Adiabatic surfac\
+e temperature          = \
 0
-set Surface pressure                        = \
+set Surface pressure\
+                       = \
 0
-set Use years in output instead of seconds = \
+set Use years in out\
+put instead of seconds = \
 false
-set Nonlinear solver scheme                = \
+set Nonlinear solver \
+ scheme                = \
 no Advection, iterated Stokes
 
-subsection Boundary temperature model
+subsection Boundary \
+temperature model
   set Model name = b\
 ox
-  set Fixed temperature boundary indicators  = 0, 1
 end
 
-subsection Discretization
-  set Stokes velocity polynomial degree  = 2
-  set Temperature polynomial degree  = 2
-  set Use locally conservative discretization  = false
 
-  subsection Stabilization parameters
+subsection Discretiz\
+ation
+  set Stokes velocit\
+y polynomial degree      \
+ = 2
+  set Temperature po\
+lynomial degree          \
+ = 2
+  set Use locally co\
+nservative discretization\
+ = false
+  subsection Stabili\
+zation parameters
     set alpha = 2
     set beta  = 0.07\
 8
     set cR    = 0.5 \
+
   end
 end
 
-subsection Geometry model
+
+subsection Geometry \
+model
   set Model name = b\
 ox
 
   subsection Box
     set X extent = 1\
+
     set Y extent = 1\
+
     set Z extent = 1\
+
   end
 end
 
-subsection Gravity model
+
+subsection Gravity m\
+odel
   set Model name = v\
 ertical
 end
 
-subsection Initial temperature model
+
+subsection Initial t\
+emperature model
   set Model name = p\
 erturbed box
 end
 
-subsection Material model
+
+subsection Material \
+model
   set Model name = S\
 olCxMaterial
 end
 
-subsection Mesh refinement
-  set Initial adaptive refinement        = 0 \
-  set Initial global refinement          = 2 \
-  set Strategy                      = de\
+
+subsection Mesh refi\
+nement
+  set Initial adapti\
+ve refinement        = 0 \
+
+  set Initial global \
+ refinement          = 2 \
+
+
+  set Strategy      \
+                     = de\
 nsity, temperature
 end
 
-subsection Boundary velocity model
-  set Tangential velocity boundary indicators  = 0,1,2,3
+
+subsection Boundary temp\
+erature model
+  set Fixed temperat\
+ure boundary indicators  \
+ = 0, 1
+end
+subsection Boundary velo\
+city model
+  set Tangential vel\
+ocity boundary indicators\
+ = 0,1,2,3
 end
 
-subsection Postprocess
-  set List of postprocessors = SolCxPostprocessor
 
-  subsection Depth average
-    set Time between graphical output = 1e8
+subsection Postproce\
+ss
+  set List of postpr\
+ocessors = SolCxPostprocessor
+  subsection Depth a\
+verage
+    set Time between \
+ graphical output = 1e8
   end
 
-  subsection Visualization
-    set Number of grouped files       = 0
-    set Output format                 = gnupl\
+  subsection Visuali\
+zation
+    set Number of gr\
+ouped files       = 0
+    set Output forma\
+t                 = gnupl\
 ot
-    set Time between graphical output = 0   #\
+    set Time between \
+ graphical output = 0   #\
  default: 1e8
   end
 end

--- a/tests/prmbackslash_2.prm
+++ b/tests/prmbackslash_2.prm
@@ -1,156 +1,94 @@
-# Based on the sol_c\
-x_2.prm test input, split\
- every input file after 20
-# characters with a \
-backslash. In some cases,\
- split it more than once.
-# The output should \
-still be the same.
+# Based on the sol_cx_2.prm test input, split every input file after 20
+# characters with a backslash. In some cases, split it more than once.
+# The output should still be the same.
 
 
 set Dimension = 2
-
-set CFL number      \
-                       = \
+set CFL number                        = \
 1.0
-set End time        \
-                       = \
+set End time                        = \
 0
-
-
-set Resume computati\
-on                     = \
+set Resume computation                     = \
 false
-set Start time      \
-                       = \
+set Start time                        = \
 0
-set Adiabatic surfac\
-e temperature          = \
+set Adiabatic surface temperature          = \
 0
-set Surface pressure\
-                       = \
+set Surface pressure                        = \
 0
-set Use years in out\
-put instead of seconds = \
+set Use years in output instead of seconds = \
 false
-set Nonlinear solver \
- scheme                = \
+set Nonlinear solver scheme                = \
 no Advection, iterated Stokes
 
-subsection Boundary \
-temperature model
+subsection Boundary temperature model
   set Model name = b\
 ox
+  set Fixed temperature boundary indicators  = 0, 1
 end
 
+subsection Discretization
+  set Stokes velocity polynomial degree  = 2
+  set Temperature polynomial degree  = 2
+  set Use locally conservative discretization  = false
 
-subsection Discretiz\
-ation
-  set Stokes velocit\
-y polynomial degree      \
- = 2
-  set Temperature po\
-lynomial degree          \
- = 2
-  set Use locally co\
-nservative discretization\
- = false
-  subsection Stabili\
-zation parameters
+  subsection Stabilization parameters
     set alpha = 2
     set beta  = 0.07\
 8
     set cR    = 0.5 \
-
   end
 end
 
-
-subsection Geometry \
-model
+subsection Geometry model
   set Model name = b\
 ox
 
   subsection Box
     set X extent = 1\
-
     set Y extent = 1\
-
     set Z extent = 1\
-
   end
 end
 
-
-subsection Gravity m\
-odel
+subsection Gravity model
   set Model name = v\
 ertical
 end
 
-
-subsection Initial t\
-emperature model
+subsection Initial temperature model
   set Model name = p\
 erturbed box
 end
 
-
-subsection Material \
-model
+subsection Material model
   set Model name = S\
 olCxMaterial
 end
 
-
-subsection Mesh refi\
-nement
-  set Initial adapti\
-ve refinement        = 0 \
-
-  set Initial global \
- refinement          = 2 \
-
-
-  set Strategy      \
-                     = de\
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0 \
+  set Initial global refinement          = 2 \
+  set Strategy                      = de\
 nsity, temperature
 end
 
-
-subsection Boundary temp\
-erature model
-  set Fixed temperat\
-ure boundary indicators  \
- = 0, 1
-end
-subsection Boundary velo\
-city model
-  set Tangential vel\
-ocity boundary indicators\
- = 0,1,2,3
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators  = 0,1,2,3
 end
 
+subsection Postprocess
+  set List of postprocessors = SolCxPostprocessor
 
-subsection Postproce\
-ss
-  set List of postpr\
-ocessors = SolCxPostprocessor
-  subsection Depth a\
-verage
-    set Time between \
- graphical output = 1e8
+  subsection Depth average
+    set Time between graphical output = 1e8
   end
 
-  subsection Visuali\
-zation
-    set Number of gr\
-ouped files       = 0
-    set Output forma\
-t                 = gnupl\
+  subsection Visualization
+    set Number of grouped files       = 0
+    set Output format                 = gnupl\
 ot
-    set Time between \
- graphical output = 0   #\
+    set Time between graphical output = 0   #\
  default: 1e8
   end
 end

--- a/tests/pure_shear.prm
+++ b/tests/pure_shear.prm
@@ -127,17 +127,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
-        set Data file name = pure_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
+      set Data file name = pure_shear_particle.dat
     end
   end
 end

--- a/tests/reactive_fluid_transport_zero_solubility.prm
+++ b/tests/reactive_fluid_transport_zero_solubility.prm
@@ -14,7 +14,6 @@ set Nonlinear solver tolerance             = 1e-5
 
 # The number of space dimensions you want to run this program in.
 set Dimension                              = 2
-
 set End time                               = 10e3
 
 # Because the model includes reactions that might be on a faster time scale
@@ -55,6 +54,7 @@ end
 # of the material is 1%.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0; 0.01
   end
@@ -79,9 +79,7 @@ subsection Geometry model
     set X extent  = 2e3
     set Y extent  = 2e3
   end
-
 end
-
 
 subsection Gravity model
   set Model name = vertical
@@ -89,13 +87,13 @@ subsection Gravity model
   subsection Vertical
     set Magnitude = 10.0
   end
-
 end
 
 # The temperature is not important for this model, so we simply
 # set it to 1600 K everywhere (including the boundary).
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Function expression = 1600
   end
@@ -111,11 +109,11 @@ subsection Boundary temperature model
   end
 end
 
-
 # The reactive fluid transport model is composited
 # on top of the visco plastic material model.
 subsection Material model
   set Model name = reactive fluid transport
+
   subsection Reactive Fluid Transport Model
     set Base model = visco plastic
     set Reference fluid density = 2995
@@ -130,31 +128,23 @@ subsection Material model
   subsection Visco Plastic
     set Reference temperature                   = 1600
     set Prefactors for diffusion creep          = 5e-21
-
     set Viscous flow law = diffusion
-
     set Densities                   = 3000
     set Viscosity averaging scheme  = harmonic
-
     set Minimum viscosity           = 1e19
     set Maximum viscosity           = 1e19
   end
 end
 
-
 subsection Mesh refinement
   set Coarsening fraction                      = 0.0
   set Refinement fraction                      = 0.0
-
   set Initial adaptive refinement              = 0
   set Initial global refinement                = 0
   set Strategy                                 = composition
   set Time steps between mesh refinement       = 0
 end
 
-
 subsection Postprocess
-
   set List of postprocessors = composition statistics, melt statistics, velocity statistics
-
 end

--- a/tests/shear_heating_limited.prm
+++ b/tests/shear_heating_limited.prm
@@ -10,8 +10,10 @@
 
 include $ASPECT_SOURCE_DIR/tests/shear_heating.prm
 
+
 subsection Heating model
   set List of model names = shear heating
+
   subsection Shear heating
     set Limit stress contribution to shear heating = true
     set Cohesion for maximum shear stress = 0.5

--- a/tests/shearbox_particle_strain_rate.prm
+++ b/tests/shearbox_particle_strain_rate.prm
@@ -157,18 +157,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles        = 10 #0
     set Time between data output = 0.001 #0.02499999999999
     set Data output format       = vtu, ascii
-    set List of particle properties =  integrated strain invariant, strain rate
-    set Particle generator name = ascii file
-
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/data/particle/generator/ascii/
-        set Data file name = shearbox_particle_strain_rate.dat
-      end
-    end
   end
 end
 
@@ -181,4 +171,16 @@ end
 
 subsection Solver parameters
   set Temperature solver tolerance = 1e-10
+end
+
+subsection Particles
+  set List of particle properties =  integrated strain invariant, strain rate
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/data/particle/generator/ascii/
+      set Data file name = shearbox_particle_strain_rate.dat
+    end
+  end
 end

--- a/tests/shell_boundary_composition_spherical_constant.prm
+++ b/tests/shell_boundary_composition_spherical_constant.prm
@@ -17,7 +17,6 @@ subsection Material model
   end
 end
 
-
 subsection Geometry model
   set Model name = spherical shell
 
@@ -28,11 +27,9 @@ subsection Geometry model
   end
 end
 
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = bottom, top
 end
-
 
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = top, bottom
@@ -44,39 +41,35 @@ subsection Boundary temperature model
   end
 end
 
-
 subsection Initial temperature model
   set Model name = spherical hexagonal perturbation
 end
-
 
 subsection Compositional fields
   set Number of fields = 2
 end
 
-
 subsection Boundary composition model
   set List of model names = spherical constant
   set Fixed composition boundary indicators = top, bottom
+
   subsection Spherical constant
     set Inner composition = 1,2
     set Outer composition = 2,3
   end
 end
 
-
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 2; 2
   end
 end
 
-
 subsection Gravity model
   set Model name = ascii data
 end
-
 
 subsection Mesh refinement
   set Initial global refinement          = 2
@@ -84,7 +77,6 @@ subsection Mesh refinement
   set Strategy                           = temperature
   set Time steps between mesh refinement = 15
 end
-
 
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, temperature statistics, composition statistics

--- a/tests/shell_surface_base_variables.prm
+++ b/tests/shell_surface_base_variables.prm
@@ -11,15 +11,18 @@ set Surface pressure                       = 0
 set Use years in output instead of seconds = false  # default: true
 set Nonlinear solver scheme                = single Advection, single Stokes
 
+# The parameters below this comment were created by the update script
+# as replacement for the old 'Model settings' subsection. They can be
+# safely merged with any existing subsections with the same name.
 
 subsection Boundary temperature model
   set List of model names = initial temperature
+  set Fixed temperature boundary indicators   = 0, 1
 end
 
 subsection Termination criteria
   set Termination criteria      = end step
   set End step                  = 1
-
 end
 
 subsection Gravity model
@@ -30,7 +33,6 @@ subsection Gravity model
   end
 end
 
-
 subsection Geometry model
   set Model name = spherical shell
 
@@ -40,7 +42,6 @@ subsection Geometry model
     set Opening angle = 90
   end
 end
-
 
 subsection Material model
   set Model name = simple
@@ -55,41 +56,27 @@ subsection Material model
   end
 end
 
-
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
   set Initial global refinement          = 4
   set Additional refinement times        = 0,0
-
   set Strategy = velocity
   set Time steps between mesh refinement = 2
-
   set Refinement fraction                = 0.8
   set Coarsening fraction                = 0.0
 end
 
-
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Variable names      = x,y
     set Function expression = if((sqrt((x-3e6)^2+(y-2e6)^2)<1e6) , 2413.0, 1613)
   end
 end
 
-# The parameters below this comment were created by the update script
-# as replacement for the old 'Model settings' subsection. They can be
-# safely merged with any existing subsections with the same name.
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = 0, 1
-end
-
 subsection Boundary velocity model
   set Tangential velocity boundary indicators = 0, 2, 3
-end
-
-subsection Boundary velocity model
   set Zero velocity boundary indicators       = 1
 end
 
@@ -106,5 +93,4 @@ subsection Postprocess
     set Output base variables on mesh surface = true
     set Output format = gnuplot
   end
-
 end

--- a/tests/simple_shear.prm
+++ b/tests/simple_shear.prm
@@ -116,17 +116,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
-        set Data file name = simple_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
+      set Data file name = simple_shear_particle.dat
     end
   end
 end

--- a/tests/simple_shear_output_the_mobility.prm
+++ b/tests/simple_shear_output_the_mobility.prm
@@ -121,17 +121,19 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 1
     set Time between data output = 0.05
     set Data output format = vtu
-    set List of particle properties = integrated strain
-    set Particle generator name = ascii file
+  end
+end
 
-    subsection Generator
-      subsection Ascii file
-        set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
-        set Data file name = simple_shear_particle.dat
-      end
+subsection Particles
+  set List of particle properties = integrated strain
+  set Particle generator name = ascii file
+
+  subsection Generator
+    subsection Ascii file
+      set Data directory = $ASPECT_SOURCE_DIR/benchmarks/finite_strain/
+      set Data file name = simple_shear_particle.dat
     end
   end
 end

--- a/tests/spherical_shell_initial_topography_function_3d.prm
+++ b/tests/spherical_shell_initial_topography_function_3d.prm
@@ -78,7 +78,6 @@ subsection Boundary temperature model
   end
 end
 
-
 subsection Postprocess
   set List of postprocessors = visualization
 

--- a/tests/surface_elevation_box_ascii_data.prm
+++ b/tests/surface_elevation_box_ascii_data.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 3
-include $ASPECT_SOURCE_DIR/tests/box_initial_topography_ascii_data.prm
 
+include $ASPECT_SOURCE_DIR/tests/box_initial_topography_ascii_data.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_box_ascii_data_moved_origin.prm
+++ b/tests/surface_elevation_box_ascii_data_moved_origin.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 3
-include $ASPECT_SOURCE_DIR/tests/box_initial_topography_ascii_data_moved_origin.prm
 
+include $ASPECT_SOURCE_DIR/tests/box_initial_topography_ascii_data_moved_origin.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_box_function.prm
+++ b/tests/surface_elevation_box_function.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 2
-include $ASPECT_SOURCE_DIR/tests/box_initial_topography_function.prm
 
+include $ASPECT_SOURCE_DIR/tests/box_initial_topography_function.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_box_prm_polygon.prm
+++ b/tests/surface_elevation_box_prm_polygon.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 3
-include $ASPECT_SOURCE_DIR/tests/box_initial_topography_prm_polygon.prm
 
+include $ASPECT_SOURCE_DIR/tests/box_initial_topography_prm_polygon.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_chunk_ascii_data.prm
+++ b/tests/surface_elevation_chunk_ascii_data.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 2
-include $ASPECT_SOURCE_DIR/tests/chunk_initial_topography_ascii_data.prm
 
+include $ASPECT_SOURCE_DIR/tests/chunk_initial_topography_ascii_data.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_chunk_ascii_data_3d.prm
+++ b/tests/surface_elevation_chunk_ascii_data_3d.prm
@@ -2,8 +2,8 @@
 # model that imposes an initial topography.
 
 set Dimension = 3
-include $ASPECT_SOURCE_DIR/tests/chunk_initial_topography_ascii_data_3d.prm
 
+include $ASPECT_SOURCE_DIR/tests/chunk_initial_topography_ascii_data_3d.prm
 
 set Nonlinear solver scheme = no Advection, no Stokes
 

--- a/tests/surface_elevation_chunk_ascii_data_3d_colatitude.prm
+++ b/tests/surface_elevation_chunk_ascii_data_3d_colatitude.prm
@@ -7,6 +7,8 @@ set Dimension = 3
 ## file because apparently we cannot recursively include .prm files.
 include $ASPECT_SOURCE_DIR/tests/chunk_initial_topography_ascii_data_3d.prm
 
+set Nonlinear solver scheme = no Advection, no Stokes
+
 subsection Geometry model
   set Model name = chunk
 
@@ -19,9 +21,6 @@ subsection Geometry model
     end
   end
 end
-
-
-set Nonlinear solver scheme = no Advection, no Stokes
 
 subsection Postprocess
   set List of postprocessors = visualization

--- a/tests/surface_elevation_chunk_ascii_data_global_3d.prm
+++ b/tests/surface_elevation_chunk_ascii_data_global_3d.prm
@@ -14,7 +14,12 @@ set Start time                             = 0
 set Adiabatic surface temperature          = 1613.0
 set Surface pressure                       = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = single Advection, single Stokes
+
+###################################
+# This is the part that is different: Specifically, do not actually
+# solve anything, and output the elevation so that we can inspect it.
+# Also use a higher mesh resolution
+set Nonlinear solver scheme = no Advection, no Stokes
 
 subsection Gravity model
   set Model name = radial constant
@@ -28,16 +33,15 @@ subsection Geometry model
   set Model name = chunk
 
   subsection Chunk
-#    set Chunk minimum longitude = -10
-#    set Chunk maximum longitude = 90
-#    set Chunk minimum latitude = -45
-#    set Chunk maximum latitude = 45
+    #    set Chunk minimum longitude = -10
+    #    set Chunk maximum longitude = 90
+    #    set Chunk minimum latitude = -45
+    #    set Chunk maximum latitude = 45
 
     set Chunk minimum longitude = -45
     set Chunk maximum longitude = 45
     set Chunk minimum latitude = -45
     set Chunk maximum latitude = 45
-
     set Longitude repetitions = 1
     set Latitude repetitions = 1
     set Chunk inner radius = 3000000
@@ -84,8 +88,10 @@ subsection Material model
 end
 
 subsection Mesh refinement
-  set Initial adaptive refinement        = 0
+  set Initial adaptive refinement        = 3
   set Initial global refinement          = 2
+  set Skip solvers on initial refinement = false
+  set Strategy                           = topography
 end
 
 subsection Boundary velocity model
@@ -95,22 +101,6 @@ end
 
 # The ascii data file prescribes a topography between -2000 m and
 # +9000 m. The topography postprocessor output should match with this.
-subsection Postprocess
-  set List of postprocessors = velocity statistics, basic statistics,  temperature statistics, topography
-end
-
-###################################
-# This is the part that is different: Specifically, do not actually
-# solve anything, and output the elevation so that we can inspect it.
-# Also use a higher mesh resolution
-set Nonlinear solver scheme = no Advection, no Stokes
-
-subsection Mesh refinement
-  set Initial adaptive refinement        = 3
-  set Initial global refinement          = 2
-  set Skip solvers on initial refinement = false
-  set Strategy                           = topography
-end
 
 subsection Postprocess
   set List of postprocessors = visualization

--- a/tests/surface_elevation_spherical_shell_ascii_data_global_3d.prm
+++ b/tests/surface_elevation_spherical_shell_ascii_data_global_3d.prm
@@ -14,7 +14,12 @@ set Start time                             = 0
 set Adiabatic surface temperature          = 1613.0
 set Surface pressure                       = 0
 set Use years in output instead of seconds = true
-set Nonlinear solver scheme                = no Advection, no Stokes
+
+###################################
+# This is the part that is different: Specifically, do not actually
+# solve anything, and output the elevation so that we can inspect it.
+# Also use a higher mesh resolution
+set Nonlinear solver scheme = no Advection, no Stokes
 
 subsection Gravity model
   set Model name = radial constant
@@ -67,7 +72,9 @@ end
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
-  set Initial global refinement          = 2
+  set Initial global refinement          = 1
+  set Skip solvers on initial refinement = false
+  set Strategy                           = topography
 end
 
 subsection Boundary velocity model
@@ -77,22 +84,6 @@ end
 
 # The ascii data file prescribes a topography between -2000 m and
 # +9000 m. The topography postprocessor output should match with this.
-subsection Postprocess
-  set List of postprocessors = velocity statistics, basic statistics,  temperature statistics, topography
-end
-
-###################################
-# This is the part that is different: Specifically, do not actually
-# solve anything, and output the elevation so that we can inspect it.
-# Also use a higher mesh resolution
-set Nonlinear solver scheme = no Advection, no Stokes
-
-subsection Mesh refinement
-  set Initial adaptive refinement        = 0
-  set Initial global refinement          = 1
-  set Skip solvers on initial refinement = false
-  set Strategy                           = topography
-end
 
 subsection Postprocess
   set List of postprocessors = visualization

--- a/tests/tian_MORB.prm
+++ b/tests/tian_MORB.prm
@@ -6,8 +6,10 @@
 # and a lateral temperature gradient is imposed to reproduce the temperature axis.
 include $ASPECT_SOURCE_DIR/tests/tian_peridotite.prm
 
+
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = initial_porosity; \
                               initial_bound_water; \

--- a/tests/tian_gabbro.prm
+++ b/tests/tian_gabbro.prm
@@ -6,8 +6,10 @@
 # and a lateral temperature gradient is imposed to reproduce the temperature axis.
 include $ASPECT_SOURCE_DIR/tests/tian_peridotite.prm
 
+
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = initial_porosity; \
                               initial_bound_water; \

--- a/tests/tian_peridotite.prm
+++ b/tests/tian_peridotite.prm
@@ -33,6 +33,7 @@ end
 # for peridotite.
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function constants  = initial_porosity=0.0, initial_bound_water=0.11
     set Function expression = initial_porosity; \
@@ -53,6 +54,7 @@ end
 # as in phase diagrams from Tian et al., 2019
 subsection Geometry model
   set Model name = box
+
   subsection Box
     set X extent  = 200e3
     set Y extent  = 200e3
@@ -64,6 +66,7 @@ end
 # 10 m/s^2 vertical gravity
 subsection Gravity model
   set Model name = vertical
+
   subsection Vertical
     set Magnitude = 10.0
   end
@@ -73,6 +76,7 @@ end
 # phase diagrams from Tian et al., 2019
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Coordinate system   = cartesian
     set Variable names      = x,y
@@ -85,12 +89,12 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators   = top, bottom, right, left
   set List of model names = initial temperature
+
   subsection Initial temperature
     set Maximal temperature = 573
     set Minimal temperature = 1273
   end
 end
-
 
 # Material model, using the simpler base model and selecting the tian approximation
 # as the fluid solid reaction scheme for the reactive fluid transport model.

--- a/tests/tian_sediment.prm
+++ b/tests/tian_sediment.prm
@@ -6,8 +6,10 @@
 # and a lateral temperature gradient is imposed to reproduce the temperature axis.
 include $ASPECT_SOURCE_DIR/tests/tian_peridotite.prm
 
+
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = initial_porosity; \
                               initial_bound_water; \

--- a/tests/time_stepping_repeat_particles.prm
+++ b/tests/time_stepping_repeat_particles.prm
@@ -85,25 +85,8 @@ subsection Postprocess
   end
 
   subsection Particles
-    set Number of particles = 64
     set Time between data output = 1e-1
-    set Minimum particles per cell  = 0
-    set Maximum particles per cell  = 100
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, composition
-    set Update ghost particles      = true
     set Data output format          = gnuplot
-    set Allow cells without particles = true
-    set Particle generator name = uniform box
-
-    subsection Generator
-      subsection Uniform box
-        set Minimum x = 0.
-        set Maximum x = 2.
-        set Minimum y = 0.
-        set Maximum y = 0.3
-      end
-    end
   end
 end
 
@@ -120,5 +103,25 @@ subsection Initial composition model
   subsection Function
     set Variable names      = x,y
     set Function expression = if(y<0.2, 1, 0) ; if(y<0.2, 1, 0)
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 0
+  set Maximum particles per cell  = 100
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, composition
+  set Update ghost particles      = true
+  set Allow cells without particles = true
+  set Particle generator name = uniform box
+
+  subsection Generator
+    subsection Uniform box
+      set Minimum x = 0.
+      set Maximum x = 2.
+      set Minimum y = 0.
+      set Maximum y = 0.3
+      set Number of particles = 64
+    end
   end
 end

--- a/tests/tomography_based_plate_motions_cookbook.prm
+++ b/tests/tomography_based_plate_motions_cookbook.prm
@@ -14,7 +14,6 @@ subsection Mesh refinement
   set Skip solvers on initial refinement = true
 end
 
-
 subsection Material model
   set Model name                    = tomography based plate motions
 
@@ -23,6 +22,7 @@ subsection Material model
       set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
       set Data file name                            = rho_vs_scaling.txt
     end
+
     subsection Temperature velocity scaling
       set Data directory                            = $ASPECT_SOURCE_DIR/cookbooks/tomography_based_plate_motions/input_data/
       set Data file name                            = dT_vs_scaling.txt

--- a/tests/transform_fault_behn_2007.prm
+++ b/tests/transform_fault_behn_2007.prm
@@ -1,7 +1,6 @@
 include $ASPECT_SOURCE_DIR/cookbooks/transform_fault_behn_2007/transform_fault_behn_2007.prm
 
 set World builder file = $ASPECT_SOURCE_DIR/contrib/world_builder/cookbooks/3d_cartesian_transform_fault/3d_cartesian_transform_fault.wb
-
 set Dimension = 3
 set End time = 0
 

--- a/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab.prm
+++ b/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab.prm
@@ -2,12 +2,14 @@
 # Solid-Fluid Reactions cookbook.
 
 include $ASPECT_SOURCE_DIR/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
+
 set Adiabatic surface temperature              = 1600
 set Nonlinear solver scheme                    = single Advection, single Stokes
 set End time                                   = 2000
 
 subsection Mesh refinement
   set Initial global refinement = 1
+
   subsection Minimum refinement function
     set Function expression = 1
   end
@@ -22,6 +24,7 @@ end
 subsection Boundary composition model
   set Fixed composition boundary indicators         = left
   set List of model names                           = function
+
   subsection Function
     set Function constants  = initial_porosity=0, initial_bound_sed=0.03, initial_bound_MORB=0.02, initial_bound_gabbro=0.01, \
                               sediment_min=0, sediment_max=5e3, MORB_min=5e3, MORB_max=12e3, gabbro_min=12e3, gabbro_max=20e3, \

--- a/tests/update_script.prm
+++ b/tests/update_script.prm
@@ -16,7 +16,6 @@ subsection Adiabatic conditions model
 
   subsection Initial profile
     set Use surface condition function = true
-
     subsection Surface condition function
       set Function expression = 1e-2*t; 1613.0+1e-13*t
     end
@@ -37,7 +36,6 @@ end
 
 subsection Boundary temperature model
   set Model name = spherical constant
-
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273
@@ -62,9 +60,9 @@ subsection Gravity model
   end
 end
 
+
 subsection Initial conditions
   set Model name = harmonic perturbation
-
   subsection Harmonic perturbation
     set Magnitude = 200.0
   end
@@ -80,22 +78,32 @@ subsection Material model
     set Viscosity = 1e21
     set Reference compressibility = 2.5e-12
   end
+
 end
+
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
+
   set Initial global refinement          = 3
+
   set Refinement fraction                = 0.0
   set Coarsening fraction                = 0.0
+
   set Strategy                           = velocity
+
   set Time steps between mesh refinement = 0
 end
 
+
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
+
+
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
 end
+
 
 subsection Postprocess
   set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, tracers, viscous dissipation statistics
@@ -119,6 +127,7 @@ subsection Postprocess
     set Time between graphical output = 0
     set Number of zones = 10
   end
+
 end
 
 subsection Heating model

--- a/tests/update_script.prm
+++ b/tests/update_script.prm
@@ -16,6 +16,7 @@ subsection Adiabatic conditions model
 
   subsection Initial profile
     set Use surface condition function = true
+
     subsection Surface condition function
       set Function expression = 1e-2*t; 1613.0+1e-13*t
     end
@@ -36,6 +37,7 @@ end
 
 subsection Boundary temperature model
   set Model name = spherical constant
+
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273
@@ -60,9 +62,9 @@ subsection Gravity model
   end
 end
 
-
 subsection Initial conditions
   set Model name = harmonic perturbation
+
   subsection Harmonic perturbation
     set Magnitude = 200.0
   end
@@ -78,32 +80,22 @@ subsection Material model
     set Viscosity = 1e21
     set Reference compressibility = 2.5e-12
   end
-
 end
-
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
-
   set Initial global refinement          = 3
-
   set Refinement fraction                = 0.0
   set Coarsening fraction                = 0.0
-
   set Strategy                           = velocity
-
   set Time steps between mesh refinement = 0
 end
 
-
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
-
-
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
 end
-
 
 subsection Postprocess
   set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, tracers, viscous dissipation statistics
@@ -127,7 +119,6 @@ subsection Postprocess
     set Time between graphical output = 0
     set Number of zones = 10
   end
-
 end
 
 subsection Heating model

--- a/tests/update_script/screen-output
+++ b/tests/update_script/screen-output
@@ -2,6 +2,8 @@
 Loading shared library <./libupdate_script.debug.so>
 Executing the update script:
 cp update_script.x.prm output-update_script/updated.prm &&sed -i.bak 's:set Additional shared libraries = ./libupdate_script.so::' output-update_script/updated.prm &&bash ASPECT_DIR/contrib/utilities/update_prm_files.sh output-update_script/updated.prm &&rm output-update_script/updated.prm.bak
+output-update_script/updated.prm
+output-update_script/updated.prm
 Running ASPECT with updated parameter file:
 ../aspect output-update_script/updated.prm
 

--- a/tests/update_script_2.prm
+++ b/tests/update_script_2.prm
@@ -20,7 +20,6 @@ subsection Adiabatic conditions model
 
   subsection Initial profile
     set Use surface condition function = true
-
     subsection Surface condition function
       set Function expression = 1e-2*t; 1613.0+1e-13*t
     end
@@ -41,7 +40,6 @@ end
 
 subsection Boundary temperature model
   set Model name = spherical constant
-
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273
@@ -67,9 +65,9 @@ subsection Gravity model
   end
 end
 
+
 subsection Initial conditions
   set Model name = harmonic perturbation
-
   subsection Harmonic perturbation
     set Magnitude = 200.0
   end
@@ -85,22 +83,32 @@ subsection Material model
     set Viscosity = 1e21
     set Reference compressibility = 2.5e-12
   end
+
 end
+
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
+
   set Initial global refinement          = 3
+
   set Refinement fraction                = 0.0
   set Coarsening fraction                = 0.0
+
   set Strategy                           = velocity
+
   set Time steps between mesh refinement = 0
 end
 
+
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
+
+
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
 end
+
 
 subsection Postprocess
   set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, tracers, viscous dissipation statistics
@@ -124,6 +132,7 @@ subsection Postprocess
     set Time between graphical output = 0
     set Number of zones = 10
   end
+
 end
 
 subsection Heating model

--- a/tests/update_script_2.prm
+++ b/tests/update_script_2.prm
@@ -20,6 +20,7 @@ subsection Adiabatic conditions model
 
   subsection Initial profile
     set Use surface condition function = true
+
     subsection Surface condition function
       set Function expression = 1e-2*t; 1613.0+1e-13*t
     end
@@ -40,6 +41,7 @@ end
 
 subsection Boundary temperature model
   set Model name = spherical constant
+
   subsection Spherical constant
     set Inner temperature = 4250
     set Outer temperature = 273
@@ -65,9 +67,9 @@ subsection Gravity model
   end
 end
 
-
 subsection Initial conditions
   set Model name = harmonic perturbation
+
   subsection Harmonic perturbation
     set Magnitude = 200.0
   end
@@ -83,32 +85,22 @@ subsection Material model
     set Viscosity = 1e21
     set Reference compressibility = 2.5e-12
   end
-
 end
-
 
 subsection Mesh refinement
   set Initial adaptive refinement        = 0
-
   set Initial global refinement          = 3
-
   set Refinement fraction                = 0.0
   set Coarsening fraction                = 0.0
-
   set Strategy                           = velocity
-
   set Time steps between mesh refinement = 0
 end
 
-
 subsection Model settings
   set Fixed temperature boundary indicators   = 0,1
-
-
   set Tangential velocity boundary indicators = 0,2,3
   set Zero velocity boundary indicators       = 1
 end
-
 
 subsection Postprocess
   set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, tracers, viscous dissipation statistics
@@ -132,7 +124,6 @@ subsection Postprocess
     set Time between graphical output = 0
     set Number of zones = 10
   end
-
 end
 
 subsection Heating model

--- a/tests/update_script_2/screen-output
+++ b/tests/update_script_2/screen-output
@@ -2,6 +2,10 @@
 Loading shared library <./libupdate_script_2.debug.so>
 Executing the update script:
 cp update_script_2.x.prm output-update_script_2/updated2.prm;sed -i.bak 's:set Additional shared libraries = ./libupdate_script_2.so::' output-update_script_2/updated2.prm;bash ASPECT_DIR/contrib/utilities/update_prm_files.sh output-update_script_2/updated2.prm;bash ASPECT_DIR/contrib/utilities/update_prm_files.sh output-update_script_2/updated2.prm;rm output-update_script_2/updated2.prm.bak
+output-update_script_2/updated2.prm
+output-update_script_2/updated2.prm
+output-update_script_2/updated2.prm
+output-update_script_2/updated2.prm
 Running ASPECT with updated parameter file:
 ../aspect output-update_script_2/updated2.prm
 

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -106,10 +106,6 @@ end
 subsection Postprocess
   set List of postprocessors = visualization,velocity statistics, basic statistics, temperature statistics,heat flux statistics, depth average, dynamic topography, particles, heating statistics
 
-  subsection Particles
-    set Number of particles = 50
-  end
-
   subsection Dynamic topography
   end
 
@@ -128,4 +124,12 @@ end
 
 subsection Heating model
   set List of model names = adiabatic heating
+end
+
+subsection Particles
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 50
+    end
+  end
 end

--- a/tests/van_keken_smooth_particle.prm
+++ b/tests/van_keken_smooth_particle.prm
@@ -87,14 +87,22 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, composition statistics,particles
 
   subsection Particles
-    set Number of particles = 10
     set Time between data output = 70
     set Data output format = vtu
-    set List of particle properties = function, initial composition, initial position
+  end
+end
 
-    subsection Function
-      set Variable names      = x,z
-      set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+subsection Particles
+  set List of particle properties = function, initial composition, initial position
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = if( (z>0.2+0.02*cos(pi*x/0.9142)) , 0 , 1 )
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 10
     end
   end
 end

--- a/tests/visco_elastic_top_beam.prm
+++ b/tests/visco_elastic_top_beam.prm
@@ -6,7 +6,6 @@ set Dimension                              = 2
 set End time                               = 2e3
 set Use years in output instead of seconds = true
 set Output directory = output_ve
-
 set CFL number                             = 0.5
 set Maximum time step                      = 1e3
 

--- a/tests/visco_plastic_vep_brick_extension.prm
+++ b/tests/visco_plastic_vep_brick_extension.prm
@@ -45,14 +45,19 @@ end
 # Post processing
 subsection Postprocess
   set List of postprocessors = velocity statistics, particles
+
   subsection Particles
-    set Minimum particles per cell  = 2
-    set Maximum particles per cell  = 8
-    subsection Generator
-      subsection Reference cell
-        set Number of particles per cell per direction = 2
-      end
-    end
     set Data output format = none
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 2
+  set Maximum particles per cell  = 8
+
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 2
+    end
   end
 end

--- a/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
+++ b/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
@@ -70,15 +70,23 @@ subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 12e3
-    set Minimum particles per cell  = 25
-    set Maximum particles per cell  = 35
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = bilinear least squares
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 1e9
     set Data output format          = vtu
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = bilinear least squares
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 12e3
+    end
   end
 end

--- a/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
+++ b/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
@@ -34,18 +34,26 @@ end
 subsection Postprocess
   set List of postprocessors = composition statistics, mass flux statistics, particles, particle count statistics, velocity statistics, visualization
 
-  subsection Particles
-    set Number of particles = 1e5
-    set Time between data output = 0
-    set Data output format = none
-    set List of particle properties = viscoplastic strain invariants
-    set Particle generator name = random uniform
-    set Interpolation scheme = nearest neighbor
-  end
-
   subsection Visualization
     set List of output variables       = named additional outputs, strain rate, viscosity
     set Time between graphical output  = 0
     set Output format                  = gnuplot
+  end
+
+  subsection Particles
+    set Time between data output = 0
+    set Data output format = none
+  end
+end
+
+subsection Particles
+  set List of particle properties = viscoplastic strain invariants
+  set Particle generator name = random uniform
+  set Interpolation scheme = nearest neighbor
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/tests/visco_plastic_yield_plastic_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_plastic_strain_weakening_particles.prm
@@ -13,11 +13,19 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles
 
   subsection Particles
-    set Number of particles = 1e5
     set Data output format = none
-    set List of particle properties = viscoplastic strain invariants
-    set Particle generator name = random uniform
-    set Maximum particles per cell = 500
-    set Interpolation scheme = nearest neighbor
+  end
+end
+
+subsection Particles
+  set List of particle properties = viscoplastic strain invariants
+  set Particle generator name = random uniform
+  set Maximum particles per cell = 500
+  set Interpolation scheme = nearest neighbor
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles.prm
@@ -13,11 +13,19 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles
 
   subsection Particles
-    set Number of particles = 1e5
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = viscoplastic strain invariants
-    set Particle generator name = random uniform
-    set Interpolation scheme = nearest neighbor
+  end
+end
+
+subsection Particles
+  set List of particle properties = viscoplastic strain invariants
+  set Particle generator name = random uniform
+  set Interpolation scheme = nearest neighbor
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/tests/visco_plastic_yield_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_strain_weakening_particles.prm
@@ -13,11 +13,19 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles
 
   subsection Particles
-    set Number of particles = 1e5
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = viscoplastic strain invariants
-    set Particle generator name = random uniform
-    set Interpolation scheme = nearest neighbor
+  end
+end
+
+subsection Particles
+  set List of particle properties = viscoplastic strain invariants
+  set Particle generator name = random uniform
+  set Interpolation scheme = nearest neighbor
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/tests/visco_plastic_yield_temperature_activated_viscous_strain_weakening.prm
+++ b/tests/visco_plastic_yield_temperature_activated_viscous_strain_weakening.prm
@@ -6,6 +6,7 @@ set Output directory = visco_plastic_yield_temperature_activated_viscous_strain_
 
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Variable names      = x,y
     set Function expression = if(x>=25.e3&x<=75.e3&y>=25.e3&y<=75.e3,0.5,0);
@@ -14,6 +15,7 @@ end
 
 subsection Material model
   set Model name = visco plastic
+
   subsection Visco Plastic
     set Use temperature activated strain softening  = true
     set Lower temperature for onset of strain weakening = 800
@@ -25,6 +27,7 @@ end
 
 subsection Initial temperature model
   set Model name = function
+
   subsection Function
     set Variable names = x,y
     set Function constants = h=100e3,ts1=800,ts2=1200
@@ -35,6 +38,7 @@ end
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = bottom, top
   set List of model names = box
+
   subsection Box
     set Bottom temperature = 1200
     set Top temperature    =  800

--- a/tests/visco_plastic_yield_viscous_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_viscous_strain_weakening_particles.prm
@@ -13,11 +13,19 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, mass flux statistics, visualization, particles
 
   subsection Particles
-    set Number of particles = 1e5
     set Time between data output = 0
     set Data output format = none
-    set List of particle properties = viscoplastic strain invariants
-    set Particle generator name = random uniform
-    set Interpolation scheme = nearest neighbor
+  end
+end
+
+subsection Particles
+  set List of particle properties = viscoplastic strain invariants
+  set Particle generator name = random uniform
+  set Interpolation scheme = nearest neighbor
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 1e5
+    end
   end
 end

--- a/tests/viscoelastic_bending_beam_particles.prm
+++ b/tests/viscoelastic_bending_beam_particles.prm
@@ -31,15 +31,23 @@ subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 4.5e3
-    set Minimum particles per cell  = 25
-    set Maximum particles per cell  = 35
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = bilinear least squares
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 1e9
     set Data output format          = vtu
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = bilinear least squares
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 4.5e3
+    end
   end
 end

--- a/tests/viscoelastic_numerical_elastic_time_step_particles.prm
+++ b/tests/viscoelastic_numerical_elastic_time_step_particles.prm
@@ -53,15 +53,23 @@ subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, particles
 
   subsection Particles
-    set Number of particles = 12e3
-    set Minimum particles per cell  = 25
-    set Maximum particles per cell  = 35
-    set Load balancing strategy     = remove and add particles
-    set List of particle properties = initial composition, elastic stress
-    set Interpolation scheme        = bilinear least squares
-    set Update ghost particles      = true
-    set Particle generator name     = random uniform
     set Time between data output    = 1e9
     set Data output format          = vtu
+  end
+end
+
+subsection Particles
+  set Minimum particles per cell  = 25
+  set Maximum particles per cell  = 35
+  set Load balancing strategy     = remove and add particles
+  set List of particle properties = initial composition, elastic stress
+  set Interpolation scheme        = bilinear least squares
+  set Update ghost particles      = true
+  set Particle generator name     = random uniform
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 12e3
+    end
   end
 end

--- a/tests/viscoplastic_melt_blob_freezing.prm
+++ b/tests/viscoplastic_melt_blob_freezing.prm
@@ -34,16 +34,17 @@ set Output directory = viscoplastic_melt_blob_freezing
 subsection Material model
   set Model name =  reactive fluid transport
   set Material averaging =  harmonic average
+
   subsection Reactive Fluid Transport Model
     set Base model = visco plastic
     set Fluid-solid reaction scheme = katz2003
+
     subsection Katz 2003 model
       set Melt extraction depth = 0.0
       set Freezing rate         = 1.0
       set Melting time scale for operator splitting = 1.442695041
     end
   end
-
 end
 
 subsection Postprocess

--- a/tests/viscoplastic_melt_fraction.prm
+++ b/tests/viscoplastic_melt_fraction.prm
@@ -16,7 +16,6 @@ set Pressure normalization                 = surface
 set Use years in output instead of seconds = true
 set Output directory                       = output-vp-melt-fraction
 
-
 subsection Boundary temperature model
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = top, bottom
@@ -27,8 +26,10 @@ subsection Boundary temperature model
   end
 end
 
+# The composition is not fixed on any boundary
 subsection Boundary composition model
   set List of model names = initial composition
+  set Fixed composition boundary indicators =
 end
 
 subsection Geometry model
@@ -55,12 +56,6 @@ subsection Compositional fields
   set Names of fields = porosity, peridotite
 end
 
-# The composition is not fixed on any boundary
-subsection Boundary composition model
-  set Fixed composition boundary indicators =
-  set List of model names = initial composition
-end
-
 subsection Initial temperature model
   set Model name = function
 
@@ -71,6 +66,7 @@ end
 
 subsection Initial composition model
   set Model name = function
+
   subsection Function
     set Function expression = 0;0
   end
@@ -83,6 +79,7 @@ end
 subsection Material model
   set Model name =  reactive fluid transport
   set Material averaging =  harmonic average
+
   subsection Reactive Fluid Transport Model
     set Base model = visco plastic
     set Fluid-solid reaction scheme = katz2003
@@ -110,11 +107,12 @@ end
 
 subsection Postprocess
   set List of postprocessors = visualization, melt statistics, pressure statistics, composition statistics
-    subsection Visualization
-      set Interpolate output = false
-      set Number of grouped files       = 0
-      set Output format                 = gnuplot
-      set List of output variables      = melt fraction, named additional outputs
-      set Time between graphical output = 0
-    end
+
+  subsection Visualization
+    set Interpolate output = false
+    set Number of grouped files       = 0
+    set Output format                 = gnuplot
+    set List of output variables      = melt fraction, named additional outputs
+    set Time between graphical output = 0
+  end
 end

--- a/tests/viscous_top_beam.prm
+++ b/tests/viscous_top_beam.prm
@@ -14,7 +14,6 @@
 set Dimension                              = 2
 set End time                               = 2e3
 set Use years in output instead of seconds = true
-
 set CFL number                             = 0.5
 set Maximum time step                      = 1e3
 

--- a/tests/visualization_shear_stress_viscoelastic.prm
+++ b/tests/visualization_shear_stress_viscoelastic.prm
@@ -18,7 +18,6 @@
 
 include $ASPECT_SOURCE_DIR/tests/visualization_shear_stress.prm
 
-
 set End time                               = 1
 
 subsection Formulation

--- a/tests/visualization_stress_viscoelastic.prm
+++ b/tests/visualization_stress_viscoelastic.prm
@@ -18,7 +18,6 @@
 
 include $ASPECT_SOURCE_DIR/tests/visualization_stress.prm
 
-
 set End time                               = 1
 
 subsection Formulation

--- a/tests/world_builder_select_grains.prm
+++ b/tests/world_builder_select_grains.prm
@@ -3,13 +3,13 @@
 # a subset of grains for which to evaluate the world builder.
 
 include $ASPECT_SOURCE_DIR/tests/world_builder_select_composition.prm
+
 set World builder file                     = $ASPECT_SOURCE_DIR/tests/world_builder_select_grains.wb
 set Use years in output instead of seconds = false
 set Adiabatic surface temperature = 1613
 set End time = 0
 set Dimension = 3
 set Nonlinear solver scheme = no Advection, no Stokes
-
 
 subsection Geometry model
   set Model name = box
@@ -18,7 +18,6 @@ subsection Geometry model
     set X extent = 1000e3
     set Y extent = 200e3
     set Z extent = 200e3
-
     set Box origin Z coordinate = -200e3
     set Box origin Y coordinate = -100e3
     set Box origin X coordinate = -50e3
@@ -43,41 +42,54 @@ end
 subsection Postprocess
   set List of postprocessors = composition statistics, visualization, particles, crystal preferred orientation
 
-  subsection Particles
-    set Time between data output = 1e6
-    set Data output format       = gnuplot
-    set List of particle properties = integrated strain invariant, crystal preferred orientation, cpo bingham average, cpo elastic tensor, elastic tensor decomposition
-    set Exclude output properties = a_cosine_matrix, volume fraction
-    set Particle generator name = random uniform
-    set Number of particles = 50
-    subsection Crystal Preferred Orientation
-      subsection Initial grains
-        set Model name = World Builder
-        set Minerals = Olivine: A-fabric , Enstatite
-        set Volume fractions minerals =1.0,0.0
-      end
-      set Random number seed = 301
-      set Number of grains per particle = 5
-      set Property advection method = Backward Euler
-      set Property advection tolerance = 1e-15
-      set CPO derivatives algorithm = D-Rex 2004
-      subsection D-Rex 2004
-        set Mobility = 125
-        set Stress exponents = 3.5
-        set Exponents p = 1.5
-        set Nucleation efficiency = 5
-        set Threshold GBS = 0.3
-      end
-    end
-    subsection CPO Bingham Average
-      set Random number seed = 200
-    end
-  end
   subsection Crystal Preferred Orientation
     set Time between data output = 1e6
     set Write in background thread = true
     set Compress cpo data files = false
     set Write out raw cpo data = mineral 0: volume fraction, mineral 0: rotation matrix, mineral 1: volume fraction, mineral 1: rotation matrix
     set Write out draw volume weighted cpo data = mineral 0: volume fraction, mineral 0: rotation matrix, mineral 1: volume fraction, mineral 1: rotation matrix
+  end
+
+  subsection Particles
+    set Time between data output = 1e6
+    set Data output format       = gnuplot
+    set Exclude output properties = a_cosine_matrix, volume fraction
+  end
+end
+
+subsection Particles
+  set List of particle properties = integrated strain invariant, crystal preferred orientation, cpo bingham average, cpo elastic tensor, elastic tensor decomposition
+  set Particle generator name = random uniform
+
+  subsection Crystal Preferred Orientation
+    set Random number seed = 301
+    set Number of grains per particle = 5
+    set Property advection method = Backward Euler
+    set Property advection tolerance = 1e-15
+    set CPO derivatives algorithm = D-Rex 2004
+
+    subsection Initial grains
+      set Model name = World Builder
+      set Minerals = Olivine: A-fabric , Enstatite
+      set Volume fractions minerals = 1.0,0.0
+    end
+
+    subsection D-Rex 2004
+      set Mobility = 125
+      set Stress exponents = 3.5
+      set Exponents p = 1.5
+      set Nucleation efficiency = 5
+      set Threshold GBS = 0.3
+    end
+  end
+
+  subsection CPO Bingham Average
+    set Random number seed = 200
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Number of particles = 50
+    end
   end
 end

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -129,27 +129,23 @@ TEST_CASE("CPO core: Store and Load")
   aspect::Particle::Property::CrystalPreferredOrientation<3> cpo;
   aspect::ParameterHandler prm;
   cpo.declare_parameters(prm);
-  prm.enter_subsection("Postprocess");
+  prm.enter_subsection("Particles");
   {
-    prm.enter_subsection("Particles");
+    prm.enter_subsection("Crystal Preferred Orientation");
     {
-      prm.enter_subsection("Crystal Preferred Orientation");
+      prm.set("Random number seed","1");
+      prm.set("Number of grains per particle","3");
+      prm.set("CPO derivatives algorithm","Spin tensor");
+      prm.set("Property advection method","Backward Euler");
+      prm.enter_subsection("Initial grains");
       {
-        prm.set("Random number seed","1");
-        prm.set("Number of grains per particle","3");
-        prm.set("CPO derivatives algorithm","Spin tensor");
-        prm.set("Property advection method","Backward Euler");
-        prm.enter_subsection("Initial grains");
-        {
-          prm.set("Model name","Uniform grains and random uniform rotations");
-          // Let the minerals just passively rotate with the rotation of
-          // the particle caused by the flow.
-          prm.set("Minerals","Passive,Passive");
-          prm.set("Volume fractions minerals","0.7,0.3");
-        }
-        prm.leave_subsection();
+        prm.set("Model name","Uniform grains and random uniform rotations");
+        // Let the minerals just passively rotate with the rotation of
+        // the particle caused by the flow.
+        prm.set("Minerals","Passive,Passive");
+        prm.set("Volume fractions minerals","0.7,0.3");
       }
-      prm.leave_subsection ();
+      prm.leave_subsection();
     }
     prm.leave_subsection ();
   }
@@ -309,27 +305,23 @@ TEST_CASE("CPO core: Spin tensor")
     aspect::Particle::Property::CrystalPreferredOrientation<3> cpo_3d;
     aspect::ParameterHandler prm;
     cpo_3d.declare_parameters(prm);
-    prm.enter_subsection("Postprocess");
+    prm.enter_subsection("Particles");
     {
-      prm.enter_subsection("Particles");
+      prm.enter_subsection("Crystal Preferred Orientation");
       {
-        prm.enter_subsection("Crystal Preferred Orientation");
+        prm.set("Random number seed","1");
+        prm.set("Number of grains per particle","5");
+        prm.set("CPO derivatives algorithm","Spin tensor");
+        prm.set("Property advection method","Forward Euler");
+        prm.enter_subsection("Initial grains");
         {
-          prm.set("Random number seed","1");
-          prm.set("Number of grains per particle","5");
-          prm.set("CPO derivatives algorithm","Spin tensor");
-          prm.set("Property advection method","Forward Euler");
-          prm.enter_subsection("Initial grains");
-          {
-            prm.set("Model name","Uniform grains and random uniform rotations");
-            // Let the minerals just passively rotate with the rotation of
-            // the particle caused by the flow.
-            prm.set("Minerals","Passive,Passive");
-            prm.set("Volume fractions minerals","0.5,0.5");
-          }
-          prm.leave_subsection();
+          prm.set("Model name","Uniform grains and random uniform rotations");
+          // Let the minerals just passively rotate with the rotation of
+          // the particle caused by the flow.
+          prm.set("Minerals","Passive,Passive");
+          prm.set("Volume fractions minerals","0.5,0.5");
         }
-        prm.leave_subsection ();
+        prm.leave_subsection();
       }
       prm.leave_subsection ();
     }
@@ -615,18 +607,12 @@ TEST_CASE("CPO")
     ParameterHandler prm;
     lpo_3d.declare_parameters(prm);
 
-    prm.enter_subsection("Postprocess");
+    prm.enter_subsection("Particles");
     {
-      prm.enter_subsection("Particles");
+      prm.enter_subsection("Crystal Preferred Orientation");
       {
-        prm.enter_subsection("Crystal Preferred Orientation");
-        {
-          prm.set("Random number seed","1");
-          prm.set("Number of grains per particle","5");
-
-
-        }
-        prm.leave_subsection ();
+        prm.set("Random number seed","1");
+        prm.set("Number of grains per particle","5");
       }
       prm.leave_subsection ();
     }
@@ -828,16 +814,12 @@ TEST_CASE("CPO")
     ParameterHandler prm;
     lpo_3d.declare_parameters(prm);
 
-    prm.enter_subsection("Postprocess");
+    prm.enter_subsection("Particles");
     {
-      prm.enter_subsection("Particles");
+      prm.enter_subsection("Crystal Preferred Orientation");
       {
-        prm.enter_subsection("Crystal Preferred Orientation");
-        {
-          prm.set("Random number seed","1");
-          prm.set("Number of grains per particle","5");
-        }
-        prm.leave_subsection ();
+        prm.set("Random number seed","1");
+        prm.set("Number of grains per particle","5");
       }
       prm.leave_subsection ();
     }
@@ -1089,27 +1071,23 @@ TEST_CASE("CPO elastic tensor")
   aspect::ParameterHandler prm;
   cpo.declare_parameters(prm);
   cpo_elastic_tensor.declare_parameters(prm);
-  prm.enter_subsection("Postprocess");
+  prm.enter_subsection("Particles");
   {
-    prm.enter_subsection("Particles");
+    prm.enter_subsection("Crystal Preferred Orientation");
     {
-      prm.enter_subsection("Crystal Preferred Orientation");
+      prm.set("Random number seed","1");
+      prm.set("Number of grains per particle","8");
+      prm.set("CPO derivatives algorithm","Spin tensor");
+      prm.set("Property advection method","Backward Euler");
+      prm.enter_subsection("Initial grains");
       {
-        prm.set("Random number seed","1");
-        prm.set("Number of grains per particle","8");
-        prm.set("CPO derivatives algorithm","Spin tensor");
-        prm.set("Property advection method","Backward Euler");
-        prm.enter_subsection("Initial grains");
-        {
-          prm.set("Model name","Uniform grains and random uniform rotations");
-          // Let the minerals just passively rotate with the rotation of
-          // the particle caused by the flow.
-          prm.set("Minerals","Passive,Passive");
-          prm.set("Volume fractions minerals","0.7,0.3");
-        }
-        prm.leave_subsection();
+        prm.set("Model name","Uniform grains and random uniform rotations");
+        // Let the minerals just passively rotate with the rotation of
+        // the particle caused by the flow.
+        prm.set("Minerals","Passive,Passive");
+        prm.set("Volume fractions minerals","0.7,0.3");
       }
-      prm.leave_subsection ();
+      prm.leave_subsection();
     }
     prm.leave_subsection ();
   }

--- a/unit_tests/particles.cc
+++ b/unit_tests/particles.cc
@@ -30,10 +30,8 @@ TEST_CASE("Particle Manager plugin names")
   aspect::Particle::World<2>::declare_parameters(prm);
   aspect::Particle::Property::Manager<2> manager;
   manager.declare_parameters(prm);
-  prm.enter_subsection("Postprocess");
   prm.enter_subsection("Particles");
   prm.set("List of particle properties","composition, position");
-  prm.leave_subsection();
   prm.leave_subsection();
   manager.parse_parameters(prm);
 


### PR DESCRIPTION
This PR extends #5381 to perform one of the updates we discussed for 3.0: To put the particle input parameters in their own top level subsection and disentangle the use of "Number of particles" parameter between different particle generators (move it into specific subsections). 

This is WIP, because I need to check the tests and also want to do some upgrades to the older update scripts before merging this one (once this is merged many users will have to use the update script, and some of our older update scripts dont work anymore, we should remove them).
