### PR TITLE
Improve functions to retrieve fields of certain type from introspection

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -57,16 +57,21 @@ namespace aspect
      */
     enum Type
     {
-      chemical_composition,
-      stress,
-      strain,
-      grain_size,
-      porosity,
-      density,
-      entropy,
-      generic,
-      unspecified
+      chemical_composition = 0,
+      stress = 1,
+      strain = 2,
+      grain_size = 3,
+      porosity = 4,
+      density = 5,
+      entropy = 6,
+      generic = 7,
+      unspecified = 8
     } type;
+
+    /**
+     * The number of different types defined in Type.
+    */
+    constexpr static unsigned int n_types = 9;
 
     /**
      * This function translates an input string into the
@@ -480,6 +485,9 @@ namespace aspect
       /**
        * A function that returns the names of
        * compositional fields that correspond to chemical compositions.
+       *
+       * This function is shorthand for
+       * get_names_for_fields_of_type(CompositionalFieldDescription::chemical_composition).
        */
       const std::vector<std::string> &
       chemical_composition_field_names () const;
@@ -487,6 +495,9 @@ namespace aspect
       /**
        * A function that returns the indices of
        * compositional fields that correspond to chemical compositions.
+       *
+       * This function is shorthand for
+       * get_indices_for_fields_of_type(CompositionalFieldDescription::chemical_composition).
        */
       const std::vector<unsigned int> &
       chemical_composition_field_indices () const;
@@ -494,6 +505,9 @@ namespace aspect
       /**
        * A function that returns the number of
        * compositional fields that correspond to chemical compositions.
+       *
+       * This function is shorthand for
+       * get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition).
        */
       unsigned int
       n_chemical_composition_fields () const;
@@ -509,7 +523,6 @@ namespace aspect
       bool
       composition_type_exists (const CompositionalFieldDescription::Type &type) const;
 
-
       /**
        * A function that gets the type of a compositional field as an input
        * parameter and returns the index of the first compositional field of
@@ -521,7 +534,6 @@ namespace aspect
        */
       unsigned int
       find_composition_type (const CompositionalFieldDescription::Type &type) const;
-
 
       /**
        * A function that gets the name of a compositional field as an input
@@ -538,14 +550,14 @@ namespace aspect
        * Get the indices of the compositional fields which are of a
        * particular type (chemical composition, porosity, etc.).
        */
-      const std::vector<unsigned int>
+      const std::vector<unsigned int> &
       get_indices_for_fields_of_type (const CompositionalFieldDescription::Type &type) const;
 
       /**
        * Get the names of the compositional fields which are of a
        * particular type (chemical composition, porosity, etc.).
        */
-      const std::vector<std::string>
+      const std::vector<std::string> &
       get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const;
 
       /**
@@ -580,26 +592,18 @@ namespace aspect
       std::vector<CompositionalFieldDescription> composition_descriptions;
 
       /**
-       * A vector that stores the names of the compositional fields
-       * corresponding to chemical compositions that will
-       * be used in the simulation.
+       * A vector of vectors of composition names that stores the
+       * names of the compositional fields corresponding to each field type
+       * given in CompositionalFieldDescription.
        */
-      std::vector<std::string> chemical_composition_names;
+      std::vector<std::vector<std::string>> composition_names_for_type;
 
       /**
-       * A vector that stores the indices of the compositional fields
-       * corresponding to chemical compositions that will
-       * be used in the simulation.
+       * A vector of vectors of composition indices that stores the
+       * indices of the compositional fields corresponding to each field type
+       * given in CompositionalFieldDescription.
        */
-      std::vector<unsigned int> chemical_composition_indices;
-
-      /**
-       * The number of compositional fields
-       * that correspond to chemical compositions that will
-       * be used in the simulation.
-       */
-      const unsigned int n_chemical_compositions;
-
+      std::vector<std::vector<unsigned int>> composition_indices_for_type;
   };
 }
 

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -454,7 +454,8 @@ namespace aspect
 
           // Rheological parameters for chemical compositions
           // increment by one for background:
