### PR TITLE
change boundary conditions to dirichlet 0 for nsinker benchmark

### DIFF
--- a/benchmarks/nsinker/nsinker.prm
+++ b/benchmarks/nsinker/nsinker.prm
@@ -39,7 +39,7 @@ subsection Geometry model
 end
 
 subsection Boundary velocity model
-  set Zero velocity boundary indicators = left,right,bottom,front,back,top
+  set Zero velocity boundary indicators = left,right,bottom,top,front,back
 end
 
 subsection Material model

--- a/benchmarks/nsinker/nsinker.prm
+++ b/benchmarks/nsinker/nsinker.prm
@@ -39,7 +39,7 @@ subsection Geometry model
 end
 
 subsection Boundary velocity model
-  set Tangential velocity boundary indicators = left,right,bottom,front,back
+  set Zero velocity boundary indicators = left,right,bottom,front,back,top
 end
 
 subsection Material model

--- a/tests/nsinker/screen-output
+++ b/tests/nsinker/screen-output
@@ -6,7 +6,7 @@ Number of degrees of freedom: 532 (375+32+125)
 
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system... 0+12 iterations.
+   Solving Stokes system... 0+19 iterations.
 
    Postprocessing:
      Writing graphical output: output-nsinker/solution/solution-00000

--- a/tests/nsinker/statistics
+++ b/tests/nsinker/statistics
@@ -9,4 +9,4 @@
 # 9: Velocity iterations in Stokes preconditioner
 # 10: Schur complement iterations in Stokes preconditioner
 # 11: Visualization file name
-0 0.000000000000e+00 0.000000000000e+00 8 407 125 1 11 13 12 output-nsinker/solution/solution-00000 
+0 0.000000000000e+00 0.000000000000e+00 8 407 125 1 18 20 19 output-nsinker/solution/solution-00000 


### PR DESCRIPTION
nsinker.cc says the benchmark is meant to be as defined in Rudi et al. (2017), which uses Dirichlet 0 boundary conditions. This is also consistent with the boundary conditions implemented for the sinker problem in Clevenger, Heister (2021). 
