### PR TITLE
Unify evaluation of number of material points

### DIFF
--- a/source/boundary_heat_flux/function.cc
+++ b/source/boundary_heat_flux/function.cc
@@ -36,7 +36,7 @@ namespace aspect
                const MaterialModel::MaterialModelOutputs<dim> &/*material_model_outputs*/,
                const std::vector<Tensor<1,dim>> &normal_vectors) const
     {
-      const unsigned int n_evaluation_points = material_model_inputs.position.size();
+      const unsigned int n_evaluation_points = material_model_inputs.n_evaluation_points();
       std::vector<Tensor<1,dim>> heat_flux(normal_vectors);
 
       for (unsigned int i=0; i<n_evaluation_points; ++i)

--- a/source/heating_model/adiabatic_heating.cc
+++ b/source/heating_model/adiabatic_heating.cc
@@ -41,7 +41,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -35,7 +35,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       AssertThrow(this->include_melt_transport(),
@@ -135,7 +135,7 @@ namespace aspect
         return;
 
       inputs.additional_inputs.push_back(
-        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
+        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.n_evaluation_points()));
     }
   }
 }

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -191,7 +191,7 @@ namespace aspect
           heating_model_outputs.rates_of_temperature_change[q] = 0.0;
         }
 
-      HeatingModel::HeatingModelOutputs individual_heating_outputs(material_model_inputs.position.size(),
+      HeatingModel::HeatingModelOutputs individual_heating_outputs(material_model_inputs.n_evaluation_points(),
                                                                    this->n_compositional_fields());
 
       const MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs

--- a/source/heating_model/latent_heat.cc
+++ b/source/heating_model/latent_heat.cc
@@ -33,7 +33,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -34,7 +34,7 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       const bool use_operator_split = (this->get_parameters().use_operator_splitting);
@@ -162,9 +162,8 @@ namespace aspect
       if (this->include_melt_transport() && retrieve_entropy_change_from_material_model
           && outputs.template get_additional_output<MaterialModel::EnthalpyOutputs<dim>>() == nullptr)
         {
-          const unsigned int n_points = outputs.densities.size();
           outputs.additional_outputs.push_back(
-            std::make_unique<MaterialModel::EnthalpyOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::EnthalpyOutputs<dim>> (outputs.n_evaluation_points()));
         }
     }
   }

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -33,11 +33,8 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
-
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.strain_rate.size(),
-             ExcMessage ("The shear heating plugin needs the strain rate!"));
 
       // Check if the material model has additional outputs relevant for the shear heating.
       const ShearHeatingOutputs<dim> *shear_heating_out =

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -36,11 +36,8 @@ namespace aspect
               const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
               HeatingModel::HeatingModelOutputs &heating_model_outputs) const
     {
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.position.size(),
+      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.n_evaluation_points(),
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
-
-      Assert(heating_model_outputs.heating_source_terms.size() == material_model_inputs.strain_rate.size(),
-             ExcMessage ("The shear heating plugin needs the strain rate!"));
 
       Assert(this->introspection().compositional_name_exists("porosity"),
              ExcMessage("Heating model shear heating with melt only works if there "
@@ -102,7 +99,7 @@ namespace aspect
         return;
 
       inputs.additional_inputs.push_back(
-        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.position.size()));
+        std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.n_evaluation_points()));
     }
   }
 }

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -595,13 +595,14 @@ namespace aspect
       // If the temperature or pressure are zero, this model does not work.
       // This should only happen when setting the melt constraints before we have the initial temperature.
       // In this case, just fill the permeabilities and fluid viscosities and return.
