### PR TITLE
Re-order particle world member variables.

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -308,13 +308,6 @@ namespace aspect
         std::unique_ptr<Interpolator::Interface<dim>> interpolator;
 
         /**
-         * The property manager stores information about the additional
-         * particle properties and handles the initialization and update of
-         * these properties.
-         */
-        std::unique_ptr<Property::Manager<dim>> property_manager;
-
-        /**
          * Particle handler object that is responsible for storing and
          * managing the internal particle structures.
          */
@@ -327,6 +320,13 @@ namespace aspect
          * each outer advection iteration.
          */
         Particles::ParticleHandler<dim> particle_handler_backup;
+
+        /**
+         * The property manager stores information about the additional
+         * particle properties and handles the initialization and update of
+         * these properties.
+         */
+        std::unique_ptr<Property::Manager<dim>> property_manager;
 
         /**
          * Strategy for particle load balancing.


### PR DESCRIPTION
I have no idea whether this is going to make any difference with the issue @ryanstoner1 sees, but thought I'd give this a try on general principle. The order of declarations in the `World` class is first the property manager and then the particle handler. They are destroyed in the opposite order. This seems wrong. So re-order these two variables.