### PR TITLE
Using constraints with two index sets for dealii-9.6 only.

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -586,8 +586,11 @@ namespace aspect
 
       // Now construct the mesh displacement constraints
       mesh_velocity_constraints.clear();
+#if DEAL_II_VERSION_GTE(9,6,0)
+      mesh_velocity_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(), mesh_locally_relevant);
+#else
       mesh_velocity_constraints.reinit(mesh_locally_relevant);
-
+#endif
       // mesh_velocity_constraints can use the same hanging node
       // information that was used for mesh_vertex constraints.
       mesh_velocity_constraints.merge(mesh_vertex_constraints);
@@ -685,8 +688,11 @@ namespace aspect
       // because this object is used for updating the displacement in
       // compute_mesh_displacements().
       mesh_velocity_constraints.clear();
+#if DEAL_II_VERSION_GTE(9,6,0)
+      mesh_velocity_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(), mesh_locally_relevant);
+#else
       mesh_velocity_constraints.reinit(mesh_locally_relevant);
-
+#endif
       // mesh_velocity_constraints can use the same hanging node
       // information that was used for mesh_vertex constraints.
       mesh_velocity_constraints.merge(mesh_vertex_constraints);
@@ -1034,7 +1040,11 @@ namespace aspect
                                                         level,
                                                         relevant_dofs);
           AffineConstraints<double> level_constraints;
+#if DEAL_II_VERSION_GTE(9,6,0)
+          level_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(), relevant_dofs);
+#else
           level_constraints.reinit(relevant_dofs);
+#endif
           level_constraints.add_lines(mg_constrained_dofs.get_boundary_indices(level));
           level_constraints.close();
 
@@ -1045,7 +1055,11 @@ namespace aspect
           if (!no_flux_boundary.empty())
             {
               AffineConstraints<double> user_level_constraints;
+#if DEAL_II_VERSION_GTE(9,6,0)
+              user_level_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(), relevant_dofs);
+#else
               user_level_constraints.reinit(relevant_dofs);
+#endif
               const IndexSet &refinement_edge_indices =
                 mg_constrained_dofs.get_refinement_edge_indices(level);
               dealii::VectorTools::compute_no_normal_flux_constraints_on_level(
@@ -1385,8 +1399,11 @@ namespace aspect
       // after setup_dofs(), as is done, for instance, during mesh
       // refinement.
       mesh_vertex_constraints.clear();
+#if DEAL_II_VERSION_GTE(9,6,0)
+      mesh_vertex_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(), mesh_locally_relevant);
+#else
       mesh_vertex_constraints.reinit(mesh_locally_relevant);
-
+#endif
       DoFTools::make_hanging_node_constraints(mesh_deformation_dof_handler, mesh_vertex_constraints);
 
       // We can safely close this now

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -657,7 +657,11 @@ namespace aspect
     // if the set of constraints has changed. If it did, we need to update the sparsity patterns.
     AffineConstraints<double> new_current_constraints;
     new_current_constraints.clear ();
+#if DEAL_II_VERSION_GTE(9,6,0)
+    new_current_constraints.reinit (dof_handler.locally_owned_dofs(), introspection.index_sets.system_relevant_set);
+#else
     new_current_constraints.reinit (introspection.index_sets.system_relevant_set);
+#endif
     new_current_constraints.merge (constraints);
     compute_current_velocity_boundary_constraints(new_current_constraints);
 
@@ -791,8 +795,14 @@ namespace aspect
                                                                       mpi_communicator) > 0;
     if (any_constrained_dofs_set_changed)
       rebuild_sparsity_and_matrices = true;
-
+    current_constraints.clear();
+#if DEAL_II_VERSION_GTE(9,6,0)
+    current_constraints.reinit (dof_handler.locally_owned_dofs(), introspection.index_sets.system_relevant_set);
+#else
+    current_constraints.reinit (introspection.index_sets.system_relevant_set);
+#endif
     current_constraints.copy_from(new_current_constraints);
+    current_constraints.close();
 
     // TODO: We should use current_constraints.is_consistent_in_parallel()
     // here to assert that our constraints are consistent between
@@ -1449,7 +1459,11 @@ namespace aspect
 
     // Reconstruct the constraint-matrix:
     constraints.clear();
+#if DEAL_II_VERSION_GTE(9,6,0)
+    constraints.reinit (dof_handler.locally_owned_dofs(), introspection.index_sets.system_relevant_set);
+#else
     constraints.reinit(introspection.index_sets.system_relevant_set);
+#endif
 
     // Set up the constraints for periodic boundary conditions:
 

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2467,7 +2467,11 @@ namespace aspect
           {
             IndexSet relevant_dofs;
             DoFTools::extract_locally_relevant_level_dofs(dof_handler_v, level, relevant_dofs);
+#if DEAL_II_VERSION_GTE(9,6,0)
+            level_constraints_v.reinit(dof_handler_v.locally_owned_dofs(), relevant_dofs);
+#else
             level_constraints_v.reinit(relevant_dofs);
+#endif
             level_constraints_v.add_lines(mg_constrained_dofs_A_block.get_boundary_indices(level));
             level_constraints_v.close();
 
@@ -2476,8 +2480,11 @@ namespace aspect
             if (!no_flux_boundary.empty())
               {
                 AffineConstraints<double> user_level_constraints;
+#if DEAL_II_VERSION_GTE(9,6,0)
+                user_level_constraints.reinit(dof_handler_v.locally_owned_dofs(), relevant_dofs);
+#else
                 user_level_constraints.reinit(relevant_dofs);
-
+#endif
                 const IndexSet &refinement_edge_indices =
                   mg_constrained_dofs_A_block.get_refinement_edge_indices(level);
                 dealii::VectorTools::compute_no_normal_flux_constraints_on_level(


### PR DESCRIPTION
Guarding #if DEAL_II_VERSION_GTE(9,6,0) blocks were added to all "constraints.reinit"
