### PR TITLE
Make sure the compiler finds worldbuilder/config.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,13 @@ if(ASPECT_WITH_WORLD_BUILDER)
     set(WORLD_BUILDER_SOURCE_DIR "${CMAKE_SOURCE_DIR}/contrib/world_builder/" CACHE PATH "" FORCE)
   endif()
 
-  # add source and include dirs:
+  # Add the WorldBuilder include dirs. This includes both the WorldBuilder
+  # header files, as well as where the cmake run we do below puts the
+  # WorldBuilder config.h file.
   include_directories("${WORLD_BUILDER_SOURCE_DIR}/include/")
+  include_directories("${CMAKE_BINARY_DIR}/world_builder/include")
+
+
   include("${WORLD_BUILDER_SOURCE_DIR}/cmake/version.cmake")
 
   message(STATUS "Using World Builder version ${WORLD_BUILDER_VERSION} found at ${WORLD_BUILDER_SOURCE_DIR}.")


### PR DESCRIPTION
It isn't quite clear what is different on my system, or why not everyone has this problem.

When you use the copy of WorldBuilder in `contrib/`, we run WorldBuilder's cmake script that creates a `config.h` in the build directory. For some reason, the path to this file is not in the include path passed to my compiler, and I think that's because we never seem to describe that path to cmake. (That's definitely true in the ASPECT `CMakeLists.txt` file. Perhaps we do that in `contrib/world_builder/CMakeLists.txt` but it's unclear to me whether that only applies to the files compiled for the WorldBuilder itself, or also for the ASPECT files. The question is whether `include_directories(...)` called in a subdirectory also affects the include path in directories higher up -- that may even depend on the cmake version.) Either way, it does not hurt to be explicit.