### PR TITLE
Restrict the types accepted by has_matching_*() and get_matching_*().

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -222,8 +222,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryCompositionType>
+        template <typename BoundaryCompositionType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryCompositionType>::value>>
         bool
         has_matching_boundary_composition_model () const;
 
@@ -234,8 +238,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no boundary composition model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryCompositionType>
+        template <typename BoundaryCompositionType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryCompositionType>::value>>
         const BoundaryCompositionType &
         get_matching_boundary_composition_model () const;
 
@@ -312,7 +320,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryCompositionType>
+    template <typename BoundaryCompositionType, typename>
     inline
     bool
     Manager<dim>::has_matching_boundary_composition_model () const
@@ -327,7 +335,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryCompositionType>
+    template <typename BoundaryCompositionType, typename>
     inline
     const BoundaryCompositionType &
     Manager<dim>::get_matching_boundary_composition_model () const

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -256,8 +256,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryTemperatureType>
+        template <typename BoundaryTemperatureType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryTemperatureType>::value>>
         bool
         has_matching_boundary_temperature_model () const;
 
@@ -268,8 +272,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no boundary temperature model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryTemperatureType>
+        template <typename BoundaryTemperatureType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryTemperatureType>::value>>
         const BoundaryTemperatureType &
         get_matching_boundary_temperature_model () const;
 
@@ -346,7 +354,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryTemperatureType>
+    template <typename BoundaryTemperatureType, typename>
     inline
     bool
     Manager<dim>::has_matching_boundary_temperature_model () const
@@ -359,7 +367,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryTemperatureType>
+    template <typename BoundaryTemperatureType, typename>
     inline
     const BoundaryTemperatureType &
     Manager<dim>::get_matching_boundary_temperature_model () const

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -247,8 +247,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryVelocityType>
+        template <typename BoundaryVelocityType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryVelocityType>::value>>
         bool
         has_matching_boundary_velocity_model () const;
 
@@ -259,8 +263,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no boundary velocity model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename BoundaryVelocityType>
+        template <typename BoundaryVelocityType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,BoundaryVelocityType>::value>>
         const BoundaryVelocityType &
         get_matching_boundary_velocity_model () const;
 
@@ -319,7 +327,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryVelocityType>
+    template <typename BoundaryVelocityType, typename>
     inline
     bool
     Manager<dim>::has_matching_boundary_velocity_model () const
@@ -333,7 +341,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename BoundaryVelocityType>
+    template <typename BoundaryVelocityType, typename>
     inline
     const BoundaryVelocityType &
     Manager<dim>::get_matching_boundary_velocity_model () const

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -335,8 +335,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename HeatingModelType>
+        template <typename HeatingModelType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,HeatingModelType>::value>>
         bool
         has_matching_heating_model () const;
 
@@ -347,8 +351,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no heating model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename HeatingModelType>
+        template <typename HeatingModelType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,HeatingModelType>::value>>
         const HeatingModelType &
         get_matching_heating_model () const;
 
@@ -391,7 +399,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename HeatingModelType>
+    template <typename HeatingModelType, typename>
     inline
     bool
     Manager<dim>::has_matching_heating_model () const
@@ -404,7 +412,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename HeatingModelType>
+    template <typename HeatingModelType, typename>
     inline
     const HeatingModelType &
     Manager<dim>::get_matching_heating_model () const

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -187,8 +187,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename InitialCompositionType>
+        template <typename InitialCompositionType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,InitialCompositionType>::value>>
         bool
         has_matching_initial_composition_model () const;
 
@@ -199,8 +203,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no initial composition model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename InitialCompositionType>
+        template <typename InitialCompositionType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,InitialCompositionType>::value>>
         const InitialCompositionType &
         get_matching_initial_composition_model () const;
 
@@ -250,7 +258,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename InitialCompositionType>
+    template <typename InitialCompositionType, typename>
     inline
     bool
     Manager<dim>::has_matching_initial_composition_model () const
@@ -263,7 +271,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename InitialCompositionType>
+    template <typename InitialCompositionType, typename>
     inline
     const InitialCompositionType &
     Manager<dim>::get_matching_initial_composition_model () const

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -184,8 +184,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename InitialTemperatureType>
+        template <typename InitialTemperatureType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,InitialTemperatureType>::value>>
         bool
         has_matching_initial_temperature_model () const;
 
@@ -196,8 +200,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no initial temperature model is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename InitialTemperatureType>
+        template <typename InitialTemperatureType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,InitialTemperatureType>::value>>
         const InitialTemperatureType &
         get_matching_initial_temperature_model () const;
 
@@ -248,7 +256,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename InitialTemperatureType>
+    template <typename InitialTemperatureType, typename>
     inline
     bool
     Manager<dim>::has_matching_initial_temperature_model () const
