### PR TITLE
Clean up some places handling initial topography in geometry models.

### DIFF
--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -224,6 +224,11 @@ namespace aspect
 
       private:
         /**
+         * A pointer to the initial topography model.
+         */
+        InitialTopographyModel::Interface<dim> *topo_model;
+
+        /**
          * Extent of the box in x-, y-, and z-direction (in 3d).
          */
         Point<dim> extents;
@@ -242,11 +247,6 @@ namespace aspect
          * The number of cells in each coordinate direction.
          */
         std::array<unsigned int, dim> repetitions;
-
-        /**
-         * A pointer to the initial topography model.
-         */
-        InitialTopographyModel::Interface<dim> *topo_model;
     };
   }
 }

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -132,6 +132,11 @@ namespace aspect
 
         private:
           /**
+           * A pointer to the topography model.
+           */
+          const InitialTopographyModel::Interface<dim> *topo;
+
+          /**
            * The minimum longitude of the domain.
            */
           double point1_lon;
@@ -164,11 +169,6 @@ namespace aspect
           virtual
           Point<dim>
           push_forward_topo(const Point<dim> &chart_point) const;
-
-          /**
-           * A pointer to the topography model.
-           */
-          const InitialTopographyModel::Interface<dim> *topo;
       };
     }
 

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -46,19 +46,17 @@ namespace aspect
           /**
            * Constructor
            */
-          EllipsoidalChunkGeometry();
+          EllipsoidalChunkGeometry(const InitialTopographyModel::Interface<dim> &topography,
+                                   const double para_semi_major_axis_a,
+                                   const double para_eccentricity,
+                                   const double para_semi_minor_axis_b,
+                                   const double para_bottom_depth,
+                                   const std::vector<Point<2>> &para_corners);
 
           /**
            * Copy constructor
            */
           EllipsoidalChunkGeometry(const EllipsoidalChunkGeometry &other);
-
-          /**
-           * An initialization function necessary to make sure that the
-           * manifold has access to the topography plugins.
-           */
-          void
-          initialize(const InitialTopographyModel::Interface<dim> *topography);
 
           /**
            * Sets several parameters for the ellipsoidal manifold object.
@@ -336,9 +334,17 @@ namespace aspect
 
 
         /**
-         * Construct manifold object Pointer to an object that describes the geometry.
+         * An object that describes the geometry. This pointer is
+         * initialized in the initialize() function, and serves as the manifold
+         * object that the triangulation is later given in create_coarse_mesh()
+         * where the triangulation clones it.
+         *
+         * The object is marked as 'const' to make it clear that it should not
+         * be modified once created. That is because the triangulation copies it,
+         * and modifying the current object will not have any impact on the
+         * manifold used by the triangulation.
          */
-        internal::EllipsoidalChunkGeometry<dim>   manifold;
+        std::unique_ptr<const internal::EllipsoidalChunkGeometry<dim>>   manifold;
 
         void
         set_boundary_ids(parallel::distributed::Triangulation<dim> &coarse_grid) const;

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -56,17 +56,7 @@ namespace aspect
           /**
            * Copy constructor
            */
-          EllipsoidalChunkGeometry(const EllipsoidalChunkGeometry &other);
-
-          /**
-           * Sets several parameters for the ellipsoidal manifold object.
-           */
-          void
-          set_manifold_parameters(const double para_semi_major_axis_a,
-                                  const double para_eccentricity,
-                                  const double para_semi_minor_axis_b,
-                                  const double para_bottom_depth,
-                                  const std::vector<Point<2>> &para_corners);
+          EllipsoidalChunkGeometry(const EllipsoidalChunkGeometry &other) = default;
 
           /**
            * The deal.ii pull back function in 3d. This function receives
@@ -130,11 +120,11 @@ namespace aspect
            */
           const InitialTopographyModel::Interface<dim> *topography;
 
-          double semi_major_axis_a;
-          double eccentricity;
-          double semi_minor_axis_b;
-          double bottom_depth;
-          std::vector<Point<2>> corners;
+          const double semi_major_axis_a;
+          const double eccentricity;
+          const double semi_minor_axis_b;
+          const double bottom_depth;
+          const std::vector<Point<2>> corners;
       };
     }
 

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -127,13 +127,16 @@ namespace aspect
            */
           Point<3> pull_back_topography (const Point<3> &phi_theta_d) const;
 
