### PR TITLE
Remove an unnecessary check

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -81,11 +81,7 @@ namespace aspect
         inline MPI_Datatype
         mpi_type_id(const bool *)
         {
-#  if DEAL_II_MPI_VERSION_GTE(2, 2)
           return MPI_CXX_BOOL;
-#  else
-          return MPI_C_BOOL;
-#  endif
         }
 
 


### PR DESCRIPTION
deal.II has required MPI >=3.0 since before version 9.5, so we do not need this check in ASPECT anymore.

This will remove one of the problems reported in #5569, namely that MPI_VERSION_MAJOR and MPI_VERSION_MINOR is not correctly set on Stampede3 with Intel MPI 21.11 (this PR does not solve the underlying problem, but makes it so that ASPECT never requires that version information).