### PR TITLE
Only set face properties for advection assemblers when method is fem

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -192,7 +192,8 @@ namespace aspect
             assemblers->advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
           }
 
-        if (i > 0 && parameters.use_discontinuous_composition_discretization)
+        if (i > 0 && parameters.use_discontinuous_composition_discretization
+            && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field)
           {
             // TODO should these only be set when method is fem_field?
             assemblers->advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;


### PR DESCRIPTION
Follow-up to #5523 as suggested by @bangerth to test if something breaks when face properties for DG are only set when the FE method is specified for a compositional field. Face assemblers are also only set when FE method is selected.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