+          /**
+           * A pointer to the topography model.
+           */
+          const InitialTopographyModel::Interface<dim> *topography;
 
           double semi_major_axis_a;
           double eccentricity;
           double semi_minor_axis_b;
           double bottom_depth;
           std::vector<Point<2>> corners;
-          const InitialTopographyModel::Interface<dim> *topography;
       };
     }
 

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -41,6 +41,7 @@ namespace aspect
     {
       // Get pointer to initial topography model
       topo_model = const_cast<InitialTopographyModel::Interface<dim>*>(&this->get_initial_topography_model());
+
       // Check that initial topography is required.
       // If so, connect the initial topography function
       // to the right signals: It should be applied after

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -43,10 +43,10 @@ namespace aspect
                                         const double min_radius,
                                         const double max_depth)
         :
+        topo (&topo),
         point1_lon(min_longitude),
         inner_radius(min_radius),
-        max_depth(max_depth),
-        topo (&topo)
+        max_depth(max_depth)
       {}
 
 

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -66,22 +66,31 @@ namespace aspect
 
       // Constructor
       template <int dim>
-      EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry()
+      EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry(const InitialTopographyModel::Interface<dim> &topo,
+                                                              const double para_semi_major_axis_a,
+                                                              const double para_eccentricity,
+                                                              const double para_semi_minor_axis_b,
+                                                              const double para_bottom_depth,
+                                                              const std::vector<Point<2>> &para_corners)
         :
-        semi_major_axis_a (-1),
-        eccentricity (-1),
-        semi_minor_axis_b (-1),
-        bottom_depth (-1),
-        topography(nullptr)
-      {}
+        topography (&topo),
+        semi_major_axis_a (para_semi_major_axis_a),
+        eccentricity (para_eccentricity),
+        semi_minor_axis_b (para_semi_minor_axis_b),
+        bottom_depth (para_bottom_depth),
+        corners (para_corners)
+      {
+        AssertThrow (dim == 3, ExcMessage("This manifold can currently only be used in 3d."));
+      }
+
 
       // Copy constructor
       template <int dim>
       EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry(const EllipsoidalChunkGeometry &other)
         :
-        ChartManifold<dim,3,3>(other)
+        ChartManifold<dim,3,3>(other),
+        topography (other.topography)
       {
-        this->initialize(other.topography);
         this->set_manifold_parameters(other.semi_major_axis_a, other.eccentricity, other.semi_minor_axis_b,
                                       other.bottom_depth, other.corners);
       }
@@ -225,23 +234,18 @@ namespace aspect
       {
         return std::make_unique<EllipsoidalChunkGeometry>(*this);
       }
-
-
-
-      template <int dim>
-      void
-      EllipsoidalChunkGeometry<dim>::initialize(const InitialTopographyModel::Interface<dim> *topography_)
-      {
-        AssertThrow (dim == 3, ExcMessage("This manifold can currently only be used in 3d."));
-        topography = topography_;
-      }
     }
 
     template <int dim>
     void
     EllipsoidalChunk<dim>::initialize()
     {
-      manifold.initialize(&(this->get_initial_topography_model()));
+      manifold = std::make_unique<internal::EllipsoidalChunkGeometry<dim>>(this->get_initial_topography_model(),
+                                                                            semi_major_axis_a,
+                                                                            eccentricity,
+                                                                            semi_minor_axis_b,
+                                                                            bottom_depth,
+                                                                            corners);
     }
 
 
@@ -280,7 +284,7 @@ namespace aspect
       GridTools::transform (
         [&](const Point<dim> &x) -> Point<dim>
       {
-        return manifold.push_forward(x);
+        return manifold->push_forward(x);
       },
       coarse_grid);
 
@@ -288,7 +292,7 @@ namespace aspect
       // We won't use it during regular operation, but we set manifold_ids for
       // all cells, faces and edges immediately before refinement and
       // clear it again afterwards
-      coarse_grid.set_manifold (15, manifold);
+      coarse_grid.set_manifold (15, *manifold);
 
       coarse_grid.signals.pre_refinement.connect (
         [&] {set_manifold_ids(coarse_grid);});
@@ -627,21 +631,13 @@ namespace aspect
         prm.leave_subsection();
       }
       prm.leave_subsection();
