### PR TITLE
Remove TODOS that are backwards incompatible

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -389,11 +389,6 @@ namespace aspect
 
           std::vector<unsigned int> n_phases_for_each_composition = phase_function.n_phases_for_each_composition();
 
-          // TODO ASPECT_3: Require all field types to be specified by the user
-          // Remove the following code block *and* replace following code snippets matching
-          // MaterialUtilities::make_csv_substring(prm.get("*"), indices) with
-          // prm.get("*")
-          // BEGIN CODE BLOCK
           const std::vector<unsigned int> indices = this->introspection().chemical_composition_field_indices();
 
           // Currently, phase_function.n_phases_for_each_composition() returns a list of length
@@ -409,7 +404,6 @@ namespace aspect
               n_phase_transitions_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1] - 1);
               n_phases += n_phases_for_each_composition[i+1];
             }
-          // END CODE BLOCK
 
           // Equation of state parameters
           equation_of_state.initialize_simulator (this->get_simulator());

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1868,8 +1868,6 @@ namespace aspect
       if (x_compositional_field_types.size() == 1)
         x_compositional_field_types = std::vector<std::string> (n_compositional_fields, x_compositional_field_types[0]);
 
-      // TODO ASPECT_4: Require all field types to be specified by the user
-      // Remove the following code block
       for (unsigned int i=0; i<n_compositional_fields; ++i)
         if (x_compositional_field_types[i] == "unspecified")
           {


### PR DESCRIPTION
According to @bobmyhill, these TODOs were discussed at the 2023 Hackathon and dismissed because they are not backwards compatible. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
