### PR TITLE
Replace the matrix free class with another.

### DIFF
--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -34,6 +34,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
+#include <deal.II/multigrid/mg_transfer_global_coarsening.templates.h>
 #include <aspect/simulator/assemblers/interface.h>
 
 
@@ -604,7 +605,7 @@ namespace aspect
         /**
          * Multigrid transfer operator for the displacements
          */
-        MGTransferMatrixFree<dim, double> mg_transfer;
+        MGTransferMF<dim, double> mg_transfer;
 
 
         /**

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -605,7 +605,11 @@ namespace aspect
         /**
          * Multigrid transfer operator for the displacements
          */
+#if DEAL_II_VERSION_GTE(9,6,0)
         MGTransferMF<dim, double> mg_transfer;
+#else
+        MGTransferMatrixFree<dim, double> mg_transfer;
+#endif
 
 
         /**

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -33,6 +33,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 #include <deal.II/multigrid/multigrid.h>
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
+#include <deal.II/multigrid/mg_transfer_global_coarsening.templates.h>
 #include <deal.II/multigrid/mg_tools.h>
 #include <deal.II/multigrid/mg_coarse.h>
 #include <deal.II/multigrid/mg_smoother.h>
@@ -482,14 +483,14 @@ namespace aspect
        * Return a pointer to the MGTransfer object used for the A block
        * of the block GMG Stokes solver.
        */
-      virtual const MGTransferMatrixFree<dim,GMGNumberType> &
+      virtual const MGTransferMF<dim,GMGNumberType> &
       get_mg_transfer_A () const = 0;
 
       /**
        * Return a pointer to the MGTransfer object used for the Schur
        * complement block of the block GMG Stokes solver.
        */
-      virtual const MGTransferMatrixFree<dim,GMGNumberType> &
+      virtual const MGTransferMF<dim,GMGNumberType> &
       get_mg_transfer_S () const = 0;
 
       /**
@@ -598,14 +599,14 @@ namespace aspect
        * Return a pointer to the MGTransfer object used for the A block
        * of the block GMG Stokes solver.
        */
-      const MGTransferMatrixFree<dim,GMGNumberType> &
+      const MGTransferMF<dim,GMGNumberType> &
       get_mg_transfer_A () const override;
 
       /**
        * Return a pointer to the MGTransfer object used for the Schur
        * complement block of the block GMG Stokes solver.
        */
-      const MGTransferMatrixFree<dim,GMGNumberType> &
+      const MGTransferMF<dim,GMGNumberType> &
       get_mg_transfer_S () const override;
 
 
@@ -690,8 +691,8 @@ namespace aspect
       MGConstrainedDoFs mg_constrained_dofs_Schur_complement;
       MGConstrainedDoFs mg_constrained_dofs_projection;
 
-      MGTransferMatrixFree<dim,GMGNumberType> mg_transfer_A_block;
-      MGTransferMatrixFree<dim,GMGNumberType> mg_transfer_Schur_complement;
+      MGTransferMF<dim,GMGNumberType> mg_transfer_A_block;
+      MGTransferMF<dim,GMGNumberType> mg_transfer_Schur_complement;
 
       std::vector<std::shared_ptr<MatrixFree<dim,double>>> matrix_free_objects;
   };

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -483,14 +483,22 @@ namespace aspect
        * Return a pointer to the MGTransfer object used for the A block
        * of the block GMG Stokes solver.
        */
+#if DEAL_II_VERSION_GTE(9,6,0)
       virtual const MGTransferMF<dim,GMGNumberType> &
+#else
+      virtual const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
       get_mg_transfer_A () const = 0;
 
       /**
        * Return a pointer to the MGTransfer object used for the Schur
        * complement block of the block GMG Stokes solver.
        */
+#if DEAL_II_VERSION_GTE(9,6,0)
       virtual const MGTransferMF<dim,GMGNumberType> &
+#else
+      virtual const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
       get_mg_transfer_S () const = 0;
 
       /**
@@ -599,14 +607,22 @@ namespace aspect
        * Return a pointer to the MGTransfer object used for the A block
        * of the block GMG Stokes solver.
        */
+#if DEAL_II_VERSION_GTE(9,6,0)
       const MGTransferMF<dim,GMGNumberType> &
+#else
+      const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
       get_mg_transfer_A () const override;
 
       /**
        * Return a pointer to the MGTransfer object used for the Schur
        * complement block of the block GMG Stokes solver.
        */
+#if DEAL_II_VERSION_GTE(9,6,0)
       const MGTransferMF<dim,GMGNumberType> &
+#else
+      const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
       get_mg_transfer_S () const override;
 
 
@@ -691,8 +707,13 @@ namespace aspect
       MGConstrainedDoFs mg_constrained_dofs_Schur_complement;
       MGConstrainedDoFs mg_constrained_dofs_projection;
 
+#if DEAL_II_VERSION_GTE(9,6,0)
       MGTransferMF<dim,GMGNumberType> mg_transfer_A_block;
       MGTransferMF<dim,GMGNumberType> mg_transfer_Schur_complement;
+#else
+      MGTransferMatrixFree<dim,GMGNumberType> mg_transfer_A_block;
+      MGTransferMatrixFree<dim,GMGNumberType> mg_transfer_Schur_complement;
+#endif
 
       std::vector<std::shared_ptr<MatrixFree<dim,double>>> matrix_free_objects;
   };

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -1115,7 +1115,7 @@ namespace aspect
                                         level);
         }
 
