### PR TITLE
pass MPI_Comm by const value

### DIFF
--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -159,7 +159,7 @@ namespace aspect
        * @param filename Name of the input file.
        */
       void read_solitary_wave_solution (const std::string &filename,
-                                        MPI_Comm comm)
+                                        const MPI_Comm comm)
       {
         std::string temp;
         std::stringstream in(Utilities::read_and_distribute_file_content(filename, comm));
@@ -195,7 +195,7 @@ namespace aspect
                              const double compaction_length,
                              const bool read_solution,
                              const std::string file_name,
-                             MPI_Comm comm)
+                             const MPI_Comm comm)
       {
         // non-dimensionalize the amplitude
         const double non_dim_amplitude = amplitude / background_porosity;

--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -65,7 +65,7 @@ namespace aspect
            * file does not exist.
            */
           void load_file(const std::string &filename,
-                         const MPI_Comm &comm);
+                         const MPI_Comm comm);
 
           /**
            * Returns the computed surface velocity in cartesian coordinates.

--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -39,7 +39,7 @@ namespace aspect
         {
           public:
             SphericalHarmonicsLookup(const std::string &filename,
-                                     const MPI_Comm &comm);
+                                     const MPI_Comm comm);
 
             /// Declare a function that returns the cosine coefficients
             const std::vector<double> &
@@ -61,7 +61,7 @@ namespace aspect
         {
           public:
             SplineDepthsLookup(const std::string &filename,
-                               const MPI_Comm &comm);
+                               const MPI_Comm comm);
 
             const std::vector<double> &
             spline_depths() const;

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -50,7 +50,7 @@ namespace aspect
            * Read in a file.
            */
           LateralViscosityLookup(const std::string &filename,
-                                 const MPI_Comm &comm);
+                                 const MPI_Comm comm);
 
           /**
            * Returns a temperature-dependency for a given depth.
@@ -89,7 +89,7 @@ namespace aspect
            * Constructor. Reads in the given file.
            */
           RadialViscosityLookup(const std::string &filename,
-                                const MPI_Comm &comm);
+                                const MPI_Comm comm);
 
           /**
            * Return the viscosity for a given depth.

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -252,7 +252,7 @@ namespace aspect
             HeFESToReader(const std::string &material_filename,
                           const std::string &derivatives_filename,
                           const bool interpol,
-                          const MPI_Comm &comm);
+                          const MPI_Comm comm);
         };
 
         /**
@@ -264,7 +264,7 @@ namespace aspect
           public:
             PerplexReader(const std::string &filename,
                           const bool interpol,
-                          const MPI_Comm &comm);
+                          const MPI_Comm comm);
         };
 
         /**

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -395,7 +395,7 @@ namespace aspect
      * verify some of the input arguments.
      */
     Parameters (ParameterHandler &prm,
-                MPI_Comm mpi_communicator);
+                const MPI_Comm mpi_communicator);
 
     /**
      * Declare the run-time parameters this class takes, and call the

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -114,7 +114,7 @@ namespace aspect
         void reinit(const std::vector<std::string> &column_names,
                     std::vector<std::vector<double>> &&coordinate_values,
                     std::vector<Table<dim,double>> &&data_table,
-                    const MPI_Comm &mpi_communicator = MPI_COMM_SELF,
+                    const MPI_Comm mpi_communicator = MPI_COMM_SELF,
                     const unsigned int root_process = numbers::invalid_unsigned_int);
 
         /**
@@ -136,7 +136,7 @@ namespace aspect
          */
         void
         load_ascii(const std::string &filename,
-                   const MPI_Comm &communicator);
+                   const MPI_Comm communicator);
 
         /**
          * Fill the current object with data read from a NetCDF file
@@ -166,7 +166,7 @@ namespace aspect
          */
         void
         load_file(const std::string &filename,
-                  const MPI_Comm &communicator);
+                  const MPI_Comm communicator);
 
         /**
          * Returns the computed data (velocity, temperature, etc. - according
@@ -701,7 +701,7 @@ namespace aspect
          */
         virtual
         void
