### PR TITLE
Cleanup: use PhaseFunction class in grain size material model

### DIFF
--- a/doc/modules/changes/20240531_dannberg
+++ b/doc/modules/changes/20240531_dannberg
@@ -1,0 +1,11 @@
+Changed: The grain size material model now uses the
+phase function class to compute where phase transitions
+occur. This means that phase transition temperature,
+depth and Clapeyron slope now have to be specified in
+a different format in the input file (rather than a
+comma-separated list, they can now be specified as
+key:value1|value2|...). This is in line with other
+material models. Note that the width of phase
+transitions is still zero in the grain size model.
+<br>
+(Juliane Dannberg, 2024/05/31)

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -599,6 +599,11 @@ namespace aspect
           double get_transition_slope (const unsigned int phase_index) const;
 
           /**
+           * Return the depth for phase transition number @p phase_index.
+           */
+          double get_transition_depth (const unsigned int phase_index) const;
+
+          /**
            * Return how many phase transitions there are for each composition.
            */
           const std::vector<unsigned int> &

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -108,73 +108,29 @@ namespace aspect
 
 
     template <int dim>
-    double
-    GrainSize<dim>::
-    phase_function (const Point<dim> &position,
-                    const double temperature,
-                    const double pressure,
-                    const unsigned int phase) const
-    {
-      Assert(phase < transition_depths.size(),
-             ExcMessage("Error: Phase index is too large. This phase index does not exist!"));
-
-      // if we already have the adiabatic conditions, we can use them
-      if (this->get_adiabatic_conditions().is_initialized())
-        {
-          // first, get the pressure at which the phase transition occurs normally
-          const Point<dim,double> transition_point = this->get_geometry_model().representative_point(transition_depths[phase]);
-          const double transition_pressure = this->get_adiabatic_conditions().pressure(transition_point);
-
-          // then calculate the deviation from the transition point (both in temperature
-          // and in pressure)
-          const double pressure_deviation = pressure - transition_pressure
-                                            - transition_slopes[phase] * (temperature - transition_temperatures[phase]);
-
-          // last, calculate the percentage of material that has undergone the transition
-          return (pressure_deviation > 0) ? 1 : 0;
-        }
-
-      // if we do not have the adiabatic conditions, we have to use the depth instead
-      // this is less precise, because we do not have the exact pressure gradient, instead we use pressure/depth
-      // (this is for calculating e.g. the density in the adiabatic profile)
-      else
-        {
-          const double depth = this->get_geometry_model().depth(position);
-          const double depth_deviation = (pressure > 0
-                                          ?
-                                          depth - transition_depths[phase]
-                                          - transition_slopes[phase] * (depth / pressure) * (temperature - transition_temperatures[phase])
-                                          :
-                                          depth - transition_depths[phase]
-                                          - transition_slopes[phase] / (this->get_gravity_model().gravity_vector(position).norm() * reference_rho)
-                                          * (temperature - transition_temperatures[phase]));
-
-          return (depth_deviation > 0) ? 1 : 0;
-        }
-    }
-
-
-
-    template <int dim>
     unsigned int
     GrainSize<dim>::
-    get_phase_index (const Point<dim> &position,
-                     const double temperature,
-                     const double pressure) const
+    get_phase_index (const MaterialUtilities::PhaseFunctionInputs<dim> &in) const
     {
       Assert(grain_growth_activation_energy.size()>0,
              ExcMessage("Error: No grain evolution parameters are given!"));
 
-      unsigned int phase_index = 0;
-      if (transition_depths.size()>0)
-        if (phase_function(position, temperature, pressure, transition_depths.size()-1) == 1)
-          phase_index = transition_depths.size();
+      // Since phase transition depth increases monotonically, we only need
+      // to check for the first phase that has not yet undergone the transition
+      // (phase function value lower than 0.5).
+      for (unsigned int j=0; j<n_phase_transitions; ++j)
+        {
+          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(in.temperature,
+                                                                   in.pressure,
+                                                                   in.depth,
+                                                                   in.pressure_depth_derivative,
+                                                                   j);
 
-      for (unsigned int j=1; j<transition_depths.size(); ++j)
-        if (phase_function(position, temperature, pressure, j) != phase_function(position, temperature, pressure, j-1))
-          phase_index = j;
+          if (phase_function.compute_value(phase_inputs) < 0.5)
+            return j;
+        }
 
-      return phase_index;
+      return n_phase_transitions;
     }
 
     template <int dim>
