### PR TITLE
Fix tester artifact upload

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,7 +168,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.result-file }}
-        path: build/${{ matrix.result-file }}}
+        path: build/${{ matrix.result-file }}
     - name: check test results
       run: |
         if [ -f build/test_run_failed ] || [ -s build/${{ matrix.result-file}} ]; then


### PR DESCRIPTION
For a while the github actions tester has not uploaded artifacts of the build to its webpage. I think this might be the reason. Let's see if this fixes it.