### PR TITLE
Avoid the use of plugin_type_matches() where not appropriate.

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -158,7 +158,55 @@ namespace aspect
         virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                      std::vector<double> &melt_fractions) const = 0;
 
+        /**
+         * Return whether an object provided as argument is of a class that is
+         * derived from the current MeltFractionModel class. (Many of these models
+         * will be derived from MaterialModel::Interface and *also* be derived
+         * from MeltFractionModel; only the latter derivation is of interest to
+         * this function.
+         */
+        template <typename ModelType>
+        static
+        bool is_melt_fraction_model (const ModelType &model_object);
+
+        /**
+         * Return a reference to the MeltFractionModel base class of
+         * the object. This function will throw an exception unless
+         * is_melt_fraction_model() returns `true` for the given argument.
+         */
+        template <typename ModelType>
+        static
+        const MeltFractionModel<dim> &
+        as_melt_fraction_model (const ModelType &model_object);
     };
+
+
+
+    template <int dim>
+    template <typename ModelType>
+    inline
+    bool
+    MeltFractionModel<dim>::is_melt_fraction_model (const ModelType &model_object)
+    {
+      return (dynamic_cast<const MeltFractionModel<dim>*>(&model_object)
+              != nullptr);
+    }
+
+
+    template <int dim>
+    template <typename ModelType>
+    inline
+    const MeltFractionModel<dim> &
+    MeltFractionModel<dim>::as_melt_fraction_model (const ModelType &model_object)
+    {
+      Assert (is_melt_fraction_model(model_object) == true,
+              ExcMessage ("This function can only be called for model objects "
+                          "whose types are derived from MeltFractionModel."));
+
+      return dynamic_cast<const MeltFractionModel<dim>&>(model_object);
+    }
+
+
 
     /**
      * Base class for material models to be used with melt transport enabled.

--- a/source/initial_composition/porosity.cc
+++ b/source/initial_composition/porosity.cc
@@ -58,8 +58,7 @@ namespace aspect
                              "compositional field called `porosity' to initialize. Please add a "
                              "compositional field with this name."));
 
-      AssertThrow(Plugins::plugin_type_matches
-                  <const MaterialModel::MeltFractionModel<dim>>(this->get_material_model()),
+      AssertThrow(MaterialModel::MeltFractionModel<dim>::is_melt_fraction_model(this->get_material_model()),
                   ExcMessage("The used material model is not derived from the 'MeltFractionModel' class, "
                              "and therefore does not support computing equilibrium melt fractions. "
                              "This is incompatible with the `porosity' "
@@ -88,8 +87,9 @@ namespace aspect
 
           std::vector<double> melt_fraction(1);
 
-          Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>>
-          (this->get_material_model()).melt_fractions(in,melt_fraction);
+          MaterialModel::MeltFractionModel<dim>::as_melt_fraction_model(this->get_material_model())
+          .melt_fractions(in, melt_fraction);
+
           return melt_fraction[0];
         }
       return 0.0;

--- a/source/postprocess/melt_statistics.cc
+++ b/source/postprocess/melt_statistics.cc
@@ -70,9 +70,9 @@ namespace aspect
             // in the simulation has implemented them
             // otherwise, set them to zero
             std::vector<double> melt_fractions(n_q_points, 0.0);
-            if (Plugins::plugin_type_matches<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()))
-              Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>>(this->get_material_model()).melt_fractions(in,
-                  melt_fractions);
+            if (MaterialModel::MeltFractionModel<dim>::is_melt_fraction_model(this->get_material_model()))
+              MaterialModel::MeltFractionModel<dim>::as_melt_fraction_model(this->get_material_model())
+              .melt_fractions(in, melt_fractions);
 
             for (unsigned int q=0; q<n_q_points; ++q)
               {

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -147,12 +147,11 @@ namespace aspect
         std::vector<double> melt_fractions(n_quadrature_points);
         if (std::find(property_names.begin(), property_names.end(), "melt fraction") != property_names.end())
           {
-            AssertThrow(Plugins::plugin_type_matches<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()),
+            AssertThrow(MaterialModel::MeltFractionModel<dim>::is_melt_fraction_model(this->get_material_model()),
                         ExcMessage("You are trying to visualize the melt fraction, but the material"
                                    "model you use does not actually compute a melt fraction."));
-
-            Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()).
-            melt_fractions(in, melt_fractions);
+            MaterialModel::MeltFractionModel<dim>::as_melt_fraction_model(this->get_material_model())
+            .melt_fractions(in, melt_fractions);
           }
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -54,7 +54,7 @@ namespace aspect
         Assert (input_data.solution_values[0].size() == this->introspection().n_components,           ExcInternalError());
 
         // in case the material model computes the melt fraction itself, we use that output
-        if (Plugins::plugin_type_matches<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model()))
+        if (MaterialModel::MeltFractionModel<dim>::is_melt_fraction_model(this->get_material_model()))
           {
             MaterialModel::MaterialModelInputs<dim> in(input_data,
                                                        this->introspection());
@@ -64,11 +64,9 @@ namespace aspect
             // Compute the melt fraction...
             this->get_material_model().evaluate(in, out);
 
-            const MaterialModel::MeltFractionModel<dim> &melt_material_model =
-              Plugins::get_plugin_as_type<const MaterialModel::MeltFractionModel<dim>> (this->get_material_model());
-
             std::vector<double> melt_fractions(n_quadrature_points);
-            melt_material_model.melt_fractions(in, melt_fractions);
+            MaterialModel::MeltFractionModel<dim>::as_melt_fraction_model(this->get_material_model())
+            .melt_fractions(in, melt_fractions);
 
             for (unsigned int q=0; q<n_quadrature_points; ++q)
               computed_quantities[q](0) = melt_fractions[q];


### PR DESCRIPTION
`plugin_type_matches()` is intended to check whether a concrete plugin object (provided via a reference to an `Interface<dim>` base class) is in fact of a specific type `TestType`. But we have a few places where we are using this function to check whether a concrete plugin object is in fact *also* derived from a class that is not part of the `Interface<dim>` hierarchy -- i.e., a second base class. This is not what `plugin_type_matches()` was meant to do, and that I would like to rule out in a follow-up patch.

The only place where we so abuse `plugin_type_matches()` is in the melt sub-system. This patch uses the better suited `dynamic_cast` approach (which is internally used in `plugin_type_matches()`) to encode the test we really want.