### PR TITLE
Use new deal.II function to retrieve particle location

### DIFF
--- a/source/particle/integrator/euler.cc
+++ b/source/particle/integrator/euler.cc
@@ -57,6 +57,7 @@ namespace aspect
              it != end_particle; ++it, ++old_velocity)
           {
 #if DEAL_II_VERSION_GTE(9, 6, 0)
+            // Get a reference to the particle location, so that we can update it in-place
             Point<dim> &location = it->get_location();
 #else
             Point<dim> location = it->get_location();

--- a/source/particle/integrator/euler.cc
+++ b/source/particle/integrator/euler.cc
@@ -56,13 +56,19 @@ namespace aspect
         for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++old_velocity)
           {
-            const Point<dim> loc = it->get_location();
-            Point<dim> new_location = loc + dt * (*old_velocity);
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+            Point<dim> &location = it->get_location();
+#else
+            Point<dim> location = it->get_location();
+#endif
+            location += dt * (*old_velocity);
 
             if (at_periodic_boundary)
-              this->get_geometry_model().adjust_positions_for_periodicity(new_location);
+              this->get_geometry_model().adjust_positions_for_periodicity(location);
 
-            it->set_location(new_location);
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
+            it->set_location(location);
+#endif
           }
       }
 

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -89,6 +89,7 @@ namespace aspect
               {
                 const Tensor<1,dim> k1 = dt * (*old_velocity);
 #if DEAL_II_VERSION_GTE(9, 6, 0)
+                // Get a reference to the particle location, so that we can update it in-place
                 Point<dim> &location = it->get_location();
 #else
                 Point<dim> location = it->get_location();

--- a/source/particle/integrator/rk_2.cc
+++ b/source/particle/integrator/rk_2.cc
@@ -88,39 +88,53 @@ namespace aspect
             if (integrator_substep == 0)
               {
                 const Tensor<1,dim> k1 = dt * (*old_velocity);
-                Point<dim> loc0 = it->get_location();
-                Point<dim> new_location = loc0 + 0.5 * k1;
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                Point<dim> &location = it->get_location();
+#else
+                Point<dim> location = it->get_location();
+#endif
+                Point<dim> new_location = location + 0.5 * k1;
 
                 // Check if we crossed a periodic boundary and if necessary adjust positions
                 if (at_periodic_boundary)
                   this->get_geometry_model().adjust_positions_for_periodicity(new_location,
-                                                                              ArrayView<Point<dim>>(loc0));
+                                                                              ArrayView<Point<dim>>(location));
 
                 for (unsigned int i=0; i<dim; ++i)
-                  properties[property_index_old_location + i] = loc0[i];
-
+                  {
+                    properties[property_index_old_location + i] = location[i];
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                    location[i] = new_location[i];
+#endif
+                  }
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
                 it->set_location(new_location);
+#endif
               }
             else if (integrator_substep == 1)
               {
                 const Tensor<1,dim> k2 = (higher_order_in_time == true)
                                          ?
-                                         dt * (*old_velocity + *velocity) / 2.0
+                                         dt * (*old_velocity + *velocity) * 0.5
                                          :
                                          dt * (*old_velocity);
 
-                Point<dim> loc0;
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                Point<dim> &location = it->get_location();
+#else
+                Point<dim> location = it->get_location();
+#endif
 
                 for (unsigned int i=0; i<dim; ++i)
-                  loc0[i] = properties[property_index_old_location + i];
+                  location[i] = properties[property_index_old_location + i] + k2[i];
 
-                Point<dim> new_location = loc0 + k2;
-
-                // no need to adjust loc0, because this is the last integrator step
+                // no need to adjust old location, because this is the last integrator step
                 if (at_periodic_boundary)
-                  this->get_geometry_model().adjust_positions_for_periodicity(new_location);
+                  this->get_geometry_model().adjust_positions_for_periodicity(location);
 
-                it->set_location(new_location);
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
+                it->set_location(location);
+#endif
               }
             else
               {

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -98,6 +98,7 @@ namespace aspect
             if (integrator_substep == 0)
               {
 #if DEAL_II_VERSION_GTE(9, 6, 0)
+                // Get a reference to the particle location, so that we can update it in-place
                 Point<dim> &location = it->get_location();
 #else
                 Point<dim> location = it->get_location();

--- a/source/particle/integrator/rk_4.cc
+++ b/source/particle/integrator/rk_4.cc
@@ -89,7 +89,6 @@ namespace aspect
         typename std::vector<Tensor<1,dim>>::const_iterator old_velocity = old_velocities.begin();
         typename std::vector<Tensor<1,dim>>::const_iterator velocity = velocities.begin();
 
-        Point<dim> old_location;
         std::array<Tensor<1,dim>,4> k;
         for (typename ParticleHandler<dim>::particle_iterator it = begin_particle;
              it != end_particle; ++it, ++velocity, ++old_velocity)
@@ -98,28 +97,38 @@ namespace aspect
 
             if (integrator_substep == 0)
               {
-                old_location = it->get_location();
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                Point<dim> &location = it->get_location();
+#else
+                Point<dim> location = it->get_location();
+#endif
                 k[0] = dt * (*old_velocity);
 
-                Point<dim> new_location = old_location + 0.5 * k[0];
+                Point<dim> new_location = location + 0.5 * k[0];
 
                 // Check if we crossed a periodic boundary and if necessary adjust positions
                 if (at_periodic_boundary)
                   this->get_geometry_model().adjust_positions_for_periodicity(new_location,
-                                                                              ArrayView<Point<dim>>(&old_location,1),
+                                                                              ArrayView<Point<dim>>(&location,1),
                                                                               ArrayView<Tensor<1,dim>>(&k[0],1));
 
                 for (unsigned int i=0; i<dim; ++i)
                   {
-                    properties[property_indices[0] + i] = old_location[i];
+                    properties[property_indices[0] + i] = location[i];
                     properties[property_indices[1] + i] = k[0][i];
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                    location[i] = new_location[i];
+#endif
                   }
 
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
                 it->set_location(new_location);
+#endif
               }
             else if (integrator_substep == 1)
               {
-                k[1] = dt * ((*old_velocity) + (*velocity)) / 2.0;
+                k[1] = dt * ((*old_velocity) + (*velocity)) * 0.5;
+                Point<dim> old_location;
                 for (unsigned int i=0; i<dim; ++i)
                   old_location[i] = properties[property_indices[0] + i];
 
@@ -149,7 +158,8 @@ namespace aspect
               }
             else if (integrator_substep == 2)
               {
-                k[2] = dt * (*old_velocity + *velocity) / 2.0;
+                k[2] = dt * (*old_velocity + *velocity) * 0.5;
+                Point<dim> old_location;
                 for (unsigned int i=0; i<dim; ++i)
                   old_location[i] = properties[property_indices[0] + i];
 
@@ -186,6 +196,7 @@ namespace aspect
               {
                 k[3] = dt * (*velocity);
 
+                Point<dim> old_location;
                 for (unsigned int i=0; i<dim; ++i)
                   {
                     old_location[i] = properties[property_indices[0] + i];


### PR DESCRIPTION
This PR makes use of dealii/dealii#16675 to make the access to particle locations more efficient in the particle integrators.