### PR TITLE
Parameter doc no escape backtick

### DIFF
--- a/contrib/utilities/jsontomarkdown.py
+++ b/contrib/utilities/jsontomarkdown.py
@@ -79,10 +79,10 @@ def escape_doc_string(text) :
     tmp = (text
            .replace("``", "&ldquo;")
            .replace("''", "&rdquo;")
-           .replace("\`", "[[[backtick]]]")
+           .replace("\`", "[[[backtick]]]") # temporarily replace escaped backticks by a placeholder
            .replace("`", "&lsquo;")
            .replace("'", "&rsquo;")
-           .replace("[[[backtick]]]", "`")
+           .replace("[[[backtick]]]", "`") # and now change them to actual backticks
            .replace("\\aspect{}", "ASPECT")
            .replace("\\dealii{}", "deal.II")
     )

--- a/contrib/utilities/jsontomarkdown.py
+++ b/contrib/utilities/jsontomarkdown.py
@@ -79,8 +79,10 @@ def escape_doc_string(text) :
     tmp = (text
            .replace("``", "&ldquo;")
            .replace("''", "&rdquo;")
+           .replace("\`", "[[[backtick]]]")
            .replace("`", "&lsquo;")
            .replace("'", "&rsquo;")
+           .replace("[[[backtick]]]", "`")
            .replace("\\aspect{}", "ASPECT")
            .replace("\\dealii{}", "deal.II")
     )

--- a/source/boundary_composition/function.cc
+++ b/source/boundary_composition/function.cc
@@ -141,6 +141,6 @@ namespace aspect
                                                "The format of these "
                                                "functions follows the syntax understood by the "
                                                "muparser library, see "
-                                               "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                               "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/boundary_heat_flux/function.cc
+++ b/source/boundary_heat_flux/function.cc
@@ -160,7 +160,7 @@ namespace aspect
                                              "``Boundary heat flux model|Function''. The format of these "
                                              "functions follows the syntax understood by the "
                                              "muparser library, see "
-                                             "{ref}`sec:run-aspect:parameters-overview:muparser-format`."
+                                             "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`."
                                              "\n\n"
                                              "The formula you describe in the mentioned "
                                              "section is a scalar value for the heat flux that is assumed "

--- a/source/boundary_temperature/function.cc
+++ b/source/boundary_temperature/function.cc
@@ -181,6 +181,6 @@ namespace aspect
                                                "\n\n"
                                                "The format of these "
                                                "functions follows the syntax understood by the "