@@ -268,10 +224,10 @@ namespace aspect
                        const double                  pressure,
                        const std::vector<double>    &compositional_fields,
                        const SymmetricTensor<2,dim> &strain_rate,
-                       const Tensor<1,dim>          &/*velocity*/,
                        const Point<dim>             &position,
                        const unsigned int            grain_size_index,
-                       const int                     crossed_transition) const
+                       const int                     crossed_transition,
+                       const unsigned int            phase_index) const
     {
       // we want to iterate over the grain size evolution here, as we solve in fact an ordinary differential equation
       // and it is not correct to use the starting grain size (and introduces instabilities)
@@ -289,9 +245,6 @@ namespace aspect
       // use a sub timestep of 500 yrs, currently fixed timestep
       double grain_growth_timestep = 500 * 3600 * 24 * 365.25;
       double time = 0;
-
-      // find out in which phase we are
-      const unsigned int phase_index = get_phase_index(position, temperature, pressure);
 
       // precompute the partitioning_fraction since its constant during the evolution.
       // this is only used for the pinned_grain_damage formulation
@@ -339,8 +292,8 @@ namespace aspect
           const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();
           const double second_strain_rate_invariant = std::sqrt(std::max(-second_invariant(shear_strain_rate), 0.));
 
-          const double current_diffusion_viscosity   = diffusion_viscosity(temperature, adiabatic_temperature, pressure, grain_size, second_strain_rate_invariant, position);
-          current_dislocation_viscosity              = dislocation_viscosity(temperature, adiabatic_temperature, pressure, strain_rate, position, current_diffusion_viscosity, current_dislocation_viscosity);
+          const double current_diffusion_viscosity   = diffusion_viscosity(temperature, adiabatic_temperature, pressure, grain_size, second_strain_rate_invariant, phase_index);
+          current_dislocation_viscosity              = dislocation_viscosity(temperature, adiabatic_temperature, pressure, strain_rate, phase_index, current_diffusion_viscosity, current_dislocation_viscosity);
 
           double current_viscosity;
           if (std::abs(second_strain_rate_invariant) > 1e-30)
@@ -436,11 +389,8 @@ namespace aspect
                          const double adiabatic_pressure,
                          const double grain_size,
                          const double second_strain_rate_invariant,
-                         const Point<dim> &position) const
+                         const unsigned int phase_index) const
     {
-      // find out in which phase we are
-      const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
-
       double energy_term = std::exp((diffusion_activation_energy[phase_index] + diffusion_activation_volume[phase_index] * adiabatic_pressure)
                                     / (diffusion_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
@@ -476,13 +426,11 @@ namespace aspect
                            const double adiabatic_temperature,
                            const double adiabatic_pressure,
                            const SymmetricTensor<2,dim> &strain_rate,
-                           const Point<dim> &position,
+                           const unsigned int phase_index,
                            const double diffusion_viscosity,
                            const double viscosity_guess) const
     {
       // find out in which phase we are
-      const unsigned int phase_index = get_phase_index(position, temperature, adiabatic_pressure);
-
       double energy_term = std::exp((dislocation_activation_energy[phase_index] + dislocation_activation_volume[phase_index] * adiabatic_pressure)
                                     / (dislocation_creep_exponent[phase_index] * constants::gas_constant * temperature));
 
@@ -829,14 +777,15 @@ namespace aspect
           // Set up an integer that tells us which phase transition has been crossed inside of the cell.
           int crossed_transition(-1);
 
+          const double gravity_norm = this->get_gravity_model().gravity_vector(in.position[i]).norm();
+          const Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i]) / gravity_norm;
+
           // Figure out if the material in the current cell underwent a phase change.
           // To do so, check if a grain has moved further than the distance from the phase transition and
           // if the velocity is in the direction of the phase change. After the check 'crossed_transition' will
           // be -1 if we crossed no transition, or the index of the phase transition, if we crossed it.
-          for (unsigned int phase=0; phase<transition_depths.size(); ++phase)
+          for (unsigned int phase=0; phase<n_phase_transitions; ++phase)
             {
-              const Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i])
-                                                       /this->get_gravity_model().gravity_vector(in.position[i]).norm();
               const double timestep = this->simulator_is_past_initialization()
                                       ?
                                       this->get_timestep()
