### PR TITLE
Add functionality for spherical system

### DIFF
--- a/source/geometry_model/initial_topography_model/function.cc
+++ b/source/geometry_model/initial_topography_model/function.cc
@@ -67,29 +67,19 @@ namespace aspect
           // Now for the vertical component:
           global_point[dim-1] = 0;
 
-          // The point as it is would have to be translated into a different
-          // coordinate system if that was requested in the input file.
-          // This is not currently implemented.
           Assert (coordinate_system == Utilities::Coordinates::CoordinateSystem::cartesian,
-                  ExcNotImplemented());
+                  ExcMessage("While using a box geometry, use cartesian coordinate system."));
         }
       else if (Plugins::plugin_type_matches<GeometryModel::Sphere<dim>>(this->get_geometry_model()) ||
                Plugins::plugin_type_matches<GeometryModel::SphericalShell<dim>>(this->get_geometry_model()) ||
                Plugins::plugin_type_matches<GeometryModel::Chunk<dim>>(this->get_geometry_model()) )
         {
-          std::array<double, dim> point;
-          point[0] = 6371000.0;
+          global_point[0] = 6371000.0;
           for (unsigned int d=0; d<dim-1; ++d)
-            point[d+1] = surface_point[d];
+            global_point[d+1] = surface_point[d];
 
-          global_point = Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(point);
-
-          // The point as it is would have to be translated into a different
-          // coordinate system (or, perhaps, better just left in the spherical
-          // coordinates we received) if that was requested in the input file.
-          // This is not currently implemented.
-          Assert (coordinate_system == Utilities::Coordinates::CoordinateSystem::cartesian,
-                  ExcNotImplemented());
+          Assert (coordinate_system == Utilities::Coordinates::CoordinateSystem::spherical,
+                  ExcMessage("Make sure that you are using a spherical coordinate system While using a spherical geometry."));
         }
       else
         AssertThrow(false, ExcNotImplemented());


### PR DESCRIPTION
This PR addresses one of the bullet points in issue #5626. In particular, it allows the user to use `spherical` coordinate system while using `initial_topography function` model. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
