### PR TITLE
Avoid the use of raw pointers. Use std::unique_ptr instead.

### DIFF
--- a/doc/modules/changes/20231128_bangerth
+++ b/doc/modules/changes/20231128_bangerth
@@ -1,0 +1,9 @@
+Changed: The interface
+Postprocess::VisualizationPostprocessors::CellDataVectorCreator::execute()
+used to return an object of type
+`std::pair<std::string, Vector<float>*>` where the second part is just a
+raw pointer. This has been changed (incompatibly) to
+`std::pair<std::string, std::unique_ptr<Vector<float>>>` to avoid the use
+of raw pointers and ensure that memory de-allocation happens automatically.
+<br>
+(Wolfgang Bangerth, 2023/11/28)

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -315,7 +315,7 @@ namespace aspect
            * to.
            */
           virtual
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const = 0;
       };
 

--- a/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
+++ b/include/aspect/postprocess/visualization/ISA_rotation_timescale.h
@@ -61,7 +61,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute() const override;
 
       };

--- a/include/aspect/postprocess/visualization/artificial_viscosity.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity.h
@@ -50,7 +50,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
       };
     }

--- a/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
+++ b/include/aspect/postprocess/visualization/artificial_viscosity_composition.h
@@ -50,7 +50,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
 
           /**

--- a/include/aspect/postprocess/visualization/boundary_indicator.h
+++ b/include/aspect/postprocess/visualization/boundary_indicator.h
@@ -54,7 +54,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
 
       };

--- a/include/aspect/postprocess/visualization/error_indicator.h
+++ b/include/aspect/postprocess/visualization/error_indicator.h
@@ -49,7 +49,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
       };
     }

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -68,7 +68,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute() const override;
 
       };

--- a/include/aspect/postprocess/visualization/particle_count.h
+++ b/include/aspect/postprocess/visualization/particle_count.h
@@ -54,7 +54,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
 
           /**

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -51,7 +51,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
 
           /**
@@ -111,7 +111,7 @@ namespace aspect
           /**
            * @copydoc CellDataVectorCreator<dim>::execute()
            */