-        initialize (const MPI_Comm &communicator);
+        initialize (const MPI_Comm communicator);
 
 
         /**

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -576,7 +576,7 @@ namespace aspect
      * @param comm MPI communicator to use.
      */
     bool fexists(const std::string &filename,
-                 MPI_Comm comm);
+                 const MPI_Comm comm);
 
     /**
      * Checks to see if the user is trying to use data from a url.
@@ -606,7 +606,7 @@ namespace aspect
      */
     std::string
     read_and_distribute_file_content(const std::string &filename,
-                                     const MPI_Comm &comm);
+                                     const MPI_Comm comm);
 
     /**
      * Collect the content of @p file_content using MPI_Gather to process 0.
@@ -623,7 +623,7 @@ namespace aspect
     void
     collect_and_write_file_content(const std::string &filename,
                                    const std::string &file_content,
-                                   const MPI_Comm &comm);
+                                   const MPI_Comm comm);
 
     /**
      * Creates a path as if created by the shell command "mkdir -p", therefore
@@ -652,7 +652,7 @@ namespace aspect
      * to true.
      */
     void create_directory(const std::string &pathname,
-                          const MPI_Comm &comm,
+                          const MPI_Comm comm,
                           bool silent);
 
     /**
@@ -1015,7 +1015,7 @@ namespace aspect
                                                const std::string &function_name,
                                                const std::vector<SolverControl> &solver_controls,
                                                const std::exception &exc,
-                                               const MPI_Comm &mpi_communicator,
+                                               const MPI_Comm mpi_communicator,
                                                const std::string &output_filename = "");
 
     /**

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -95,7 +95,7 @@ namespace aspect
       template <int dim>
       void
       GPlatesLookup<dim>::load_file(const std::string &filename,
-                                    const MPI_Comm &comm)
+                                    const MPI_Comm comm)
       {
         // Read data from disk and distribute among processes
         std::istringstream filecontent(

--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -49,7 +49,7 @@ namespace aspect
 
         SphericalHarmonicsLookup::
         SphericalHarmonicsLookup(const std::string &filename,
-                                 const MPI_Comm &comm)
+                                 const MPI_Comm comm)
         {
           std::string temp;
           // Read data from disk and distribute among processes
@@ -119,7 +119,7 @@ namespace aspect
         // lib/libS20/splhsetup.f which is part of the plotting package downloadable at
         // http://www.earth.lsa.umich.edu/~jritsema/research.html
         SplineDepthsLookup::SplineDepthsLookup(const std::string &filename,
-                                               const MPI_Comm &comm)
+                                               const MPI_Comm comm)
         {
           std::string temp;
           // Read data from disk and distribute among processes

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -46,7 +46,7 @@ namespace aspect
         {
           public:
             SphericalHarmonicsLookup(const std::string &filename,
-                                     const MPI_Comm &comm)
+                                     const MPI_Comm comm)
             {
               std::string temp;
               // Read data from disk and distribute among processes
@@ -120,7 +120,7 @@ namespace aspect
         {
           public:
             SplineDepthsLookup(const std::string &filename,
-                               const MPI_Comm &comm)
+                               const MPI_Comm comm)
             {
               std::string temp;
               // Read data from disk and distribute among processes

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -38,7 +38,7 @@ namespace aspect
     namespace internal
     {
       LateralViscosityLookup::LateralViscosityLookup(const std::string &filename,
-                                                     const MPI_Comm &comm)
+                                                     const MPI_Comm comm)
       {
         std::string temp;
         // Read data from disk and distribute among processes
@@ -85,7 +85,7 @@ namespace aspect
       }
 
       RadialViscosityLookup::RadialViscosityLookup(const std::string &filename,
-                                                   const MPI_Comm &comm)
+                                                   const MPI_Comm comm)
       {
         std::string temp;
         // Read data from disk and distribute among processes

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -305,7 +305,7 @@ namespace aspect
         HeFESToReader::HeFESToReader(const std::string &material_filename,
                                      const std::string &derivatives_filename,
                                      const bool interpol,
-                                     const MPI_Comm &comm)
+                                     const MPI_Comm comm)
         {
           /* Initializing variables */
           interpolation = interpol;
