### PR TITLE
Reorder arguments. Improve documentation.

### DIFF
--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -89,11 +89,22 @@ namespace aspect
 
           /**
            * A function that computes by how much the rheologic parameters change
-           * if strain weakening is applied. Given a compositional field with
-           * the index j and a vector of all compositional fields, it returns
-           * reduction factors for the cohesion, friction angle and the prefactor
-           * of the viscous flow law(s) used in the computation for that composition.
+           * if strain weakening is applied. Given a vector @p composition of all
+           * fields, it returns reduction factors for the cohesion, friction angle
+           * and the prefactor of the viscous flow law(s) for the compositional
+           * field with index @p j. The reason all fields are passed is that
+           * the weakening factors can depend on the values of fields that track
+           * different measures of previously applied strain.
            */
+          std::array<double, 3>
+          compute_strain_weakening_factors(const std::vector<double> &composition,
+                                           const unsigned int j) const;
+
+          /**
+           * @deprecated: Deprecated version of the function of the same
+           * name described above.
+          */
+          DEAL_II_DEPRECATED
           std::array<double, 3>
           compute_strain_weakening_factors(const unsigned int j,
                                            const std::vector<double> &composition) const;

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -377,11 +377,12 @@ namespace aspect
       }
 
 
+
       template <int dim>
       std::array<double, 3>
       StrainDependent<dim>::
-      compute_strain_weakening_factors(const unsigned int j,
-                                       const std::vector<double> &composition) const
+      compute_strain_weakening_factors(const std::vector<double> &composition,
+                                       const unsigned int j) const
       {
         double viscous_weakening = 1.0;
         std::pair<double, double> brittle_weakening (1.0, 1.0);
@@ -449,6 +450,19 @@ namespace aspect
         return weakening_factors;
 
       }
+
+
+
+      template <int dim>
+      std::array<double, 3>
+      StrainDependent<dim>::
+      compute_strain_weakening_factors(const unsigned int j,
+                                       const std::vector<double> &composition) const
+      {
+        return compute_strain_weakening_factors(composition,j);
+      }
+
+
 
       template <int dim>
       double

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -245,7 +245,7 @@ namespace aspect
 
             // Step 2: calculate strain weakening factors for the cohesion, friction, and pre-yield viscosity
             // If no strain weakening is applied, the factors are 1.
-            const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(j, in.composition[i]);
+            const std::array<double, 3> weakening_factors = strain_rheology.compute_strain_weakening_factors(in.composition[i], j);
             // Apply strain weakening to the viscous viscosity.
             non_yielding_viscosity *= weakening_factors[2];
 


### PR DESCRIPTION
All other functions in strain_dependent take `j` as last index that determines the compositional field to work on, except for `compute_strain_weakening_factors`. Correct this and also improve the documentation. Technically this is an incompatible change, because the function is public, which is why I deprecated the existing function.