### PR TITLE
Adds a a new file CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,73 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: ASPECT
+message: >-
+  If you use this software, please so our website for the latest citation information. https://aspect.geodynamics.org/citing.html?src=www&ver=release
+type: software
+authors:
+  - given-names: Wolfgang
+    family-names: Bangerth
+    affiliation: 'Colorado State University, USA'
+    orcid: 'https://orcid.org/0000-0003-2311-9402'
+    email: bangerth@colostate.edu
+  - given-names: 'Juliane '
+    family-names: Dannberg
+    email: judannberg@gmail.com
+    affiliation: >-
+      GEOMAR Helmholtz Centre for Ocean Research Kiel and
+      Kiel University
+    orcid: 'https://orcid.org/0000-0003-0357-7115'
+  - given-names: ' Menno'
+    family-names: Fraters
+    email: menno.fraters@tutanota.com
+    orcid: 'https://orcid.org/0000-0003-0035-7723'
+  - given-names: Rene
+    family-names: Gassmoeller
+    affiliation: GEOMAR Helmholtz Centre for Ocean Research Kiel
+    email: rene.gassmoeller@mailbox.org
+    orcid: 'https://orcid.org/0000-0001-7098-8198'
+  - given-names: Anne
+    family-names: Glerum
+    orcid: 'https://orcid.org/0000-0002-9481-1749'
+    email: acglerum@gfz-potsdam.de
+    affiliation: 'GFZ Potsdam, Germany'
+  - given-names: ' Timo'
+    family-names: Heister
+    email: timo.heister@gmail.com
+    affiliation: Clemson University
+    orcid: 'https://orcid.org/0000-0002-8137-3903'
+  - given-names: Bob
+    family-names: Myhill
+    email: bob.myhill@bristol.ac.uk
+    affiliation: University of Bristol
+    orcid: 'https://orcid.org/0000-0001-9489-5236'
+  - given-names: John
+    family-names: Naliboff
+    email: john.naliboff@gmail.com
+    affiliation: New Mexico Tech
+    orcid: 'https://orcid.org/0000-0002-5697-7203'
+  - {}
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.592692
+    description: concept DOI
+  - type: doi
+    value: 10.5281/zenodo.8200213
+    description: verson 2.5.0
+repository-code: 'https://github.com/geodynamics/aspect'
+url: 'https://aspect.geodynamics.org/'
+abstract: >-
+  ASPECT is a code to simulate convection and tectonic
+  processes in Earth and other planetary bodies. It has
+  grown from a pure mantle-convection code into a tool for
+  many geodynamic applications including applications for
+  inner core convection, lithospheric scale deformation,
+  two-phase flow, and numerical methods development. The
+  project is supported by CIG (https://geodynamics.org).
+keywords:
+  - geodynamics
+  - mantle convection
+  - lithospheric deformation
+license: GPL-2.0-or-later


### PR DESCRIPTION
The use of CITATION.cff files is becoming more widely accepted.  It is supported by GItHub, Zenodo and Zotero. In addition, projects that do metadata analysis on software often scrape open repositories for this information. I am recommending we include this file so it can be included in such studies. 

Zenodo will in the near future transition to CITATION.cff away from .zenodo.json.  The .cff file should be considered a substitute and the .json file deleted.

CAUTION: 
- I believe this file overrides defaults when using the Zenodo webhook which I do not think we use anyways.
- This file contains both the concept DOI and the version DOI. Hence, we need to be updated in new releases.

Named principle developers should review their personal information in this file.

For more information, see: https://citation-file-format.github.io/

Thoughts?