@@ -511,7 +511,7 @@ namespace aspect
 
         PerplexReader::PerplexReader(const std::string &filename,
                                      const bool interpol,
-                                     const MPI_Comm &comm)
+                                     const MPI_Comm comm)
         {
           /* Initializing variables */
           interpolation = interpol;

--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -30,7 +30,7 @@ namespace
   const std::string
   get_stats(const aspect::LinearAlgebra::BlockSparseMatrix &matrix,
             const std::string &matrix_name,
-            const MPI_Comm &comm)
+            const MPI_Comm comm)
   {
     std::ostringstream output;
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -39,7 +39,7 @@ namespace aspect
 {
   template <int dim>
   Parameters<dim>::Parameters (ParameterHandler &prm,
-                               MPI_Comm mpi_communicator)
+                               const MPI_Comm mpi_communicator)
   {
     parse_parameters (prm, mpi_communicator);
   }
@@ -2252,7 +2252,7 @@ namespace aspect
 {
 #define INSTANTIATE(dim) \
   template Parameters<dim>::Parameters (ParameterHandler &prm, \
-                                        MPI_Comm mpi_communicator); \
+                                        const MPI_Comm mpi_communicator); \
   template void Parameters<dim>::declare_parameters (ParameterHandler &prm); \
   template void Parameters<dim>::parse_parameters(ParameterHandler &prm, \
                                                   const MPI_Comm mpi_communicator); \

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -189,7 +189,7 @@ namespace aspect
     StructuredDataLookup<dim>::reinit(const std::vector<std::string> &column_names,
                                       std::vector<std::vector<double>> &&coordinate_values_,
                                       std::vector<Table<dim,double>> &&data_table,
-                                      const MPI_Comm &mpi_communicator,
+                                      const MPI_Comm mpi_communicator,
                                       const unsigned int root_process)
     {
       // If this is the root process, or if the user did not request
@@ -333,7 +333,7 @@ namespace aspect
     template <int dim>
     void
     StructuredDataLookup<dim>::load_ascii(const std::string &filename,
-                                          const MPI_Comm &comm)
+                                          const MPI_Comm comm)
     {
       const unsigned int root_process = 0;
 
@@ -841,7 +841,7 @@ namespace aspect
     template <int dim>
     void
     StructuredDataLookup<dim>::load_file(const std::string &filename,
-                                         const MPI_Comm &communicator)
+                                         const MPI_Comm communicator)
     {
       load_ascii(filename, communicator);
     }
@@ -1844,7 +1844,7 @@ namespace aspect
 
     template <int dim>
     void
-    AsciiDataProfile<dim>::initialize (const MPI_Comm &communicator)
+    AsciiDataProfile<dim>::initialize (const MPI_Comm communicator)
     {
       lookup = std::make_unique<Utilities::StructuredDataLookup<1>> (this->scale_factor);
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1336,8 +1336,7 @@ namespace aspect
 
 
     bool
-    fexists(const std::string &filename,
-            MPI_Comm comm)
+    fexists(const std::string &filename, const MPI_Comm comm)
     {
       bool file_exists = false;
       if (Utilities::MPI::this_mpi_process(comm) == 0)
@@ -1366,7 +1365,7 @@ namespace aspect
 
     std::string
     read_and_distribute_file_content(const std::string &filename,
-                                     const MPI_Comm &comm)
+                                     const MPI_Comm comm)
     {
       std::string data_string;
 
@@ -1561,7 +1560,7 @@ namespace aspect
     void
     collect_and_write_file_content(const std::string &filename,
                                    const std::string &file_content,
-                                   const MPI_Comm &comm)
+                                   const MPI_Comm comm)
     {
       const std::vector<std::string> collected_content = Utilities::MPI::gather(comm, file_content);
 
@@ -1639,7 +1638,7 @@ namespace aspect
 
 
     void create_directory(const std::string &pathname,
-                          const MPI_Comm &comm,
+                          const MPI_Comm comm,
                           bool silent)
     {
       // verify that the output directory actually exists. if it doesn't, create
@@ -2890,7 +2889,7 @@ namespace aspect
                                                const std::string &function_name,
                                                const std::vector<SolverControl> &solver_controls,
                                                const std::exception &exc,
-                                               const MPI_Comm &mpi_communicator,
+                                               const MPI_Comm mpi_communicator,
                                                const std::string &output_filename)
     {
       if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)

--- a/tests/solidus_initial_conditions.cc
+++ b/tests/solidus_initial_conditions.cc
@@ -42,7 +42,7 @@ namespace aspect
          * Read the data file into the class.
          */
         void read(const std::string &filename,
-                  const MPI_Comm &comm);
+                  const MPI_Comm comm);
 
         /**
          * Get the melting temperature.
@@ -166,7 +166,7 @@ namespace aspect
     };
 
     void MeltingCurve::read(const std::string &filename,
-                            const MPI_Comm &comm)
+                            const MPI_Comm comm)
     {
       data_filename=filename;
       // Read data from disk and distribute among processes

--- a/tests/stokes_solver_fail_A/screen-output
+++ b/tests/stokes_solver_fail_A/screen-output
@@ -36,7 +36,7 @@ Additional information:
 (line in output replaced by default.sh script)
     void aspect::Utilities::throw_linear_solver_failure_exception(const
     string&, const string&, const std::vector<dealii::SolverControl>&,
-    const std::exception&, ompi_communicator_t* const&, const string&)
+    const std::exception&, MPI_Comm, const string&)
     The violated condition was:
     false
     Additional information:

--- a/tests/stokes_solver_fail_S/screen-output
+++ b/tests/stokes_solver_fail_S/screen-output
@@ -36,7 +36,7 @@ Additional information:
 (line in output replaced by default.sh script)
     void aspect::Utilities::throw_linear_solver_failure_exception(const
     string&, const string&, const std::vector<dealii::SolverControl>&,
-    const std::exception&, ompi_communicator_t* const&, const string&)
+    const std::exception&, MPI_Comm, const string&)
     The violated condition was:
     false
     Additional information:


### PR DESCRIPTION
This mirrors what we did in deal.II a while ago: in MPI implementations MPI_Comm is a simple value (typically int or pointer) that we should pass by value. Otherwise, returning references of ``get_communicator()`` functions can be complicated to implement.