### PR TITLE
Change plugin name in cpo elastic tensor and use olivine stiffness matrix in initialization

### DIFF
--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -125,10 +125,6 @@ namespace aspect
                                                               std::vector<double> &data) const
       {
 
-        // Get a reference to the CPO particle property.
-        const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
-          this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
-
         // At initialization, the deformation type for cpo is initialized to -1.
         // Initialize with the stiffness matrix of olivine to avoid errors in the computation.
 

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -73,7 +73,7 @@ namespace aspect
         AssertThrow(manager.check_plugin_order("crystal preferred orientation","cpo elastic tensor"),
                     ExcMessage("To use the cpo elastic tensor plugin, the cpo plugin needs to be defined before this plugin."));
 
-        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("cpo"));
+        cpo_data_position = manager.get_data_info().get_position_by_plugin_index(manager.get_plugin_index_by_name("crystal preferred orientation"));
       }
 
 
@@ -129,9 +129,23 @@ namespace aspect
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
           this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
 
-        const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
-                                                                            cpo_data_position,
-                                                                            data);
+        // At initialization, the deformation type for cpo is initialized to -1,
+        // but voigt_average_elastic_tensor need a non -1 value to compute the average.
+        // Initialize with the stiffness matrix of olivine to avoid the error.
+        // const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
+        //                                                                     cpo_data_position,
+        //                                                                     data);
+
+        SymmetricTensor<2,6> C_average;
+        C_average[0][0] = stiffness_matrix_olivine[0][0];
+        C_average[0][1] = stiffness_matrix_olivine[0][1];
+        C_average[0][2] = stiffness_matrix_olivine[0][2];
+        C_average[1][1] = stiffness_matrix_olivine[1][1];
+        C_average[1][2] = stiffness_matrix_olivine[1][2];
+        C_average[2][2] = stiffness_matrix_olivine[2][2];
+        C_average[3][3] = stiffness_matrix_olivine[3][3];
+        C_average[4][4] = stiffness_matrix_olivine[4][4];
+        C_average[5][5] = stiffness_matrix_olivine[5][5];
 
         for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
           {

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -129,27 +129,12 @@ namespace aspect
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
           this->get_particle_world().get_property_manager().template get_matching_property<Particle::Property::CrystalPreferredOrientation<dim>>();
 
-        // At initialization, the deformation type for cpo is initialized to -1,
-        // but voigt_average_elastic_tensor need a non -1 value to compute the average.
-        // Initialize with the stiffness matrix of olivine to avoid the error.
-        // const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
-        //                                                                     cpo_data_position,
-        //                                                                     data);
-
-        SymmetricTensor<2,6> C_average;
-        C_average[0][0] = stiffness_matrix_olivine[0][0];
-        C_average[0][1] = stiffness_matrix_olivine[0][1];
-        C_average[0][2] = stiffness_matrix_olivine[0][2];
-        C_average[1][1] = stiffness_matrix_olivine[1][1];
-        C_average[1][2] = stiffness_matrix_olivine[1][2];
-        C_average[2][2] = stiffness_matrix_olivine[2][2];
-        C_average[3][3] = stiffness_matrix_olivine[3][3];
-        C_average[4][4] = stiffness_matrix_olivine[4][4];
-        C_average[5][5] = stiffness_matrix_olivine[5][5];
+        // At initialization, the deformation type for cpo is initialized to -1.
+        // Initialize with the stiffness matrix of olivine to avoid errors in the computation.
 
         for (unsigned int i = 0; i < SymmetricTensor<2,6>::n_independent_components ; ++i)
           {
-            data.push_back(C_average[SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
+            data.push_back(stiffness_matrix_olivine[SymmetricTensor<2,6>::unrolled_to_component_indices(i)]);
           }
 
 


### PR DESCRIPTION
Following issue #3885 and PR #5116, I added some changes to the cpo elastic tensor to be able to use it:
1. The plugin name is changed from "cpo" to "crystal preferred orientation".
2. In the initialization stage of cpo elastic tensor, the default deformation type is -1. Under this condition computing the voigt average is not implemented yet. I changed to use the olivine stiffness matrix instead of using voigt_average_elastic_tensor.