### PR TITLE
Use the deepest initial lithostatic pressure on the bottom traction boundary

### DIFF
--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -107,10 +107,17 @@ namespace aspect
         double interpolate_pressure (const Point<dim> &p) const;
 
         /**
-         * A list of those boundary indicators that are prescribed
-         * the initial lithostatic pressure computed by this plugin.
+         * The id of the bottom boundary.
          */
-        std::set<types::boundary_id> traction_bi;
+        types::boundary_id bottom_boundary_id;
+
+        /**
+         * Whether or not initial lithostatic pressure is prescribed
+         * on the bottom boundary only and initial topography is included,
+         * and therefore the deepest pressure in the lithostatic pressure 
+         * profile is returned.
+         */
+        bool prescribe_constant_pressure_at_bottom_boundary = false;
     };
   }
 }

--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -114,7 +114,7 @@ namespace aspect
         /**
          * Whether or not initial lithostatic pressure is prescribed
          * on the bottom boundary only and initial topography is included,
-         * and therefore the deepest pressure in the lithostatic pressure 
+         * and therefore the deepest pressure in the lithostatic pressure
          * profile is returned.
          */
         bool prescribe_constant_pressure_at_bottom_boundary = false;

--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -105,6 +105,12 @@ namespace aspect
          * based on depth interpolation between computed pressure values.
          */
         double interpolate_pressure (const Point<dim> &p) const;
+
+        /**
+         * A list of those boundary indicators that are prescribed
+         * the initial lithostatic pressure computed by this plugin.
+         */
+        std::set<types::boundary_id> traction_bi;
     };
   }
 }

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -279,12 +279,16 @@ namespace aspect
       // to the lithostatic pressure, the rest of the traction
       // components are left set to zero. We get the lithostatic pressure
       // from a linear interpolation of the calculated profile,
-      // unless boundary traction is only applied to the bottom boundary.
+      // unless boundary traction is only applied to the bottom boundary
+      // and initial topography is included.
       // In that case we return the deepest pressure of the pressure
-      // profile directly.
+      // profile directly. Otherwise, points on the bottom boundary
+      // with horizontal coordinates other than the reference point
+      // will not have a depth equal to the deepest depth of the profile.
       const types::boundary_id bottom_bi = this->get_geometry_model().translate_symbolic_boundary_name_to_id("bottom");
       Tensor<1, dim> traction;
-      if (boundary_indicator == bottom_bi &&
+      if (!Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()) &&
+          boundary_indicator == bottom_bi &&
           traction_bi.size() == 1 &&
           *traction_bi.begin() == bottom_bi)
         traction = -pressure.back() * normal_vector;


### PR DESCRIPTION
This is a follow-up to #5089. If traction is prescribed on the bottom boundary, we want it to be the same traction all along the boundary according to the deepest pressure calculated at the reference horizontal coordinates. However, when variable initial topography is applied, points whose horizontal coordinates do not coincide with reference point will have a depth that does not equal the deepest depth of the pressure profile. Therefore, with this PR, if non-zero initial topography is applied, and if the bottom boundary is the only boundary with prescribed initial lithostatic pressure tractions, then we directly return the deepest pressure instead of looking up the current point's depth within the pressure profile.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