@@ -261,7 +269,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename InitialTemperatureType>
+    template <typename InitialTemperatureType, typename>
     inline
     const InitialTemperatureType &
     Manager<dim>::get_matching_initial_temperature_model () const

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -338,8 +338,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename MeshDeformationType>
+        template <typename MeshDeformationType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,MeshDeformationType>::value>>
         bool
         has_matching_mesh_deformation_object () const;
 
@@ -350,8 +354,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no mesh deformation object is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename MeshDeformationType>
+        template <typename MeshDeformationType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,MeshDeformationType>::value>>
         const MeshDeformationType &
         get_matching_mesh_deformation_object () const;
 
@@ -611,7 +619,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename MeshDeformationType>
+    template <typename MeshDeformationType, typename>
     inline
     bool
     MeshDeformationHandler<dim>::has_matching_mesh_deformation_object () const
@@ -627,7 +635,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename MeshDeformationType>
+    template <typename MeshDeformationType, typename>
     inline
     const MeshDeformationType &
     MeshDeformationHandler<dim>::get_matching_mesh_deformation_object () const

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -226,8 +226,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename MeshRefinementType>
+        template <typename MeshRefinementType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,MeshRefinementType>::value>>
         bool
         has_matching_mesh_refinement_strategy () const;
 
@@ -238,8 +242,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no mesh refinement strategy is active that matches the
          * given type, throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename MeshRefinementType>
+        template <typename MeshRefinementType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,MeshRefinementType>::value>>
         const MeshRefinementType &
         get_matching_mesh_refinement_strategy () const;
 
@@ -323,7 +331,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename MeshRefinementType>
+    template <typename MeshRefinementType, typename>
     inline
     bool
     Manager<dim>::has_matching_mesh_refinement_strategy () const
@@ -340,7 +348,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename MeshRefinementType>
+    template <typename MeshRefinementType, typename>
     inline
     const MeshRefinementType &
     Manager<dim>::get_matching_mesh_refinement_strategy () const

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -656,9 +656,12 @@ namespace aspect
            * in the input file (and are consequently currently active) and return
            * true if one of them has the desired type specified by the template
            * argument.
+           *
+           * This function can only be called if the given template type (the first template
+           * argument) is a class derived from the Interface class in this namespace.
            */
-          template <typename ParticlePropertyType>
-          inline
+          template <typename ParticlePropertyType,
+                    typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,ParticlePropertyType>::value>>
           bool
           has_matching_property () const;
 
@@ -669,9 +672,12 @@ namespace aspect
            * argument or can be casted to that type. If so, return a reference
            * to it. If no property is active that matches the given type,
            * throw an exception.
+           *
+           * This function can only be called if the given template type (the first template
+           * argument) is a class derived from the Interface class in this namespace.
            */
-          template <typename ParticlePropertyType>
-          inline
+          template <typename ParticlePropertyType,
+                    typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,ParticlePropertyType>::value>>
           const ParticlePropertyType &
           get_matching_property () const;
 
@@ -793,7 +799,7 @@ namespace aspect
 
 
       template <int dim>
-      template <typename ParticlePropertyType>
+      template <typename ParticlePropertyType, typename>
       inline
       bool
       Manager<dim>::has_matching_property () const
@@ -807,7 +813,7 @@ namespace aspect
 
 
       template <int dim>
-      template <typename ParticlePropertyType>
+      template <typename ParticlePropertyType, typename>
       inline
       const ParticlePropertyType &
       Manager<dim>::get_matching_property () const

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -234,8 +234,12 @@ namespace aspect
          * in the input file (and are consequently currently active) and return
          * true if one of them has the desired type specified by the template
          * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename PostprocessorType>
+        template <typename PostprocessorType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,PostprocessorType>::value>>
         bool
         has_matching_postprocessor () const;
 
@@ -246,8 +250,12 @@ namespace aspect
          * argument or can be casted to that type. If so, return a reference
          * to it. If no postprocessor is active that matches the given type,
          * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
          */
-        template <typename PostprocessorType>
+        template <typename PostprocessorType,
+                  typename = typename std::enable_if_t<std::is_base_of<Interface<dim>,PostprocessorType>::value>>
         const PostprocessorType &
         get_matching_postprocessor () const;
 
@@ -376,7 +384,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename PostprocessorType>
+    template <typename PostprocessorType, typename>
     inline
     bool
     Manager<dim>::has_matching_postprocessor () const
@@ -391,7 +399,7 @@ namespace aspect
 
 
     template <int dim>
-    template <typename PostprocessorType>
+    template <typename PostprocessorType, typename>
     inline
     const PostprocessorType &
     Manager<dim>::get_matching_postprocessor () const


### PR DESCRIPTION
This is similar to #5522. We have a bunch of places where you can ask whether a plugin manager has a plugin of a specific type. This will always return `false` if the given type is not in the right class hierarchy (i.e., if it is not derived from `Interface<dim>` in this namespace) and likely represents a programming mistake. This patch only enables the function to be called if the given type is derived from `Interface<dim>`.

In the long run, all of these things will be better implemented by C++20 `requires` clauses. But we can't use that yet.