### PR TITLE
VSCode: build configurations

### DIFF
--- a/.vscode/cmake_configurations.json
+++ b/.vscode/cmake_configurations.json
@@ -1,0 +1,16 @@
+{
+  "configurations": [
+    {
+      "name": "DebugRelease",
+      "buildType": "DebugRelease"
+    },
+    {
+      "name": "Debug",
+      "buildType": "Debug"
+    },
+    {
+      "name": "Release",
+      "buildType": "Release"
+    }
+  ]
+}


### PR DESCRIPTION
The VS Code build variants do not include "DebugRelease". As a consequence, it would switch the build variant to Debug everytime you invoke cmake inside vscode. Fix this. This also gets rid of some other default variants.