### PR TITLE
Update 'Peierls strain rate residual tolerance'

### DIFF
--- a/doc/sphinx/parameters/Material_20model.md
+++ b/doc/sphinx/parameters/Material_20model.md
@@ -3914,11 +3914,11 @@ If the function you are describing represents a vector-valued function with mult
 
 (parameters:Material_20model/Visco_20Plastic/Peierls_20strain_20rate_20residual_20tolerance)=
 ### __Parameter name:__ Peierls strain rate residual tolerance
-**Default value:** 1e-22
+**Default value:** 1e-10
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Tolerance for the iterative solve to find the correct Peierls creep strain rate.
+**Documentation:** Tolerance for the iterative solve to find the correct Peierls creep strain rate. The tolerance is expressed as the difference between the natural logarithm of the input strain rate and the strain rate at the current iteration.
 
 (parameters:Material_20model/Visco_20Plastic/Peierls_20stresses)=
 ### __Parameter name:__ Peierls stresses

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -284,7 +284,12 @@ namespace aspect
 
           // Viscosity iteration parameters
           prm.declare_entry ("Strain rate residual tolerance", "1e-10", Patterns::Double(0.),
-                             "Tolerance for determining the correct stress and viscosity from the strain rate by internal iteration. The tolerance is expressed as the difference between the natural logarithm of the input strain rate and the strain rate at the current iteration. This determines that strain rate is correctly partitioned between diffusion and dislocation creep assuming that both mechanisms experience the same stress.");
+                             "Tolerance for determining the correct stress and viscosity from the "
+                             "strain rate by internal iteration. The tolerance is expressed as the "
+                             "difference between the natural logarithm of the input strain rate and "
+                             "the strain rate at the current iteration. This determines that strain "
+                             "rate is correctly partitioned between diffusion and dislocation creep "
+                             "assuming that both mechanisms experience the same stress.");
           prm.declare_entry ("Maximum strain rate ratio iterations", "40", Patterns::Integer(0),
                              "Maximum number of iterations to find the correct "
                              "diffusion/dislocation strain rate ratio.");

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -492,8 +492,10 @@ namespace aspect
                            "rather than stress. ");
 
         // Viscosity iteration parameters
-        prm.declare_entry ("Peierls strain rate residual tolerance", "1e-22", Patterns::Double(0.),
-                           "Tolerance for the iterative solve to find the correct Peierls creep strain rate.");
+        prm.declare_entry ("Peierls strain rate residual tolerance", "1e-10", Patterns::Double(0.),
+                           "Tolerance for the iterative solve to find the correct Peierls creep strain rate. "
+                           "The tolerance is expressed as the difference between the natural logarithm of the "
+                           "input strain rate and the strain rate at the current iteration.");
         prm.declare_entry ("Maximum Peierls strain rate iterations", "40", Patterns::Integer(0),
                            "Maximum number of iterations to find the correct "
                            "Peierls strain rate.");

--- a/tests/visco_plastic_peierls_idrissi_exact.prm
+++ b/tests/visco_plastic_peierls_idrissi_exact.prm
@@ -100,8 +100,8 @@ subsection Material model
     set Peierls fitting parameters                = 0.15
     set Peierls glide parameters p                = 0.5
     set Peierls glide parameters q                = 2.0
-    set Peierls strain rate residual tolerance = 1e-6
-    set Maximum Peierls strain rate iterations = 40
+    set Peierls strain rate residual tolerance    = 1e-6
+    set Maximum Peierls strain rate iterations    = 40
   end
 end
 

--- a/tests/visco_plastic_peierls_mei_exact.prm
+++ b/tests/visco_plastic_peierls_mei_exact.prm
@@ -100,8 +100,8 @@ subsection Material model
     set Peierls fitting parameters                = 0.15
     set Peierls glide parameters p                = 0.5
     set Peierls glide parameters q                = 1.0
-    set Peierls strain rate residual tolerance = 1e-12
-    set Maximum Peierls strain rate iterations = 40
+    set Peierls strain rate residual tolerance    = 1e-12
+    set Maximum Peierls strain rate iterations    = 40
   end
 end
 

--- a/tests/visco_plastic_phases_peierls_mei_exact.prm
+++ b/tests/visco_plastic_phases_peierls_mei_exact.prm
@@ -59,8 +59,8 @@ subsection Material model
     set Peierls fitting parameters                = 0.15
     set Peierls glide parameters p                = 0.5
     set Peierls glide parameters q                = 1.0
-    set Peierls strain rate residual tolerance = 1e-12
-    set Maximum Peierls strain rate iterations = 40
+    set Peierls strain rate residual tolerance    = 1e-12
+    set Maximum Peierls strain rate iterations    = 40
   end
 end
 


### PR DESCRIPTION
Following #5338, the default value for the parameter `Peierls strain rate residual tolerance` seemingly doesn't need to be so strict because the residual is now relative to the log of the strain rate. Opening this PR was motivated by models that I was running using the default value that could not converge, but using a value of 1e-10 - 1e-12 converged and produced negligible differences in the solution. Lowering the value should make models with Peierls creep more stable and faster when using the default value.

This PR updates the documentation of this parameter and changes the default value to mirror the changes in diffusion/dislocation merged in #5338. 
