### PR TITLE
Add authors in a separate page.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -19,7 +19,7 @@
 
 project = 'ASPECT'
 copyright = '2023'
-author = 'Authors of the ASPECT manual'
+author = 'the authors of the ASPECT manual'
 
 # The full version, including alpha/beta/rc tags
 with open('../../VERSION', 'r') as file:

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -19,7 +19,7 @@
 
 project = 'ASPECT'
 copyright = '2023'
-author = 'ASPECT Community'
+author = 'Authors of the ASPECT manual'
 
 # The full version, including alpha/beta/rc tags
 with open('../../VERSION', 'r') as file:

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -19,7 +19,7 @@
 
 project = 'ASPECT'
 copyright = '2023'
-author = 'Wolfgang Bangerth, Juliane Dannberg, Menno Fraters, Rene Gassmöller, Anne Glerum, Timo Heister, Bob Myhill, John Naliboff; with contributions by: Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang'
+author = 'ASPECT Community'
 
 # The full version, including alpha/beta/rc tags
 with open('../../VERSION', 'r') as file:

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -3,7 +3,7 @@
 ```{admonition} Community Project
 :class: information
 
-ASPECT is a community software project with the list of software developers and contributors available in {ref}`sec:authors`. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
+ASPECT is a community software project. A list of ASPECT developers and contributors is available {ref}`here <sec:authors>`. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
 ```
 
 ```{image} _static/images/aspect_logo.png

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -3,7 +3,7 @@
 ```{admonition} Community Project
 :class: information
 
-ASPECT is a community software project with the list of software developers and contributors available {ref}`sec:authors`. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
+ASPECT is a community software project with the list of software developers and contributors available in {ref}`sec:authors`. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
 ```
 
 ```{image} _static/images/aspect_logo.png

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -3,7 +3,7 @@
 ```{admonition} Community Project
 :class: information
 
-ASPECT is a community project. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
+ASPECT is a community software project with the list of software developers and contributors available {ref}`sec:authors`. Contributions to software or documentation by every user are welcome and encouraged. See [here](https://github.com/geodynamics/aspect/blob/main/CONTRIBUTING.md) for how to contribute.
 ```
 
 ```{image} _static/images/aspect_logo.png

--- a/doc/sphinx/user/authors.md
+++ b/doc/sphinx/user/authors.md
@@ -1,0 +1,15 @@
+(sec:authors)=
+# ASPECT community
+
+## Principal developers
+
+* Wolfgang Bangerth
+* Juliane Dannberg
+* Menno Fraters
+* Rene Gassmöller
+* Anne Glerum
+* Timo Heister
+* Bob Myhill 
+* John Naliboff
+
+**with contributions by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang'

--- a/doc/sphinx/user/authors.md
+++ b/doc/sphinx/user/authors.md
@@ -1,5 +1,5 @@
 (sec:authors)=
-# ASPECT community
+# Authors of the ASPECT manual
 ASPECT is primarily maintained and developed by a group of principal developers. Several people have contributed significantly to the software and manual, and the list of authors in the documentation is compiled below.
 
 ## Principal developers
@@ -13,4 +13,4 @@ ASPECT is primarily maintained and developed by a group of principal developers.
 * Bob Myhill
 * John Naliboff
 
-**with contributions by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang'
+**With contributions by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang

--- a/doc/sphinx/user/authors.md
+++ b/doc/sphinx/user/authors.md
@@ -1,5 +1,6 @@
 (sec:authors)=
 # ASPECT community
+ASPECT is primarily maintained and developed by a group of principal developers. Several people have contributed significantly to the software and manual, and the list of authors in the documentation is compiled below.
 
 ## Principal developers
 
@@ -9,7 +10,7 @@
 * Rene Gassmöller
 * Anne Glerum
 * Timo Heister
-* Bob Myhill 
+* Bob Myhill
 * John Naliboff
 
 **with contributions by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang'

--- a/doc/sphinx/user/index.md
+++ b/doc/sphinx/user/index.md
@@ -4,7 +4,6 @@
 ---
 maxdepth: 2
 ---
-authors.md
 intro.md
 methods/index.md
 install/index.md
@@ -13,4 +12,5 @@ cookbooks/index.md
 benchmarks/index.md
 extending/index.md
 answers.md
+authors.md
 :::

--- a/doc/sphinx/user/index.md
+++ b/doc/sphinx/user/index.md
@@ -4,6 +4,7 @@
 ---
 maxdepth: 2
 ---
+authors.md
 intro.md
 methods/index.md
 install/index.md


### PR DESCRIPTION
This PR addresses #5494  so that we now have authors as a separate page. Currently, the new page is under `user guide` but maybe we want to move it somewhere else (?), open to suggetions.

![image](https://github.com/geodynamics/aspect/assets/19296817/1cf639cd-01b2-41fd-96bb-6a2c4c7342be)



### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).