-
-
-      // Construct manifold object Pointer to an object that describes the geometry.
-      manifold.set_manifold_parameters(semi_major_axis_a,
-                                       eccentricity,
-                                       semi_minor_axis_b,
-                                       bottom_depth,
-                                       corners);
     }
 
     template <int dim>
     double
     EllipsoidalChunk<dim>::depth(const Point<dim> &position) const
     {
-      return std::max(std::min(-manifold.pull_back(position)[dim-1], maximal_depth()), 0.0);
+      return std::max(std::min(-manifold->pull_back(position)[dim-1], maximal_depth()), 0.0);
     }
 
     template <int dim>
@@ -666,7 +662,7 @@ namespace aspect
     double
     EllipsoidalChunk<dim>::get_radius(const Point<dim> &position) const
     {
-      const Point<dim> long_lat_depth = manifold.pull_back(position);
+      const Point<dim> long_lat_depth = manifold->pull_back(position);
       return semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(long_lat_depth[1]) * std::sin(long_lat_depth[1])));
     }
 
@@ -732,7 +728,7 @@ namespace aspect
                               (southLatitude + northLatitude) * 0.5 * constants::degree_to_radians,
                               -depth);
 
-      return manifold.push_forward(p);
+      return manifold->push_forward(p);
     }
 
 
@@ -745,7 +741,7 @@ namespace aspect
                   ExcMessage("After displacement of the mesh, this function can no longer be used to determine whether a point lies in the domain or not."));
 
       // dim = 3
-      const Point<dim> ellipsoidal_point = manifold.pull_back(point);
+      const Point<dim> ellipsoidal_point = manifold->pull_back(point);
 
       // compare deflection from the ellipsoid surface
       if (ellipsoidal_point[dim-1] > 0.0+std::numeric_limits<double>::epsilon()*bottom_depth ||
@@ -771,7 +767,7 @@ namespace aspect
       for (unsigned int d=0; d<dim; ++d)
         cartesian_point[d] = position_point[d];
 
-      Point<3> transformed_point = manifold.pull_back_ellipsoid(cartesian_point, semi_major_axis_a, eccentricity);
+      Point<3> transformed_point = manifold->pull_back_ellipsoid(cartesian_point, semi_major_axis_a, eccentricity);
 
       const double radius =  semi_major_axis_a /
                              (std::sqrt(1 - eccentricity * eccentricity * std::sin(transformed_point[1]) * std::sin(transformed_point[1])));
@@ -807,7 +803,7 @@ namespace aspect
       const double radius = semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(position_point(1)) * std::sin(position_point(1))));
       position_point(2) = position_tensor[0] - radius;
 
-      Point<3> transformed_point = manifold.push_forward_ellipsoid(position_point, semi_major_axis_a, eccentricity);
+      Point<3> transformed_point = manifold->push_forward_ellipsoid(position_point, semi_major_axis_a, eccentricity);
       return transformed_point;
     }
 
@@ -827,7 +823,7 @@ template <int dim>
 typename aspect::GeometryModel::internal::EllipsoidalChunkGeometry<dim>
 aspect::GeometryModel::EllipsoidalChunk<dim>::get_manifold() const
 {
-  return manifold;
+  return *manifold;
 }
 
 // explicit instantiations

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -84,34 +84,6 @@ namespace aspect
       }
 
 
-      // Copy constructor
-      template <int dim>
-      EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry(const EllipsoidalChunkGeometry &other)
-        :
-        ChartManifold<dim,3,3>(other),
-        topography (other.topography)
-      {
-        this->set_manifold_parameters(other.semi_major_axis_a, other.eccentricity, other.semi_minor_axis_b,
-                                      other.bottom_depth, other.corners);
-      }
-
-
-      template <int dim>
-      void
-      EllipsoidalChunkGeometry<dim>::set_manifold_parameters(const double para_semi_major_axis_a,
-                                                             const double para_eccentricity,
-                                                             const double para_semi_minor_axis_b,
-                                                             const double para_bottom_depth,
-                                                             const std::vector<Point<2>> &para_corners)
-      {
-        AssertThrow (dim == 3, ExcMessage("This manifold can currently only be used in 3d."));
-
-        semi_major_axis_a = para_semi_major_axis_a;
-        eccentricity = para_eccentricity;
-        semi_minor_axis_b = para_semi_minor_axis_b;
-        bottom_depth = para_bottom_depth;
-        corners=para_corners;
-      }
 
       template <int dim>
       Point<3>

