### PR TITLE
Only evaluate particle velocities if needed

### DIFF
--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -45,7 +45,7 @@ namespace aspect
           /**
            * Perform an integration step of moving the particles of one cell
            * by the specified timestep dt. This function implements an explicit
-           * euler integration scheme.
+           * Euler integration scheme.
            *
            * @param [in] begin_particle An iterator to the first particle to be moved.
            * @param [in] end_particle An iterator to the last particle to be moved.
@@ -75,8 +75,8 @@ namespace aspect
            * indicates if the particle integrator requires the solution vector
            * at the new time (k+1).
            *
-           * The forward euler integrator only requires the solution vector at the
-           * old time (k).
+           * The forward Euler integrator only requires the solution vector at the
+           * old time (k), and consequently returns `{false, true, false}`.
           */
           std::array<bool, 3> required_solution_vectors() const override;
 
@@ -89,7 +89,7 @@ namespace aspect
            * a static property of this class. Therefore, the property manager can access this variable even
            * before any object is constructed.
            *
-           * The forward euler integrator does not need any intermediate storage space.
+           * The forward Euler integrator does not need any intermediate storage space.
            */
           static const unsigned int n_integrator_properties = 0;
       };

--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -67,6 +67,20 @@ namespace aspect
                                const double dt) override;
 
           /**
+           * Return a list of boolean values indicating which solution vectors
+           * are required for the integration. The first entry indicates if
+           * the particle integrator requires the solution vector at the old
+           * old time (k-1), the second entry indicates if the particle integrator
+           * requires the solution vector at the old time (k), and the third entry
+           * indicates if the particle integrator requires the solution vector
+           * at the new time (k+1).
+           *
+           * The forward euler integrator only requires the solution vector at the
+           * old time (k).
+          */
+          std::array<bool, 3> required_solution_vectors() const override;
+
+          /**
            * We need to tell the property manager how many intermediate properties this integrator requires,
            * so that it can allocate sufficient space for each particle. However, the integrator is not
            * created at the time the property manager is set up and we can not reverse the order of creation,

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -115,6 +115,17 @@ namespace aspect
           virtual std::size_t get_data_size() const;
 
           /**
+           * Return a list of boolean values indicating which solution vectors
+           * are required for the integration. The first entry indicates if
+           * the particle integrator requires the solution vector at the old
+           * old time (k-1), the second entry indicates if the particle integrator
+           * requires the solution vector at the old time (k), and the third entry
+           * indicates if the particle integrator requires the solution vector
+           * at the new time (k+1).
+          */
+          virtual std::array<bool, 3> required_solution_vectors() const;
+
+          /**
            * Read integration related data for a particle specified by particle_id
            * from the data array. This function is called after transferring
            * a particle to the local domain during an integration step.

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -123,7 +123,7 @@ namespace aspect
            * indicates if the particle integrator requires the solution vector
            * at the new time (k+1).
           */
