### PR TITLE
Make dg limiter field specific

### DIFF
--- a/doc/modules/changes/20240601_gassmoeller
+++ b/doc/modules/changes/20240601_gassmoeller
@@ -1,0 +1,6 @@
+Improved: The limiter for the DG solution can now be selected
+for each compositional field individually, instead of using
+a single setting that applies to all compositional fields.
+If only a single setting is found it will still apply to all fields.
+<br>
+(Rene Gassmoeller, 2024/06/01)

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -620,7 +620,7 @@ namespace aspect
     double                         stabilization_gamma;
     double                         discontinuous_penalty;
     bool                           use_limiter_for_discontinuous_temperature_solution;
-    bool                           use_limiter_for_discontinuous_composition_solution;
+    std::vector<bool>              use_limiter_for_discontinuous_composition_solution;
     double                         global_temperature_max_preset;
     double                         global_temperature_min_preset;
     std::vector<double>            global_composition_max_preset;

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -746,6 +746,18 @@ namespace aspect
     std::string parenthesize_if_nonempty (const std::string &s);
 
     /**
+     * Given a string @p s, convert it to a boolean value.
+     */
+    bool
+    string_to_bool(const std::string &s);
+
+    /**
+     * Given a vector of strings @p s, convert it to a vector of boolean values.
+     */
+    std::vector<bool>
+    string_to_bool(const std::vector<std::string> &s);
+
+    /**
      * Returns if a vector of strings @p strings only contains unique
      * entries.
      */

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -34,14 +34,6 @@ namespace aspect
   {
     namespace Interpolator
     {
-      namespace internal
-      {
-        bool string_to_bool(const std::string &s)
-        {
-          return (s == "true" || s == "yes");
-        }
-      }
-
       template <int dim>
       std::vector<std::vector<double>>
       BilinearLeastSquares<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
@@ -337,12 +329,12 @@ namespace aspect
                 std::vector<bool> linear_least_squares_limiter_parsed;
                 if (linear_least_squares_limiter_split.size() == 1)
                   {
-                    linear_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, internal::string_to_bool(linear_least_squares_limiter_split[0]));
+                    linear_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(linear_least_squares_limiter_split[0]));
                   }
                 else if (linear_least_squares_limiter_split.size() == n_property_components - n_internal_components)
                   {
                     for (const auto &component: linear_least_squares_limiter_split)
-                      linear_least_squares_limiter_parsed.push_back(internal::string_to_bool(component));
+                      linear_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
                   }
                 else
                   {
@@ -358,12 +350,12 @@ namespace aspect
                 std::vector<bool> boundary_extrapolation_parsed;
                 if (boundary_extrapolation_split.size() == 1)
                   {
-                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, internal::string_to_bool(boundary_extrapolation_split[0]));
+                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
                   }
                 else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
                   {
                     for (const auto &component: boundary_extrapolation_split)
-                      boundary_extrapolation_parsed.push_back(internal::string_to_bool(component));
+                      boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
                   }
                 else
                   {

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -607,12 +607,12 @@ namespace aspect
                 std::vector<bool> quadratic_least_squares_limiter_parsed;
                 if (quadratic_least_squares_limiter_split.size() == 1)
                   {
-                    quadratic_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, internal::string_to_bool(quadratic_least_squares_limiter_split[0]));
+                    quadratic_least_squares_limiter_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(quadratic_least_squares_limiter_split[0]));
                   }
                 else if (quadratic_least_squares_limiter_split.size() == n_property_components - n_internal_components)
                   {
                     for (const auto &component: quadratic_least_squares_limiter_split)
-                      quadratic_least_squares_limiter_parsed.push_back(internal::string_to_bool(component));
+                      quadratic_least_squares_limiter_parsed.push_back(Utilities::string_to_bool(component));
                   }
                 else
                   {
@@ -627,12 +627,12 @@ namespace aspect
                 std::vector<bool> boundary_extrapolation_parsed;
                 if (boundary_extrapolation_split.size() == 1)
                   {
-                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, internal::string_to_bool(boundary_extrapolation_split[0]));
+                    boundary_extrapolation_parsed = std::vector<bool>(n_property_components - n_internal_components, Utilities::string_to_bool(boundary_extrapolation_split[0]));
                   }
                 else if (boundary_extrapolation_split.size() == n_property_components - n_internal_components)
                   {
                     for (const auto &component: boundary_extrapolation_split)
-                      boundary_extrapolation_parsed.push_back(internal::string_to_bool(component));
+                      boundary_extrapolation_parsed.push_back(Utilities::string_to_bool(component));
                   }
                 else
                   {

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -477,9 +477,12 @@ namespace aspect
     if (MappingQCache<dim> *map = dynamic_cast<MappingQCache<dim>*>(&(*mapping)))
       map->initialize(MappingQGeneric<dim>(4), triangulation);
 
+    bool dg_limiter_enabled = parameters.use_limiter_for_discontinuous_temperature_solution;
+    for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
+      dg_limiter_enabled = dg_limiter_enabled || parameters.use_limiter_for_discontinuous_composition_solution[c];
+
     // Check that DG limiters are only used with cartesian mapping
-    if (parameters.use_limiter_for_discontinuous_temperature_solution ||
-        parameters.use_limiter_for_discontinuous_composition_solution)
+    if (dg_limiter_enabled)
       AssertThrow(geometry_model->natural_coordinate_system() == Utilities::Coordinates::CoordinateSystem::cartesian,
                   ExcMessage("The limiter for the discontinuous temperature and composition solutions "
                              "has not been tested in non-Cartesian geometries and currently requires "

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1113,13 +1113,18 @@ namespace aspect
                            "This limiter keeps the discontinuous solution in the range given by "
                            "'Global temperature maximum' and 'Global temperature minimum'.");
         prm.declare_entry ("Use limiter for discontinuous composition solution", "false",
-                           Patterns::Bool (),
+                           Patterns::List(Patterns::Bool()),
                            "Whether to apply the bound preserving limiter as a correction after having "
-                           "the discontinuous composition solution. Currently we apply this only to the "
+                           "the discontinuous composition solution. We apply this limiter only to the "
                            "compositional solution if the 'Global composition maximum' and "
-                           "'Global composition minimum' are already defined in the .prm file. "
+                           "'Global composition minimum' are also defined in the .prm file. "
                            "This limiter keeps the discontinuous solution in the range given by "
-                           "Global composition maximum' and 'Global composition minimum'.");
+                           "Global composition maximum' and 'Global composition minimum'. "
+                           "The number of input values in this parameter separated by ',' has to be "
+                           "one or the number of the compositional fields. When only one value "
+                           "is supplied, this same value is assumed for all compositional fields, otherwise "
+                           "each value represents if the limiter should be applied to the respective "
+                           "compositional field.");
         prm.declare_entry ("Global temperature maximum",
                            boost::lexical_cast<std::string>(std::numeric_limits<double>::max()),
                            Patterns::Double (),
@@ -1729,7 +1734,10 @@ namespace aspect
         use_limiter_for_discontinuous_temperature_solution
           = prm.get_bool("Use limiter for discontinuous temperature solution");
         use_limiter_for_discontinuous_composition_solution
-          = prm.get_bool("Use limiter for discontinuous composition solution");
+          = Utilities::possibly_extend_from_1_to_N(Utilities::string_to_bool
+                                                   (Utilities::split_string_list(prm.get("Use limiter for discontinuous composition solution"))),
+                                                   n_compositional_fields,
+                                                   "Use limiter for discontinuous composition solution");
         global_temperature_max_preset       = prm.get_double ("Global temperature maximum");
         global_temperature_min_preset       = prm.get_double ("Global temperature minimum");
         global_composition_max_preset       = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_double

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1107,17 +1107,17 @@ namespace aspect
         prm.declare_entry ("Use limiter for discontinuous temperature solution", "false",
                            Patterns::Bool (),
                            "Whether to apply the bound preserving limiter as a correction after computing "
-                           "the discontinuous temperature solution. Currently we apply this only to the "
-                           "temperature solution if the 'Global temperature maximum' and "
-                           "'Global temperature minimum' are already defined in the .prm file. "
+                           "the discontinuous temperature solution. The limiter will only have an "
+                           "effect if the 'Global temperature maximum' and "
+                           "'Global temperature minimum' parameters are defined in the .prm file. "
                            "This limiter keeps the discontinuous solution in the range given by "
                            "'Global temperature maximum' and 'Global temperature minimum'.");
         prm.declare_entry ("Use limiter for discontinuous composition solution", "false",
                            Patterns::List(Patterns::Bool()),
                            "Whether to apply the bound preserving limiter as a correction after having "
-                           "the discontinuous composition solution. We apply this limiter only to the "
-                           "compositional solution if the 'Global composition maximum' and "
-                           "'Global composition minimum' are also defined in the .prm file. "
+                           "the discontinuous composition solution. The limiter will only have an "
+                           "effect if the 'Global composition maximum' and "
+                           "'Global composition minimum' parameters are defined in the .prm file. "
                            "This limiter keeps the discontinuous solution in the range given by "
                            "Global composition maximum' and 'Global composition minimum'. "
                            "The number of input values in this parameter separated by ',' has to be "

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -534,7 +534,7 @@ namespace aspect
         ||
         (!advection_field.is_temperature()
          && parameters.use_discontinuous_composition_discretization
-         && parameters.use_limiter_for_discontinuous_composition_solution))
+         && parameters.use_limiter_for_discontinuous_composition_solution[advection_field.compositional_variable]))
       apply_limiter_to_dg_solutions(advection_field);
 
     return initial_residual;

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2210,6 +2210,28 @@ namespace aspect
 
 
     bool