@@ -844,7 +793,7 @@ namespace aspect
                                       0.0;
 
               // Both distances are positive when they are downward from the transition (since gravity points down)
-              const double distance_from_transition = this->get_geometry_model().depth(in.position[i]) - transition_depths[phase];
+              const double distance_from_transition = this->get_geometry_model().depth(in.position[i]) - phase_function.get_transition_depth(phase);
               const double distance_moved = in.velocity[i] * vertical_direction * timestep;
 
               // If we are close to the phase boundary (closer than the distance a grain has moved
@@ -858,6 +807,15 @@ namespace aspect
                 crossed_transition = phase;
             }
 
+          out.densities[i] = density(in.temperature[i], adiabatic_pressure, in.composition[i], in.position[i]);
+          out.thermal_conductivities[i] = k_value;
+          out.compressibilities[i] = compressibility(in.temperature[i], adiabatic_pressure, composition, in.position[i]);
+
+          // We do not fill the phase function index, because that will be done internally in the get_phase_index() function
+          const double depth = this->get_geometry_model().depth(in.position[i]);
+          const double rho_g = out.densities[i] * gravity_norm;
+          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(in.temperature[i], adiabatic_pressure, depth, rho_g, numbers::invalid_unsigned_int);
+          const unsigned int phase_index = get_phase_index(phase_inputs);
 
           if (in.requests_property(MaterialProperties::viscosity))
             {
@@ -880,11 +838,11 @@ namespace aspect
                                                                 adiabatic_pressure,
                                                                 composition[grain_size_index],
                                                                 second_strain_rate_invariant,
-                                                                in.position[i]);
+                                                                phase_index);
 
               if (std::abs(second_strain_rate_invariant) > 1e-30)
                 {
-                  disl_viscosity = dislocation_viscosity(in.temperature[i], adiabatic_temperature, adiabatic_pressure, in.strain_rate[i], in.position[i], diff_viscosity);
+                  disl_viscosity = dislocation_viscosity(in.temperature[i], adiabatic_temperature, adiabatic_pressure, in.strain_rate[i], phase_index, diff_viscosity);
                   effective_viscosity = disl_viscosity * diff_viscosity / (disl_viscosity + diff_viscosity);
                 }
               else
@@ -902,7 +860,8 @@ namespace aspect
                 {
                   if (grain_size_evolution_formulation == Formulation::paleowattmeter)
                     {
-                      const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],adiabatic_pressure)];
+                      const unsigned int phase_index = get_phase_index(phase_inputs);
+                      const double f = boundary_area_change_work_fraction[phase_index];
                       shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / std::min(std::max(min_eta,disl_viscosity),1e300);
                     }
                   else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
@@ -915,9 +874,7 @@ namespace aspect
                 }
             }
 
-          out.densities[i] = density(in.temperature[i], adiabatic_pressure, in.composition[i], in.position[i]);
-          out.thermal_conductivities[i] = k_value;
-          out.compressibilities[i] = compressibility(in.temperature[i], adiabatic_pressure, composition, in.position[i]);
+
 
           if (in.requests_property(MaterialProperties::reaction_terms))
             for (unsigned int c=0; c<composition.size(); ++c)
@@ -925,7 +882,7 @@ namespace aspect
                 if (this->introspection().name_for_compositional_index(c) == "grain_size")
                   {
                     out.reaction_terms[i][c] = grain_size_change(in.temperature[i], adiabatic_pressure, composition,
-                                                                 in.strain_rate[i], in.velocity[i], in.position[i], c, crossed_transition);
+                                                                 in.strain_rate[i], in.position[i], c, crossed_transition, phase_index);
                     if (advect_log_grainsize)
                       out.reaction_terms[i][c] = - out.reaction_terms[i][c] / composition[c];
                   }
@@ -1046,29 +1003,9 @@ namespace aspect
                              Patterns::Double (0.),
                              "The value of the reference compressibility. "
                              "Units: \\si{\\per\\pascal}.");
