### PR TITLE
Fix prescribed velocity cookbooks for dc stokes

### DIFF
--- a/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
+++ b/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
@@ -25,6 +25,7 @@
 #include <aspect/utilities.h>
 #include <aspect/simulator_signals.h>
 #include <aspect/initial_composition/ascii_data.h>
+#include <aspect/parameters.h>
 
 namespace aspect
 {
@@ -192,6 +193,7 @@ namespace aspect
 
     if (prescribe_internal_velocities)
       {
+        const Parameters<dim> &parameters = simulator_access.get_parameters();
         const std::vector<Point<dim>> points = aspect::Utilities::get_unit_support_points(simulator_access);
         const Quadrature<dim> quadrature (points);
         FEValues<dim> fe_values (simulator_access.get_fe(), quadrature, update_quadrature_points);
@@ -266,7 +268,19 @@ namespace aspect
                             // Add a constraint of the form dof[q] = u_i
                             // to the list of constraints.
                             current_constraints.add_line (local_dof_indices[q]);
-                            current_constraints.set_inhomogeneity (local_dof_indices[q], u_i);
+                            // When using a defect correction solver, the constraints should only be set on
+                            // nonlinear iteration 0.
+                            if (
+                              (parameters.nonlinear_solver!=Parameters<dim>::NonlinearSolver::no_Advection_iterated_defect_correction_Stokes &&
+                               parameters.nonlinear_solver!=Parameters<dim>::NonlinearSolver::single_Advection_iterated_defect_correction_Stokes &&
+                               parameters.nonlinear_solver!=Parameters<dim>::NonlinearSolver::iterated_Advection_and_defect_correction_Stokes &&
+                               parameters.nonlinear_solver!=Parameters<dim>::NonlinearSolver::iterated_Advection_and_Newton_Stokes &&
+                               parameters.nonlinear_solver!=Parameters<dim>::NonlinearSolver::single_Advection_iterated_Newton_Stokes ) ||
+                              simulator_access.get_nonlinear_iteration() == 0
+                            )
+                              {
+                                current_constraints.set_inhomogeneity (local_dof_indices[q], u_i);
+                              }
                           }
                       }
                   }


### PR DESCRIPTION
When working on a project I noticed that the prescribed velocities within the domain where a multiple of the prescribed value too high, and that the multiple was the number of nonlinear iterations. When using a defect correction Stokes (which includes the Newton Stokes), this should only be added at nonlinear iteration 0.

I am not sure if there is a cleaner way of checking this then what I am currently doing, so I am open to suggestions.