### PR TITLE
Use apt packaged cmake version in tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,7 +87,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
+        /usr/bin/cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
         -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_INSTALL_EXAMPLES=ON ..
         make -j 2
         ./aspect --test


### PR DESCRIPTION
We have some unexplained test failures in the `indent` tester in the `compile` stage (see e.g. #5560
).  After some investigation I found this: It looks like the new cmake (3.28.2) version that was included in the github actions runner yesterday broke the compatibility of precompiled headers and unity builds (see discussion [here](https://gitlab.kitware.com/cmake/cmake/-/issues/25650)). cmake 3.28.3 should fix this, but who knows when it will be released and deployed in the actions runner. Therefore this PR tries to circumvent the problem by using the apt packaged version of cmake on the runner (that we install anyway). If this works the tester should now use cmake 3.16 which comes with ubuntu 20.04. We can revert this change later.