-          prm.declare_entry ("Phase transition depths", "",
-                             Patterns::List (Patterns::Double (0.)),
-                             "A list of depths where phase transitions occur. Values must "
-                             "monotonically increase. "
-                             "Units: \\si{\\meter}.");
-          prm.declare_entry ("Phase transition temperatures", "",
-                             Patterns::List (Patterns::Double (0.)),
-                             "A list of temperatures where phase transitions occur. Higher or lower "
-                             "temperatures lead to phase transition occurring in smaller or greater "
-                             "depths than given in Phase transition depths, depending on the "
-                             "Clapeyron slope given in Phase transition Clapeyron slopes. "
-                             "List must have the same number of entries as Phase transition depths. "
-                             "Units: \\si{\\kelvin}.");
-          prm.declare_entry ("Phase transition Clapeyron slopes", "",
-                             Patterns::List (Patterns::Double()),
-                             "A list of Clapeyron slopes for each phase transition. A positive "
-                             "Clapeyron slope indicates that the phase transition will occur in "
-                             "a greater depth, if the temperature is higher than the one given in "
-                             "Phase transition temperatures and in a smaller depth, if the "
-                             "temperature is smaller than the one given in Phase transition temperatures. "
-                             "For negative slopes the other way round. "
-                             "List must have the same number of entries as Phase transition depths. "
-                             "Units: \\si{\\pascal\\per\\kelvin}.");
+
+          MaterialUtilities::PhaseFunction<dim>::declare_parameters(prm);
+
           prm.declare_entry ("Grain growth activation energy", "3.5e5",
                              Patterns::List (Patterns::Double (0.)),
                              "The activation energy for grain growth $E_g$. "
@@ -1362,26 +1299,23 @@ namespace aspect
           thermal_alpha              = prm.get_double ("Thermal expansion coefficient");
           reference_compressibility  = prm.get_double ("Reference compressibility");
 
+          // Phase transition parameters
+          phase_function.initialize_simulator (this->get_simulator());
+          phase_function.parse_parameters (prm);
 
-          transition_depths         = Utilities::string_to_double
-                                      (Utilities::split_string_list(prm.get ("Phase transition depths")));
-          transition_temperatures   = Utilities::string_to_double
-                                      (Utilities::split_string_list(prm.get ("Phase transition temperatures")));
-          transition_slopes         = Utilities::string_to_double
-                                      (Utilities::split_string_list(prm.get ("Phase transition Clapeyron slopes")));
+          std::vector<unsigned int> n_phases_for_each_composition = phase_function.n_phases_for_each_composition();
+          n_phase_transitions = n_phases_for_each_composition[0] - 1;
+
           recrystallized_grain_size = Utilities::string_to_double
                                       (Utilities::split_string_list(prm.get ("Recrystallized grain size")));
 
-          if (transition_temperatures.size() != transition_depths.size() ||
-              transition_slopes.size() != transition_depths.size() ||
-              recrystallized_grain_size.size() != transition_depths.size() )
+          if (recrystallized_grain_size.size() != n_phase_transitions)
             AssertThrow(false,
-                        ExcMessage("Error: At least one list that gives input parameters for the phase transitions has the wrong size."));
+                        ExcMessage("Error: The list of recrystallized grain sizes has to have as many entries as there are phases."));
 
-          if (transition_depths.size()>1)
-            for (unsigned int i=0; i<transition_depths.size()-2; ++i)
-              AssertThrow(transition_depths[i]<transition_depths[i+1],
-                          ExcMessage("Error: Phase transition depths have to be sorted in ascending order!"));
+          for (unsigned int i=0; i<n_phase_transitions-1; ++i)
+            AssertThrow(phase_function.get_transition_depth(i)<phase_function.get_transition_depth(i+1),
+                        ExcMessage("Error: Phase transition depths have to be sorted in ascending order!"));
 
           // grain evolution parameters
           grain_growth_activation_energy        = Utilities::string_to_double
@@ -1529,7 +1463,7 @@ namespace aspect
             }
           else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
             {
-              AssertThrow(transition_depths.size() == 0,
+              AssertThrow(n_phase_transitions == 0,
                           ExcMessage("Error: Currently, the pinned grain damage formulation is only implemented for one mineral phase."));
             }
           else
@@ -1538,7 +1472,7 @@ namespace aspect
                                    "should follow either of the 'paleowattmeter|paleopiezometer|pinned grain damage' "
                                    "formulations!"));
 
