### PR TITLE
Add NETCDF_DIR variable to tester image

### DIFF
--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -29,6 +29,7 @@ RUN cd /opt && \
 # by Github Actions
 ENV PATH="/opt/astyle-2.04:/opt/cmake-3.20.5-linux-x86_64/bin:$PATH"
 ENV DEAL_II_DIR /opt/deal.II-master
+ENV NETCDF_DIR /opt/netcdf-4.7.4
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 ENV OMPI_MCA_mpi_yield_when_idle=1
 ENV OMPI_MCA_rmaps_base_oversubscribe=1
@@ -39,6 +40,7 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 # are build by Jenkins
 ONBUILD ENV PATH="/opt/astyle-2.04:/opt/cmake-3.20.5-linux-x86_64/bin:$PATH"
 ONBUILD ENV DEAL_II_DIR /opt/deal.II-master
+ONBUILD ENV NETCDF_DIR /opt/netcdf-4.7.4
 ONBUILD ENV OMPI_MCA_btl_base_warn_component_unused=0
 ONBUILD ENV OMPI_MCA_mpi_yield_when_idle=1
 ONBUILD ENV OMPI_MCA_rmaps_base_oversubscribe=1


### PR DESCRIPTION
Supports #5484.
Deal.II 9.4 and 9.5 images are already updated. Once this is merged the development image should be rebuild over night.