### PR TITLE
Ensure we only run the WGS84 code if in 3d.

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -762,6 +762,8 @@ namespace aspect
       std::array<double,dim>
       WGS84_coordinates(const Point<dim> &position)
       {
+        Assert (dim==3, ExcNotImplemented());
+
         std::array<double,dim> ecoord;
 
         // Define WGS84 ellipsoid constants.


### PR DESCRIPTION
part of  #5656.

As far as I can see, we don't call this function to begin with from anywhere. But if we ever do, make sure it is only in a 3d context.