### PR TITLE
candi local.cfg: use deal.II 9.5.2

### DIFF
--- a/contrib/install/local.cfg
+++ b/contrib/install/local.cfg
@@ -1,6 +1,6 @@
 PACKAGES="load:dealii-prepare once:cmake once:astyle once:hdf5 once:netcdf once:sundials once:p4est once:trilinos dealii"
 
-DEAL_II_VERSION=v9.5.1
+DEAL_II_VERSION=v9.5.2
 NATIVE_OPTIMIZATIONS=ON
 BUILD_EXAMPLES=OFF
 MKL=OFF


### PR DESCRIPTION
The changes in .2 are fairly small and we are likely not affected, but it doesn't hurt being on the latest version.
