### PR TITLE
Update email for Jenkins tester configuration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
           not {changeRequest authorEmail: "judannberg@gmail.com"}
           not {changeRequest authorEmail: "ja3170@columbia.edu"}
           not {changeRequest authorEmail: "jbnaliboff@ucdavis.edu"}
-          not {changeRequest authorEmail: "menno.fraters@outlook.com"}
+          not {changeRequest authorEmail: "menno.fraters@tutanota.com"}
           not {changeRequest authorEmail: "a.c.glerum@uu.nl"}
           not {changeRequest authorEmail: "myhill.bob@gmail.com"}
           not {changeRequest authorEmail: "ljhwang@ucdavis.edu"}


### PR DESCRIPTION
@MFraters it looks like you updated the email you use for your git commits. This updates the configuration of the Jenkins tester to run your PRs without waiting for the ready-to-test label. Are you ok with this change?