### PR TITLE
make entropy_reader a vector

### DIFF
--- a/include/aspect/material_model/entropy_model.h
+++ b/include/aspect/material_model/entropy_model.h
@@ -155,14 +155,14 @@ namespace aspect
          * Information about the location of data files.
          */
         std::string data_directory;
-        std::string material_file_name;
+        std::vector<std::string> material_file_names;
         std::string lateral_viscosity_file_name;
 
         /**
-         * Pointer to the EntropyReader that reads in material data for
-         * given entropy and pressure.
+         * List of pointers to the EntropyReader that reads in material data for
+         * given entropy and pressure. There is one pointer/object per lookup file.
          */
-        std::unique_ptr<MaterialUtilities::Lookup::EntropyReader> entropy_reader;
+        std::vector<std::unique_ptr<MaterialUtilities::Lookup::EntropyReader>> entropy_reader;
 
         /**
          * Pointer to an object that reads and processes data for the lateral


### PR DESCRIPTION
I made the current entropy model able to read in multiple lookup table files. This is the first step of making the entropy method able to handle multiple compositions. There is an assert throw for using more than 1 lookup files because the rest of method have not been implemented yet.

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).