### PR TITLE
Add Assert for stress type fields without elasticity enabled

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1885,7 +1885,17 @@ namespace aspect
             // choosing "chemical composition" as the standard field name
             // stress, strain, grain_size, porosity, density
             if (names_of_compositional_fields[i].find("stress") != std::string::npos)
-              x_compositional_field_types[i] = "stress";
+              {
+                x_compositional_field_types[i] = "stress";
+                // Fields that are of stress type will not be taken into
+                // account by the viscoplastic and viscoelastic material model
+                // when material properties are computed. Force the user to set a field type
+                // for fields with 'stress' in their name if elasticity is not enabled.
+                AssertThrow(enable_elasticity,
+                            ExcMessage("Even though elasticity is not enabled, ASPECT deduced a stress field type from the name of a compositional field. "
+                                       "Please specify the compositional field types explicitly. "
+                                       "At the moment the type of field " + names_of_compositional_fields[i] + " is unspecified."));
+              }
             else if ((names_of_compositional_fields[i].find("strain") != std::string::npos)
                      || (std::regex_match(names_of_compositional_fields[i],std::regex("s[1-3][1-3]"))))
               x_compositional_field_types[i] = "strain";

--- a/tests/sea_level_postprocessor.prm
+++ b/tests/sea_level_postprocessor.prm
@@ -46,26 +46,6 @@ subsection Nullspace removal
   set Remove nullspace = angular momentum
 end
 
-subsection Compositional fields
-  set Number of fields = 6
-  set Names of fields = ve_stress_xx, ve_stress_yy, ve_stress_zz, ve_stress_xy, ve_stress_xz, ve_stress_yz
-end
-
-subsection Initial composition model
-  set Model name = function
-
-  subsection Function
-    set Variable names      = x,y,z
-    set Function constants  =
-    set Function expression = 0; 0; 0; 0; 0; 0;
-  end
-end
-
-subsection Boundary composition model
-  set Allow fixed composition on outflow boundaries = true
-  set List of model names = initial composition
-end
-
 subsection Boundary temperature model
   set Fixed temperature boundary indicators = inner, outer
   set List of model names = initial temperature
@@ -92,7 +72,7 @@ subsection Gravity model
 end
 
 subsection Postprocess
-  set List of postprocessors = basic statistics, composition statistics, temperature statistics, velocity statistics, topography, geoid, sea level
+  set List of postprocessors = basic statistics, temperature statistics, velocity statistics, topography, geoid, sea level
 
   subsection Topography
     set Output to file = true

--- a/tests/sea_level_postprocessor/screen-output
+++ b/tests/sea_level_postprocessor/screen-output
@@ -1,10 +1,6 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 Number of active cells: 96 (on 1 levels)
-Number of degrees of freedom: 9,030 (2,910+150+150+970+970+970+970+970+970)
+Number of degrees of freedom: 3,210 (2,910+150+150)
 
 Number of mesh deformation degrees of freedom: 450
    Solving mesh displacement system... 0 iterations.
@@ -12,26 +8,17 @@ Number of mesh deformation degrees of freedom: 450
    Solving mesh displacement system... 0 iterations.
 
    Postprocessing:
-     Compositions min/max/mass:            0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0 // 0/0/0
      Temperature min/avg/max:              293 K, 293 K, 293 K
      RMS, max velocity:                    0 m/year, 0 m/year
      Topography min/max:                   -2.794e-09 m, 0 m
      Density at top/bottom of domain:      3300 kg/m^3, 3300 kg/m^3
      Writing geoid anomaly:                output-sea_level_postprocessor/geoid_anomaly.00000
-     Non-uniform sea level change min/max: -7.202e-11 m, 2.824e-09 m
+     Non-uniform sea level change min/max: -1.59e-10 m, 2.874e-09 m
 
 
 
-+---------------------------------------------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-+---------------------------------+-----------+------------+------------+
 
 Termination requested by criterion: end time
 
 
-+---------------------------------------------+------------+------------+
-+---------------------------------+-----------+------------+------------+
-+---------------------------------+-----------+------------+------------+
 
------------------------------------------------------------------------------
------------------------------------------------------------------------------

--- a/tests/sea_level_postprocessor/statistics
+++ b/tests/sea_level_postprocessor/statistics
@@ -4,36 +4,17 @@
 # 4: Number of mesh cells
 # 5: Number of Stokes degrees of freedom
 # 6: Number of temperature degrees of freedom