-          const unsigned int n_chemical_composition_fields = this->introspection().n_chemical_composition_fields() + 1;
+          const unsigned int n_chemical_composition_fields =
+            this->introspection().n_chemical_composition_fields() + 1;
 
           // Diffusion creep parameters
           diffusion_creep.initialize_simulator (this->get_simulator());

--- a/source/material_model/multicomponent.cc
+++ b/source/material_model/multicomponent.cc
@@ -42,7 +42,8 @@ namespace aspect
           // The (incompressible) Boussinesq approximation treats the
           // buoyancy term as Delta rho[i] * C[i], which implies that
           // compositional fields are given as volume fractions.
-          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i], this->introspection().chemical_composition_field_indices());
+          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i],
+                                                       this->introspection().chemical_composition_field_indices());
 
           equation_of_state.evaluate(in, i, eos_outputs);
           out.viscosities[i] = MaterialUtilities::average_value(volume_fractions, viscosities, viscosity_averaging);

--- a/source/material_model/rheology/friction_models.cc
+++ b/source/material_model/rheology/friction_models.cc
@@ -97,7 +97,7 @@ namespace aspect
               // If chemical fields are present, volume_fractions will be of size 1+n_chemical_composition_fields.
               // The size of chemical_composition_field_indices will be one less.
               unsigned int index = 0;
-              if (this->introspection().n_chemical_composition_fields() > 0)
+              if (this->introspection().composition_type_exists(CompositionalFieldDescription::chemical_composition))
                 index = this->introspection().chemical_composition_field_indices()[volume_fraction_index-1];
               double friction_from_function =
                 friction_function->value(Utilities::convert_array_to_point<dim>(point.get_coordinates()),index);

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -291,7 +291,8 @@ namespace aspect
           else
             {
               // We only want to compute mass/volume fractions for fields that are chemical compositions.
-              mass_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i], this->introspection().chemical_composition_field_indices());
+              mass_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i],
+                                                                                     this->introspection().chemical_composition_field_indices());
 
               // The function compute_volumes_from_masses expects as many mass_fractions as densities.
               // But the function compute_composition_fractions always adds another element at the start
@@ -534,11 +535,12 @@ namespace aspect
           equation_of_state.parse_parameters(prm);
 
           // Assign background field and do some error checking
+          const unsigned int n_chemical_composition_fields = this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition);
           has_background_field = ((equation_of_state.number_of_lookups() == 1) ||
-                                  (equation_of_state.number_of_lookups() == this->introspection().n_chemical_composition_fields() + 1));
+                                  (equation_of_state.number_of_lookups() == n_chemical_composition_fields + 1));
           AssertThrow ((equation_of_state.number_of_lookups() == 1) ||
-                       (equation_of_state.number_of_lookups() == this->introspection().n_chemical_composition_fields()) ||
-                       (equation_of_state.number_of_lookups() == this->introspection().n_chemical_composition_fields() + 1),
+                       (equation_of_state.number_of_lookups() == n_chemical_composition_fields) ||
+                       (equation_of_state.number_of_lookups() == n_chemical_composition_fields + 1),
                        ExcMessage("The Steinberger material model assumes that either there is a single material "
                                   "in the simulation, or that all compositional fields of the type "
                                   "chemical composition correspond to mass fractions of different materials. "
@@ -547,7 +549,7 @@ namespace aspect
                                   "or one additional file (if a background field is used). You have "
                                   + Utilities::int_to_string(equation_of_state.number_of_lookups())
                                   + " material data files, but there are "
-                                  + Utilities::int_to_string(this->introspection().n_chemical_composition_fields())
+                                  + Utilities::int_to_string(n_chemical_composition_fields)
                                   + " fields of type chemical composition."));
 
           // Parse the Composition viscosity prefactors parameter

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -133,7 +133,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      EquationOfStateOutputs<dim> eos_outputs (this->introspection().n_chemical_composition_fields()+1);
+      EquationOfStateOutputs<dim> eos_outputs (this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition)+1);
       EquationOfStateOutputs<dim> eos_outputs_all_phases (n_phases);
 
       std::vector<double> average_elastic_shear_moduli (in.n_evaluation_points());