-          std::pair<std::string, Vector<float> *>
+          std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute () const override;
 
           /**

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -871,7 +871,7 @@ namespace aspect
                          (& *p))
                 {
                   // get the data produced here
-                  const std::pair<std::string, Vector<float> *>
+                  std::pair<std::string, std::unique_ptr<Vector<float>>>
                   cell_data = cell_data_creator->execute();
                   Assert (cell_data.second->size() ==
                           this->get_triangulation().n_active_cells(),
@@ -884,16 +884,15 @@ namespace aspect
                                                      visualization_field_names_and_units);
 
                   // store the pointer, then attach the vector to the DataOut object
-                  cell_data_vectors.push_back (std::unique_ptr<Vector<float>>
-                                               (cell_data.second));
+                  cell_data_vectors.push_back (std::move(cell_data.second));
 
                   if (dynamic_cast<const VisualizationPostprocessors::SurfaceOnlyVisualization<dim>*>
                       (& *p) == nullptr)
-                    data_out.add_data_vector (*cell_data.second,
+                    data_out.add_data_vector (*cell_data_vectors.back(),
                                               cell_data.first,
                                               DataOut<dim>::type_cell_data);
                   else
-                    data_out_faces.add_data_vector (*cell_data.second,
+                    data_out_faces.add_data_vector (*cell_data_vectors.back(),
                                                     cell_data.first,
                                                     DataOutFaces<dim>::type_cell_data);
                 }

--- a/source/postprocess/visualization/ISA_rotation_timescale.cc
+++ b/source/postprocess/visualization/ISA_rotation_timescale.cc
@@ -43,11 +43,11 @@ namespace aspect
 
 
       template<int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       ISARotationTimescale<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *> return_value("ISA_rotation_timescale",
-                                                             new Vector<float>(this->get_triangulation().n_active_cells()));
+        std::pair<std::string, std::unique_ptr<Vector<float>>> return_value("ISA_rotation_timescale",
+                                                                              std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         const QMidpoint<dim> quadrature_formula;
         const unsigned int n_q_points = quadrature_formula.size();

--- a/source/postprocess/visualization/artificial_viscosity.cc
+++ b/source/postprocess/visualization/artificial_viscosity.cc
@@ -38,12 +38,12 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       ArtificialViscosity<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("artificial_viscosity",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
         this->get_artificial_viscosity(*return_value.second);
 
         // The function we call above sets the artificial viscosity to

--- a/source/postprocess/visualization/artificial_viscosity_composition.cc
+++ b/source/postprocess/visualization/artificial_viscosity_composition.cc
@@ -36,16 +36,16 @@ namespace aspect
       {}
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       ArtificialViscosityComposition<dim>::execute() const
       {
         Assert(this->n_compositional_fields()>0,
                ExcMessage ("The artificial viscosity for compositional fields can "
                            "only be calculated if compositional fields are used in the simulation."));
 
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("artificial_viscosity_composition",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
         this->get_artificial_viscosity_composition(*return_value.second, compositional_field);
 
         // The function we call above sets the artificial viscosity to

--- a/source/postprocess/visualization/boundary_indicator.cc
+++ b/source/postprocess/visualization/boundary_indicator.cc
@@ -40,12 +40,12 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       BoundaryIndicator<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("boundary_indicator",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         // retrieve the largest used boundary indicator and add one.
         // this value will be set for internal cells

--- a/source/postprocess/visualization/error_indicator.cc
+++ b/source/postprocess/visualization/error_indicator.cc
@@ -38,12 +38,12 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       ErrorIndicator<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("error_indicator",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
         this->get_refinement_criteria(*return_value.second);
 
         return return_value;

--- a/source/postprocess/visualization/grain_lag_angle.cc
+++ b/source/postprocess/visualization/grain_lag_angle.cc
@@ -43,11 +43,11 @@ namespace aspect
 
 
       template<int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       GrainLagAngle<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *> return_value("grain_lag_angle",
-                                                             new Vector<float>(this->get_triangulation().n_active_cells()));
+        std::pair<std::string, std::unique_ptr<Vector<float>>> return_value("grain_lag_angle",
+                                                                              std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         const QMidpoint<dim> quadrature_formula;
         const unsigned int n_q_points = quadrature_formula.size(); // this is 1 for QMidpoint

--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -42,7 +42,7 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       ParticleCount<dim>::execute() const
       {
         const Postprocess::Particles<dim> &particle_postprocessor =
@@ -51,9 +51,9 @@ namespace aspect
         const Particle::ParticleHandler<dim> &particle_handler =
           particle_postprocessor.get_particle_world().get_particle_handler();
 
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("particles_per_cell",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         // loop over all of the cells and count particles in them
         for (const auto &cell : this->get_dof_handler().active_cell_iterators())

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -43,12 +43,12 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       SeismicVsAnomaly<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("Vs_anomaly",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         // Calculate the maximum depth of the domain
         const double max_depth = this->get_geometry_model().maximal_depth();
@@ -187,12 +187,12 @@ namespace aspect
 
 
       template <int dim>
-      std::pair<std::string, Vector<float> *>
+      std::pair<std::string, std::unique_ptr<Vector<float>>>
       SeismicVpAnomaly<dim>::execute() const
       {
-        std::pair<std::string, Vector<float> *>
+        std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("Vp_anomaly",
-                      new Vector<float>(this->get_triangulation().n_active_cells()));
+                      std::make_unique<Vector<float>>(this->get_triangulation().n_active_cells()));
 
         // Calculate the maximum depth of the domain
         const double max_depth = this->get_geometry_model().maximal_depth();


### PR DESCRIPTION
Inspired by #5488, these are the only places I could find where we still call `operator new` explicitly. This is, strictly speaking, an incompatible change because it changes the interface of a plugin system. Thoughts?