### PR TITLE
periodic GMG

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1693,8 +1693,6 @@ namespace aspect
       // Possibly store data of plugins associated with cells
       signals.pre_refinement_store_user_data(triangulation);
 
-
-
       exchange_refinement_flags();
 
       triangulation.prepare_coarsening_and_refinement();

--- a/tests/periodic_box_gmg.prm
+++ b/tests/periodic_box_gmg.prm
@@ -1,0 +1,126 @@
+# Test that periodic boundary conditions work with GMG. This test will
+# currently crash if run with a larger end time as we will run into a
+# situation with adaptive refinement across the periodic border, which
+# is not supported.
+
+# MPI: 2
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 20000
+set Output directory                       = output
+set Resume computation                     = false
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Pressure normalization = no
+set Use years in output instead of seconds = true
+set Nonlinear solver scheme                = single Advection, single Stokes
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = bottom, top
+  set List of model names = box
+
+  subsection Box
+    set Top temperature = 0.0
+    set Bottom temperature = 1000.0
+  end
+end
+
+subsection Discretization
+  set Stokes velocity polynomial degree       = 2
+  set Temperature polynomial degree           = 2
+  set Use locally conservative discretization = false
+
+  subsection Stabilization parameters
+    set alpha = 2
+    set beta  = 0.078
+    set cR    = 0.5
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X periodic = true
+    set X extent = 1.e6
+    set Y extent = 5.e5
+    set Z extent = 5.e5
+  end
+end
+
+subsection Nullspace removal
+  set Remove nullspace                        = net x translation
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = if((sqrt((x-1.e5)^2+(y-4.0e5)^2)<5.0e4) | (sqrt((x-3.e5)^2+(y-2.e5)^2)<1.0e5) , 800.0, 0)
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Linear solver tolerance = 1e-8
+    set Number of cheap Stokes solver steps = 100
+  end
+  subsection Matrix Free
+    set Output details = true
+  end
+end
+
+subsection Material model
+  set Material averaging = harmonic average
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 3300
+    set Reference specific heat       = 1250
+    set Reference temperature         = 0.0
+    set Thermal conductivity          = 4.7
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1.e20
+  end
+end
+
+subsection Mesh refinement
+  set Additional refinement times        =
+  set Initial adaptive refinement        = 2
+  set Initial global refinement          = 5                       # default: 2
+ set Minimum refinement level                            = 5
+
+  set Refinement fraction                = 0.3
+  set Coarsening fraction                = 0.03
+  set Strategy                           = thermal energy density#, equal periodic refinement
+  set Time steps between mesh refinement = 5
+end
+
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = bottom, top
+end
+
+
+subsection Postprocess
+  set List of postprocessors = visualization
+
+  subsection Visualization
+    set List of output variables =
+    set Number of grouped files       = 1
+    set Output format                 = vtu
+    set Time between graphical output = 0#1.e3
+  end
+end

--- a/tests/periodic_box_gmg/screen-output
+++ b/tests/periodic_box_gmg/screen-output
@@ -1,0 +1,124 @@
+
+Vectorization over 2 doubles = 128 bits (SSE2), VECTORIZATION_LEVEL=1
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 6
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.00073
+    Stokes solver: 52+0 iterations.
+    Schur complement preconditioner: 54+0 iterations.
+    A block preconditioner: 54+0 iterations.
+
+Number of active cells: 1,114 (on 7 levels)
+Number of degrees of freedom: 15,480 (9,506+1,221+4,753)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.00067
+    Stokes solver: 77+0 iterations.
+    Schur complement preconditioner: 79+0 iterations.
+    A block preconditioner: 79+0 iterations.
+
+Number of active cells: 1,183 (on 7 levels)
+Number of degrees of freedom: 16,481 (10,122+1,298+5,061)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 82+0 iterations.
+    Schur complement preconditioner: 84+0 iterations.
+    A block preconditioner: 84+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00000
+
+*** Timestep 1:  t=4926.45 years, dt=4926.45 years
+   Solving temperature system... 15 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 78+0 iterations.
+    Schur complement preconditioner: 80+0 iterations.
+    A block preconditioner: 80+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00001
+
+*** Timestep 2:  t=9796.69 years, dt=4870.24 years
+   Solving temperature system... 15 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 78+0 iterations.
+    Schur complement preconditioner: 80+0 iterations.
+    A block preconditioner: 80+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00002
+
+*** Timestep 3:  t=14611.9 years, dt=4815.25 years
+   Solving temperature system... 15 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 78+0 iterations.
+    Schur complement preconditioner: 80+0 iterations.
+    A block preconditioner: 80+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00003
+
+*** Timestep 4:  t=19376.6 years, dt=4764.69 years
+   Solving temperature system... 14 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 78+0 iterations.
+    Schur complement preconditioner: 80+0 iterations.
+    A block preconditioner: 80+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00004
+
+*** Timestep 5:  t=20000 years, dt=623.378 years
+   Solving temperature system... 12 iterations.
+   Solving Stokes system... 
+    GMG coarse size A: 18, coarse size S: 4
+    GMG n_levels: 7
+    Viscosity range: 1e+20 - 1e+20
+    GMG workload imbalance: 1.0298
+    Stokes solver: 78+0 iterations.
+    Schur complement preconditioner: 80+0 iterations.
+    A block preconditioner: 80+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-periodic_box_gmg/solution/solution-00005
+
+Number of active cells: 1,285 (on 8 levels)
+Number of degrees of freedom: 18,041 (11,082+1,418+5,541)
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/periodic_box_gmg/statistics
+++ b/tests/periodic_box_gmg/statistics
@@ -1,0 +1,17 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 1183 11420 5061  0 81 84 84 output-periodic_box_gmg/solution/solution-00000 
+1 4.926446589980e+03 4.926446589980e+03 1183 11420 5061 15 77 80 80 output-periodic_box_gmg/solution/solution-00001 
+2 9.796687352611e+03 4.870240762631e+03 1183 11420 5061 15 77 80 80 output-periodic_box_gmg/solution/solution-00002 
+3 1.461193301446e+04 4.815245661852e+03 1183 11420 5061 15 77 80 80 output-periodic_box_gmg/solution/solution-00003 
+4 1.937662151295e+04 4.764688498488e+03 1183 11420 5061 14 77 80 80 output-periodic_box_gmg/solution/solution-00004 
+5 2.000000000000e+04 6.233784870485e+02 1183 11420 5061 12 77 80 80 output-periodic_box_gmg/solution/solution-00005 


### PR DESCRIPTION
Enable periodic boundary conditions with GMG. Note that the linear solver crashes if we have adaptive refinement across periodic boundaries. This is not that easy to fix, so this will need to happen at a later time. Instead, we detect this situation and error out.