### PR TITLE
Disable pdf sphinx documentation for now

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,8 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - htmlzip
-  - pdf
+# TODO: reenable once the pdf errors are fixed
+#  - pdf
 
 conda:
   environment: ./doc/sphinx/environment.yml


### PR DESCRIPTION
This essentially reverts #5375 for now. I know we want the pdf docs, but I dont have time to fix them right now, and it looks like the online html doc was not properly rebuilt since #5375 was merged (it lists Aug 23 as last updated date).