### PR TITLE
Use typos github action

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Check spelling with typos
-        #uses: crate-ci/typos@master
         env:
           GH_TOKEN: "${{ github.token }}"
         run: |
@@ -33,8 +32,21 @@ jobs:
           "${{ runner.temp }}/typos/typos" --version
 
           "${{ runner.temp }}/typos/typos" --config .typos.toml --format json >> ${{ runner.temp }}/typos.jsonl || true
-          
-
+      - name: Update repo with fixable typos
+        uses: crate-ci/typos@v1.19.0
+        with:
+          write_changes: true
+          config: ./.typos.toml
+          files: .
+      - name: Store typos diff file
+        run:  git diff > changes-typos.diff
+      - name: archive typos results
+        uses: actions/upload-artifact@v4
+        with:
+          name: changes-typos.diff
+          path: changes-typos.diff
+      - name: Report typos as warnings
+        run: |
           python -c '
           import sys, json
           old = set()
@@ -48,4 +60,3 @@ jobs:
                   new["path"], new["line_num"], new["byte_offset"],
                   new["typo"], " or ".join(new["corrections"])))
           sys.exit(1 if not clean else 0)' "${{ runner.temp }}/typos.jsonl"
-


### PR DESCRIPTION
#5600 added a typos checker, which is now failing for recent PRs. This is because so far we always use the latest release of the spell checker, which periodically changes its dictionary of typos. I would rather rely on a fixed version of the spell check and occasionally update that version. This is more similar to what we do with astyle, and it will reduce the maintenance effort of constantly fiddling with the configuration of the spell checker to make sure it doesnt flag new things, which are likely just false positives. This also allows us to use the existing Github action, and avoids using a hand-written script for reporting errors, which doesnt seem to work at the moment anyway.

Do not merge this PR, I introduced  a  typo on purpose to test the action.

@MFraters: What was the reason for writing the custom script in the first place? I didnt see anything in #5600 about it.