### PR TITLE
Move internal function and class to header file world.h

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -29,6 +29,8 @@
 #include <deal.II/particles/particle_handler.h>
 #include <deal.II/particles/property_pool.h>
 
+#include <deal.II/matrix_free/fe_point_evaluation.h>
+
 #include <aspect/particle/generator/interface.h>
 #include <aspect/particle/integrator/interface.h>
 #include <aspect/particle/interpolator/interface.h>
@@ -67,8 +69,55 @@ namespace aspect
 
     namespace internal
     {
+      // This class evaluates the solution vector at arbitrary positions inside a cell.
+      // This base class only provides the interface for SolutionEvaluatorsImplementation.
+      // See there for more details.
       template <int dim>
-      class SolutionEvaluators;
+      class SolutionEvaluators
+      {
+        public:
+          // virtual Destructor.
+          virtual ~SolutionEvaluators() = default;
+
+          // Reinitialize all variables to evaluate the given solution for the given cell
+          // and the given positions. The update flags control if only the solution or
+          // also the gradients should be evaluated.
+          // If other flags are set an assertion is triggered.
+          virtual void
+          reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
+                 const ArrayView<Point<dim>> &positions,
+                 const ArrayView<double> &solution_values,
+                 const UpdateFlags update_flags) = 0;
+
+          // Fill @p solution with all solution components at the given @p evaluation_point. Note
+          // that this function only works after a successful call to reinit(),
+          // because this function only returns the results of the computation that
+          // happened in reinit().
+          virtual void get_solution(const unsigned int evaluation_point,
+                                    Vector<double> &solution) = 0;
+
+          // Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
+          // that this function only works after a successful call to reinit(),
+          // because this function only returns the results of the computation that
+          // happened in reinit().
+          virtual void get_gradients(const unsigned int evaluation_point,
+                                     std::vector<Tensor<1, dim>> &gradients) = 0;
+
+          // Return the evaluator for velocity or fluid velocity. This is the only
+          // information necessary for advecting particles.
+          virtual FEPointEvaluation<dim, dim> &
+          get_velocity_or_fluid_velocity_evaluator(const bool use_fluid_velocity) = 0;
+
+          // Return the cached mapping information.
+          virtual NonMatching::MappingInfo<dim> &
+          get_mapping_info() = 0;
+      };
+
+      // A function to create a pointer to a SolutionEvaluators object.
+      template <int dim>
+      std::unique_ptr<internal::SolutionEvaluators<dim>>
+      construct_solution_evaluators(const SimulatorAccess<dim> &simulator_access,
+                                    const UpdateFlags update_flags);
     }
 
     /**

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -69,51 +69,67 @@ namespace aspect
 
     namespace internal
     {
-      // This class evaluates the solution vector at arbitrary positions inside a cell.
-      // This base class only provides the interface for SolutionEvaluatorsImplementation.
-      // See there for more details.
+      /**
+       * This class evaluates the solution vector at arbitrary positions inside a cell.
+       * This base class only provides the interface for SolutionEvaluatorsImplementation.
+       * See there for more details.
+       */
       template <int dim>
       class SolutionEvaluators
       {
         public:
-          // virtual Destructor.
+          /**
+           * virtual Destructor.
+           */
           virtual ~SolutionEvaluators() = default;
 
-          // Reinitialize all variables to evaluate the given solution for the given cell
-          // and the given positions. The update flags control if only the solution or
-          // also the gradients should be evaluated.
-          // If other flags are set an assertion is triggered.
+          /**
+           * Reinitialize all variables to evaluate the given solution for the given cell
+           * and the given positions. The update flags control if only the solution or
+           * also the gradients should be evaluated.
+           * If other flags are set an assertion is triggered.
+           */
           virtual void
           reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
                  const ArrayView<Point<dim>> &positions,
                  const ArrayView<double> &solution_values,
                  const UpdateFlags update_flags) = 0;
 
-          // Fill @p solution with all solution components at the given @p evaluation_point. Note
-          // that this function only works after a successful call to reinit(),
-          // because this function only returns the results of the computation that
-          // happened in reinit().
+          /**
+           * Fill @p solution with all solution components at the given @p evaluation_point. Note
+           * that this function only works after a successful call to reinit(),
+           * because this function only returns the results of the computation that
+           * happened in reinit().
+           */
           virtual void get_solution(const unsigned int evaluation_point,
                                     Vector<double> &solution) = 0;
 