-          AssertThrow(grain_growth_activation_energy.size() == transition_depths.size()+1,
+          AssertThrow(grain_growth_activation_energy.size() == n_phase_transitions+1,
                       ExcMessage("Error: The lists of grain size evolution and flow law parameters need to "
                                  "have exactly one more entry than the number of phase transitions "
                                  "(which is defined by the length of the lists of phase transition depths, ...)!"));

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -778,7 +778,9 @@ namespace aspect
           int crossed_transition(-1);
 
           const double gravity_norm = this->get_gravity_model().gravity_vector(in.position[i]).norm();
-          const Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i]) / gravity_norm;
+          Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i]);
+          if (gravity_norm > 0.0)
+            vertical_direction /= gravity_norm;
 
           // Figure out if the material in the current cell underwent a phase change.
           // To do so, check if a grain has moved further than the distance from the phase transition and
@@ -1313,8 +1315,8 @@ namespace aspect
             AssertThrow(false,
                         ExcMessage("Error: The list of recrystallized grain sizes has to have as many entries as there are phases."));
 
-          for (unsigned int i=0; i<n_phase_transitions-1; ++i)
-            AssertThrow(phase_function.get_transition_depth(i)<phase_function.get_transition_depth(i+1),
+          for (unsigned int i=1; i<n_phase_transitions; ++i)
+            AssertThrow(phase_function.get_transition_depth(i-1)<phase_function.get_transition_depth(i),
                         ExcMessage("Error: Phase transition depths have to be sorted in ascending order!"));
 
           // grain evolution parameters

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1319,12 +1319,23 @@ namespace aspect
       }
 
 
+
       template <int dim>
       double
       PhaseFunction<dim>::
       get_transition_slope (const unsigned int phase_index) const
       {
         return transition_slopes[phase_index];
+      }
+
+
+
+      template <int dim>
+      double
+      PhaseFunction<dim>::
+      get_transition_depth (const unsigned int phase_index) const
+      {
+        return transition_depths[phase_index];
       }
 
 

--- a/tests/grain_size_crossed_transition.prm
+++ b/tests/grain_size_crossed_transition.prm
@@ -107,6 +107,7 @@ subsection Material model
     set Phase transition depths              = 50000
     set Phase transition Clapeyron slopes    = 1e6
     set Phase transition temperatures        = 1600
+    set Phase transition widths              = 0
     set Recrystallized grain size            = 1e-3
 
     # Faul and Jackson 2007

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -144,7 +144,7 @@ namespace aspect
               // To do so, check if a grain has moved further than the distance from the phase transition and
               // if the velocity is in the direction of the phase change. After the check 'crossed_transition' will
               // be -1 if we crossed no transition, or the index of the phase transition, if we crossed it.
-              for (unsigned int phase=0; phase<this->transition_depths.size(); ++phase)
+              for (unsigned int phase=0; phase<this->n_phase_transitions; ++phase)
                 {
                   const Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i])
                                                            /this->get_gravity_model().gravity_vector(in.position[i]).norm();
@@ -155,7 +155,7 @@ namespace aspect
                                           0.0;
 
                   // Both distances are positive when they are downward from the transition (since gravity points down)
-                  const double distance_from_transition = this->get_geometry_model().depth(in.position[i]) - this->transition_depths[phase];
+                  const double distance_from_transition = this->get_geometry_model().depth(in.position[i]) - this->phase_function.get_transition_depth(phase);
                   const double distance_moved = in.velocity[i] * vertical_direction * timestep;
 
                   // If we are close to the phase boundary (closer than the distance a grain has moved

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -140,14 +140,17 @@ namespace aspect
               // Set up an integer that tells us which phase transition has been crossed inside of the cell.
               int crossed_transition(-1);
 
+              const double gravity_norm = this->get_gravity_model().gravity_vector(in.position[i]).norm();
+              Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i]);
+              if (gravity_norm > 0.0)
+                vertical_direction /= gravity_norm;
+
               // Figure out if the material in the current cell underwent a phase change.
               // To do so, check if a grain has moved further than the distance from the phase transition and
               // if the velocity is in the direction of the phase change. After the check 'crossed_transition' will
               // be -1 if we crossed no transition, or the index of the phase transition, if we crossed it.
               for (unsigned int phase=0; phase<this->n_phase_transitions; ++phase)
                 {
-                  const Tensor<1,dim> vertical_direction = this->get_gravity_model().gravity_vector(in.position[i])
-                                                           /this->get_gravity_model().gravity_vector(in.position[i]).norm();
                   const double timestep = this->simulator_is_past_initialization()
                                           ?
                                           this->get_timestep()
@@ -169,6 +172,19 @@ namespace aspect
                     crossed_transition = phase;
                 }
 