-      MGTransferMatrixFree<dim, double> mg_transfer(mg_constrained_dofs);
+      MGTransferMF<dim, double> mg_transfer(mg_constrained_dofs);
       mg_transfer.build(mesh_deformation_dof_handler);
 
       using SmootherType =
@@ -1171,7 +1171,7 @@ namespace aspect
       mg.set_edge_matrices(mg_interface, mg_interface);
       PreconditionMG<dim,
                      dealii::LinearAlgebra::distributed::Vector<double>,
-                     MGTransferMatrixFree<dim, double>>
+                     MGTransferMF<dim, double>>
                      preconditioner(mesh_deformation_dof_handler, mg, mg_transfer);
 
       // solve

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1246,7 +1246,7 @@ namespace aspect
     // Project the active level viscosity vector to multilevel vector representations
     // using MG transfer objects. This transfer is based on the same linear operator used to
     // transfer data inside a v-cycle.
-    MGTransferMatrixFree<dim,GMGNumberType> transfer;
+    MGTransferMF<dim,GMGNumberType> transfer;
     transfer.build(dof_handler_projection);
 
     transfer.interpolate_to_mg(dof_handler_projection,
@@ -1824,7 +1824,7 @@ namespace aspect
     mg_Schur.set_edge_matrices(mg_interface_Schur, mg_interface_Schur);
 
     // GMG Preconditioner for ABlock and Schur complement
-    using GMGPreconditioner = PreconditionMG<dim, VectorType, MGTransferMatrixFree<dim,GMGNumberType>>;
+    using GMGPreconditioner = PreconditionMG<dim, VectorType, MGTransferMF<dim,GMGNumberType>>;
     GMGPreconditioner prec_A(dof_handler_v, mg_A, mg_transfer_A_block);
     GMGPreconditioner prec_Schur(dof_handler_p, mg_Schur, mg_transfer_Schur_complement);
 
@@ -2650,7 +2650,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  const MGTransferMatrixFree<dim,GMGNumberType> &
+  const MGTransferMF<dim,GMGNumberType> &
   StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::get_mg_transfer_A() const
   {
     return mg_transfer_A_block;
@@ -2659,7 +2659,7 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  const MGTransferMatrixFree<dim,GMGNumberType> &
+  const MGTransferMF<dim,GMGNumberType> &
   StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::get_mg_transfer_S() const
   {
     return mg_transfer_Schur_complement;

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1246,7 +1246,12 @@ namespace aspect
     // Project the active level viscosity vector to multilevel vector representations
     // using MG transfer objects. This transfer is based on the same linear operator used to
     // transfer data inside a v-cycle.
+#if DEAL_II_VERSION_GTE(9,6,0)
     MGTransferMF<dim,GMGNumberType> transfer;
+#else
+    MGTransferMatrixFree<dim,GMGNumberType> transfer;
+#endif
+
     transfer.build(dof_handler_projection);
 
     transfer.interpolate_to_mg(dof_handler_projection,
@@ -1824,7 +1829,11 @@ namespace aspect
     mg_Schur.set_edge_matrices(mg_interface_Schur, mg_interface_Schur);
 
     // GMG Preconditioner for ABlock and Schur complement
+#if DEAL_II_VERSION_GTE(9,6,0)
     using GMGPreconditioner = PreconditionMG<dim, VectorType, MGTransferMF<dim,GMGNumberType>>;
+#else
+    using GMGPreconditioner = PreconditionMG<dim, VectorType, MGTransferMatrixFree<dim,GMGNumberType>>;
+#endif
     GMGPreconditioner prec_A(dof_handler_v, mg_A, mg_transfer_A_block);
     GMGPreconditioner prec_Schur(dof_handler_p, mg_Schur, mg_transfer_Schur_complement);
 
@@ -2650,7 +2659,11 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
+#if DEAL_II_VERSION_GTE(9,6,0)
   const MGTransferMF<dim,GMGNumberType> &
+#else
+  const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
   StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::get_mg_transfer_A() const
   {
     return mg_transfer_A_block;
@@ -2659,7 +2672,11 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
+#if DEAL_II_VERSION_GTE(9,6,0)
   const MGTransferMF<dim,GMGNumberType> &
+#else
+  const MGTransferMatrixFree<dim,GMGNumberType> &
+#endif
   StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::get_mg_transfer_S() const
   {
     return mg_transfer_Schur_complement;


### PR DESCRIPTION
This PR uses the `MGTransferMF` class from deal.ii instead of `MGTransferMatrixFree` to address the #5504.

We get the following error when we use GMG with mesh deformation (test: `gmg_mesh_deform.prm`) using the current master version of deal.ii and this PR:

```
An error occurred in line <970> of file </home/arushi/opt/dealii/include/deal.II/lac/la_parallel_vector.templates.h> in function
    void dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>::compress_start(unsigned int, dealii::VectorOperation::values) [with Number = double; MemorySpace = dealii::MemorySpace::Host]
The violated condition was: 
    vector_is_ghosted == false
Additional information: 
    Cannot call compress() on a ghosted vector

```

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
