### PR TITLE
fix struct->class MaterialModelOutputs

### DIFF
--- a/doc/sphinx/user/extending/plugin-types/material-models.md
+++ b/doc/sphinx/user/extending/plugin-types/material-models.md
@@ -45,20 +45,20 @@ template <int dim>
 
 The main properties of the material are computed in the function evaluate()
 that takes a struct of type MaterialModelInputs and is supposed to fill a
-MaterialModelOutputs structure. For performance reasons this function is
+MaterialModelOutputs class. For performance reasons this function is
 handling lookups at an arbitrary number of positions, so for each variable
-(for example viscosity), a std::vector is returned. The following members of
-MaterialModelOutputs need to be filled:
+(for example viscosity), a std::vector is returned. Some of the MaterialModelOutputs
+members that need to be filled are:
 
 ```{code-block} c++
-struct MaterialModelOutputs
+class MaterialModelOutputs
 {
-          std::vector<double> viscosities;
-          std::vector<double> densities;
-          std::vector<double> thermal_expansion_coefficients;
-          std::vector<double> specific_heat;
-          std::vector<double> thermal_conductivities;
-          std::vector<double> compressibilities;
+  public:
+    std::vector<double> viscosities;
+    std::vector<double> densities;
+    std::vector<double> thermal_expansion_coefficients;
+    std::vector<double> specific_heat;
+    // more here
 }
 ```
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -467,7 +467,7 @@ namespace aspect
 
     // Forward declaration:
     template <int dim>
-    struct AdditionalMaterialOutputs;
+    class AdditionalMaterialOutputs;
 
 
     /**

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -43,7 +43,7 @@ namespace aspect
   {
     using namespace dealii;
 
-    template <int dim> struct MaterialModelOutputs;
+    template <int dim> class MaterialModelOutputs;
     template <int dim> struct EquationOfStateOutputs;
 
     /**

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -1222,7 +1222,7 @@ namespace aspect
   \
   template struct MaterialModelInputs<dim>; \
   \
-  template struct MaterialModelOutputs<dim>; \
+  template class MaterialModelOutputs<dim>; \
   \
   template class AdditionalMaterialOutputs<dim>; \
   \


### PR DESCRIPTION
fixes warnings introduced in  #5665

