### PR TITLE
Do not mark functions as 'virtual' if not necessary.

### DIFF
--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -254,10 +254,8 @@ namespace aspect
         /**
          * Bind boundary indicators to child cells after each mesh refinement round.
          */
-        virtual
         void
         set_boundary_indicators (parallel::distributed::Triangulation<dim> &triangulation) const;
-
     };
   }
 }

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -318,7 +318,7 @@ namespace aspect
         /**
          * Bind boundary indicators to child cells after each mesh refinement round.
          */
-        virtual void set_boundary_indicators (parallel::distributed::Triangulation<dim> &triangulation) const;
+        void set_boundary_indicators (parallel::distributed::Triangulation<dim> &triangulation) const;
     };
   }
 }


### PR DESCRIPTION
Specifically, in these two cases, the functions are 'private', so could only possibly be usefully marked 'virtual' if that interface existed in the base class -- but it doesn't. I think it was simply a mistake to mark them as 'virtual' to begin with.
