### PR TITLE
Report World Builder version on model start

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ if(ASPECT_WITH_WORLD_BUILDER)
   IF(WORLD_BUILDER_VERSION VERSION_GREATER_EQUAL 0.6.0)
     ADD_SUBDIRECTORY("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
     INCLUDE_DIRECTORIES("${CMAKE_BINARY_DIR}/world_builder/include/")
+    # if we configured with 0.5.0 before, we have a stray include file here. delete it.
+    FILE(REMOVE "${CMAKE_BINARY_DIR}/include/world_builder/config.h")
   ELSE()
     FILE(GLOB_RECURSE wb_files "${WORLD_BUILDER_SOURCE_DIR}/source/world_builder/*.cc")
     LIST(APPEND TARGET_SRC ${wb_files})

--- a/source/global.cc
+++ b/source/global.cc
@@ -26,6 +26,10 @@
 #include <deal.II/base/revision.h>
 #include <deal.II/base/vectorization.h>
 
+#ifdef ASPECT_WITH_WORLD_BUILDER
+#include <world_builder/config.h>
+#endif
+
 #include <cstring>
 
 
@@ -70,6 +74,18 @@ void print_aspect_header(Stream &stream)
          << DEAL_II_P4EST_VERSION_MAJOR << '.'
          << DEAL_II_P4EST_VERSION_MINOR << '.'
          << DEAL_II_P4EST_VERSION_SUBMINOR << '\n';
+
+#ifdef ASPECT_WITH_WORLD_BUILDER
+  stream << "--     . using Geodynamic World Builder "
+         << WORLD_BUILDER_VERSION_MAJOR << '.'
+         << WORLD_BUILDER_VERSION_MINOR << '.'
+         << WORLD_BUILDER_VERSION_PATCH;
+
+  if (WorldBuilder::Version::GIT_SHA1 != "")
+    stream << " (" << WorldBuilder::Version::GIT_BRANCH << ", " << WorldBuilder::Version::GIT_SHA1.substr(0,9) << ')';
+
+  stream << '\n';
+#endif
 
 #ifdef DEBUG
   stream << "--     . running in DEBUG mode\n"


### PR DESCRIPTION
This adds the world builder to the list of reported dependency version on model start. Output looks like this:

```
-----------------------------------------------------------------------------
--                             This is ASPECT                              --
-- The Advanced Solver for Planetary Evolution, Convection, and Tectonics. --
-----------------------------------------------------------------------------
--     . version 2.6.0-pre (report_world_builder, fec55396d)
--     . using deal.II 9.5.0
--     .       with 32 bit indices and vectorization level 3 (512 bits)
--     . using Trilinos 13.2.0
--     . using p4est 2.3.2
--     . using Geodynamic World Builder 0.6.0 (main, 2d07a63e6)
--     . running in DEBUG mode
--     . running with 1 MPI process
-----------------------------------------------------------------------------
```

This should not change any tests as the header output is filtered out of the test output.