### PR TITLE
Try a better choice for the SPD factor in Newton's method.

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2536,7 +2536,7 @@ namespace aspect
       //   [eta + a:b] > (1-safety_factor)*eta
       // is already satisfied, then we can choose alpha=1
       const double a_colon_b = strain_rate * dviscosities_dstrain_rate;
-      if (eta + a_colon_b > eta * (1-SPD_safety_factor))
+      if (eta + a_colon_b > eta * (1. - SPD_safety_factor))
         return 1.0;
       else
         {

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2521,19 +2521,32 @@ namespace aspect
       if ((strain_rate.norm() == 0) || (dviscosities_dstrain_rate.norm() == 0))
         return 1;
 
-      // If the correction a:b+b:a is smaller than 2*eta (by at least
-      // the safety factor), then we are on the safe side and can
-      // use the optimal value 1. (We are here assuming the common case
-      // where a is parallel to b, so a:b+b:a = 2a*b and we can drop
-      // the factor of 2 on both sides
+
+      // The factor in the Newton matrix is going to be of the form
+      //   2*eta I + (a \otimes b + b \otimes a)
+      // where a=strain_rate and b=dviscosities_dstrain_rate.
+      //
+      // If a,b are parallel, this simplifies to
+      //   [2*eta + 2 a:b] I =  2 [eta + a:b] I
+      // and we need to make sure that
+      //   [eta + alpha a:b] > (1-safety_factor)*eta
+      // by choosing alpha appropriately.
+
+      // So, first check: If
+      //   [eta + a:b] > (1-safety_factor)*eta
+      // is already satisfied, then we can choose alpha=1
       const double a_colon_b = strain_rate * dviscosities_dstrain_rate;
-      if (a_colon_b < eta * SPD_safety_factor)
+      if (eta + a_colon_b > eta * (1-SPD_safety_factor))
         return 1.0;
       else
-        // Otherwise we have that the correction a:b+b:a=2a*b is
-        // too large and we have to return a factor smaller than
-        // one.
-        return SPD_safety_factor * std::abs(eta / a_colon_b);
+        {
+          // Otherwise solve the equation above for alpha, which yields
+          //   a:b = -safety_factor*eta / a:b
+          // This can only ever happen if a:b < 0, so we get
+          //   a:b = safety_factor * abs(eta / a:b)
+          Assert (a_colon_b < 0, ExcInternalError());
+          return SPD_safety_factor * std::abs(eta / a_colon_b);
+        }
     }
 
 


### PR DESCRIPTION
This is another follow-up to #5671 and @YiminJin 's patches in #5580 (and following #5555).

@YiminJin 's choice of alpha was demonstrably better than what was implemented before, but I can not quite convince myself that it chooses alpha=1 correctly. To wit, the previous condition for alpha=1 was
```
 if (a_colon_b < eta * SPD_safety_factor)
   return 1.0;
```
But, the whole machinery is only necessary if `a:b < 0`, which is the strain rate weakening case. If the material is strain rate hardening (`a:b>0`), Newton's method should always be ok. But the condition above gets this wrong I believe. It uses the full Newton step *always* for `a:b < 0`, which I think is wrong. Furthermore, it *never* chooses alpha=1 if `a:b` happens to be large, which is the uncritical case.

This patch fixes this, and adds some documentation of why I think the implementation is correct. I'm going to be curious to see how this affects the tests.

@naliboff Since you wanted to play with this, I'd be interested in seeing what happens with your tests if you applied this patch.