### PR TITLE
fix a GWB warning

### DIFF
--- a/contrib/world_builder/source/world_builder/utilities.cc
+++ b/contrib/world_builder/source/world_builder/utilities.cc
@@ -27,6 +27,7 @@
 
 #ifdef WB_WITH_MPI
 #define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 

--- a/contrib/world_builder/source/world_builder/world.cc
+++ b/contrib/world_builder/source/world_builder/world.cc
@@ -37,6 +37,7 @@
 
 #ifdef WB_WITH_MPI
 #define OMPI_SKIP_MPICXX 1
+#define MPICH_SKIP_MPICXX
 #include <mpi.h>
 #endif
 


### PR DESCRIPTION
fixes warnings like
/usr/include/x86_64-linux-gnu/mpich/mpicxx.h:1513:24: warning: ‘virtual MPI::Nullcomm& MPI::Nullcomm::Clone() const’ can be marked override [-Wsuggest-override]

This is already fixed in the main branch of GWB but it is worth bringing into ASPECT. I like to compile without warnings...

see https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/631