### PR TITLE
Use constructor and unroll function for tensors

### DIFF
--- a/cookbooks/finite_strain/doc/finite_strain.cc
+++ b/cookbooks/finite_strain/doc/finite_strain.cc
@@ -18,17 +18,16 @@
   <http://www.gnu.org/licenses/>.
 */
 
-for (unsigned int q=0; q < in.position.size(); ++q)
+for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
   {
     // Convert the compositional fields into the tensor quantity they represent.
-    Tensor<2,dim> strain;
-    for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-      strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+    const Tensor<2,dim> strain(make_array_view(&in.composition[q][0],
+                                               &in.composition[q][0] + Tensor<2,dim>::n_independent_components));
 
     // Compute the strain accumulated in this timestep.
     const Tensor<2,dim> strain_increment = this->get_timestep() * (velocity_gradients[q] * strain);
 
     // Output the strain increment component-wise to its respective compositional field's reaction terms.
-    for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-      out.reaction_terms[q][i] = strain_increment[Tensor<2,dim>::unrolled_to_component_indices(i)];
+    strain_increment.unroll(&out.reaction_terms[q][0],
+                            &out.reaction_terms[q][0] + Tensor<2,dim>::n_independent_components);
   }

--- a/cookbooks/finite_strain/finite_strain.cc
+++ b/cookbooks/finite_strain/finite_strain.cc
@@ -80,16 +80,15 @@ namespace aspect
           for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // Convert the compositional fields into the tensor quantity they represent.
-              Tensor<2,dim> strain;
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+              const Tensor<2,dim> strain(make_array_view(&in.composition[q][0],
+                                                         &in.composition[q][0] + Tensor<2,dim>::n_independent_components));
 
               // Compute the strain accumulated in this timestep.
               const Tensor<2,dim> strain_increment = this->get_timestep() * (velocity_gradients[q] * strain);
 
               // Output the strain increment component-wise to its respective compositional field's reaction terms.
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                out.reaction_terms[q][i] = strain_increment[Tensor<2,dim>::unrolled_to_component_indices(i)];
+              strain_increment.unroll(&out.reaction_terms[q][0],
+                                      &out.reaction_terms[q][0] + Tensor<2,dim>::n_independent_components);
             }
         }
     }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -395,9 +395,8 @@ namespace aspect
             case finite_strain_tensor:
             {
               // Calculate second invariant of left stretching tensor "L"
-              Tensor<2,dim> strain;
-              for (unsigned int q = 0; q < Tensor<2,dim>::n_independent_components ; ++q)
-                strain[Tensor<2,dim>::unrolled_to_component_indices(q)] = composition[q];
+              const Tensor<2,dim> strain(make_array_view(&composition[0],
+                                                         &composition[0] + Tensor<2,dim>::n_independent_components));
               const SymmetricTensor<2,dim> L = symmetrize( strain * transpose(strain) );
 
               const double strain_ii = std::fabs(second_invariant(L));

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -43,11 +43,8 @@ namespace aspect
                                                       const std::vector<Tensor<1,dim>> &gradients,
                                                       typename ParticleHandler<dim>::particle_iterator &particle) const
       {
-        const auto data = particle->get_properties();
-
-        Tensor<2,dim> old_strain;
-        for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-          old_strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = data[data_position + i];
+        const Tensor<2,dim> old_strain(make_array_view(&particle->get_properties()[data_position],
+                                                       &particle->get_properties()[data_position] + Tensor<2,dim>::n_independent_components));
 
         Tensor<2,dim> grad_u;
         for (unsigned int d=0; d<dim; ++d)
@@ -75,8 +72,9 @@ namespace aspect
         // strain of the current time step
         new_strain = old_strain + (k1 + 2.0*k2 + 2.0*k3 + k4)/6.0;
 
-        for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-          data[data_position + i] = new_strain[Tensor<2,dim>::unrolled_to_component_indices(i)];
+        // unroll and store the new strain
+        new_strain.unroll(&particle->get_properties()[data_position],
+                          &particle->get_properties()[data_position] + Tensor<2,dim>::n_independent_components);
       }
 
       template <int dim>

--- a/tests/simple_shear.cc
+++ b/tests/simple_shear.cc
@@ -80,16 +80,15 @@ namespace aspect
           for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // Convert the compositional fields into the tensor quantity they represent.
-              Tensor<2,dim> strain;
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+              const Tensor<2,dim> strain(make_array_view(&in.composition[q][0],
+                                                         &in.composition[q][0] + Tensor<2,dim>::n_independent_components));
 
               // Compute the strain accumulated in this timestep.
               const Tensor<2,dim> strain_increment = this->get_timestep() * (velocity_gradients[q] * strain);
 
               // Output the strain increment component-wise to its respective compositional field's reaction terms.
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                out.reaction_terms[q][i] = strain_increment[Tensor<2,dim>::unrolled_to_component_indices(i)];
+              strain_increment.unroll(&out.reaction_terms[q][0],
+                                      &out.reaction_terms[q][0] + Tensor<2,dim>::n_independent_components);
             }
         }
     }

--- a/tests/simple_shear_output_the_mobility.cc
+++ b/tests/simple_shear_output_the_mobility.cc
@@ -80,16 +80,15 @@ namespace aspect
           for (unsigned int q=0; q < in.n_evaluation_points(); ++q)
             {
               // Convert the compositional fields into the tensor quantity they represent.
-              Tensor<2,dim> strain;
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                strain[Tensor<2,dim>::unrolled_to_component_indices(i)] = in.composition[q][i];
+              const Tensor<2,dim> strain(make_array_view(&in.composition[q][0],
+                                                         &in.composition[q][0] + Tensor<2,dim>::n_independent_components));
 
               // Compute the strain accumulated in this timestep.
               const Tensor<2,dim> strain_increment = this->get_timestep() * (velocity_gradients[q] * strain);
 
               // Output the strain increment component-wise to its respective compositional field's reaction terms.
-              for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-                out.reaction_terms[q][i] = strain_increment[Tensor<2,dim>::unrolled_to_component_indices(i)];
+              strain_increment.unroll(&out.reaction_terms[q][0],
+                                      &out.reaction_terms[q][0] + Tensor<2,dim>::n_independent_components);
             }
         }
     }


### PR DESCRIPTION
This PR is similar to #5640, except it only uses the existing unroll functions and constructors of the `Tensor` class to simplify the creation and unrolling of tensors from and into compositional fields.