### PR TITLE
Fix for git incompatibility

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,6 +163,9 @@ jobs:
       run: |
         cd build
         ninja generate_reference_output
+        # TODO: temporary fix for a git incompability.
+        # Can likely be removed when the tester image runs on Ubuntu 22.04
+        /usr/bin/git config --system --add safe.directory /__w/aspect/aspect
         git diff ../tests > ${{ matrix.result-file }}
     - name: archive test results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
#5496 fixed one of the issues with the artifact upload from github actions, however there is a second one. There is a incompatibility between the git versions on the actions runner, and inside our test container that leads to error messages if we try to diff the test results with the reference results (see https://github.com/geodynamics/aspect/actions/runs/6893928842/job/18754607549?pr=5498#step:7:16).

This is an attempt to fix this.