### PR TITLE
fix brittle test melt_restart

### DIFF
--- a/tests/melt_restart.prm
+++ b/tests/melt_restart.prm
@@ -207,7 +207,8 @@ subsection Postprocess
 end
 
 subsection Checkpointing
-  set Time between checkpoint = 1
+  set Time between checkpoint = 0
+  set Steps between checkpoint = 1
 end
 
 subsection Solver parameters


### PR DESCRIPTION
Previously, this test checkpoints every 1 seconds of wall time. This means the test sometimes fails if the tester manages to finish the first timestep in less then one second.
