### PR TITLE
docker image: add netcdf

### DIFF
--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && \
   gfortran git libblas-dev liblapack-dev libopenmpi-dev \
   lsb-release ninja-build numdiff openmpi-bin \
   openmpi-common wget zlib1g-dev \
-  libboost-all-dev &&\
+  libboost-all-dev libnetcdf-dev &&\
   add-apt-repository $REPO && apt update && \
   apt install -yq libdeal.ii-$VERSION libdeal.ii-dev && \
   apt-get clean && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
part of #5447

This image installs deal.II from Ubuntu packages, so we can just install the system netcdf and it works (I checked).

@gassmoeller Can you update the image as well? Or is it built automatically?