### PR TITLE
Add sundials to tester image

### DIFF
--- a/contrib/docker/tester/local.cfg
+++ b/contrib/docker/tester/local.cfg
@@ -10,4 +10,4 @@ DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DCMAKE_BUILD_TYPE='DebugRel
 TRILINOS_CONFOPTS="-DTrilinos_ENABLE_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_FLOAT:BOOL=OFF -DTeuchos_ENABLE_COMPLEX:BOOL=OFF -DTrilinos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF -D CMAKE_CXX_FLAGS:STRING='-fPIC -O3' -D CMAKE_C_FLAGS:STRING='-fPIC -O3' -D CMAKE_FORTRAN_FLAGS:STRING='-O3'"
 
 # Compile packages necessary for all ASPECT functionality
-PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos dealii"
+PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos once:sundials dealii"


### PR DESCRIPTION
In order for #5367 to require sundials we need to make sure to install it inside the tester image. For some reason I thought I had done this already, but apparently we only added netcdf so far. This PR needs to be merged before we can proceed with #5367.