### PR TITLE
Remove unused particle code path

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -480,19 +480,6 @@ namespace aspect
         void
         local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
                                const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
-
-        /**
-         * Update the particle properties of one cell.
-         *
-         * This version of the function above uses the deal.II class FEPointEvaluation,
-         * which allows for a faster evaluation of the solution under certain conditions.
-         * Check the place where this function is called for a list of conditions
-         * (they will change while FEPointEvaluation is generalized).
-         */
-        void
-        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
                                const typename ParticleHandler<dim>::particle_iterator &end_particle,
                                internal::SolutionEvaluators<dim> &evaluators);
 
@@ -503,24 +490,6 @@ namespace aspect
          * during this advection step are removed from the local multimap and
          * stored in @p particles_out_of_cell for further treatment (sorting
          * them into the new cell).
-         */
-        void
-        local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               const typename ParticleHandler<dim>::particle_iterator &begin_particle,
-                               const typename ParticleHandler<dim>::particle_iterator &end_particle);
-
-        /**
-         * Advect the particles of one cell. Performs only one step for
-         * multi-step integrators. Needs to be called until integrator->continue()
-         * evaluates to false. Particles that moved out of their old cell
-         * during this advection step are removed from the local multimap and
-         * stored in @p particles_out_of_cell for further treatment (sorting
-         * them into the new cell).
-         *
-         * This version of the above function uses the deal.II class FEPointEvaluation,
-         * which allows for a faster evaluation of the solution under certain conditions.
-         * Check the place where this function is called for a list of conditions
-         * (they will change while FEPointEvaluation is generalized).
          */
         void
         local_advect_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,


### PR DESCRIPTION
These functions were the old (and slow) way to evaluate the solution at particle positions. They were necessary in the past, because FEPointEvaluation did not support all the mappings we use (in particular MappingCartesian) and prior to deal.II 9.4 there was a bug in FEPointEvaluation if evaluation started not a the first component of an FESystem. Both limitations have been fixed for a while and I couldnt think of (or find) any configuration in which we would still need the old code path. I still left an assert in that ensure we will not use the slow path of FEPointEvaluation (which is even slower than the implementation I am removing here). This will make sure that if someone uses an exotic mapping in the future, or other conditions change we at least learn about it.