### PR TITLE
Allow triggering the deal.II master tester image build

### DIFF
--- a/.github/workflows/build_tester_base_image.yml
+++ b/.github/workflows/build_tester_base_image.yml
@@ -1,6 +1,7 @@
 name: build-tester-base-image
 
 on:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # trigger at 1:30 am every day


### PR DESCRIPTION
Usually the deal.II master image for the tester is built daily. However, in the past days we had two times the situation that the image had a bug that would cause all runs with the tester to fail. It was fast to fix these problems, but then we had to wait and live with a broken tester until the image was rebuild at the end of the day. This PR adds the option to trigger the build of a new image manually. It is still built daily by default.