-      for (unsigned int q=0; q<in.position.size(); ++q)
+      const unsigned int n_points = in.n_evaluation_points();
+      for (unsigned int q=0; q<n_points; ++q)
         {
           if (in.temperature[q] == 0.0)
             {
               if (melt_out != nullptr)
                 {
-                  for (unsigned int q=0; q<in.position.size(); ++q)
+                  for (unsigned int q=0; q<n_points; ++q)
                     {
                       const double porosity = std::max(in.composition[q][porosity_idx],0.0);
                       melt_out->fluid_viscosities[q] = eta_f;
@@ -881,7 +882,8 @@ namespace aspect
       // fill melt outputs if they exist
       if (melt_out != nullptr)
         {
-          for (unsigned int q=0; q<in.position.size(); ++q)
+          const unsigned int n_points = in.n_evaluation_points();
+          for (unsigned int q=0; q<n_points; ++q)
             {
               double porosity = std::max(in.composition[q][porosity_idx],0.0);
 

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -1272,16 +1272,14 @@ namespace aspect
       if (this->get_parameters().use_operator_splitting
           && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (out.n_evaluation_points(), this->n_compositional_fields()));
         }
 
       if (out.template get_additional_output<BoukareOutputs<dim>>() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_unique<MaterialModel::BoukareOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::BoukareOutputs<dim>> (out.n_evaluation_points()));
         }
     }
   }

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -483,9 +483,8 @@ namespace aspect
       if (this->get_parameters().use_operator_splitting
           && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
         {
-          const unsigned int n_points = out.viscosities.size();
           out.additional_outputs.push_back(
-            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (n_points, this->n_compositional_fields()));
+            std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (out.n_evaluation_points(), this->n_compositional_fields()));
         }
     }
   }

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -274,13 +274,11 @@ namespace aspect
     NewtonStokesPreconditioner<dim>::
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
-      const unsigned int n_points = outputs.viscosities.size();
-
       if (this->get_parameters().enable_elasticity &&
           outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
+            std::make_unique<MaterialModel::ElasticOutputs<dim>> (outputs.n_evaluation_points()));
         }
 
       if (this->get_newton_handler().parameters.newton_derivative_scaling_factor != 0)
@@ -574,7 +572,7 @@ namespace aspect
     NewtonStokesIncompressibleTerms<dim>::
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
-      const unsigned int n_points = outputs.viscosities.size();
+      const unsigned int n_points = outputs.n_evaluation_points();
 
       if (this->get_parameters().enable_additional_stokes_rhs
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -447,7 +447,7 @@ namespace aspect
     StokesIncompressibleTerms<dim>::
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
-      const unsigned int n_points = outputs.viscosities.size();
+      const unsigned int n_points = outputs.n_evaluation_points();
 
       // Stokes RHS:
       if (this->get_parameters().enable_additional_stokes_rhs

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -148,7 +148,8 @@ namespace aspect
                         const LinearAlgebra::BlockVector &,
                         std::vector<double> &output) override
         {
-          for (unsigned i = 0; i < out.viscosities.size(); ++i)
+          const unsigned int n_points = out.n_evaluation_points();
+          for (unsigned i = 0; i < n_points; ++i)
             output[i] = std::log10 (out.viscosities[i]);
         }
     };

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -173,19 +173,17 @@ namespace aspect
     {
       MeltHandler<dim>::create_material_model_outputs(outputs);
 
-      const unsigned int n_points = outputs.viscosities.size();
-
       if (this->get_parameters().enable_additional_stokes_rhs
           && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
-            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>(n_points));
+            std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>(outputs.n_evaluation_points()));
         }
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
              outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
-             == n_points, ExcInternalError());
+             == outputs.n_evaluation_points(), ExcInternalError());
     }
 
 
@@ -1834,10 +1832,9 @@ namespace aspect
     if (output.template get_additional_output<MaterialModel::MeltOutputs<dim>>() != nullptr)
       return;
 
-    const unsigned int n_points = output.viscosities.size();
     const unsigned int n_comp = output.reaction_terms[0].size();
     output.additional_outputs.push_back(
-      std::make_unique<MaterialModel::MeltOutputs<dim>> (n_points, n_comp));
+      std::make_unique<MaterialModel::MeltOutputs<dim>> (output.n_evaluation_points(), n_comp));
   }
 
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -119,9 +119,8 @@ namespace aspect
     if (output.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>() != nullptr)
       return;
 
-    const unsigned int n_points = output.viscosities.size();
     output.additional_outputs.push_back(
-      std::make_unique<MaterialModel::MaterialModelDerivatives<dim>>(n_points));
+      std::make_unique<MaterialModel::MaterialModelDerivatives<dim>>(output.n_evaluation_points()));
   }
 
 


### PR DESCRIPTION
`MaterialModelOutputs` and `MaterialModelInputs` have functions to get the number of points it is supposed to be evaluated on. However, I found some old places that do not use that function and instead compute the number locally. This PR unifies the calling of this function in as many places I could find. I also removed a few checks for whether the strain_rate was provided to the material model, because since #5268 it is always provided.