### PR TITLE
Sort the order of base classes.

### DIFF
--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -39,7 +39,9 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class LatentHeatMelt : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class LatentHeatMelt : public MaterialModel::Interface<dim>,
+      public MaterialModel::MeltFractionModel<dim>,
+      public ::aspect::SimulatorAccess<dim>
     {
       public:
         /**

--- a/include/aspect/material_model/melt_boukare.h
+++ b/include/aspect/material_model/melt_boukare.h
@@ -65,7 +65,9 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltBoukare : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltBoukare : public MaterialModel::MeltInterface<dim>,
+      public MaterialModel::MeltFractionModel<dim>,
+      public ::aspect::SimulatorAccess<dim>
     {
       public:
         /**

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -44,7 +44,9 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltGlobal : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltGlobal : public MaterialModel::MeltInterface<dim>,
+      public MaterialModel::MeltFractionModel<dim>,
+      public ::aspect::SimulatorAccess<dim>
     {
       public:
         /**

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -52,7 +52,9 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class MeltSimple : public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>, public MaterialModel::MeltFractionModel<dim>
+    class MeltSimple : public MaterialModel::MeltInterface<dim>,
+      public MaterialModel::MeltFractionModel<dim>,
+      public ::aspect::SimulatorAccess<dim>
     {
       public:
         /**

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -129,11 +129,24 @@ namespace aspect
     /**
      * Base class for material models that implement a melt fraction function.
      * This is used to compute some statistics about the melt fraction.
+     *
+     * This class is used as a "mix-in" class: Concrete material models will
+     * be derived from MaterialModel::Interface (and consequently have to
+     * implement the `virtual` functions of that class) *and also* from the
+     * current class (and consequently have to implement the `virtual` function
+     * of the current class). The inheritance from MaterialModel::Interface is
+     * typically via the MaterialModel::MeltInterface intermediate class.
      */
     template <int dim>
     class MeltFractionModel
     {
       public:
+        /**
+         * Destructor. Does nothing but is virtual so that derived classes
+         * destructors are also virtual.
+         */
+        virtual ~MeltFractionModel () = default;
+
         /**
          * Compute the equilibrium melt fractions for the given input conditions.
          * @p in and @p melt_fractions need to have the same size.
@@ -145,11 +158,6 @@ namespace aspect
         virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                      std::vector<double> &melt_fractions) const = 0;
 
-        /**
-         * Destructor. Does nothing but is virtual so that derived classes
-         * destructors are also virtual.
-         */
-        virtual ~MeltFractionModel () = default;
     };
 
     /**


### PR DESCRIPTION
I tend to read the list of base classes of a class as from most to least important -- perhaps that's just me, but I was surprised to find cases where we have `SimulatorAccess` in the middle of two material model-related base classes of the melt models.

So sort things. While there, also document the `MeltFractionModel` class a bit better.