### PR TITLE
Do not store manifolds in geometry models.

### DIFF
--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -20,7 +20,6 @@
 #ifndef _aspect_geometry_model_sphere_h
 #define _aspect_geometry_model_sphere_h
 
-#include <deal.II/grid/manifold_lib.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
 
@@ -37,7 +36,7 @@ namespace aspect
         /**
          * Constructor.
          */
-        Sphere();
+        Sphere() = default;
 
         /**
          * Generate a coarse mesh for the geometry described by this class.
@@ -157,11 +156,6 @@ namespace aspect
          * Radius of the sphere
          */
         double R;
-
-        /**
-         * The manifold that describes the geometry.
-         */
-        const SphericalManifold<dim> spherical_manifold;
     };
   }
 }

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -25,8 +25,6 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/grid/manifold_lib.h>
-
 namespace aspect
 {
   namespace GeometryModel
@@ -50,7 +48,7 @@ namespace aspect
         /**
          * Constructor.
          */
-        SphericalShell();
+        SphericalShell() = default;
 
         /**
          * Generate a coarse mesh for the geometry described by this class.
@@ -269,11 +267,6 @@ namespace aspect
          * Number of tangential mesh cells in the initial, coarse mesh.
          */
         int n_cells_along_circumference;
-
-        /**
-         * The manifold that describes the geometry.
-         */
-        const SphericalManifold<dim> spherical_manifold;
 
         /**
          * Set the manifold ids on all cells (also boundaries) before

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -23,20 +23,13 @@
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <aspect/utilities.h>
 
 namespace aspect
 {
   namespace GeometryModel
   {
-    template <int dim>
-    Sphere<dim>::Sphere()
-      :
-      spherical_manifold()
-    {}
-
-
-
     template <int dim>
     void
     Sphere<dim>::
@@ -46,7 +39,7 @@ namespace aspect
                                  Point<dim>(),
                                  R);
 
-      coarse_grid.set_manifold(0,spherical_manifold);
+      coarse_grid.set_manifold(0, SphericalManifold<dim>());
       coarse_grid.set_all_manifold_ids_on_boundary(0);
     }
 

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -24,6 +24,7 @@
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
 #include <aspect/utilities.h>
 #include <deal.II/dofs/dof_tools.h>
 
@@ -52,14 +53,6 @@ namespace aspect
         subcell_data.boundary_quads.push_back(face);
       }
     }
-
-
-
-    template <int dim>
-    SphericalShell<dim>::SphericalShell()
-      :
-      spherical_manifold()
-    {}
 
 
 
@@ -251,11 +244,10 @@ namespace aspect
           Assert (false, ExcInternalError());
         }
 
-      // Use a manifold description for all cells. use manifold_id 99 in order
-      // not to step on the boundary indicators used below
-      coarse_grid.set_manifold (99, spherical_manifold);
+      // Use a manifold description for all cells. Use manifold_id 99 in order
+      // not to step on the boundary indicators used below.
+      coarse_grid.set_manifold (99, SphericalManifold<dim>());
       set_manifold_ids(coarse_grid);
-
     }
 
 


### PR DESCRIPTION
The Triangulation class copies them anyway when calling set_manifold(), so we need to store a manifold object anywhere in the geometry models.

This patch addresses the `SphericalShell` and `Sphere` models. The `Chunk` model and variations also store manifolds, but in a more intricate way, and I will have to address that in separate pull requests because I think that they way they do that lends itself to complications.

First small part towards #5241.