### PR TITLE
Use TARGET_LINK_LIBRARIES instead of DEAL_II_SETUP_TARGET.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,15 +550,17 @@ endif()
 # Setup targets for ASPECT:
 if(${CMAKE_BUILD_TYPE} MATCHES "DebugRelease")
   add_executable(${TARGET} ${TARGET_SRC})
-  deal_ii_setup_target(${TARGET} DEBUG)
+  target_link_libraries(${TARGET} dealii::dealii_debug)
+
   add_executable(${TARGET}-release ${TARGET_SRC})
-  deal_ii_setup_target(${TARGET}-release RELEASE)
+  target_link_libraries(${TARGET}-release dealii::dealii_release)
+
   set(TARGETS ${TARGET}-release ${TARGET})
   # default for testing:
   set(TARGET ${TARGET})
 else()
   add_executable(${TARGET} ${TARGET_SRC})
-  deal_ii_setup_target(${TARGET})
+  target_link_libraries(${TARGET} dealii::dealii_debug)
 endif()
 
 # This should be done in DEAL_II_SETUP_TARGET, but deal.II 9.5


### PR DESCRIPTION
This should fix #5632, but it does not work. I get the following error:
```
CMake Error at CMakeLists.txt:553 (target_link_libraries):
  Target "aspect" links to:

    dealii::dealii_debug

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



CMake Error at CMakeLists.txt:556 (target_link_libraries):
  Target "aspect-release" links to:

    dealii::dealii_release

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
 ```
 I must admit that I'm confused why this is so. I declare the target in the line immediately above, so it should exist. I looked at how @tamiko does this in ryujin, see https://github.com/conservation-laws/ryujin/blob/development/source/CMakeLists.txt#L31-L37, with `EXTERNAL_TARGETS` set in https://github.com/conservation-laws/ryujin/blob/development/CMakeLists.txt#L157-L182 So in ryujin, he still calls `deal_ii_setup_target` anyway. 

@tjhei @tamiko Help appreciated!