### PR TITLE
[WIP] Add custom initialization function to particle property interface

### DIFF
--- a/doc/modules/changes/20240604_gassmoeller
+++ b/doc/modules/changes/20240604_gassmoeller
@@ -1,0 +1,5 @@
+Added: The particle property plugins can now specify a custom
+function to initialize properties of particles that are
+added during simulations.
+<br>
+(Rene Gassmoeller, 2024/06/04)

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -293,7 +293,12 @@ namespace aspect
          * updated over time its update function is called as usual, if not
          * the property will remain zero throughout the model run.
          */
-        initialize_to_zero
+        initialize_to_zero,
+        /**
+         * Allow the property plugins to define their own initialization
+         * behavior.
+        */
+        custom_initialization
       };
 
       /**
@@ -453,6 +458,30 @@ namespace aspect
           virtual
           InitializationModeForLateParticles
           late_initialization_mode () const;
+
+          /**
+           * Initialization function for particles that are added later
+           * during the simulation. This function is only called if the
+           * late_initialization_mode() function specifies that a custom
+           * initialization is necessary.
+           *
+           * @param [in] position The current particle position.
+           * @param [in] particle_handler A reference to the particle handler
+           * giving access to the collection of existing particles.
+           * @param [in] interpolator A reference to the particle interpolator
+           * plugin.
+           * @param [in] cell A cell iterator pointing to the cell the current particle
+           * lives in.
+           * @param [in,out] properties The properties of the particle
+           * that are to be initialized within the call of this function.
+           */
+          virtual
+          void
+          custom_late_initialization (const Point<dim> &position,
+                                      const ParticleHandler<dim> &particle_handler,
+                                      const Interpolator::Interface<dim> &interpolator,
+                                      const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
+                                      const ArrayView<double> &properties) const;
 
           /**
            * Set up the information about the names and number of components

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -272,6 +272,27 @@ namespace aspect
 
       template <int dim>
       void
+      Interface<dim>::custom_late_initialization (const Point<dim> &location,
+                                                  const ParticleHandler<dim> &particle_handler,
+                                                  const Interpolator::Interface<dim> &interpolator,
+                                                  const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
+                                                  const ArrayView<double> &properties) const
+      {
+        // By default, throw an exception. Note that by default this function is
+        // not called, because late_initialization_mode() returns 'interpolate' in the
+        // default implementation.
+        AssertThrow(false,
+                    ExcMessage("You selected a particle property that specifies that "
+                               "a custom initialization function should be called for "
+                               "particle initialization, but no such function is "
+                               "implemented in the current particle property."));
+        return;
+      }
+
+
+
+      template <int dim>
+      void
       Interface<dim>::declare_parameters (ParameterHandler &)
       {}
 
@@ -536,6 +557,20 @@ namespace aspect
                         }
                     }
 
+                  break;
+                }
+                case custom_late_initialization:
+                {
+                  const unsigned int starting_property_index = particle_properties.size();
+                  particle_properties.resize(particle_properties.size() + property_information.get_components_by_plugin_index(property_index));
+                  const unsigned int end_property_index = particle_properties.size();
+
+                  (*p)->custom_late_initialization(particle_location,
+                                                   particle_handler,
+                                                   interpolator,
+                                                   cell,
+                                                   make_array_view(particle_properties[starting_property_index],
+                                                                   particle_properties[end_property_index]));
                   break;
                 }
 


### PR DESCRIPTION
This is currently a work-in-progress PR to allow @Wang-yijun to start working on her particle interpolation scheme. The PR allows particle properties to specify a function which controls how the properties of particles are initialized that are added later (i.e. not at model start).