### PR TITLE
Better document and check initial topography models.

### DIFF
--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -67,10 +67,17 @@ namespace aspect
         virtual void initialize ();
 
         /**
-         * Return the value of the elevation at the given point.
+         * Return the value of the elevation at the given surface point.
+         *
+         * Note that different geometry models use different conventions for
+         * how they describe surface points. In general, the models use
+         * their own "natural" coordinate system. For example, box-type
+         * geometry models will generally provide points as x-y coordinates
+         * on the surface, whereas spherical-type geometry models will generally
+         * provide surface points in spherical coordinates.
          */
         virtual
-        double value (const Point<dim-1> &p) const = 0;
+        double value (const Point<dim-1> &surface_point) const = 0;
 
         /**
          * Return the maximum value of the elevation.
@@ -97,7 +104,6 @@ namespace aspect
         virtual
         void
         parse_parameters (ParameterHandler &prm);
-
     };
 
 

--- a/source/geometry_model/initial_topography_model/prm_polygon.cc
+++ b/source/geometry_model/initial_topography_model/prm_polygon.cc
@@ -32,7 +32,7 @@ namespace aspect
     PrmPolygon<dim>::
     value (const Point<dim-1> &p) const
     {
-      Point<2> p1 = (dim == 2 ?Point<2>(p[0],0) : Point<2>(p[0],p[1]));
+      const Point<2> p1 = (dim == 2 ? Point<2>(p[0],0) : Point<2>(p[0],p[1]));
 
       /**
        * We go through the loop in the reverse order, because we


### PR DESCRIPTION
We did not document very well how the initial topography models are supposed to interact with the geometry models. I think that there is some confusion with regards to coordinate systems, and at least in the `Function` model, we convert between coordinate systems in a place where we ignore a user-settable parameter to choose which coordinate system the user wants to use for the function expression.

This patch adds documentation to explain at least what I *believe* we are currently doing, and asserts that the coordinate transformation mentioned above does what is intended. I'm curious to see whether that survives the test suite.

In reference to #5421 .