+              out.densities[i] = this->density(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
+
+              // We do not fill the phase function index, because that will be done internally in the get_phase_index() function
+              const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
+                                                ?
+                                                this->get_adiabatic_conditions().pressure(in.position[i])
+                                                :
+                                                in.pressure[i];
+              const double depth = this->get_geometry_model().depth(in.position[i]);
+              const double rho_g = out.densities[i] * gravity_norm;
+              MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(in.temperature[i], adiabatic_pressure, depth, rho_g, numbers::invalid_unsigned_int);
+              const unsigned int phase_index = this->get_phase_index(phase_inputs);
+
               if (in.requests_property(MaterialProperties::viscosity))
                 {
                   double effective_viscosity;
@@ -184,11 +200,6 @@ namespace aspect
                                                        this->get_adiabatic_conditions().temperature(in.position[i])
                                                        :
                                                        in.temperature[i];
-                  const double adiabatic_pressure = this->get_adiabatic_conditions().is_initialized()
-                                                    ?
-                                                    this->get_adiabatic_conditions().pressure(in.position[i])
-                                                    :
-                                                    in.pressure[i];
 
                   const unsigned int grain_size_index = this->introspection().compositional_index_for_name("grain_size");
 
@@ -197,11 +208,11 @@ namespace aspect
                                                                           adiabatic_pressure,
                                                                           composition[grain_size_index],
                                                                           second_strain_rate_invariant,
-                                                                          in.position[i]);
+                                                                          phase_index);
 
                   if (std::abs(second_strain_rate_invariant) > 1e-30)
                     {
-                      disl_viscosity = this->dislocation_viscosity(in.temperature[i], adiabatic_temperature, adiabatic_pressure, in.strain_rate[i], in.position[i],diff_viscosity);
+                      disl_viscosity = this->dislocation_viscosity(in.temperature[i], adiabatic_temperature, adiabatic_pressure, in.strain_rate[i], phase_index, diff_viscosity);
                       effective_viscosity = disl_viscosity * diff_viscosity / (disl_viscosity + diff_viscosity);
                     }
                   else
@@ -209,8 +220,6 @@ namespace aspect
 
                   out.viscosities[i] = std::min(std::max(this->min_eta,effective_viscosity),this->max_eta);
                 }
