### PR TITLE
Remove unnecessary header files.

### DIFF
--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -20,9 +20,6 @@
 
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/geometry_model/interface.h>
-#include <world_builder/grains.h>
-#include <world_builder/world.h>
-
 #include <aspect/citation_info.h>
 #include <aspect/utilities.h>
 


### PR DESCRIPTION
As far as I can see these header files are not needed at the moment. They will be needed later when world builder can set initial grain orientations, but we should not require headers that are not used. Fixes #5591.