### PR TITLE
Do not keep around a manifold object in the Chunk class.

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -57,19 +57,15 @@ namespace aspect
           /**
            * Constructor
            */
-          ChunkGeometry();
+          ChunkGeometry(const InitialTopographyModel::Interface<dim> &topography,
+                        const double min_longitude,
+                        const double min_radius,
+                        const double max_depth);
 
           /**
            * Copy constructor
            */
-          ChunkGeometry(const ChunkGeometry &other);
-
-          /*
-           * An initialization function to make sure that the
-           * manifold has access to the topography plugins.
-           */
-          void
-          initialize(const InitialTopographyModel::Interface<dim> *topography);
+          ChunkGeometry(const ChunkGeometry &other) = default;
 
           /**
            * This function receives a point in cartesian coordinates x, y and z,

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -445,9 +445,17 @@ namespace aspect
         std::array<unsigned int, dim> repetitions;
 
         /**
-         * An object that describes the geometry.
+         * An object that describes the geometry. This pointer is
+         * initialized in the initialize() function, and serves as the manifold
+         * object that the triangulation is later given in create_coarse_mesh()
+         * where the triangulation clones it.
          */
-        internal::ChunkGeometry<dim> manifold;
+        std::unique_ptr<internal::ChunkGeometry<dim>> manifold;
+
+        /**
+         * Give a symbolic name to the manifold id to be used by this class.
+         */
+        static const types::manifold_id my_manifold_id = 15;
     };
   }
 }

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -423,8 +423,13 @@ namespace aspect
          * initialized in the initialize() function, and serves as the manifold
          * object that the triangulation is later given in create_coarse_mesh()
          * where the triangulation clones it.
+         *
+         * The object is marked as 'const' to make it clear that it should not
+         * be modified once created. That is because the triangulation copies it,
+         * and modifying the current object will not have any impact on the
+         * manifold used by the triangulation.
          */
-        std::unique_ptr<internal::ChunkGeometry<dim>> manifold;
+        std::unique_ptr<const internal::ChunkGeometry<dim>> manifold;
 
         /**
          * Give a symbolic name to the manifold id to be used by this class.

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -125,32 +125,10 @@ namespace aspect
           get_radius(const Point<dim> &space_point) const;
 
           /**
-           * Set the minimum longitude of the domain,
-           * which is used in pulling back cartesian coordinates
-           * to spherical to get the longitude in the correct
-           * quarter.
-           */
-          virtual
-          void
-          set_min_longitude(const double p1_lon);
-
-          /**
            * Return a copy of this manifold.
            */
           std::unique_ptr<Manifold<dim,dim>>
           clone() const override;
-
-          /**
-           * Set the minimal radius of the domain.
-           */
-          void
-          set_min_radius(const double p1_rad);
-
-          /**
-           * Set the maximum depth of the domain.
-           */
-          void
-          set_max_depth(const double p2_rad_minus_p1_rad);
 
         private:
           /**

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -311,9 +311,17 @@ namespace aspect
         std::array<unsigned int, dim> upper_repetitions;
 
         /**
-         * An object that describes the geometry.
+         * An object that describes the geometry. This pointer is
+         * initialized in the initialize() function, and serves as the manifold
+         * object that the triangulation is later given in create_coarse_mesh()
+         * where the triangulation clones it.
+         *
+         * The object is marked as 'const' to make it clear that it should not
+         * be modified once created. That is because the triangulation copies it,
+         * and modifying the current object will not have any impact on the
+         * manifold used by the triangulation.
          */
-        std::unique_ptr<internal::ChunkGeometry<dim>> manifold;
+        std::unique_ptr<const internal::ChunkGeometry<dim>> manifold;
 
         /**
          * Give a symbolic name to the manifold id to be used by this class.

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -313,7 +313,12 @@ namespace aspect
         /**
          * An object that describes the geometry.
          */
