### PR TITLE
Avoid a warning about cmake backward compatibility.

### DIFF
--- a/contrib/world_builder/CMakeLists.txt
+++ b/contrib/world_builder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.13.4)
 
 project(WorldBuilder C CXX)
 


### PR DESCRIPTION
I get warnings running cmake that the cmake version still supported by WorldBuilder is too old and will soon be dropped. This patch just increases the minimum required version to the same of ASPECT. 