### PR TITLE
Fix check field type and typos

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -479,7 +479,7 @@ namespace aspect
          * a sea level of zero will represent the initial maximum unperturbed
          * Y (2D) or Z (3D) extent of the ASPECT domain. A negative value of
          * the sea level means the sea level lies below the initial unperturbed
-         * top boundary of the domain. 
+         * top boundary of the domain.
          */
         double sea_level;
 

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -296,7 +296,7 @@ namespace aspect
 
         /**
          * Sediment rain in m/yr, added as a flat increase to the FastScape surface
-         * every ASPECT timestep before running FastScape.
+         * in the marine domain every ASPECT timestep before running FastScape.
          */
         std::vector<double> sediment_rain_rates;
 
@@ -374,7 +374,7 @@ namespace aspect
         unsigned int left;
 
         /**
-         * Parameters that set the fastscape boundaries periodic even though the ghost nodes are set 'fixed'
+         * Parameters that set the FastScape boundaries periodic even though the ghost nodes are set 'fixed'
          */
         bool topbottom_ghost_nodes_periodic;
         bool leftright_ghost_nodes_periodic;
@@ -408,7 +408,7 @@ namespace aspect
          */
 
         /**
-         * @name Fastscape subaerial erosional parameters
+         * @name FastScape subaerial erosional parameters
          * @{
          */
 
@@ -418,7 +418,7 @@ namespace aspect
         double drainage_area_exponent_m;
 
         /**
-         * Slope exponent for the steam power law. ($n$ variable in FastScape surface equation.)
+         * Slope exponent for the stream power law. ($n$ variable in FastScape surface equation.)
          */
         double slope_exponent_n;
 
@@ -460,7 +460,7 @@ namespace aspect
         double bedrock_transport_coefficient;
 
         /**
-         * Bedrock transport coefficient for hillslope diffusion (m^2/yr). When set to -1 this is
+         * Sediment transport coefficient for hillslope diffusion (m^2/yr). When set to -1 this is
          * identical to the bedrock value.
          * (kd in FastScape surface equation applied to sediment).
          */
@@ -476,8 +476,10 @@ namespace aspect
 
         /**
          * Fastscape sea level (m), set relative to the ASPECT surface where
-         * a sea level of zero will represent the maximum Y (2D) or Z (3D) extent
-         * inside ASPECT.
+         * a sea level of zero will represent the initial maximum unperturbed
+         * Y (2D) or Z (3D) extent of the ASPECT domain. A negative value of
+         * the sea level means the sea level lies below the initial unperturbed
+         * top boundary of the domain. 
          */
         double sea_level;
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -235,7 +235,8 @@ namespace aspect
                                   "Please change it to type generic so that it does not affect material properties."));
         }
       if (this->introspection().compositional_name_exists("deposition_depth"))
-        {          const std::vector<std::string>::const_iterator
+        {
+          const std::vector<std::string>::const_iterator
           it = std::find(chemical_field_names.begin(), chemical_field_names.end(), "deposition_depth");
           AssertThrow (it == chemical_field_names.end(),
                        ExcMessage("There is a field deposition_depth that is of type chemical composition. "

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -228,15 +228,18 @@ namespace aspect
       const std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
       if (this->introspection().compositional_name_exists("sediment_age"))
         {
-          AssertThrow(chemical_field_names.find("sediment_age") == std::string::npos,
-                      ExcMessage("There is a field sediment_age that is of type chemical composition. "
-                                 "Please change it to type generic so that it does not affect material properties."));
+          const std::vector<std::string>::const_iterator
+          it = std::find(chemical_field_names.begin(), chemical_field_names.end(), "sediment_age");
+          AssertThrow (it == chemical_field_names.end(),
+                       ExcMessage("There is a field sediment_age that is of type chemical composition. "
+                                  "Please change it to type generic so that it does not affect material properties."));
         }
       if (this->introspection().compositional_name_exists("deposition_depth"))
-        {
-          AssertThrow(chemical_field_names.find("deposition_depth") != std::string::npos,
-                      ExcMessage("There is a field deposition_depth that is of type chemical composition. "
-                                 "Please change it to type generic so that it does not affect material properties."));
+        {          const std::vector<std::string>::const_iterator
+          it = std::find(chemical_field_names.begin(), chemical_field_names.end(), "deposition_depth");
+          AssertThrow (it == chemical_field_names.end(),
+                       ExcMessage("There is a field deposition_depth that is of type chemical composition. "
+                                  "Please change it to type generic so that it does not affect material properties."));
         }
 
       // Initialize parameters for restarting FastScape


### PR DESCRIPTION
In #5588 some code was introduced that doesn't compile. I didn't realize because the file in which the changes were made is only compiled if ASPECT links to FastScape. This PR does compile and I checked that the checks throw as expected when linked to FastScape.

This PR also fixes some typos and extens some doc strings about FastScape parameters.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.

