### PR TITLE
Changed python list comprehensions into numpy array operations

### DIFF
--- a/contrib/python/scripts/pyvista_2d_annulus_example.py
+++ b/contrib/python/scripts/pyvista_2d_annulus_example.py
@@ -53,10 +53,10 @@ for ts in range(out_n_min, out_n_max + 1):
     mesh = pv.read(dir + "output/solution/solution-" + num_str + ".pvtu")
 
     #   Extract cartesian coordinates of the mesh and x-y velocities
-    mesh.point_data["x"] = [z[0] for z in mesh.points]
-    mesh.point_data["y"] = [z[1] for z in mesh.points]
-    mesh.point_data["vx"] = [z[0] for z in mesh.point_data["velocity"]]
-    mesh.point_data["vy"] = [z[1] for z in mesh.point_data["velocity"]]
+    mesh.point_data["x"] = mesh.points.T[0] # equivalently: [z[0] for z in mesh.points]
+    mesh.point_data["y"] = mesh.points.T[1] # equivalently [z[1] for z in mesh.points]
+    mesh.point_data["vx"] = mesh.point_data["velocity"].T[0]
+    mesh.point_data["vy"] = mesh.point_data["velocity"].T[1]
 
     #   Compute polar coordinates of the mesh and radial
     #   and angular velocities


### PR DESCRIPTION
Instead of using python list comprehensions to loop through coordinate points of a mesh object to extract the x,y coordinate points and x,y velocity components, I used the numpy array functionality to transpose the Nxd array into a dxN one (where d is the dimension and N is the number of points in the mesh) and then take the first (x-component) and second (y-component) of that transposed array which results in the same Nx1 array as before, it just looks nicer (and is potentially faster).
The images plotting the phi-component of the velocity are the same and show the before and after of making this change.
![vphi_new00025](https://github.com/geodynamics/aspect/assets/102504165/5095507e-edf1-4b19-a510-de01a8fe8a4a)
![vphi_00025](https://github.com/geodynamics/aspect/assets/102504165/817d3d7e-98c1-485c-9025-e04dfe20e684)


### For new features/models or changes of existing features:
* [ X] I have tested my new feature locally to ensure it is correct.