--- a/tests/ellipsoidal_chunk_geometry.cc
+++ b/tests/ellipsoidal_chunk_geometry.cc
@@ -53,19 +53,8 @@ int f()
 
   const unsigned int dim=3;
 
-  InitialTopographyModel::ZeroTopography<dim> topography;
-  GeometryModel::internal::EllipsoidalChunkGeometry<dim> ellipsoidal_manifold;
-  ellipsoidal_manifold.initialize(&topography);
-
   std::vector<Point<2>> corners(2,Point<2>(-15.0,-15.0));
   corners[1] *= -1.0;
-
-  std::cout << "Simple sphere test" << std::endl;
-  ellipsoidal_manifold.set_manifold_parameters(6371000.0,
-                                               0.0,
-                                               6371000.0,
-                                               2890000.0,
-                                               corners);
 
   std::vector<Point<3>> test_points;
   test_points.push_back(Point<3> (6371000.0,0,0));
@@ -78,33 +67,50 @@ int f()
   test_points.push_back(Point<3> (25000.0,25000.0,500000.0));
   test_points.push_back(Point<3> (25000.0,25000.0,50000.0));
 
-  for (unsigned int i=0; i<test_points.size(); ++i)
-    test_point(ellipsoidal_manifold,test_points[i]);
 
-  std::cout << "WGS84 test" << std::endl;
+  InitialTopographyModel::ZeroTopography<dim> topography;
+  {
+    std::cout << "Simple sphere test" << std::endl;
+    GeometryModel::internal::EllipsoidalChunkGeometry<dim> ellipsoidal_manifold(topography,
+                                                                                6371000.0,
+                                                                                0.0,
+                                                                                6371000.0,
+                                                                                2890000.0,
+                                                                                corners);
+
+    for (unsigned int i=0; i<test_points.size(); ++i)
+      test_point(ellipsoidal_manifold,test_points[i]);
+  }
+
   const double semi_major_axis_a = 6378137.0;
   const double eccentricity = 8.1819190842622e-2;
   const double semi_minor = std::sqrt((1 - pow(eccentricity,2)) * pow(semi_major_axis_a,2));
+  {
+    std::cout << "WGS84 test" << std::endl;
 
-  ellipsoidal_manifold.set_manifold_parameters(semi_major_axis_a,
-                                               eccentricity,
-                                               semi_minor,
-                                               2890000.0,
-                                               corners);
+    GeometryModel::internal::EllipsoidalChunkGeometry<dim> ellipsoidal_manifold(topography,
+                                                                                semi_major_axis_a,
+                                                                                eccentricity,
+                                                                                semi_minor,
+                                                                                2890000.0,
+                                                                                corners);
 
-  for (unsigned int i=0; i<test_points.size(); ++i)
-    test_point(ellipsoidal_manifold,test_points[i]);
+    for (unsigned int i=0; i<test_points.size(); ++i)
+      test_point(ellipsoidal_manifold,test_points[i]);
+  }
 
+  {
+    std::cout << "Test for points outside of the provided depth range" << std::endl;
+    GeometryModel::internal::EllipsoidalChunkGeometry<dim> ellipsoidal_manifold(topography,
+                                                                                semi_major_axis_a,
+                                                                                eccentricity,
+                                                                                semi_minor,
+                                                                                500000.0,
+                                                                                corners);
 
-  std::cout << "Test for points outside of the provided depth range" << std::endl;
-  ellipsoidal_manifold.set_manifold_parameters(semi_major_axis_a,
-                                               eccentricity,
-                                               semi_minor,
-                                               500000.0,
-                                               corners);
-
-  for (unsigned int i=0; i<test_points.size(); ++i)
-    test_point(ellipsoidal_manifold,test_points[i]);
+    for (unsigned int i=0; i<test_points.size(); ++i)
+      test_point(ellipsoidal_manifold,test_points[i]);
+  }
 
   exit (0);
   return 42;


### PR DESCRIPTION
The goal is to make them all look the same: They all should be handling their manifold objects the same way, for example -- create them in the same places, copy them the same way, have key member variables in the same order, etc.