### PR TITLE
Ensure correct solver scheme for PDA

### DIFF
--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -36,26 +36,27 @@ namespace aspect
     namespace
     {
       template <int dim>
-      bool solver_scheme_iterates_coupled_equations(const Parameters<dim> &parameters)
+      bool solver_scheme_is_supported(const Parameters<dim> &parameters)
       {
-        // Check if we use a solver scheme that solves the advection equations
+        // If we solve advection equations, we need to iterate them, because this material
+        // models splits temperature diffusion from entropy advection.
         switch (parameters.nonlinear_solver)
           {
             case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_defect_correction_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_Newton_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_no_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_defect_correction_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_single_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::first_timestep_only_single_Stokes:
               return true;
 
             case Parameters<dim>::NonlinearSolver::Kind::single_Advection_single_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_Stokes:
-            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_defect_correction_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_defect_correction_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_Newton_Stokes:
             case Parameters<dim>::NonlinearSolver::Kind::single_Advection_no_Stokes:
-            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_Stokes:
-            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_single_Stokes:
-            case Parameters<dim>::NonlinearSolver::Kind::first_timestep_only_single_Stokes:
-            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_no_Stokes:
               return false;
           }
         Assert(false, ExcNotImplemented());
@@ -79,7 +80,7 @@ namespace aspect
                    ExcMessage("The 'entropy model' material model requires the existence of a compositional field "
                               "named 'entropy'. This field does not exist."));
 
-      AssertThrow(solver_scheme_iterates_coupled_equations(this->get_parameters()) == true,
+      AssertThrow(solver_scheme_is_supported(this->get_parameters()) == true,
                   ExcMessage("The 'entropy model' material model requires the use of a solver scheme that "
                              "iterates over the advection equations but a non iterating solver scheme was selected. "
                              "Please check the consistency of your solver scheme."));

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -33,6 +33,38 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace
+    {
+      template <int dim>
+      bool solver_scheme_iterates_coupled_equations(const Parameters<dim> &parameters)
+      {
+        // Check if we use a solver scheme that solves the advection equations
+        switch (parameters.nonlinear_solver)
+          {
+            case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_defect_correction_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::iterated_Advection_and_Newton_Stokes:
+              return true;
+
+            case Parameters<dim>::NonlinearSolver::Kind::single_Advection_single_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_defect_correction_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_defect_correction_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::single_Advection_iterated_Newton_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::single_Advection_no_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_iterated_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_single_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::first_timestep_only_single_Stokes:
+            case Parameters<dim>::NonlinearSolver::Kind::no_Advection_no_Stokes:
+              return false;
+          }
+        Assert(false, ExcNotImplemented());
+        return false;
+      }
+    }
+
+
+
     template <int dim>
     void
     EntropyModel<dim>::initialize()
@@ -46,6 +78,11 @@ namespace aspect
       AssertThrow (this->introspection().compositional_name_exists("entropy"),
                    ExcMessage("The 'entropy model' material model requires the existence of a compositional field "
                               "named 'entropy'. This field does not exist."));
+
+      AssertThrow(solver_scheme_iterates_coupled_equations(this->get_parameters()) == true,
+                  ExcMessage("The 'entropy model' material model requires the use of a solver scheme that "
+                             "iterates over the advection equations but a non iterating solver scheme was selected. "
+                             "Please check the consistency of your solver scheme."));
 
       entropy_reader = std::make_unique<MaterialUtilities::Lookup::EntropyReader>();
       entropy_reader->initialize(this->get_mpi_communicator(), data_directory, material_file_name);

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2005,6 +2005,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   void
   Simulator<dim>::check_consistency_of_formulation()
@@ -2030,7 +2031,8 @@ namespace aspect
       }
     else if (parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::isentropic_compression
              || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::reference_density_profile
-             || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile)
+             || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::implicit_reference_density_profile
+             || parameters.formulation_mass_conservation == Parameters<dim>::Formulation::MassConservation::projected_density_field)
       {
         AssertThrow(material_model->is_compressible() == true,
                     ExcMessage("ASPECT detected an inconsistency in the provided input file. "

--- a/tests/entropy_initial_lookup.prm
+++ b/tests/entropy_initial_lookup.prm
@@ -5,7 +5,7 @@ set Dimension                              = 2
 set Use years in output instead of seconds = true
 
 set End time                               = 0
-set Nonlinear solver scheme                = single Advection, single Stokes
+set Nonlinear solver scheme                = iterated Advection and Stokes
 
 
 subsection Formulation

--- a/tests/entropy_initial_lookup/screen-output
+++ b/tests/entropy_initial_lookup/screen-output
@@ -11,12 +11,60 @@ Number of degrees of freedom: 3,217 (1,206+202+603+603+603)
    Copying properties into prescribed compositional field density_field... done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000495634, 4.77467e-10, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Copying properties into prescribed temperature field... done.
+   Solving temperature system... 3 iterations.
+   Solving entropy system ... 3 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 2+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 8.51534e-10, 5.64728e-10, 0, 0.0114835
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0114835
+
+   Copying properties into prescribed temperature field... done.
+   Solving temperature system... 3 iterations.
+   Solving entropy system ... 3 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.01722e-09, 4.2244e-10, 0, 0.00282275
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00282275
+
+   Copying properties into prescribed temperature field... done.
+   Solving temperature system... 3 iterations.
+   Solving entropy system ... 3 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.51013e-10, 3.95146e-10, 0, 0.000413138
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000413138
+
+   Copying properties into prescribed temperature field... done.
+   Solving temperature system... 3 iterations.
+   Solving entropy system ... 2 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.21895e-10, 4.19474e-10, 0, 4.24952e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 4.24952e-05
+
+   Copying properties into prescribed temperature field... done.
+   Solving temperature system... 3 iterations.
+   Solving entropy system ... 3 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 1+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.79118e-10, 3.18101e-10, 0, 3.41063e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.41063e-06
+
 
    Postprocessing:
      Writing graphical output:           output-entropy_initial_lookup/solution/solution-00000
-     RMS, max velocity:                  0.01 m/year, 0.01 m/year
+     RMS, max velocity:                  0.00788 m/year, 0.00998 m/year
      Temperature min/avg/max:            1596 K, 1600 K, 1603 K
-     Mass fluxes through boundary parts: 0 kg/yr, 0 kg/yr, 6.213e+05 kg/yr, -4.081e+05 kg/yr
+     Mass fluxes through boundary parts: 0 kg/yr, 0 kg/yr, 4.081e+05 kg/yr, -4.081e+05 kg/yr
      Compositions min/max/mass:          2197/2533/3.957e+13 // 3140/4779/6.908e+13
 
 Termination requested by criterion: end time

--- a/tests/entropy_initial_lookup_wb.prm
+++ b/tests/entropy_initial_lookup_wb.prm
@@ -11,7 +11,7 @@ set Pressure normalization = surface
 set Surface pressure = 0
 set Adiabatic surface temperature = 1573.0
 set Resume computation = false
-set Nonlinear solver scheme                = single Advection, single Stokes
+set Nonlinear solver scheme                = iterated Advection and Stokes
 set World builder file = $ASPECT_SOURCE_DIR/tests/entropy_initial_lookup_wb.wb
 
 

--- a/tests/entropy_initial_lookup_wb/screen-output
+++ b/tests/entropy_initial_lookup_wb/screen-output
@@ -40,12 +40,55 @@ Number of degrees of freedom: 47,413 (18,018+2,368+9,009+9,009+9,009)
    Copying properties into prescribed compositional field density_field... done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 68+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Solving entropy system ... 0 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 59+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 0.34314
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.34314
+
+   Solving temperature system... 0 iterations.
+   Solving entropy system ... 0 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 38+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 0.0161443
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0161443
+
+   Solving temperature system... 0 iterations.
+   Solving entropy system ... 0 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 31+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 0.00117625
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00117625
+
+   Solving temperature system... 0 iterations.
+   Solving entropy system ... 0 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 19+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 7.68509e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 7.68509e-05
+
+   Solving temperature system... 0 iterations.
+   Solving entropy system ... 0 iterations.
+   Copying properties into prescribed compositional field density_field... done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 12+0 iterations.
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.6188e-16, 1.74361e-16, 0, 8.23767e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 8.23767e-06
+
 
    Postprocessing:
      Writing graphical output:           output-entropy_initial_lookup_wb/solution/solution-00003
-     RMS, max velocity:                  0.0129 m/year, 0.121 m/year
+     RMS, max velocity:                  0.0138 m/year, 0.124 m/year
      Temperature min/avg/max:            273 K, 2184 K, 3500 K
-     Mass fluxes through boundary parts: 0.004753 kg/yr, 0.04504 kg/yr, 0 kg/yr, -6.767e-09 kg/yr
+     Mass fluxes through boundary parts: 0.004601 kg/yr, 0.04039 kg/yr, 0 kg/yr, -6.395e-09 kg/yr
      Compositions min/max/mass:          577.9/2758/1.089e+17 // 3228/5592/1.939e+17
 
 Termination requested by criterion: end time


### PR DESCRIPTION
The entropy material model requires iterating over advection and Stokes equations (because temperature diffusion is computed split from entropy advection). This was not asserted so far and has let to problems with temperature overshoot in other solver schemes. Also assert that the projected density mass conservation formulation always uses a compressible material model.

@jdannberg, @RanpengLi does this make sense?