@@ -176,7 +176,8 @@ namespace aspect
                                                   n_phase_transitions_for_each_chemical_composition,
                                                   eos_outputs);
 
-          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i], this->introspection().chemical_composition_field_indices());
+          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(in.composition[i],
+                                                       this->introspection().chemical_composition_field_indices());
 
           // not strictly correct if thermal expansivities are different, since we are interpreting
           // these compositions as volume fractions, but the error introduced should not be too bad.
@@ -385,8 +386,6 @@ namespace aspect
 
           std::vector<unsigned int> n_phases_for_each_composition = phase_function.n_phases_for_each_composition();
 
-          const std::vector<unsigned int> indices = this->introspection().chemical_composition_field_indices();
-
           // Currently, phase_function.n_phases_for_each_composition() returns a list of length
           // equal to the total number of compositions, whether or not they are chemical compositions.
           // The equation_of_state (multicomponent incompressible) requires a list only for
@@ -394,7 +393,7 @@ namespace aspect
           std::vector<unsigned int> n_phases_for_each_chemical_composition = {n_phases_for_each_composition[0]};
           n_phase_transitions_for_each_chemical_composition = {n_phases_for_each_composition[0] - 1};
           n_phases = n_phases_for_each_composition[0];
-          for (auto i : indices)
+          for (auto i : this->introspection().chemical_composition_field_indices())
             {
               n_phases_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1]);
               n_phase_transitions_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1] - 1);

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -34,7 +34,7 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      EquationOfStateOutputs<dim> eos_outputs (this->introspection().n_chemical_composition_fields()+1);
+      EquationOfStateOutputs<dim> eos_outputs (this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition)+1);
 
       // Store which components to exclude during volume fraction computation.
       ComponentMask composition_mask(this->n_compositional_fields(), true);
@@ -50,7 +50,8 @@ namespace aspect
         {
           const std::vector<double> composition = in.composition[i];
 
-          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(composition, this->introspection().chemical_composition_field_indices());
+          const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(composition,
+                                                       this->introspection().chemical_composition_field_indices());
 
           equation_of_state.evaluate(in, i, eos_outputs);
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -405,6 +405,8 @@ namespace aspect
   bool
   Introspection<dim>::composition_type_exists (const CompositionalFieldDescription::Type &type) const
   {
+    Assert(type < composition_indices_for_type.size(), ExcInternalError());
+
     return composition_indices_for_type[type].size() > 0;
   }
 
@@ -414,6 +416,8 @@ namespace aspect
   unsigned int
   Introspection<dim>::find_composition_type (const typename CompositionalFieldDescription::Type &type) const
   {
+    Assert(type < composition_indices_for_type.size(), ExcInternalError());
+
     if (composition_indices_for_type[type].size() > 0)
       return composition_indices_for_type[type][0];
 
@@ -439,6 +443,7 @@ namespace aspect
   const std::vector<unsigned int> &
   Introspection<dim>::get_indices_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
+    Assert(type < composition_indices_for_type.size(), ExcInternalError());
     return composition_indices_for_type[type];
   }
 
@@ -448,6 +453,7 @@ namespace aspect
   const std::vector<std::string> &
   Introspection<dim>::get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
+    Assert(type < composition_names_for_type.size(), ExcInternalError());
     return composition_names_for_type[type];
   }
 
@@ -457,6 +463,7 @@ namespace aspect
   unsigned int
   Introspection<dim>::get_number_of_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
+    Assert(type < composition_indices_for_type.size(), ExcInternalError());
     return composition_indices_for_type[type].size();
   }
 

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -256,10 +256,16 @@ namespace aspect
     compositional_field_methods(parameters.compositional_field_methods),
     composition_names(parameters.names_of_compositional_fields),
     composition_descriptions(parameters.composition_descriptions),
