### PR TITLE
Remove an unused function from two geometry models.

### DIFF
--- a/doc/modules/changes/20231207_bangerth
+++ b/doc/modules/changes/20231207_bangerth
@@ -1,0 +1,6 @@
+Removed: The GeometryModel::Chunk and GeometryModel::TwoMergedChunks
+classes had member functions `depth_wrt_topo()`, but these were not
+used anywhere and did not work with the mesh deformation
+framework. They have consequently been removed.
+<br>
+(Wolfgang Bangerth, 2023/12/07)

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -278,21 +278,6 @@ namespace aspect
         Point<dim> representative_point(const double depth) const override;
 
         /**
-         * Whereas the depth function returns the depth with respect
-         * to the unperturbed surface, this function
-         * returns the depth with respect to the surface
-         * including the initial topography. For models without
-         * initial topography, the result will be the same.
-         *
-         * Note that the perturbed surface only considers the
-         * initially prescribed topography, not any perturbations
-         * due to a displacement of the free surface. Therefore,
-         * be careful with using this function if the surface changes
-         * over time.
-         */
-        double depth_wrt_topo(const Point<dim> &position) const;
-
-        /**
          * Return the longitude at the western edge of the chunk measured in
          * radians.
          */

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -143,21 +143,6 @@ namespace aspect
         Point<dim> representative_point(const double depth) const override;
 
         /**
-         * Whereas the depth function returns the depth with respect
-         * to the unperturbed surface, this function
-         * returns the depth with respect to the surface
-         * including the initial topography. For models without
-         * initial topography, the result will be the same.
-         *
-         * Note that the perturbed surface only considers the
-         * initially prescribed topography, not any perturbations
-         * due to a displacement of the free surface. Therefore,
-         * be careful with using this function if the surface changes
-         * over time.
-         */
-        double depth_wrt_topo(const Point<dim> &position) const;
-
-        /**
          * Return the longitude at the western edge of the chunk measured in
          * radians.
          */

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -553,20 +553,6 @@ namespace aspect
 
     template <int dim>
     double
-    Chunk<dim>::depth_wrt_topo(const Point<dim> &position) const
-    {
-      // depth is defined wrt the reference surface point2[0] + the topography
-      // depth is therefore always positive
-      const double outer_radius = manifold->get_radius(position);
-      const Point<dim> rtopo_phi_theta = manifold->pull_back_sphere(position);
-      Assert (rtopo_phi_theta[0] <= outer_radius, ExcMessage("The radius is bigger than the maximum radius."));
-      return std::max(0.0, outer_radius - rtopo_phi_theta[0]);
-    }
-
-
-
-    template <int dim>
-    double
     Chunk<dim>::height_above_reference_surface(const Point<dim> &position) const
     {
       return position.norm()-point2[0];

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -257,20 +257,6 @@ namespace aspect
 
     template <int dim>
     double
-    TwoMergedChunks<dim>::depth_wrt_topo(const Point<dim> &position) const
-    {
-      // depth is defined wrt the reference surface point2[0] + the topography
-      // depth is therefore always positive
-      const double outer_radius = manifold->get_radius(position);
-      const Point<dim> rtopo_phi_theta = manifold->pull_back_sphere(position);
-      Assert (rtopo_phi_theta[0] <= outer_radius, ExcMessage("The radius is bigger than the maximum radius."));
-      return std::max(0.0, outer_radius - rtopo_phi_theta[0]);
-    }
-
-
-
-    template <int dim>
-    double
     TwoMergedChunks<dim>::height_above_reference_surface(const Point<dim> &position) const
     {
       return position.norm()-point2[0];


### PR DESCRIPTION
In working on #5421, I'm looking at the way the existing geometry models with topography access the manifold. In doing so, I came across the fact that the `Chunk` and `TwoMergedChunks` models have a member function `depth_wrt_topo()`, which seems to be a useful question to ask -- but these functions are not used anywhere and we've generally found that (i) functions that are not used or tested accumulate bugs over time, (ii) if they exist in one model, someone might expect them to exist in other models as well where they may be much more difficult to implement.

For these reasons, this patch simply removes this function from the two models in question.