### PR TITLE
Simplify creating and unrolling symmetric tensors

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1245,6 +1245,45 @@ namespace aspect
      */
     namespace Tensors
     {
+      /**
+       * Convert a series of doubles to a SymmetricTensor of the same size.
+       * The input is expected to be ordered according to the
+       * SymmetricTensor::unrolled_to_component_indices() function.
+       */
+      template <int dim, class Iterator>
+      inline
+      SymmetricTensor<2,dim>
+      to_symmetric_tensor(const Iterator begin,
+                          const Iterator end)
+      {
+        AssertDimension(std::distance(begin, end), (SymmetricTensor<2,dim>::n_independent_components));
+
+        SymmetricTensor<2,dim> output;
+
+        Iterator next = begin;
+        for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i, ++next)
+          output[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)] = *next;
+
+        return output;
+      }
+
+      /**
+       * Unroll a SymmetricTensor into a series of doubles. The output is ordered
+       * according to the SymmetricTensor::unrolled_to_component_indices() function.
+       */
+      template <int dim, class Iterator>
+      inline
+      void
+      unroll_symmetric_tensor_into_array(const SymmetricTensor<2,dim> &tensor,
+                                         const Iterator begin,
+                                         const Iterator end)
+      {
+        AssertDimension(std::distance(begin, end), (SymmetricTensor<2,dim>::n_independent_components));
+
+        Iterator next = begin;
+        for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i, ++next)
+          *next = tensor[SymmetricTensor<2,dim>::unrolled_to_component_indices(i)];
+      }
 
       /**
        * Rotate a 3D 4th order tensor representing the full stiffnexx matrix using a 3D 2nd order rotation tensor

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1257,6 +1257,7 @@ namespace aspect
                           const Iterator end)
       {
         AssertDimension(std::distance(begin, end), (SymmetricTensor<2,dim>::n_independent_components));
+        (void) end;
 
         SymmetricTensor<2,dim> output;
 
@@ -1279,6 +1280,7 @@ namespace aspect
                                          const Iterator end)
       {
         AssertDimension(std::distance(begin, end), (SymmetricTensor<2,dim>::n_independent_components));
+        (void) end;
 
         Iterator next = begin;
         for (unsigned int i=0; i < SymmetricTensor<2,dim>::n_independent_components; ++i, ++next)

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -174,10 +174,8 @@ namespace aspect
       CpoElasticTensor<dim>::get_elastic_tensor(unsigned int cpo_data_position,
                                                 const ArrayView<double> &data)
       {
-        SymmetricTensor<2,6> elastic_tensor;
-        for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
-          elastic_tensor[SymmetricTensor<2,6>::unrolled_to_component_indices(i)] = data[cpo_data_position + i];
-        return elastic_tensor;
+        return Utilities::Tensors::to_symmetric_tensor<6>(&data[cpo_data_position],
+                                                          &data[cpo_data_position]+SymmetricTensor<2,6>::n_independent_components);
       }
 
 
@@ -188,8 +186,9 @@ namespace aspect
                                                 const ArrayView<double> &data,
                                                 const SymmetricTensor<2,6> &elastic_tensor)
       {
-        for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
-          data[cpo_data_position + i] = elastic_tensor[SymmetricTensor<2,6>::unrolled_to_component_indices(i)];
+        Utilities::Tensors::unroll_symmetric_tensor_into_array(elastic_tensor,
+                                                               &data[cpo_data_position],
+                                                               &data[cpo_data_position]+SymmetricTensor<2,6>::n_independent_components);
       }
 
 


### PR DESCRIPTION
Something I noticed while reviewing #4370. We have quite a number of places in the code where we create Tensors from arrays or vectors, or unroll Tensors into arrays or vectors. We could simplify this using Tensor constructors, and appropriate `unroll` functions. Such functions are already provided by deal.II for the `Tensor` class, but they dont exist for `SymmetricTensor`. I here created small utility functions for `SymmetricTensor`, but of course it would be nice to use a version inside deal.II. Would that be of interest?

I can extend this PR to simplify a lot of places in ASPECT with the utility functions, but I first wanted to ask for feedback if the current interface is correct and if this is useful overall.