-
-              out.densities[i] = this->density(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
 
               if (this->get_adiabatic_conditions().is_initialized())
                 {
@@ -242,8 +251,8 @@ namespace aspect
                   {
                     if (this->introspection().name_for_compositional_index(c) == "olivine_grain_size")
                       {
-                        out.reaction_terms[i][c] = this->grain_size_change(in.temperature[i], in.pressure[i], composition,
-                                                                           in.strain_rate[i], in.velocity[i], in.position[i], c, crossed_transition);
+                        out.reaction_terms[i][c] = this->grain_size_change(in.temperature[i], adiabatic_pressure, composition,
+                                                                           in.strain_rate[i], in.position[i], c, crossed_transition, phase_index);
                         if (this->advect_log_grainsize)
                           out.reaction_terms[i][c] = - out.reaction_terms[i][c] / composition[c];
                       }

--- a/tests/grain_size_phase_function.prm
+++ b/tests/grain_size_phase_function.prm
@@ -1,0 +1,135 @@
+# A test for the grain size material model to see if the
+# phase transitions work correctly. The test has three phase
+# transitions with different Clapeyron slopes that affect
+# the viscosity and the grain size growth.
+
+set Dimension                              = 2
+set End time                               = 10000
+set Use years in output instead of seconds = true
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100000
+    set Y extent = 100000
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top,bottom
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 1600
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, top, bottom
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 1400 + 0.004 * x
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  =
+    set Function expression = 1e-3
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields   = grain_size
+  set Compositional field methods = particles
+  set Types of fields = grain size
+  set Mapped particle properties = grain_size:grain_size
+end
+
+subsection Material model
+  set Model name = grain size
+
+  subsection Grain size model
+    set Reference density                    = 1000
+    set Thermal conductivity                 = 0
+    set Thermal expansion coefficient        = 0
+    set Reference compressibility            = 0
+    set Viscosity                            = 1e19
+    set Minimum viscosity                    = 1e16
+    set Reference temperature                = 1600
+    set Grain growth activation energy       = 0, 0, 0, 0
+    set Grain growth activation volume       = 0, 0, 0, 0
+    set Grain growth rate constant           = 0, 1e-20, 0, 5e-21
+    set Grain growth exponent                = 3, 3, 3, 3
+    set Average specific grain boundary energy = 1, 1, 1, 1
+    set Work fraction for boundary area change = 0.1, 0.1, 0.1, 0.1
+    set Geometric constant                   = 3, 3, 3, 3
+    set Grain size evolution formulation     = paleowattmeter
+    set Reciprocal required strain           = 10
+
+    set Phase transition depths              = background:20000|50000|65000
+    set Phase transition Clapeyron slopes    = background:1e6|-5e5|2.5e5
+    set Phase transition temperatures        = background:1600|1600|1600
+    set Phase transition widths              = background:0|0|0
+    set Recrystallized grain size            = 1e-3, 1e-3, 1e-3
+
+    # Faul and Jackson 2007
+    # Diffusion creep
+    # new scaled prefactors to match vertical viscosity profile
+    set Diffusion creep prefactor            = 3.0e-016, 3.0e-015, 3.0e-017, 3.0e-016
+    set Diffusion creep exponent             = 1, 1, 1, 1
+    set Diffusion creep grain size exponent  = 3, 3, 3, 3
+    set Diffusion activation energy          = 3.75e5, 3.75e5, 3.75e5, 3.75e5
+    set Diffusion activation volume          = 0, 0, 0, 0
+    set Dislocation viscosity iteration threshold = 1e-3
+
+    # No dislocation creep
+    set Dislocation creep prefactor          = 1e-200, 1e-200, 1e-200, 1e-200
+    set Dislocation creep exponent           = 1, 1, 1, 1
+    set Dislocation activation energy        = 0, 0, 0, 0
+    set Dislocation activation volume        = 0, 0, 0, 0
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, composition statistics, particles, material statistics
+  subsection Visualization
+    set List of output variables  = material properties
+    set Time between graphical output = 0
+  end
+
+  subsection Particles
+    set List of particle properties = grain size
+    set Number of particles = 10000
+    set Time between data output = 0
+  end
+end

--- a/tests/grain_size_phase_function/screen-output
+++ b/tests/grain_size_phase_function/screen-output
@@ -1,0 +1,42 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+27 iterations.
+
+   Postprocessing:
+     Writing graphical output:                          output-grain_size_phase_function/solution/solution-00000
+     Compositions min/max/mass:                         0.001/0.001/1e+07
+     Writing particle output:                           output-grain_size_phase_function/particles/particles-00000
+     Average density / Average viscosity / Total mass:  1000 kg/m^3, 3.199e+19 Pa s, 1e+13 kg
+
+*** Timestep 1:  t=10000 years, dt=10000 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 200+25 iterations.
+
+   Postprocessing:
+     Writing graphical output:                          output-grain_size_phase_function/solution/solution-00001
+     Compositions min/max/mass:                         0.001/0.001618/1.308e+07
+     Writing particle output:                           output-grain_size_phase_function/particles/particles-00001
+     Average density / Average viscosity / Total mass:  1000 kg/m^3, 7.041e+19 Pa s, 1e+13 kg
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/grain_size_phase_function/statistics
+++ b/tests/grain_size_phase_function/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Number of advected particles
+# 17: Particle file name
+# 18: Average density (kg/m^3)
+# 19: Average viscosity (Pa s)
+# 20: Total mass (kg)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 227 600 741 output-grain_size_phase_function/solution/solution-00000 1.00000000e-03 1.00000000e-03 1.00000000e+07 10000 output-grain_size_phase_function/particles/particles-00000 1.00000000e+03 3.19873350e+19 1.00000000e+13 
+1 1.000000000000e+04 1.000000000000e+04 256 2467 1089 1089 0 225 521 693 output-grain_size_phase_function/solution/solution-00001 1.00000000e-03 1.61770049e-03 1.30808174e+07 10000 output-grain_size_phase_function/particles/particles-00001 1.00000000e+03 7.04132651e+19 1.00000000e+13 


### PR DESCRIPTION
This pull request changes the grain size material model to use the phase function from the material model utilities rather than implementing its own phase function. This should not change any of the functionality, but it changes how phase transitions have to be specified in the input file (see changelog entry).

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.

Output of the test case is below (in higher resolution)
![phase_transitions](https://github.com/geodynamics/aspect/assets/7517347/ecf6eb62-7239-4d11-9352-c306feb9fe27)