-        internal::ChunkGeometry<dim> manifold;
+        std::unique_ptr<internal::ChunkGeometry<dim>> manifold;
+
+        /**
+         * Give a symbolic name to the manifold id to be used by this class.
+         */
+        static const types::manifold_id my_manifold_id = 15;
 
         /**
          * Bind boundary indicators to child cells after each mesh refinement round.

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -340,16 +340,6 @@ namespace aspect
 
 
       template <int dim>
-      void
-      ChunkGeometry<dim>::
-      set_min_longitude(const double p1_lon)
-      {
-        point1_lon = p1_lon;
-      }
-
-
-
-      template <int dim>
       std::unique_ptr<Manifold<dim,dim>>
       ChunkGeometry<dim>::
       clone() const
@@ -434,26 +424,6 @@ namespace aspect
 
         // return the outer radius at this phi, theta point including topography
         return topography + inner_radius + max_depth;
-      }
-
-
-
-      template <int dim>
-      void
-      ChunkGeometry<dim>::
-      set_min_radius(const double p1_rad)
-      {
-        inner_radius = p1_rad;
-      }
-
-
-
-      template <int dim>
-      void
-      ChunkGeometry<dim>::
-      set_max_depth(const double p2_p1_rad)
-      {
-        max_depth = p2_p1_rad;
       }
     }
 

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -38,35 +38,16 @@ namespace aspect
     namespace internal
     {
       template <int dim>
-      ChunkGeometry<dim>::ChunkGeometry()
+      ChunkGeometry<dim>::ChunkGeometry(const InitialTopographyModel::Interface<dim> &topo,
+                                        const double min_longitude,
+                                        const double min_radius,
+                                        const double max_depth)
         :
-        point1_lon(0.0),
-        inner_radius(3471e3),
-        max_depth(2900e3)
+        point1_lon(min_longitude),
+        inner_radius(min_radius),
+        max_depth(max_depth),
+        topo (&topo)
       {}
-
-
-
-      template <int dim>
-      ChunkGeometry<dim>::ChunkGeometry(const ChunkGeometry &other)
-        :
-        ChartManifold<dim,dim>(other),
-        point1_lon(other.point1_lon),
-        inner_radius(other.inner_radius),
-        max_depth(other.max_depth)
-      {
-        this->initialize(other.topo);
-      }
-
-
-
-      template <int dim>
-      void
-      ChunkGeometry<dim>::
-      initialize(const InitialTopographyModel::Interface<dim> *topo_pointer)
-      {
-        topo = topo_pointer;
-      }
 
 
 
@@ -486,12 +467,10 @@ namespace aspect
                   dynamic_cast<const InitialTopographyModel::AsciiData<dim>*>(&this->get_initial_topography_model()) != nullptr,
                   ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the Chunk geometry model."));
 
-      manifold = std::make_unique<internal::ChunkGeometry<dim>>();
-
-      manifold->initialize(&(this->get_initial_topography_model()));
-      manifold->set_min_longitude(point1[1]);
-      manifold->set_min_radius(point1[0]);
-      manifold->set_max_depth(point2[0]-point1[0]);
+      manifold = std::make_unique<internal::ChunkGeometry<dim>>(this->get_initial_topography_model(),
+                                                                 point1[1],
+                                                                 point1[0],
+                                                                 point2[0]-point1[0]);
     }
 
 

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -43,12 +43,10 @@ namespace aspect
                   dynamic_cast<const InitialTopographyModel::AsciiData<dim>*>(&this->get_initial_topography_model()) != nullptr,
                   ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the TwoMergedChunks geometry model."));
 
-      manifold = std::make_unique<internal::ChunkGeometry<dim>>();
-
-      manifold->initialize(&(this->get_initial_topography_model()));
-      manifold->set_min_longitude(point1[1]);
-      manifold->set_min_radius(point1[0]);
-      manifold->set_max_depth(point2[0]-point1[0]);
+      manifold = std::make_unique<internal::ChunkGeometry<dim>>(this->get_initial_topography_model(),
+                                                                 point1[1],
+                                                                 point1[0],
+                                                                 point2[0]-point1[0]);
     }
 
 

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -43,7 +43,12 @@ namespace aspect
                   dynamic_cast<const InitialTopographyModel::AsciiData<dim>*>(&this->get_initial_topography_model()) != nullptr,
                   ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the TwoMergedChunks geometry model."));
 
-      manifold.initialize(&(this->get_initial_topography_model()));
+      manifold = std::make_unique<internal::ChunkGeometry<dim>>();
+
+      manifold->initialize(&(this->get_initial_topography_model()));
+      manifold->set_min_longitude(point1[1]);
+      manifold->set_min_radius(point1[0]);
+      manifold->set_max_depth(point2[0]-point1[0]);
     }
 
 
@@ -97,15 +102,15 @@ namespace aspect
       GridTools::transform (
         [&](const Point<dim> &p) -> Point<dim>
       {
-        return manifold.push_forward(p);
+        return manifold->push_forward(p);
       },
       coarse_grid);
 
       // Deal with a curved mesh by assigning a manifold. We arbitrarily
       // choose manifold_id 15 for this.
-      coarse_grid.set_manifold (15, manifold);
+      coarse_grid.set_manifold (my_manifold_id, *manifold);
       for (const auto &cell : coarse_grid.active_cell_iterators())
-        cell->set_all_manifold_ids (15);
+        cell->set_all_manifold_ids (my_manifold_id);
 
       // Set the boundary indicators.
       set_boundary_indicators(coarse_grid);
@@ -258,8 +263,8 @@ namespace aspect
     {
       // depth is defined wrt the reference surface point2[0] + the topography
       // depth is therefore always positive
-      const double outer_radius = manifold.get_radius(position);
-      const Point<dim> rtopo_phi_theta = manifold.pull_back_sphere(position);
+      const double outer_radius = manifold->get_radius(position);
+      const Point<dim> rtopo_phi_theta = manifold->pull_back_sphere(position);
       Assert (rtopo_phi_theta[0] <= outer_radius, ExcMessage("The radius is bigger than the maximum radius."));
       return std::max(0.0, outer_radius - rtopo_phi_theta[0]);
     }
@@ -290,7 +295,7 @@ namespace aspect
       p[0] = point2[0]-depth;
 
       // Now convert to Cartesian coordinates
-      return manifold.push_forward_sphere(p);
+      return manifold->push_forward_sphere(p);
     }
 
 
@@ -407,7 +412,7 @@ namespace aspect
       AssertThrow(Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()),
                   ExcMessage("After adding topography, this function can no longer be used to determine whether a point lies in the domain or not."));
 
-      const Point<dim> spherical_point = manifold.pull_back(point);
+      const Point<dim> spherical_point = manifold->pull_back(point);
 
       for (unsigned int d = 0; d < dim; ++d)
         if (spherical_point[d] > point2[d]+std::numeric_limits<double>::epsilon()*std::abs(point2[d]) ||
@@ -427,7 +432,7 @@ namespace aspect
       // This is exactly what we need.
       // Ignore the topography to avoid a loop when calling the
       // AsciiDataBoundary for topography which uses this function....
-      const Point<dim> transformed_point = manifold.pull_back_sphere(position_point);
+      const Point<dim> transformed_point = manifold->pull_back_sphere(position_point);
       std::array<double,dim> position_array;
       for (unsigned int i = 0; i < dim; ++i)
         position_array[i] = transformed_point(i);
@@ -459,7 +464,7 @@ namespace aspect
       Point<dim> position_point;
       for (unsigned int i = 0; i < dim; ++i)
         position_point[i] = position_tensor[i];
-      const Point<dim> transformed_point = manifold.push_forward_sphere(position_point);
+      const Point<dim> transformed_point = manifold->push_forward_sphere(position_point);
 
       return transformed_point;
     }
@@ -567,13 +572,6 @@ namespace aspect
                       ExcMessage("Maximum - minimum longitude should be less than 360 degrees."));
           AssertThrow(point3[0] < point2[0],
                       ExcMessage("Middle boundary radius must be less than outer radius."));
-
-          // Inform the manifold about the minimum longitude
-          manifold.set_min_longitude(point1[1]);
-          // Inform the manifold about the minimum radius
-          manifold.set_min_radius(point1[0]);
-          // Inform the manifold about the maximum depth (without topo)
-          manifold.set_max_depth(point2[0]-point1[0]);
 
           if (dim == 3)
             {


### PR DESCRIPTION
Rather, create it where necessary.

This is a follow-up to #5467 for the `Chunk` geometry. It makes sure that we only create a manifold object in the `create_geometry()` function, from which the `Triangulation` will then copy it. In all of the other places where we require a manifold object, we ask the triangulation for it.
