### PR TITLE
Fastscape: Rename Qtrapez function, fix some warnings, and add stabilization flag.

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -64,7 +64,12 @@ namespace aspect
         void
         compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                  AffineConstraints<double> &mesh_velocity_constraints,
-                                                 const std::set<types::boundary_id> &boundary_id) const;
+                                                 const std::set<types::boundary_id> &boundary_id) const override;
+
+        /**
+         * Returns whether or not the plugin requires surface stabilization
+         */
+        bool needs_surface_stabilization () const override;
 
         /**
          * Declare parameters for the FastScape plugin.
@@ -75,7 +80,7 @@ namespace aspect
         /**
          * Parse parameters for the FastScape plugin.
          */
-        void parse_parameters (ParameterHandler &prm);
+        void parse_parameters (ParameterHandler &prm) override;
 
       private:
         /**

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -578,7 +578,7 @@ namespace aspect
       std::vector<std::vector<double>> local_aspect_values(dim+2, std::vector<double>());
 
       // Get a quadrature rule that exists only on the corners, and increase the refinement if specified.
-      const QIterated<dim-1> face_corners (QTrapez<1>(),
+      const QIterated<dim-1> face_corners (QTrapezoid<1>(),
                                            std::pow(2,additional_refinement_levels+surface_refinement_difference));
 
       FEFaceValues<dim> fe_face_values (this->get_mapping(),
@@ -1548,6 +1548,18 @@ namespace aspect
       if (use_marine_component)
         out_silt_fraction << buffer_silt_fraction.str();
     }
+
+
+
+    template <int dim>
+    bool
+    FastScape<dim>::
+    needs_surface_stabilization () const
+    {
+      return true;
+    }
+
+
 
     template <int dim>
     void FastScape<dim>::declare_parameters(ParameterHandler &prm)


### PR DESCRIPTION
Hi all, here are some minor changes to the fastscape plugin to fix some warnings and rename Qtrapez to Qtrapezoid. Also, this adds the flag so the plugin can use the free surface stabilization.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
