### PR TITLE
Fix tester warning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,10 +162,10 @@ jobs:
       continue-on-error: true
       run: |
         cd build
-        ninja generate_reference_output
         # TODO: temporary fix for a git incompability.
         # Can likely be removed when the tester image runs on Ubuntu 22.04
         /usr/bin/git config --system --add safe.directory /__w/aspect/aspect
+        ninja generate_reference_output
         git diff ../tests > ${{ matrix.result-file }}
     - name: archive test results
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
This is a follow-up to #5499, after Wolfgang observed in #5512 that we still get warnings. I didnt notice before that the `generate_reference_output` target already calls git commands. The temporary git config change has to happen, before we can execute any git commands inside the tester container.