### PR TITLE
Make reset of grain size at phase transitions only depend on velocity

### DIFF
--- a/doc/modules/changes/20240530_dannberg
+++ b/doc/modules/changes/20240530_dannberg
@@ -1,0 +1,6 @@
+Changed: The reset of the grain size at phase transitions
+is now determined only by the velocity of the material
+moving through a transition rather than by a somewhat
+arbitrary 'transition width' parameter.
+<br>
+(Juliane Dannberg, 2024/05/30)

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -450,13 +450,12 @@ namespace aspect
         convert_log_grain_size (std::vector<double> &compositional_fields) const;
 
         /**
-         * list of depth, width and Clapeyron slopes for the different phase
+         * List of depth, temperature and Clapeyron slopes for the different phase
          * transitions and in which phase they occur
          */
         std::vector<double> transition_depths;
         std::vector<double> transition_temperatures;
         std::vector<double> transition_slopes;
-        std::vector<double> transition_widths;
 
 
         /**

--- a/tests/grain_size_crossed_transition.prm
+++ b/tests/grain_size_crossed_transition.prm
@@ -1,0 +1,161 @@
+# A test for the grain size material model to see if the grain
+# size is reset correctly after crossing a phase transition.
+# The model contains a phase transition in the middle at 50 km depth
+# where the grain size is reset to 1 mm (from the initial value of
+# 2 mm). The vertical component of the velocity prescribed at the top
+# and bottom boundary is a sine wave, so that in the left half of
+# the model, grain size is reset above the transition, and in the
+# right half it is reset below the phase transition.
+
+set Dimension                              = 2
+set End time                               = 10000
+set Use years in output instead of seconds = true
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 300000
+    set Y extent = 100000
+    set X periodic = true
+    set X repetitions = 3
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top,bottom
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 1600
+  end
+end
+
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = top:function, bottom:function
+
+  subsection Function
+    set Function expression = 0.1; sin(x/300000*2*pi)
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = adiabatic
+
+  subsection Adiabatic
+    set Age top boundary layer      = 0
+
+    subsection Function
+      set Function expression       = 0
+    end
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  =
+    set Function expression = 2e-3
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields   = grain_size
+  set Compositional field methods = particles
+  set Types of fields = grain size
+  set Mapped particle properties = grain_size:grain_size
+end
+
+subsection Material model
+  set Model name = grain size
+
+  subsection Grain size model
+    set Reference density                    = 3400
+    set Thermal conductivity                 = 0
+    set Thermal expansion coefficient        = 0
+    set Reference compressibility            = 0
+    set Viscosity                            = 1e19
+    set Minimum viscosity                    = 1e16
+    set Reference temperature                = 1600
+    set Grain growth activation energy       = 4e5, 4e5
+    set Grain growth activation volume       = 0, 0
+    set Grain growth rate constant           = 0, 0
+    set Grain growth exponent                = 3, 3
+    set Average specific grain boundary energy = 1, 1
+    set Work fraction for boundary area change = 0.1, 0.1
+    set Geometric constant                   = 3, 3
+    set Grain size evolution formulation     = paleowattmeter
+    set Reciprocal required strain           = 10
+
+    set Phase transition depths              = 50000
+    set Phase transition Clapeyron slopes    = 1e6
+    set Phase transition temperatures        = 1600
+    set Recrystallized grain size            = 1e-3
+
+    # Faul and Jackson 2007
+    # Diffusion creep
+    # new scaled prefactors to match vertical viscosity profile
+    set Diffusion creep prefactor            = 3.0e-016, 3.0e-016 # s^-1 Pa^-1 m^p
+    set Diffusion creep exponent             = 1, 1 # 1 for diffusion creep
+    set Diffusion creep grain size exponent  = 3, 3
+    set Diffusion activation energy          = 3.75e5, 3.75e5 #J/mol
+    set Diffusion activation volume          = 0, 0 # m^3/mol (from Karato 2010)
+    set Dislocation viscosity iteration threshold = 1e-3
+
+    # No dislocation creep
+    set Dislocation creep prefactor          = 1e-200, 1e-200 # s^-1 Pa^-n
+    set Dislocation creep exponent           = 1, 1
+    set Dislocation activation energy        = 0, 0 # J/mol
+    set Dislocation activation volume        = 0, 0 # m^3/mol
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 1
+  set Initial global refinement          = 3
+  set Time steps between mesh refinement = 0
+  set Strategy                           = minimum refinement function
+
+  subsection Minimum refinement function
+    set Variable names = depth, nothing
+    set Function expression = if(depth>40000 && depth <60000, 4, 2)
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, composition statistics, particles
+  subsection Visualization
+    set List of output variables  = material properties
+    set Time between graphical output = 0
+  end
+
+  subsection Particles
+    set List of particle properties = grain size
+    set Number of particles = 10000
+    set Time between data output = 0
+    set Particle generator name = probability density function
+
+    subsection Generator
+      subsection Probability density function
+        set Function expression = sin(y/100000*pi)
+      end
+    end
+  end
+end

--- a/tests/grain_size_crossed_transition/screen-output
+++ b/tests/grain_size_crossed_transition/screen-output
@@ -1,0 +1,81 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 3,557 (1,666+225+833+833)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 10+0 iterations.
+
+Number of active cells: 264 (on 5 levels)
+Number of degrees of freedom: 5,285 (2,482+321+1,241+1,241)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 31+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition/solution/solution-00000
+     Compositions min/max/mass: 0.002/0.002/6e+07
+     Writing particle output:   output-grain_size_crossed_transition/particles/particles-00000
+
+*** Timestep 1:  t=3221.89 years, dt=3221.89 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition/solution/solution-00001
+     Compositions min/max/mass: 0.001313/0.002/5.938e+07
+     Writing particle output:   output-grain_size_crossed_transition/particles/particles-00001
+
+*** Timestep 2:  t=6442.31 years, dt=3220.42 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 29+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition/solution/solution-00002
+     Compositions min/max/mass: 0.001/0.002/5.876e+07
+     Writing particle output:   output-grain_size_crossed_transition/particles/particles-00002
+
+*** Timestep 3:  t=9648.75 years, dt=3206.45 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition/solution/solution-00003
+     Compositions min/max/mass: 0.001/0.002/5.816e+07
+     Writing particle output:   output-grain_size_crossed_transition/particles/particles-00003
+
+*** Timestep 4:  t=10000 years, dt=351.245 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 25+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition/solution/solution-00004
+     Compositions min/max/mass: 0.001/0.002/5.81e+07
+     Writing particle output:   output-grain_size_crossed_transition/particles/particles-00004
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/grain_size_crossed_transition/statistics
+++ b/tests/grain_size_crossed_transition/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Number of advected particles
+# 17: Particle file name
+0 0.000000000000e+00 0.000000000000e+00 264 2803 1241 1241 0 30 32 160 output-grain_size_crossed_transition/solution/solution-00000 2.00000000e-03 2.00000000e-03 6.00000000e+07 10000 output-grain_size_crossed_transition/particles/particles-00000 
+1 3.221888105682e+03 3.221888105682e+03 264 2803 1241 1241 0 24 26 130 output-grain_size_crossed_transition/solution/solution-00001 1.31250000e-03 2.00000000e-03 5.93820271e+07  9956 output-grain_size_crossed_transition/particles/particles-00001 
+2 6.442308952690e+03 3.220420847008e+03 264 2803 1241 1241 0 28 30 150 output-grain_size_crossed_transition/solution/solution-00002 1.00000000e-03 2.00000000e-03 5.87617466e+07  9890 output-grain_size_crossed_transition/particles/particles-00002 
+3 9.648754753904e+03 3.206445801214e+03 264 2803 1241 1241 0 29 31 155 output-grain_size_crossed_transition/solution/solution-00003 1.00000000e-03 2.00000000e-03 5.81631659e+07  9815 output-grain_size_crossed_transition/particles/particles-00003 
+4 1.000000000000e+04 3.512452460959e+02 264 2803 1241 1241 0 24 26 130 output-grain_size_crossed_transition/solution/solution-00004 1.00000000e-03 2.00000000e-03 5.81049139e+07  9811 output-grain_size_crossed_transition/particles/particles-00004 


### PR DESCRIPTION
This PR makes the reset of the grain size at phase transitions now only depend on the velocity of the material moving through a transition (and how far away from the transition it is) rather than on a somewhat arbitrary 'transition width' parameter. I am attaching the graphical output of the test case I made below, which clearly shows that the new feature works as intended. 

This also has the advantage that we can use the phase function class from the material model utilities in this material model in the future (to replace the hand-written phase function). 

![grain_size_test](https://github.com/geodynamics/aspect/assets/7517347/ff8e59f7-b6bd-4874-a665-c92ca04c2b2b)


### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