-          // Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
-          // that this function only works after a successful call to reinit(),
-          // because this function only returns the results of the computation that
-          // happened in reinit().
+          /**
+           * Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
+           * that this function only works after a successful call to reinit(),
+           * because this function only returns the results of the computation that
+           * happened in reinit().
+           */
           virtual void get_gradients(const unsigned int evaluation_point,
                                      std::vector<Tensor<1, dim>> &gradients) = 0;
 
-          // Return the evaluator for velocity or fluid velocity. This is the only
-          // information necessary for advecting particles.
+          /**
+           * Return the evaluator for velocity or fluid velocity. This is the only
+           * information necessary for advecting particles.
+           */
           virtual FEPointEvaluation<dim, dim> &
           get_velocity_or_fluid_velocity_evaluator(const bool use_fluid_velocity) = 0;
 
-          // Return the cached mapping information.
+          /**
+           * Return the cached mapping information.
+           */
           virtual NonMatching::MappingInfo<dim> &
           get_mapping_info() = 0;
       };
 
-      // A function to create a pointer to a SolutionEvaluators object.
+      /**
+       * A function to create a pointer to a SolutionEvaluators object.
+       */
       template <int dim>
       std::unique_ptr<internal::SolutionEvaluators<dim>>
       construct_solution_evaluators(const SimulatorAccess<dim> &simulator_access,

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -29,7 +29,6 @@
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/grid/grid_tools.h>
 
-#include <deal.II/matrix_free/fe_point_evaluation.h>
 #include <deal.II/fe/mapping_cartesian.h>
 
 #include <boost/serialization/map.hpp>
@@ -747,55 +746,6 @@ namespace aspect
 
     namespace internal
     {
-      // This class evaluates the solution vector at arbitrary positions inside a cell.
-      // This base class only provides the interface for SolutionEvaluatorsImplementation.
-      // See there for more details.
-      template <int dim>
-      class SolutionEvaluators
-      {
-        public:
-          // virtual Destructor.
-          virtual ~SolutionEvaluators() = default;
-
-          // Reinitialize all variables to evaluate the given solution for the given cell
-          // and the given positions. The update flags control if only the solution or
-          // also the gradients should be evaluated.
-          // If other flags are set an assertion is triggered.
-          virtual
-          void
-          reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                 const ArrayView<Point<dim>> &positions,
-                 const ArrayView<double> &solution_values,
-                 const UpdateFlags update_flags) = 0;
-
-          // Fill @p solution with all solution components at the given @p evaluation_point. Note
-          // that this function only works after a successful call to reinit(),
-          // because this function only returns the results of the computation that
-          // happened in reinit().
-          virtual
-          void get_solution(const unsigned int evaluation_point,
-                            Vector<double> &solution) = 0;
-
-          // Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
-          // that this function only works after a successful call to reinit(),
-          // because this function only returns the results of the computation that
-          // happened in reinit().
-          virtual
-          void get_gradients(const unsigned int evaluation_point,
-                             std::vector<Tensor<1,dim>> &gradients) = 0;
-
-          // Return the evaluator for velocity or fluid velocity. This is the only
-          // information necessary for advecting particles.
-          virtual
-          FEPointEvaluation<dim, dim> &
-          get_velocity_or_fluid_velocity_evaluator(const bool use_fluid_velocity) = 0;
-
-          // Return the cached mapping information.
-          virtual
-          NonMatching::MappingInfo<dim> &
-          get_mapping_info() = 0;
-      };
-
       // This class evaluates the solution vector at arbitrary positions inside a cell.
       // It uses the deal.II class FEPointEvaluation to do this efficiently. Because
       // FEPointEvaluation only supports a single finite element, but ASPECT uses a FESystem with


### PR DESCRIPTION
For #4370 , some functionality is copied from world.cc into the particle property elastic_stress.cc. However, this requires including world.cc instead of world.h, as some functions and classes are only declared in world.cc. This PR moves the necessary class and function declaration to world.h. It shouldn't change anything.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
