### PR TITLE
Check that FS sediment depth and age do not have chemical composition type

### DIFF
--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -161,7 +161,7 @@ namespace aspect
            * physical proportion of the material, e.g. volume fraction of peridotite
            * (as opposed to non-volumetric quantities like the amount of finite-strain).
            */
-          //ComponentMask get_volumetric_composition_mask() const;
+          ComponentMask get_volumetric_composition_mask() const;
 
           /**
            * Declare the parameters this function takes through input files.

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -161,7 +161,7 @@ namespace aspect
            * physical proportion of the material, e.g. volume fraction of peridotite
            * (as opposed to non-volumetric quantities like the amount of finite-strain).
            */
-          ComponentMask get_volumetric_composition_mask() const;
+          //ComponentMask get_volumetric_composition_mask() const;
 
           /**
            * Declare the parameters this function takes through input files.

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -492,7 +492,7 @@ namespace aspect
 
 
 
-/*       template <int dim>
+      template <int dim>
       ComponentMask
       ViscoPlastic<dim>::
       get_volumetric_composition_mask() const
@@ -506,22 +506,8 @@ namespace aspect
               composition_mask.set(i,false);
           }
 
-        // Mask fields that track the age and deposition depth of deposited sediments.
-#ifdef ASPECT_WITH_FASTSCAPE
-        if (this->introspection().compositional_name_exists("sediment_age"))
-          {
-            const unsigned int sedi_age_position_tmp = this->introspection().compositional_index_for_name("sediment_age");
-            composition_mask.set(sedi_age_position_tmp,false);
-          }
-        if (this->introspection().compositional_name_exists("deposition_depth"))
-          {
-            const unsigned int depo_depth_position_tmp = this->introspection().compositional_index_for_name("deposition_depth");
-            composition_mask.set(depo_depth_position_tmp,false);
-          }
-#endif
-
         return composition_mask;
-      } */
+      }
 
 
 
@@ -671,24 +657,6 @@ namespace aspect
             // if they are to be used for all phases associated with a given key.
             options.check_values_per_key = true;
           }
-
-        // Make sure fields that track the age and deposition depth of deposited sediments
-        // do not have a chemical composition field type.
-#ifdef ASPECT_WITH_FASTSCAPE
-        if (this->introspection().compositional_name_exists("sediment_age"))
-          {
-            AssertThrow (chemical_field_names.find("sediment_age") == std::string::npos,
-                         ExcMessage("There is a field sediment_age that is of type chemical composition. "
-                                    "Please change it to type generic so that it does not affect material properties."));
-
-          }
-        if (this->introspection().compositional_name_exists("deposition_depth"))
-          {
-            AssertThrow(chemical_field_names.find("deposition_depth") != std::string::npos,
-                        ExcMessage("There is a field deposition_depth that is of type chemical composition. "
-                                   "Please change it to type generic so that it does not affect material properties."));
-          }
-#endif
 
         minimum_viscosity = Utilities::MapParsing::parse_map_to_double_array (prm.get("Minimum viscosity"),
                                                                               options);

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -492,7 +492,7 @@ namespace aspect
 
 
 
-      template <int dim>
+/*       template <int dim>
       ComponentMask
       ViscoPlastic<dim>::
       get_volumetric_composition_mask() const
@@ -521,7 +521,7 @@ namespace aspect
 #endif
 
         return composition_mask;
-      }
+      } */
 
 
 

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -672,6 +672,24 @@ namespace aspect
             options.check_values_per_key = true;
           }
 
+        // Make sure fields that track the age and deposition depth of deposited sediments
+        // do not have a chemical composition field type.
+#ifdef ASPECT_WITH_FASTSCAPE
+        if (this->introspection().compositional_name_exists("sediment_age"))
+          {
+            AssertThrow (chemical_field_names.find("sediment_age") == std::string::npos,
+                         ExcMessage("There is a field sediment_age that is of type chemical composition. "
+                                    "Please change it to type generic so that it does not affect material properties."));
+
+          }
+        if (this->introspection().compositional_name_exists("deposition_depth"))
+          {
+            AssertThrow(chemical_field_names.find("deposition_depth") != std::string::npos,
+                        ExcMessage("There is a field deposition_depth that is of type chemical composition. "
+                                   "Please change it to type generic so that it does not affect material properties."));
+          }
+#endif
+
         minimum_viscosity = Utilities::MapParsing::parse_map_to_double_array (prm.get("Minimum viscosity"),
                                                                               options);
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -218,6 +218,27 @@ namespace aspect
             }
         }
 
