### PR TITLE
[WIP] interpolate into non-ghosted vector to avoid assert

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1482,21 +1482,21 @@ namespace aspect
 
       MGLevelObject<dealii::LinearAlgebra::distributed::Vector<double>> distributed_level_displacements;
       distributed_level_displacements.resize(0, n_levels-1);
-          for (unsigned int level = 0; level < n_levels; ++level)
-            {
-              distributed_level_displacements[level].reinit(mesh_deformation_dof_handler.locally_owned_mg_dofs(level),
-                                                sim.mpi_communicator);
-            }
+      for (unsigned int level = 0; level < n_levels; ++level)
+        {
+          distributed_level_displacements[level].reinit(mesh_deformation_dof_handler.locally_owned_mg_dofs(level),
+                                                        sim.mpi_communicator);
+        }
 
       mg_transfer.interpolate_to_mg(mesh_deformation_dof_handler,
                                     distributed_level_displacements,
                                     displacements);
 
       for (unsigned int level = 0; level < n_levels; ++level)
-      {
-        level_displacements[level] = distributed_level_displacements[level];
-        level_displacements[level].update_ghost_values();
-      }
+        {
+          level_displacements[level] = distributed_level_displacements[level];
+          level_displacements[level].update_ghost_values();
+        }
 
     }
 


### PR DESCRIPTION
This avoids an assert triggered if we use the current main branch of ASPECT with the experimental deal.II version of dealii/dealii#16301. I have not looked deeper into the question if our current handling (handing over a ghosted vector to `interpolate_to_mg`) is correct or not, this is simply a crude fix to circumvent the assert. There are probably better or more efficient ways to do this.

Happy to hear opinions.