### PR TITLE
Update outdated comment in shear heating plugin

### DIFF
--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -39,8 +39,7 @@ namespace aspect
       Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.strain_rate.size(),
              ExcMessage ("The shear heating plugin needs the strain rate!"));
 
-      // Some material models provide dislocation viscosities and boundary area work fractions
-      // as additional material outputs. If they are attached, use them.
+      // Check if the material model has additional outputs relevant for the shear heating.
       const ShearHeatingOutputs<dim> *shear_heating_out =
         material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
 


### PR DESCRIPTION
This comment is outdated. Dislocation viscosities and boundary area work fractions were previously in this additional output, but it was reworked in #5021. What exactly happens with these outputs is described below in line 78/79.