### PR TITLE
Remove an outdated version check.

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -110,12 +110,8 @@ namespace aspect
       if (geometry_model.has_curved_elements())
         return std::make_unique<MappingQCache<dim>>(4);
 
-#if DEAL_II_VERSION_GTE(9,4,1)
       if (Plugins::plugin_type_matches<const InitialTopographyModel::ZeroTopography<dim>>(initial_topography_model))
         return std::make_unique<MappingCartesian<dim>>();
-#else
-      (void) initial_topography_model;
-#endif
 
       return std::make_unique<MappingQ1<dim>>();
     }


### PR DESCRIPTION
We now require deal.II 9.5, so this check is no longer needed.