+    string_to_bool(const std::string &s)
+    {
+      return (s == "true" || s == "yes");
+    }
+
+
+
+    std::vector<bool>
+    string_to_bool(const std::vector<std::string> &s)
+    {
+      std::vector<bool> result;
+      result.reserve(s.size());
+
+      for (auto &i : s)
+        result.push_back(string_to_bool(i));
+
+      return result;
+    }
+
+
+
+    bool
     has_unique_entries (const std::vector<std::string> &strings)
     {
       const std::set<std::string> set_of_strings(strings.begin(),strings.end());

--- a/tests/discontinuous_composition_bound_preserving_limiter_selected_fields.prm
+++ b/tests/discontinuous_composition_bound_preserving_limiter_selected_fields.prm
@@ -1,0 +1,88 @@
+# This test uses the bound-preserving limiter, but only for
+# one of the two existing fields. Because both fields are
+# set up identically, any difference in the output of the
+# two fields stems from the limiter algorithm.
+
+set Dimension                              = 2
+set Start time                             = 0
+set End time                               = 25000
+set Use years in output instead of seconds = true
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent  = 500e3
+    set Y extent  = 500e3
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, bottom, top
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 3200
+    set Viscosity                     = 1e21
+    set Thermal expansion coefficient = 0
+    set Density differential for compositional field 1 = 100
+    set Composition viscosity prefactor = 1
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 9.81
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Function expression = x<251e3 ? 0 : 1; x<251e3 ? 0 : 1;
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, composition statistics
+
+  subsection Visualization
+    set Time between graphical output = 0
+  end
+end
+
+subsection Discretization
+  set Use discontinuous composition discretization = true
+
+  subsection Stabilization parameters
+    # apply the limiter to the DG solution of field 1, but not field 2
+    set Use limiter for discontinuous composition solution = true, false
+    set Global composition maximum = 1.0, 1.0
+    set Global composition minimum = 0.0, 0.0
+  end
+end

--- a/tests/discontinuous_composition_bound_preserving_limiter_selected_fields/screen-output
+++ b/tests/discontinuous_composition_bound_preserving_limiter_selected_fields/screen-output
@@ -1,0 +1,31 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 8,164 (2,178+289+1,089+2,304+2,304)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 0 iterations.
+   Solving C_2 system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 34+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-discontinuous_composition_bound_preserving_limiter_selected_fields/solution/solution-00000
+     RMS, max velocity:         0.113 m/year, 0.179 m/year
+     Compositions min/max/mass: 0/1/1.224e+11 // 0/1/1.224e+11
+
+*** Timestep 1:  t=25000 years, dt=25000 years
+   Skipping temperature solve because RHS is zero.
+   Solving C_1 system ... 4 iterations.
+   Solving C_2 system ... 4 iterations.
+   Solving Stokes system... 27+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-discontinuous_composition_bound_preserving_limiter_selected_fields/solution/solution-00001
+     RMS, max velocity:         0.113 m/year, 0.179 m/year
+     Compositions min/max/mass: -0.0009377/1/1.224e+11 // -0.1602/1.081/1.224e+11
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/discontinuous_composition_bound_preserving_limiter_selected_fields/statistics
+++ b/tests/discontinuous_composition_bound_preserving_limiter_selected_fields/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for composition solver 2
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: Visualization file name
+# 15: RMS velocity (m/year)
+# 16: Max. velocity (m/year)
+# 17: Minimal value for composition C_1
+# 18: Maximal value for composition C_1
+# 19: Global mass for composition C_1
+# 20: Minimal value for composition C_2
+# 21: Maximal value for composition C_2
+# 22: Global mass for composition C_2
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 4608 0 0 0 33 35 34 output-discontinuous_composition_bound_preserving_limiter_selected_fields/solution/solution-00000 1.12785220e-01 1.78736865e-01  0.00000000e+00 1.00000000e+00 1.22395833e+11  0.00000000e+00 1.00000000e+00 1.22395833e+11 
+1 2.500000000000e+04 2.500000000000e+04 256 2467 1089 4608 0 4 4 26 28 28 output-discontinuous_composition_bound_preserving_limiter_selected_fields/solution/solution-00001 1.12744114e-01 1.78560244e-01 -9.37682603e-04 1.00000001e+00 1.22395787e+11 -1.60230133e-01 1.08097724e+00 1.22395761e+11 


### PR DESCRIPTION
Currently the DG limiter can only be enabled for all compositional fields, or no fields. This PR allows to switch it on selectively for some fields. However, it is not working yet, and I dont see why. At the moment for the attached test it does not seem to limit anything. I will look more into it tomorrow.
@anne-glerum: FYI