### PR TITLE
Make sure we set flags before we use them to output physical units.

### DIFF
--- a/doc/modules/changes/20240601_bangerth
+++ b/doc/modules/changes/20240601_bangerth
@@ -1,0 +1,3 @@
+New: ASPECT now outputs the physical units of quantities into .pvtu files.
+<br>
+(Wolfgang Bangerth, 2024/06/01)

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -537,6 +537,21 @@ namespace aspect
         }
       else if (output_format == "vtu")
         {
+          // Pass time step number and time as metadata into the output file
+          DataOutBase::VtkFlags vtk_flags;
+          vtk_flags.cycle = this->get_timestep_number();
+          vtk_flags.time = time_in_years_or_seconds;
+
+          // Also describe the physical units if we have them. Postprocessors do
+          // describe them, but it's a slight hassle to get at the information:
+          vtk_flags.physical_units = visualization_field_names_and_units;
+
+          // Finally, set or do not set whether we want to describe cells
+          // with curved edges and faces:
+          vtk_flags.write_higher_order_cells = write_higher_order_output;
+
+          data_out.set_flags(vtk_flags);
+
           // Write master files (.pvtu,.pvd,.visit) on the master process
           const int my_id = Utilities::MPI::this_mpi_process(
                               this->get_mpi_communicator());
@@ -561,22 +576,6 @@ namespace aspect
           const std::string filename = this->get_output_directory() + "solution/"
                                        + solution_file_prefix + "."
                                        + Utilities::int_to_string(my_file_id, 4) + ".vtu";
-
-          // Pass time step number and time as metadata into the output file
-          DataOutBase::VtkFlags vtk_flags;
-          vtk_flags.cycle = this->get_timestep_number();
-          vtk_flags.time = time_in_years_or_seconds;
-
-          // Also describe the physical units if we have them. Postprocessors do
-          // describe them, but it's a slight hassle to get at the information:
-          vtk_flags.physical_units = visualization_field_names_and_units;
-
-          // Finally, set or do not set whether we want to describe cells
-          // with curved edges and faces:
-          vtk_flags.write_higher_order_cells = write_higher_order_output;
-
-          data_out.set_flags(vtk_flags);
-
 
           // Write as many files as processes. For this case we support writing in a
           // background thread and to a temporary location, so we first write everything

--- a/tests/parallel_output_group_0/solution/solution-00000.pvtu
+++ b/tests/parallel_output_group_0/solution/solution-00000.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_0/solution/solution-00001.pvtu
+++ b/tests/parallel_output_group_0/solution/solution-00001.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_1/solution/solution-00000.pvtu
+++ b/tests/parallel_output_group_1/solution/solution-00000.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_1/solution/solution-00001.pvtu
+++ b/tests/parallel_output_group_1/solution/solution-00001.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_2/solution/solution-00000.pvtu
+++ b/tests/parallel_output_group_2/solution/solution-00000.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>

--- a/tests/parallel_output_group_2/solution/solution-00001.pvtu
+++ b/tests/parallel_output_group_2/solution/solution-00001.pvtu
@@ -4,9 +4,9 @@
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
     <PPointData Scalars="scalars">
-    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii"/>
-    <PDataArray type="Float32" Name="p" format="ascii"/>
-    <PDataArray type="Float32" Name="T" format="ascii"/>
+    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>
+    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>
+    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>
     </PPointData>
     <PPoints>
       <PDataArray type="Float32" NumberOfComponents="3"/>


### PR DESCRIPTION
We had an ordering problem in that we first create the `.pvtu` file and only then populated fields in the `VtkFlags` structure that is used in determining metadata for the `.pvtu` file. This is easily fixed by moving the code blocks into their correct order. As a result, we now put physical units also into the `.pvtu` file:
```
<?xml version="1.0"?>
<!--
#This file was generated by the deal.II library on 2024/6/1 at 10:32:26
-->
<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
  <PUnstructuredGrid GhostLevel="0">
    <PPointData Scalars="scalars">
    <PDataArray type="Float32" Name="velocity" NumberOfComponents="3" format="ascii" units="m/year"/>  *********
    <PDataArray type="Float32" Name="p" format="ascii" units="Pa"/>                                    *********
    <PDataArray type="Float32" Name="T" format="ascii" units="K"/>                                    *********
    </PPointData>
    <PPoints>
      <PDataArray type="Float32" NumberOfComponents="3"/>
    </PPoints>
    <Piece Source="solution-00000.0000.vtu"/>
  </PUnstructuredGrid>
</VTKFile>
```

Fixes #4128.