-          virtual std::array<bool, 3> required_solution_vectors() const;
+          virtual std::array<bool, 3> required_solution_vectors() const = 0;
 
           /**
            * Read integration related data for a particle specified by particle_id

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -88,6 +88,22 @@ namespace aspect
           bool new_integration_step() override;
 
           /**
+           * Return a list of boolean values indicating which solution vectors
+           * are required for the integration. The first entry indicates if
+           * the particle integrator requires the solution vector at the old
+           * old time (k-1), the second entry indicates if the particle integrator
+           * requires the solution vector at the old time (k), and the third entry
+           * indicates if the particle integrator requires the solution vector
+           * at the new time (k+1).
+           *
+           * The RK2 integrator requires the solution vector at the
+           * old time (k) for the first integration step, and the solution
+           * vector at both the old and new time for the second integration step
+           * (if higher_order_in_time is set to true).
+           */
+          std::array<bool, 3> required_solution_vectors() const override;
+
+          /**
            * Declare the parameters this class takes through input files.
            */
           static

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -87,6 +87,23 @@ namespace aspect
           bool new_integration_step() override;
 
           /**
+           * Return a list of boolean values indicating which solution vectors
+           * are required for the integration. The first entry indicates if
+           * the particle integrator requires the solution vector at the old
+           * old time (k-1), the second entry indicates if the particle integrator
+           * requires the solution vector at the old time (k), and the third entry
+           * indicates if the particle integrator requires the solution vector
+           * at the new time (k+1).
+           *
+           * The RK4 integrator requires the solution vector at the
+           * old time (k) for the first integration step, the solution
+           * vector at both the old and new time for the second
+           * and third integration steps and the solution vector at the
+           * new time (k+1) for the fourth integration step.
+           */
+          std::array<bool, 3> required_solution_vectors() const override;
+
+          /**
            * We need to tell the property manager how many intermediate properties this integrator requires,
            * so that it can allocate sufficient space for each particle. However, the integrator is not
            * created at the time the property manager is set up and we can not reverse the order of creation,

--- a/source/particle/integrator/euler.cc
+++ b/source/particle/integrator/euler.cc
@@ -55,6 +55,15 @@ namespace aspect
             it->set_location(new_location);
           }
       }
+
+
+
+      template <int dim>
+      std::array<bool, 3>
+      Euler<dim>::required_solution_vectors() const
+      {
+        return {{false, true, false}};
+      }
     }
   }
 }

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -69,6 +69,15 @@ namespace aspect
 
 
       template <int dim>
+      std::array<bool, 3>
+      Interface<dim>::required_solution_vectors() const
+      {
+        return {{false, true, true}};
+      }
+
+
+
+      template <int dim>
       const void *
       Interface<dim>::read_data(const typename ParticleHandler<dim>::particle_iterator &/*particle*/,
                                 const void *data)

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -69,15 +69,6 @@ namespace aspect
 
 
       template <int dim>
-      std::array<bool, 3>
-      Interface<dim>::required_solution_vectors() const
-      {
-        return {{false, true, true}};
-      }
-
-
-
-      template <int dim>
       const void *
       Interface<dim>::read_data(const typename ParticleHandler<dim>::particle_iterator &/*particle*/,
                                 const void *data)

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -60,10 +60,11 @@ namespace aspect
                           "to the number of particles to advect. For some unknown reason they are different, "
                           "most likely something went wrong in the calling function."));
 
-        Assert(old_velocities.size() == velocities.size(),
-               ExcMessage("The particle integrator expects the velocity vector to be of equal size "
-                          "to the number of particles to advect. For some unknown reason they are different, "
-                          "most likely something went wrong in the calling function."));
+        if (higher_order_in_time == true && integrator_substep == 1)
+          Assert(old_velocities.size() == velocities.size(),
+                 ExcMessage("The particle integrator expects the velocity vector to be of equal size "
+                            "to the number of particles to advect. For some unknown reason they are different, "
+                            "most likely something went wrong in the calling function."));
 
         const bool geometry_has_periodic_boundary = (this->get_geometry_model().get_periodic_boundary_pairs().size() != 0);
 
@@ -130,6 +131,31 @@ namespace aspect
 
         // Continue until we're at the last step
         return (integrator_substep != 0);
+      }
+
+
+
+      template <int dim>
+      std::array<bool, 3>
+      RK2<dim>::required_solution_vectors() const
+      {
+        switch (integrator_substep)
+          {
+            case 0:
+              return {{false, true, false}};
+            case 1:
+            {
+              if (higher_order_in_time)
+                return {{false, true, true}};
+              else
+                return {{false, true, false}};
+            }
+            default:
+              Assert(false,
+                     ExcMessage("The RK4 integrator should never continue after four integration steps."));
+
+              return {{false, false, false}};
+          }
       }
 
 


### PR DESCRIPTION
This is a change to the particle advection algorithm that I wanted to implement for a while. Each particle integrator only needs a subset of the available velocity solutions on the particle location for each integrator step. E.g. the forward euler integrator only needs the old solution to move particles, while RK2 and RK4 sometimes also need particle velocities at other timesteps (depending on their integrator step). This PR implements an interface for the particle integrators to tell the particle world which velocities are needed at the current integrator step. This allows the world to only compute the velocities that are needed. 

Because of all the other operations that are needed for the advection this optimization is not huge (it saves ~5% of the particle advection time), but it is also not a big change so I think it is worth it. All the relevant change happens in world.cc, and it is only a resorting of code lines so that I can make the operations dependent on the result of the `required_solution_vectors` function.