-# 7: Number of degrees of freedom for all compositions
-# 8: Number of nonlinear iterations
-# 9: Minimal value for composition ve_stress_xx
-# 10: Maximal value for composition ve_stress_xx
-# 11: Global mass for composition ve_stress_xx
-# 12: Minimal value for composition ve_stress_yy
-# 13: Maximal value for composition ve_stress_yy
-# 14: Global mass for composition ve_stress_yy
-# 15: Minimal value for composition ve_stress_zz
-# 16: Maximal value for composition ve_stress_zz
-# 17: Global mass for composition ve_stress_zz
-# 18: Minimal value for composition ve_stress_xy
-# 19: Maximal value for composition ve_stress_xy
-# 20: Global mass for composition ve_stress_xy
-# 21: Minimal value for composition ve_stress_xz
-# 22: Maximal value for composition ve_stress_xz
-# 23: Global mass for composition ve_stress_xz
-# 24: Minimal value for composition ve_stress_yz
-# 25: Maximal value for composition ve_stress_yz
-# 26: Global mass for composition ve_stress_yz
-# 27: Minimal temperature (K)
-# 28: Average temperature (K)
-# 29: Maximal temperature (K)
-# 30: Average nondimensional temperature (K)
-# 31: RMS velocity (m/year)
-# 32: Max. velocity (m/year)
-# 33: Minimum topography (m)
-# 34: Maximum topography (m)
-# 35: Density at top (kg/m^3)
-# 36: Density at bottom (kg/m^3)
-# 37: Minimum non-uniform sea_level change (m)
-# 38: Maximum non-uniform sea_level change (m)
-0 0.000000000000e+00 0.000000000000e+00 96 3060 150 5820 0 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 0.00000000e+00 2.93000000e+02 2.93000000e+02 2.93000000e+02 4.51975236e-17 0.00000000e+00 0.00000000e+00 -2.79396772e-09 0.00000000e+00 3.30000000e+03 3.30000000e+03 -7.20241082e-11 2.82444796e-09 
+# 7: Number of nonlinear iterations
+# 8: Minimal temperature (K)
+# 9: Average temperature (K)
+# 10: Maximal temperature (K)
+# 11: Average nondimensional temperature (K)
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimum topography (m)
+# 15: Maximum topography (m)
+# 16: Density at top (kg/m^3)
+# 17: Density at bottom (kg/m^3)
+# 18: Minimum non-uniform sea_level change (m)
+# 19: Maximum non-uniform sea_level change (m)
+0 0.000000000000e+00 0.000000000000e+00 96 3060 150 0 2.93000000e+02 2.93000000e+02 2.93000000e+02 4.51975236e-17 0.00000000e+00 0.00000000e+00 -2.79396772e-09 0.00000000e+00 3.30000000e+03 3.30000000e+03 -1.59018958e-10 2.87385445e-09 

--- a/tests/viscous_top_beam.prm
+++ b/tests/viscous_top_beam.prm
@@ -8,7 +8,7 @@
 # benchmark to check the directions of computed stress in the
 # postprocessors.
 #
-# In additional, elasticity is switched off.
+# In addition, elasticity is switched off.
 
 # Global parameters
 set Dimension                              = 2

--- a/tests/viscous_top_beam.prm
+++ b/tests/viscous_top_beam.prm
@@ -7,6 +7,8 @@
 # The test uses a vertical beam instead of the one in the original
 # benchmark to check the directions of computed stress in the
 # postprocessors.
+#
+# In additional, elasticity is switched off.
 
 # Global parameters
 set Dimension                              = 2
@@ -71,6 +73,7 @@ end
 subsection Compositional fields
   set Number of fields = 4
   set Names of fields  = ve_stress_xx, ve_stress_yy, ve_stress_xy, beam
+  set Types of fields = generic, generic, generic, chemical composition
 end
 
 # Spatial domain of different compositional fields


### PR DESCRIPTION
Compositional field types do not have to be specified; if they are not specified, they get the type 'unspecified' and ASPECT tries to deduce their type from their name. A field called ve_stress_xx, for example, will get the type 'stress'. If elasticity is disabled, there is at the moment no special function for fields of the type stress, which would imply this field is actually meant as a chemical composition. However, it now has the type 'stress' and is therefore not taken into account when computing material properties in the viscoelastic and viscoplastic material models. 

This PR throws if
1) Elasticity is disabled, and
2) A field of type 'unspecified' has 'stress' in its name.
It tells the user to explicitly specify the field types in the input file. 

Several tests will fail, as they already have fields with stress names without using elasticity, e.g. viscous_top_beam. I'll add the field types of those tests to their input files once the tester is done.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