-                                               "muparser library, see {ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                               "muparser library, see {ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/boundary_velocity/function.cc
+++ b/source/boundary_velocity/function.cc
@@ -165,7 +165,7 @@ namespace aspect
                                             "``Boundary velocity model|Function''. The format of these "
                                             "functions follows the syntax understood by the "
                                             "muparser library, see "
-                                            "{ref}`sec:run-aspect:parameters-overview:muparser-format`."
+                                            "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`."
                                             "\n\n"
                                             "The formula you describe in the mentioned "
                                             "section is a semicolon separated list of velocities "

--- a/source/gravity_model/function.cc
+++ b/source/gravity_model/function.cc
@@ -115,6 +115,6 @@ namespace aspect
                                   "``Gravity model|Function''. The format of these "
                                   "functions follows the syntax understood by the "
                                   "muparser library, see "
-                                  "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                  "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -125,7 +125,7 @@ namespace aspect
                                   "``Heating model|Function''. The format of these "
                                   "functions follows the syntax understood by the "
                                   "muparser library, see "
-                                  "{ref}`sec:run-aspect:parameters-overview:muparser-format`."
+                                  "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`."
                                   "\n\n"
                                   "The formula is interpreted as having units "
                                   "W/kg."

--- a/source/initial_composition/function.cc
+++ b/source/initial_composition/function.cc
@@ -120,6 +120,6 @@ namespace aspect
                                               "function",
                                               "Specify the composition in terms of an explicit formula. The format of these "
                                               "functions follows the syntax understood by the "
-                                              "muparser library, see {ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                              "muparser library, see {ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -413,7 +413,7 @@ namespace aspect
                              "profile for calculating the thermal diffusivity. "
                              "This function is one-dimensional and depends only on depth. The format of this "
                              "functions follows the syntax understood by the "
-                             "muparser library, see {ref}`sec:run-aspect:parameters-overview:muparser-format`.");
+                             "muparser library, see {ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.");
           prm.declare_entry ("Top boundary layer age model", "constant",
                              Patterns::Selection ("constant|function|ascii data"),
                              "How to define the age of the top thermal boundary layer. "

--- a/source/initial_temperature/function.cc
+++ b/source/initial_temperature/function.cc
@@ -124,6 +124,6 @@ namespace aspect
                                               "Specify the initial temperature in terms of an "
                                               "explicit formula. The format of these "
                                               "functions follows the syntax understood by the "
-                                              "muparser library, see {ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                              "muparser library, see {ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/mesh_deformation/function.cc
+++ b/source/mesh_deformation/function.cc
@@ -144,6 +144,6 @@ namespace aspect
                                            "the boundary deformation velocity should still be given "
                                            "in m/s. The format of the "
                                            "functions follows the syntax understood by the "
-                                           "muparser library, see {ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                           "muparser library, see {ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/mesh_refinement/maximum_refinement_function.cc
+++ b/source/mesh_refinement/maximum_refinement_function.cc
@@ -188,6 +188,6 @@ namespace aspect
                                               "The format of these "
                                               "functions follows the syntax understood by the "
                                               "muparser library, see "
-                                              "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                              "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/mesh_refinement/minimum_refinement_function.cc
+++ b/source/mesh_refinement/minimum_refinement_function.cc
@@ -187,6 +187,6 @@ namespace aspect
                                               "The format of these "
                                               "functions follows the syntax understood by the "
                                               "muparser library, see "
-                                              "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                              "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }

--- a/source/particle/generator/probability_density_function.cc
+++ b/source/particle/generator/probability_density_function.cc
@@ -156,7 +156,7 @@ namespace aspect
                                          "form of a user-prescribed function. The "
                                          "format of this function follows the syntax "
                                          "understood by the muparser library, see "
-                                         "{ref}`sec:run-aspect:parameters-overview:muparser-format`. The "
+                                         "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`. The "
                                          "return value of the function is always "
                                          "checked to be a non-negative probability "
                                          "density but it can be zero in "

--- a/source/particle/property/function.cc
+++ b/source/particle/property/function.cc
@@ -123,7 +123,7 @@ namespace aspect
                                         "``Particles|Function''. The format of these "
                                         "functions follows the syntax understood by the "
                                         "muparser library, see "
-                                        "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                        "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
     }
   }
 }

--- a/source/prescribed_stokes_solution/function.cc
+++ b/source/prescribed_stokes_solution/function.cc
@@ -241,6 +241,6 @@ namespace aspect
                                                "explicit formula. The format of these "
                                                "functions follows the syntax understood by the "
                                                "muparser library, see "
-                                               "{ref}`sec:run-aspect:parameters-overview:muparser-format`.")
+                                               "{ref}\\`sec:run-aspect:parameters-overview:muparser-format\\`.")
   }
 }


### PR DESCRIPTION
We use backticks in the parameter documentation for two things:
1. We use it for latex style single quotes `` `Howdy!'``
2. We now use it for sphinx commands like ``{ref}`bla` ``

The jsontomarkdown.py unconditionally replaces all backticks by ``&lsquo;``, which makes 1. render correctly, but obviously breaks 2. Note that PRs like #5285 manually replaced the text in the automatically generated .md files.

Instead, I propose the following:
1. If you want to use backticks to issue sphinx commands, they need to be escaped using ``\`` (which means ``\\`` inside a string in a .cc file).
2. All other backticks will be rendered literally like before