+        // Several compositional fields are commonly used in conjunction with the FastScape plugin, i.e.
+        // "sediment_age" to track the age of the sediment deposited and "deposition_depth" to track the depth
+        // with respect to the unperturbed surface of the model domain. Their values are controlled by setting
+        // boundary conditions on the top boundary that is deformed by FastScape. While it is useful to track these
+        // fields, they are not necessary for any function in the FastScape plugin. If they exist however, we need
+        // to make sure that these fields to not have the type "chemical composition" and are therefore not taken
+        // into account when computing material properties.
+        const std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+        if (this->introspection().compositional_name_exists("sediment_age"))
+        {
+          AssertThrow(chemical_field_names.find("sediment_age") == std::string::npos,
+                      ExcMessage("There is a field sediment_age that is of type chemical composition. "
+                                 "Please change it to type generic so that it does not affect material properties."));
+        }
+        if (this->introspection().compositional_name_exists("deposition_depth"))
+        {
+          AssertThrow(chemical_field_names.find("deposition_depth") != std::string::npos,
+                      ExcMessage("There is a field deposition_depth that is of type chemical composition. "
+                                 "Please change it to type generic so that it does not affect material properties."));
+        }
+
       // Initialize parameters for restarting FastScape
       restart = this->get_parameters().resume_computation;
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -222,8 +222,8 @@ namespace aspect
         // "sediment_age" to track the age of the sediment deposited and "deposition_depth" to track the depth
         // with respect to the unperturbed surface of the model domain. Their values are controlled by setting
         // boundary conditions on the top boundary that is deformed by FastScape. While it is useful to track these
-        // fields, they are not necessary for any function in the FastScape plugin. If they exist however, we need
-        // to make sure that these fields to not have the type "chemical composition" and are therefore not taken
+        // fields, they are not needed for any function in the FastScape plugin. If they exist however, we need
+        // to make sure that these fields do not have the type "chemical composition" and are therefore not taken
         // into account when computing material properties.
         const std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
         if (this->introspection().compositional_name_exists("sediment_age"))

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -218,21 +218,21 @@ namespace aspect
             }
         }
 
-        // Several compositional fields are commonly used in conjunction with the FastScape plugin, i.e.
-        // "sediment_age" to track the age of the sediment deposited and "deposition_depth" to track the depth
-        // with respect to the unperturbed surface of the model domain. Their values are controlled by setting
-        // boundary conditions on the top boundary that is deformed by FastScape. While it is useful to track these
-        // fields, they are not needed for any function in the FastScape plugin. If they exist however, we need
-        // to make sure that these fields do not have the type "chemical composition" and are therefore not taken
-        // into account when computing material properties.
-        const std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
-        if (this->introspection().compositional_name_exists("sediment_age"))
+      // Several compositional fields are commonly used in conjunction with the FastScape plugin, i.e.
+      // "sediment_age" to track the age of the sediment deposited and "deposition_depth" to track the depth
+      // with respect to the unperturbed surface of the model domain. Their values are controlled by setting
+      // boundary conditions on the top boundary that is deformed by FastScape. While it is useful to track these
+      // fields, they are not needed for any function in the FastScape plugin. If they exist however, we need
+      // to make sure that these fields do not have the type "chemical composition" and are therefore not taken
+      // into account when computing material properties.
+      const std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+      if (this->introspection().compositional_name_exists("sediment_age"))
         {
           AssertThrow(chemical_field_names.find("sediment_age") == std::string::npos,
                       ExcMessage("There is a field sediment_age that is of type chemical composition. "
                                  "Please change it to type generic so that it does not affect material properties."));
         }
-        if (this->introspection().compositional_name_exists("deposition_depth"))
+      if (this->introspection().compositional_name_exists("deposition_depth"))
         {
           AssertThrow(chemical_field_names.find("deposition_depth") != std::string::npos,
                       ExcMessage("There is a field deposition_depth that is of type chemical composition. "


### PR DESCRIPTION
Since #5542, masks for compositional fields are no longer needed as the compositional field type is used to compute the volume fractions in the viscoelastic and viscoplastic material models. This PR ensures that two fields that can be used in conjunction with FastScape are not of chemical composition type. Originally, they are masked in get_volumetric_composition_mask(). I think that function be removed, but I've kept it in for now.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
