### PR TITLE
Clean test parameter files of outdated comments

### DIFF
--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -90,14 +90,6 @@ set Surface pressure                       = 0
 set Use years in output instead of seconds = false
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = box
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -142,14 +134,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -170,21 +154,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -194,19 +163,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = simple
 
   subsection Simple model

--- a/tests/diffusion_velocity.prm
+++ b/tests/diffusion_velocity.prm
@@ -90,14 +90,6 @@ set Surface pressure                       = 0
 set Use years in output instead of seconds = false
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = box
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -142,14 +134,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -170,21 +154,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -194,19 +163,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = simple
 
   subsection Simple model

--- a/tests/maximum_refinement_function.prm
+++ b/tests/maximum_refinement_function.prm
@@ -29,16 +29,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,3
 
@@ -63,19 +53,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = box
 
   subsection Box

--- a/tests/maximum_refinement_function_cartesian.prm
+++ b/tests/maximum_refinement_function_cartesian.prm
@@ -29,16 +29,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,3
 
@@ -63,19 +53,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = box
 
   subsection Box

--- a/tests/maximum_refinement_function_spherical.prm
+++ b/tests/maximum_refinement_function_spherical.prm
@@ -22,16 +22,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,1
 
@@ -56,19 +46,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = spherical shell
 
   subsection Spherical shell

--- a/tests/minimum_refinement_function.prm
+++ b/tests/minimum_refinement_function.prm
@@ -29,16 +29,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,3
 
@@ -63,19 +53,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = box
 
   subsection Box

--- a/tests/minimum_refinement_function_cartesian.prm
+++ b/tests/minimum_refinement_function_cartesian.prm
@@ -29,16 +29,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,3
 
@@ -63,19 +53,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = box
 
   subsection Box

--- a/tests/minimum_refinement_function_spherical.prm
+++ b/tests/minimum_refinement_function_spherical.prm
@@ -22,16 +22,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,1
 
@@ -56,19 +46,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = spherical shell
 
   subsection Spherical shell

--- a/tests/minimum_refinement_function_time_dependent.prm
+++ b/tests/minimum_refinement_function_time_dependent.prm
@@ -29,16 +29,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = true
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `Tan Gurnis': A model for the Tan/Gurnis benchmark.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on all the
-  # sides of a box.
   set List of model names = initial temperature
   set Fixed temperature boundary indicators   = 0,3
 
@@ -63,19 +53,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file. The box
-  # geometry labels its 2*dim sides as follows: in 2d, boundary indicators 0
-  # through 3 denote the left, right, bottom and top boundaries; in 3d,
-  # boundary indicators 0 through 5 indicate left, right, front, back, bottom
-  # and top boundaries. See also the documentation of the deal.II class
-  # ``GeometryInfo''.
   set Model name = box
 
   subsection Box

--- a/tests/passive_comp.prm
+++ b/tests/passive_comp.prm
@@ -39,15 +39,6 @@ set Start time                             = 0
 set Use years in output instead of seconds = false
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `spherical constant': A model in
-  # which the temperature is chosen constant on the inner and outer boundaries
-  # of a spherical shell. Parameters are read from subsection 'Spherical
-  # constant'.
-  #
-  # `box': A model in which the temperature is chosen constant on
-  # the left and right sides of a box.
   set List of model names = spherical constant
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -103,15 +94,6 @@ subsection Compositional fields
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `spherical shell': A geometry
-  # representing a spherical shell or a piece of it. Inner and outer radii are
-  # read from the parameter file in subsection 'Spherical shell'.
-  #
-  # `box': A
-  # box geometry parallel to the coordinate directions. The extent of the box
-  # in each coordinate direction is set in the parameter file.
   set Model name = spherical shell
 
   subsection Spherical shell
@@ -138,24 +120,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `spherical hexagonal perturbation':
-  # An initial temperature field in which the temperature is perturbed
-  # following a six-fold pattern in angular direction from an otherwise
-  # spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An
-  # initial temperature field in which the temperature is perturbed by a
-  # single Gaussian added to an otherwise spherically symmetric state.
-  # Additional parameters are read from the parameter file in subsection
-  # 'Spherical gaussian perturbation'.
-  #
-  # `perturbed box': An initial
-  # temperature field in which the temperature is perturbed slightly from an
-  # otherwise constant value equal to one. The perturbation is chosen in such
-  # a way that the initial temperature is constant to one along the entire
-  # boundary.
   set Model name = spherical hexagonal perturbation
 
   subsection Spherical gaussian perturbation
@@ -178,12 +142,6 @@ subsection Initial temperature model
 end
 
 subsection Initial composition model
-  # Select one of the following models:
-  #
-  # `function':
-  # An initial compositional field that is determined by the functions stated under
-  # set Function expression. Give as many functions as there are compositional fields,
-  # separate functions by semicolons.
   set Model name = function
 
   subsection Function
