### PR TITLE
[WIP] Make treatment of no-flow boundary conditions dependent on diffusivity

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1521,7 +1521,8 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/helper_functions.cc</code>.
        */
-      void replace_outflow_boundary_ids(const unsigned int boundary_id_offset);
+      void replace_outflow_boundary_ids(const unsigned int boundary_id_offset,
+                                        const bool replace_noflow_boundary_ids);
 
       /**
        * Undo the offset of the boundary ids done in replace_outflow_boundary_ids

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -677,7 +677,7 @@ namespace aspect
     // so we want to offset them by 128 and not allow more than 128 boundary ids.
     const unsigned int boundary_id_offset = 128;
     if (!boundary_temperature_manager.allows_fixed_temperature_on_outflow_boundaries())
-      replace_outflow_boundary_ids(boundary_id_offset);
+      replace_outflow_boundary_ids(boundary_id_offset, /*replace_noflow_boundary_ids=*/ false);
 
     // if using continuous temperature FE, do the same for the temperature variable:
     // evaluate the current boundary temperature and add these constraints as well
@@ -716,7 +716,7 @@ namespace aspect
     // use the same trick for marking up outflow boundary conditions for compositional fields
     // as we did above already for the temperature.
     if (!boundary_composition_manager.allows_fixed_composition_on_outflow_boundaries())
-      replace_outflow_boundary_ids(boundary_id_offset);
+      replace_outflow_boundary_ids(boundary_id_offset, /*replace_noflow_boundary_ids=*/ true);
 
     // now do the same for the composition variable:
     if (!parameters.use_discontinuous_composition_discretization)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2102,7 +2102,8 @@ namespace aspect
 
   template <int dim>
   void
-  Simulator<dim>::replace_outflow_boundary_ids(const unsigned int offset)
+  Simulator<dim>::replace_outflow_boundary_ids(const unsigned int offset,
+                                               const bool replace_noflow_boundary_ids)
   {
     const Quadrature<dim-1> &quadrature_formula = introspection.face_quadratures.temperature;
 
@@ -2146,7 +2147,8 @@ namespace aspect
 
                 // ... and change the boundary id of any outflow boundary faces.
                 // If there is no flow, we do not want to apply dirichlet boundary conditions either.
-                if (integrated_flow >= 0)
+                if ((integrated_flow > 0) ||
+                 (integrated_flow == 0 && replace_noflow_boundary_ids == true))
                   face->set_boundary_id(face->boundary_id() + offset);
               }
           }
@@ -2516,7 +2518,8 @@ namespace aspect
   template void Simulator<dim>::compute_reactions(); \
   template void Simulator<dim>::interpolate_material_output_into_advection_field(const AdvectionField &adv_field); \
   template void Simulator<dim>::check_consistency_of_formulation(); \
-  template void Simulator<dim>::replace_outflow_boundary_ids(const unsigned int boundary_id_offset); \
+  template void Simulator<dim>::replace_outflow_boundary_ids(const unsigned int boundary_id_offset, \
+                                                             const bool replace_noflow_boundary_ids); \
   template void Simulator<dim>::restore_outflow_boundary_ids(const unsigned int boundary_id_offset); \
   template void Simulator<dim>::check_consistency_of_boundary_conditions() const; \
   template double Simulator<dim>::compute_initial_newton_residual(const LinearAlgebra::BlockVector &linearized_stokes_initial_guess); \


### PR DESCRIPTION
I have a setup where I do not want to prescribe temperatures at outflow boundaries (even though theoretically possible), but do want to prescribe them at a boundary with a prescribed velocity. In the current implementation this is impossible, because as soon as I select to replace boundary ids at outflow boundaries, the no-flow boundaries are considered outflow as well (this was changed in #5043). I think we need a more careful consideration of these cases. I mark this WIP, because I want to look more into making this more flexible (e.g. what if someone wants to use a diffusive compositional field, in that case they still have this problem even with this PR). Probably we need a separate parameter in the boundary temperature / boundary composition manager that determines what to do with no-flow boundaries.
