### PR TITLE
Remove a function that is never used.

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -231,12 +231,6 @@ namespace aspect
         void initialize () override;
 
         /**
-         * This function calls the initialize function of the manifold
-         * with the given pointer to the initial topography model.
-         */
-        void set_topography_model (const InitialTopographyModel::Interface<dim> *topo_pointer);
-
-        /**
          * Generate a coarse mesh for the geometry described by this class.
          */
         void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const override;

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -77,12 +77,6 @@ namespace aspect
         void initialize () override;
 
         /**
-         * This function calls the initialize function of the manifold
-         * with the given pointer to the initial topography model.
-         */
-        void set_topography_model (const InitialTopographyModel::Interface<dim> *topo_pointer);
-
-        /**
          * Generate a coarse mesh for the geometry described by this class.
          */
         void create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const override;

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -492,19 +492,6 @@ namespace aspect
 
     template <int dim>
     void
-    Chunk<dim>::set_topography_model (const InitialTopographyModel::Interface<dim> *topo_pointer)
-    {
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(topo_pointer) != nullptr ||
-                  dynamic_cast<const InitialTopographyModel::AsciiData<dim>*>(topo_pointer) != nullptr,
-                  ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the Chunk geometry model."));
-
-      manifold.initialize(topo_pointer);
-    }
-
-
-
-    template <int dim>
-    void
     Chunk<dim>::
     create_coarse_mesh (parallel::distributed::Triangulation<dim> &coarse_grid) const
     {

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -47,18 +47,6 @@ namespace aspect
     }
 
 
-    template <int dim>
-    void
-    TwoMergedChunks<dim>::set_topography_model (const InitialTopographyModel::Interface<dim> *topo_pointer)
-    {
-      AssertThrow(dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(topo_pointer) != nullptr ||
-                  dynamic_cast<const InitialTopographyModel::AsciiData<dim>*>(topo_pointer) != nullptr,
-                  ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the TwoMergedChunks geometry model."));
-
-      manifold.initialize(topo_pointer);
-    }
-
-
 
     template <int dim>
     void

--- a/tests/natural_coordinates_conversion.cc
+++ b/tests/natural_coordinates_conversion.cc
@@ -91,7 +91,6 @@ int f()
   // Chunk 2d
   {
     GeometryModel::Chunk<2> chunk;
-    InitialTopographyModel::ZeroTopography<2> zero_topo;
     ParameterHandler prm_chunk;
     chunk.declare_parameters(prm_chunk);
     prm_chunk.enter_subsection("Geometry model");
@@ -101,7 +100,6 @@ int f()
     prm_chunk.leave_subsection();
     prm_chunk.leave_subsection();
     chunk.parse_parameters(prm_chunk);
-    chunk.set_topography_model(&zero_topo);
 
     inter_point_2d = chunk.cartesian_to_natural_coordinates(point_2d);
     new_point_2d = chunk.natural_to_cartesian_coordinates(inter_point_2d);
@@ -167,7 +165,6 @@ int f()
   // Chunk 3d
   {
     GeometryModel::Chunk<3> chunk;
-    InitialTopographyModel::ZeroTopography<3> zero_topo;
     ParameterHandler prm_chunk;
     chunk.declare_parameters(prm_chunk);
     prm_chunk.enter_subsection("Geometry model");
@@ -177,7 +174,6 @@ int f()
     prm_chunk.leave_subsection();
     prm_chunk.leave_subsection();
     chunk.parse_parameters(prm_chunk);
-    chunk.set_topography_model(&zero_topo);
 
     inter_point_3d = chunk.cartesian_to_natural_coordinates(point_3d);
     new_point_3d = chunk.natural_to_cartesian_coordinates(inter_point_3d);


### PR DESCRIPTION
Both of the chunk geometry variations have a function `set_topography_model()` that is, however, not used anywhere other than in one test where we set a zero topography -- which should not actually do anything useful.

As mentioned in #5467, I would like to get rid of explicitly storing manifolds because this leads to problems: What matters is the state of the manifold object *when we create the triangulation* because the triangulation copies the manifold. Storing a manifold explicitly invites problems when one later modifies the manifold and expects that that affects what the triangulation sees. It's better to get rid of the explicit objects, and removing these functions is one step towards that goa.