@@ -193,21 +151,6 @@ subsection Initial composition model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `table': A material model that reads
-  # tables of pressure and temperature dependent material coefficients from
-  # files.
-  #
-  # `Steinberger': lookup from the paper of
-  # Steinberger/Calderwood
-  #
-  # `simple': A simple material model that has
-  # constant values for all coefficients but the density. This model uses the
-  # formulation that assumes an incompressible medium despite the fact that
-  # the density follows the law $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$.
-  # The value for the components of this formula and additional parameters are
-  # read from the parameter file in subsection 'Simple model'.
   set Model name = simple
 
   subsection Simple model

--- a/tests/tangurnis_ba.prm
+++ b/tests/tangurnis_ba.prm
@@ -90,14 +90,6 @@ subsection Formulation
 end
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = Tan Gurnis
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -137,14 +129,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -165,21 +149,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -188,19 +157,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = Tan Gurnis
 
   subsection Tan Gurnis model

--- a/tests/tangurnis_ba_custom.prm
+++ b/tests/tangurnis_ba_custom.prm
@@ -89,14 +89,6 @@ subsection Formulation
 end
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = Tan Gurnis
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -136,14 +128,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -164,21 +148,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -187,19 +156,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = Tan Gurnis
 
   subsection Tan Gurnis model

--- a/tests/tangurnis_tala.prm
+++ b/tests/tangurnis_tala.prm
@@ -89,14 +89,6 @@ subsection Formulation
 end
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = Tan Gurnis
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -136,14 +128,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -164,21 +148,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -187,19 +156,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = Tan Gurnis
 
   subsection Tan Gurnis model

--- a/tests/tangurnis_tala_c.prm
+++ b/tests/tangurnis_tala_c.prm
@@ -89,14 +89,6 @@ subsection Formulation
 end
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = Tan Gurnis
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -136,14 +128,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -164,21 +148,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -187,19 +156,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = Tan Gurnis
 
   subsection Tan Gurnis model

--- a/tests/tangurnis_tala_implicit.prm
+++ b/tests/tangurnis_tala_implicit.prm
@@ -90,14 +90,6 @@ subsection Formulation
 end
 
 subsection Boundary temperature model
-  # Select one of the following models:
-  #
-  # `box': A model in which the temperature is chosen constant on the left and
-  # right sides of a box.
-  #
-  # `spherical constant': A model in which the temperature is chosen constant
-  # on the inner and outer boundaries of a spherical shell. Parameters are
-  # read from subsection 'Spherical constant'.
   set List of model names = Tan Gurnis
 
   # A comma separated list of integers denoting those boundaries on which the
@@ -137,14 +129,6 @@ subsection Discretization
 end
 
 subsection Geometry model
-  # Select one of the following models:
-  #
-  # `box': A box geometry parallel to the coordinate directions. The extent of
-  # the box in each coordinate direction is set in the parameter file.
-  #
-  # `spherical shell': A geometry representing a spherical shell or a piece of
-  # it. Inner and outer radii are read from the parameter file in subsection
-  # 'Spherical shell'.
   set Model name = box
 
   subsection Box
@@ -165,21 +149,6 @@ subsection Gravity model
 end
 
 subsection Initial temperature model
-  # Select one of the following models:
-  #
-  # `perturbed box': An initial temperature field in which the temperature is
-  # perturbed slightly from an otherwise constant value equal to one. The
-  # perturbation is chosen in such a way that the initial temperature is
-  # constant to one along the entire boundary.
-  #
-  # `spherical hexagonal perturbation': An initial temperature field in which
-  # the temperature is perturbed following a six-fold pattern in angular
-  # direction from an otherwise spherically symmetric state.
-  #
-  # `spherical gaussian perturbation': An initial temperature field in which
-  # the temperature is perturbed by a single Gaussian added to an otherwise
-  # spherically symmetric state. Additional parameters are read from the
-  # parameter file in subsection 'Spherical gaussian perturbation'.
   set Model name = function
 
   subsection Function
@@ -188,19 +157,6 @@ subsection Initial temperature model
 end
 
 subsection Material model
-  # Select one of the following models:
-  #
-  # `simple': A simple material model that has constant values for all
-  # coefficients but the density. This model uses the formulation that assumes
-  # an incompressible medium despite the fact that the density follows the law
-  # $\rho(T)=\rho_0(1-\beta(T-T_{\text{ref}})$. The value for the components
-  # of this formula and additional parameters are read from the parameter file
-  # in subsection 'Simple model'.
-  #
-  # `Steinberger': lookup from the paper of Steinberger/Calderwood
-  #
-  # `table': A material model that reads tables of pressure and temperature
-  # dependent material coefficients from files.
   set Model name = Tan Gurnis
 
   subsection Tan Gurnis model


### PR DESCRIPTION
While working on something else I saw these outdated comments in many of our test prm files. They were created from the parameters.prm output of models, and so they contain all parameter documentation as well. That doesnt matter for most parameters, because their description rarely changes, but the list of available models changes a lot, and if someone starts a new model from one of the test files, we want to avoid having wrong comments in these files. I purely removed the same sort of comment here ("Select one of the following models: ...").