### PR TITLE
Fix compiler warnings

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2365,7 +2365,7 @@ namespace aspect
       {
         const auto &pbs = sim.geometry_model->get_periodic_boundary_pairs();
 
-        for (const auto p: pbs)
+        for (const auto &p: pbs)
           {
             DoFTools::make_periodicity_constraints(dof_handler_v,
                                                    p.first.first,  // first boundary id
@@ -2403,7 +2403,7 @@ namespace aspect
       {
         const auto &pbs = sim.geometry_model->get_periodic_boundary_pairs();
 
-        for (const auto p: pbs)
+        for (const auto &p: pbs)
           {
             DoFTools::make_periodicity_constraints(dof_handler_p,
                                                    p.first.first,  // first boundary id


### PR DESCRIPTION
gcc warns me #5617 creates a copy  `warning: loop variable ‘p’ creates a copy from type ‘const std::pair<std::pair<unsigned int, unsigned int>, unsigned int>’ [-Wrange-loop-construct]`. Probably not very expensive, but fixing the warning anyway.