-    chemical_composition_names (get_names_for_fields_of_type(CompositionalFieldDescription::chemical_composition)),
-    chemical_composition_indices (get_indices_for_fields_of_type(CompositionalFieldDescription::chemical_composition)),
-    n_chemical_compositions (get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition))
-  {}
+    composition_names_for_type(CompositionalFieldDescription::n_types),
+    composition_indices_for_type(CompositionalFieldDescription::n_types)
+  {
+    // Set up the indices for the different types of compositional fields
+    for (unsigned int c=0; c<composition_descriptions.size(); ++c)
+      {
+        composition_indices_for_type[composition_descriptions[c].type].push_back(c);
+        composition_names_for_type[composition_descriptions[c].type].push_back(composition_names[c]);
+      }
+  }
 
 
 
@@ -372,7 +378,7 @@ namespace aspect
   const std::vector<std::string> &
   Introspection<dim>::chemical_composition_field_names () const
   {
-    return chemical_composition_names;
+    return get_names_for_fields_of_type(CompositionalFieldDescription::chemical_composition);
   }
 
 
@@ -381,7 +387,7 @@ namespace aspect
   const std::vector<unsigned int> &
   Introspection<dim>::chemical_composition_field_indices () const
   {
-    return chemical_composition_indices;
+    return get_indices_for_fields_of_type(CompositionalFieldDescription::chemical_composition);
   }
 
 
@@ -390,7 +396,7 @@ namespace aspect
   unsigned int
   Introspection<dim>::n_chemical_composition_fields () const
   {
-    return n_chemical_compositions;
+    return get_number_of_fields_of_type(CompositionalFieldDescription::Type::chemical_composition);
   }
 
 
@@ -399,10 +405,7 @@ namespace aspect
   bool
   Introspection<dim>::composition_type_exists (const CompositionalFieldDescription::Type &type) const
   {
-    for (unsigned int c=0; c<composition_descriptions.size(); ++c)
-      if (composition_descriptions[c].type == type)
-        return true;
-    return false;
+    return composition_indices_for_type[type].size() > 0;
   }
 
 
@@ -411,9 +414,9 @@ namespace aspect
   unsigned int
   Introspection<dim>::find_composition_type (const typename CompositionalFieldDescription::Type &type) const
   {
-    for (unsigned int c=0; c<composition_descriptions.size(); ++c)
-      if (composition_descriptions[c].type == type)
-        return c;
+    if (composition_indices_for_type[type].size() > 0)
+      return composition_indices_for_type[type][0];
+
     return composition_descriptions.size();
   }
 
@@ -433,31 +436,19 @@ namespace aspect
 
 
   template <int dim>
-  const std::vector<unsigned int>
+  const std::vector<unsigned int> &
   Introspection<dim>::get_indices_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
-    std::vector<unsigned int> indices;
-
-    for (unsigned int i=0; i<n_compositional_fields; ++i)
-      if (composition_descriptions[i].type == type)
-        indices.push_back(i);
-
-    return indices;
+    return composition_indices_for_type[type];
   }
 
 
 
   template <int dim>
-  const std::vector<std::string>
+  const std::vector<std::string> &
   Introspection<dim>::get_names_for_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
-    std::vector<std::string> names;
-
-    for (unsigned int i=0; i<n_compositional_fields; ++i)
-      if (composition_descriptions[i].type == type)
-        names.push_back(composition_names[i]);
-
-    return names;
+    return composition_names_for_type[type];
   }
 
 
@@ -466,13 +457,7 @@ namespace aspect
   unsigned int
   Introspection<dim>::get_number_of_fields_of_type (const CompositionalFieldDescription::Type &type) const
   {
-    unsigned int n = 0;
-
-    for (unsigned int i=0; i<n_compositional_fields; ++i)
-      if (composition_descriptions[i].type == type)
-        n += 1;
-
-    return n;
+    return composition_indices_for_type[type].size();
   }
 
 


### PR DESCRIPTION
This PR improves the functionality inside the `Introspection` class to retrieve the names or indices of certain field types. In particular it changes:
- some functions now return references instead of copies of vectors, saving on dynamic allocations
- the information returned in a number of functions is now precomputed on model start, which makes returning this information much faster (no more `push_back` into a vector which is then returned by-value)

This PR should allow to retrieve this information quickly even in loops over cells without significant performance penalty.

This should help somewhat with an application in #4370.

@anne-glerum, @jdannberg or @bobmyhill could you take a look at  this PR?