### PR TITLE
Disentangle CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,25 +46,25 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   "begin a build in a different directory.")
 endif()
 
-#
-# Setup CMAKE_BUILD_TYPE:
-#
-
-set(CMAKE_BUILD_TYPE
-  "DebugRelease"
-  CACHE STRING
-  "Choose the type of build, options are: Debug, Release and DebugRelease."
+# Set up CMAKE_BUILD_TYPE. Newer cmake versions (such as 3.29) set it
+# to DebugRelease in the call to project() above, whereas older ones
+# set it to the empty string or not at all. So if it's empty, set it
+# to DebugRelease.
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+  set(CMAKE_BUILD_TYPE
+      "DebugRelease"
+      CACHE STRING
+      "Choose the type of build, options are: Debug, Release and DebugRelease."
   )
+endif()
 
-# This is a strict check. But it is better to only have a known number of
-# options for CMAKE_BUILD_TYPE...
-if( NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release" AND
-    NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND
-    NOT "${CMAKE_BUILD_TYPE}" STREQUAL "DebugRelease" )
+if("${CMAKE_BUILD_TYPE}" STREQUAL "Release" OR
+   "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR
+   "${CMAKE_BUILD_TYPE}" STREQUAL "DebugRelease" )
+  message(STATUS "Setting up ASPECT for ${CMAKE_BUILD_TYPE} mode.")
+else()
   message(FATAL_ERROR
     "CMAKE_BUILD_TYPE must either be 'Release', 'Debug', or 'DebugRelease', but is set to '${CMAKE_BUILD_TYPE}'.")
-else()
-  message(STATUS "Setting up ASPECT for ${CMAKE_BUILD_TYPE} mode.")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
       "DebugRelease"
       CACHE STRING
       "Choose the type of build, options are: Debug, Release and DebugRelease."
+      FORCE
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,18 @@
 # <http://www.gnu.org/licenses/>.
 
 cmake_minimum_required(VERSION 3.13.4)
+project(aspect CXX)
 
 message(STATUS "====================================================")
 message(STATUS "============ Configuring ASPECT ====================")
 message(STATUS "====================================================")
+
+
+
+# ####################################################################
+# First figure out some global stuff
+# ####################################################################
+
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/CMakeCache.txt)
   message(FATAL_ERROR  "Detected the file\n"
@@ -60,51 +68,22 @@ else()
 endif()
 
 
-# Set the name of the project and main target. If we are generating
-# ASPECT debug and release mode, we have the debug build as 'aspect'
-# and we populate a list of all targets (by default they are the same):
-set(TARGET "aspect")
-set(TARGETS "aspect")
 
 
 # ##############################################################################
-# Collect source files
+# Find external libraries
+# ##############################################################################
 
-file(GLOB_RECURSE ASPECT_SOURCE_FILES    "source/*.cc" "include/*.h")
-list(REMOVE_ITEM  ASPECT_SOURCE_FILES    ${CMAKE_CURRENT_SOURCE_DIR}/source/main.cc)
-file(GLOB_RECURSE ASPECT_UNIT_TEST_FILES "unit_tests/*.cc" "contrib/catch/catch.hpp")
-set(ASPECT_MAIN_FILE "source/main.cc")
-
-# Special treatment of some files for unity builds. We need to exclude them
-# because otherwise template class instantiations split across several
-# .cc files (for example Simulator<dim> in core.cc, helper_functions.cc,
-# solver_schemes.cc, etc. might end up in the same unity file. This would
-# lead to errors with duplicate instantiations. The only reliable option
-# is to exclude the files that instantiate the whole class.
-set(UNITY_SEPARATE_FILES
-  "source/simulator/core.cc;source/volume_of_fluid/handler.cc")
-
-foreach(_source_file ${UNITY_SEPARATE_FILES})
-  set(_full_name "${CMAKE_SOURCE_DIR}/${_source_file}")
-  set_property(SOURCE ${_full_name} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
-endforeach()
-
-
-
-# Set up include directories. Put the ASPECT header files
-# to the front of the list, whereas the 'catch' headers can
-# be preempted by the system
-include_directories(BEFORE ${CMAKE_BINARY_DIR}/include include)
-include_directories(AFTER  contrib/catch)
-
-# Generate compile_commands.json for tooling (VS Code, etc.)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+message(STATUS "")
+message(STATUS "===== Configuring external libraries ===============")
 
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/cmake/modules
   )
 
+
+# deal.II first
 find_package(deal.II 9.5.0 QUIET
   HINTS ${deal.II_DIR} ${DEAL_II_DIR} $ENV{DEAL_II_DIR}
   )
@@ -148,12 +127,104 @@ if(NOT _DEALII_GOOD)
 endif()
 
 deal_ii_initialize_cached_variables()
-project(${TARGET} CXX)
 
-set(FORCE_COLORED_OUTPUT ON CACHE BOOL "Forces colored output when compiling with gcc and clang.")
 
+# zlib
+set(ZLIB_DIR "" CACHE PATH "An optional hint to a ZLIB installation")
+if("${ZLIB_DIR}" STREQUAL "")
+  set(ZLIB_DIR "$ENV{ZLIB_DIR}" CACHE PATH "An optional hint to a ZLIB installation" FORCE)
+endif()
+find_package(ZLIB)
+if(${ZLIB_FOUND})
+  message(STATUS "Using ASPECT_WITH_ZLIB = 'ON'")
+  set(ASPECT_WITH_ZLIB ON)
+else()
+  message(STATUS "Using ASPECT_WITH_ZLIB = 'OFF'")
+  set(ASPECT_WITH_ZLIB OFF)
+endif()
+
+# PerpleX
+find_package(PerpleX QUIET
+  HINTS ./contrib/perplex/install/ ../ ../../ ${PERPLEX_DIR} $ENV{PERPLEX_DIR})
+if(${PerpleX_FOUND})
+  message(STATUS "PerpleX found at ${PerpleX_INCLUDE_DIR}")
+  set(ASPECT_WITH_PERPLEX ON)
+else()
+  set(ASPECT_WITH_PERPLEX OFF)
+endif()
+
+# libdap so that ASPECT can connect to the OPeNDAP servers
+set(ASPECT_WITH_LIBDAP OFF CACHE BOOL "Check if the user wants to compile ASPECT with the libdap libraries.")
+message(STATUS "Using ASPECT_WITH_LIBDAP = '${ASPECT_WITH_LIBDAP}'")
+if(ASPECT_WITH_LIBDAP)
+  find_package(LIBDAP)
+  if(${LIBDAP_FOUND})
+    include_directories(${LIBDAP_INCLUDE_DIRS})
+    message(STATUS "LIBDAP found at ${LIBDAP_LIBRARY}\n")
+  else()
+    message(FATAL_ERROR "LIBDAP not found. Disable ASPECT_WITH_LIBDAP or specify a hint to your installation directory with LIBDAP_DIR.")
+  endif()
+endif()
+
+
+# FastScape library and link it to ASPECT if requested
+set(ASPECT_WITH_FASTSCAPE OFF CACHE BOOL "Whether the user wants to compile ASPECT with the landscape evolution code FastScape, or not.")
+message(STATUS "Using ASPECT_WITH_FASTSCAPE = '${ASPECT_WITH_FASTSCAPE}'")
+if(ASPECT_WITH_FASTSCAPE)
+  find_library(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+  if(FASTSCAPE)
+     message(STATUS "FastScape library found at ${FASTSCAPE_DIR}")
+
+    # Get the fastscape source path so we can check the version.
+    file(STRINGS "${FASTSCAPE_DIR}/Makefile" _fastscape_makefile)
+    foreach(_line ${_fastscape_makefile})
+        if("${_line}" MATCHES "^CMAKE_SOURCE_DIR")
+          string(REPLACE "CMAKE_SOURCE_DIR = " "" FASTSCAPE_SOURCE_DIR ${_line})
+        endif()
+    endforeach()
+
+    # Now get the version from setup.py
+    message(STATUS "Parsing '${FASTSCAPE_SOURCE_DIR}/setup.py' for version information")
+    file(STRINGS "${FASTSCAPE_SOURCE_DIR}/setup.py" _fastscape_info)
+    foreach(_line ${_fastscape_info})
+      string(STRIP ${_line} _line)
+      if("${_line}" MATCHES "^version")
+        string(REGEX REPLACE "[^0-9.]" "" FASTSCAPE_VERSION ${_line})
+      endif()
+    endforeach()
+
+    # Throw an error if the version is too old.
+    if(${FASTSCAPE_VERSION} VERSION_LESS 2.8)
+      message(FATAL_ERROR "The linked FastScape version is ${FASTSCAPE_VERSION}, however at least 2.8.0 is required.")
+    endif()
+  else()
+     message(FATAL_ERROR "Trying to link with FastScape but libfastscapelib_fortran.so was not found in ${FASTSCAPE_DIR}")
+  endif()
+endif()
+
+
+# NetCDF (c including parallel)
+set(ASPECT_WITH_NETCDF ON CACHE BOOL "Check if the user wants to compile ASPECT with the NetCDF libraries.")
+
+if(ASPECT_WITH_NETCDF)
+  find_package(NETCDF)
+  if(${NETCDF_FOUND})
+    message(STATUS "Using ASPECT_WITH_NETCDF = '${ASPECT_WITH_NETCDF}'")
+    message(STATUS "  NETCDF_INCLUDE_DIR: ${NETCDF_INCLUDE_DIR}")
+    message(STATUS "  NETCDF_LIBRARY: ${NETCDF_LIBRARY}")
+    message(STATUS "  NETCDF_VERSION: ${NETCDF_VERSION}")
+  else()
+    message(STATUS "NetCDF not found. Disabling ASPECT_WITH_NETCDF. You can specify a hint to your installation directory with NETCDF_DIR.")
+    set(ASPECT_WITH_NETCDF OFF CACHE BOOL "" FORCE)
+  endif()
+else()
+  message(STATUS "Using ASPECT_WITH_NETCDF = 'OFF'")
+endif()
+
+
+# WorldBuilder
 set(ASPECT_WITH_WORLD_BUILDER ON CACHE BOOL "Whether to enable compiling aspect with the Geodynamic World Builder.")
-message(STATUS "ASPECT_WITH_WORLD_BUILDER = '${ASPECT_WITH_WORLD_BUILDER}'")
+message(STATUS "Using ASPECT_WITH_WORLD_BUILDER = '${ASPECT_WITH_WORLD_BUILDER}'")
 if(ASPECT_WITH_WORLD_BUILDER)
   # Check whether we can find the WorldBuilder.
   set(WORLD_BUILDER_SOURCE_DIR "" CACHE PATH "Provide an external World Builder directory to be compiled with ASPECT. If the path is not provided or the World Builder is not found in the provided location, the version in the contrib folder is used.")
@@ -183,27 +254,50 @@ if(ASPECT_WITH_WORLD_BUILDER)
     set(WB_ENABLE_PYTHON OFF)
 
     if(${CMAKE_BUILD_TYPE} MATCHES "DebugRelease")
+      # First for debug mode...
       set(CMAKE_BUILD_TYPE Debug)
+
+      message (STATUS "")
+      message(STATUS "===== Setting up Geodynamic World Builder version ${WORLD_BUILDER_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+
       set(WB_TARGET "WorldBuilderDebug")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
       target_compile_options(WorldBuilderDebug PRIVATE "-g" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
 
+
+      # ...then for release mode
       set(CMAKE_BUILD_TYPE Release)
+
+      message (STATUS "")
+      message(STATUS "===== Setting up Geodynamic World Builder version ${WORLD_BUILDER_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+
       set(WB_TARGET "WorldBuilderRelease")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder_release/)
       target_compile_definitions(WorldBuilderRelease PUBLIC "NDEBUG")
       target_compile_options(WorldBuilderRelease PRIVATE "-O3" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
 
       set(CMAKE_BUILD_TYPE DebugRelease)
+
     elseif(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+
+      message (STATUS "")
+      message(STATUS "===== Setting up Geodynamic World Builder version ${WORLD_BUILDER_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
       target_compile_options(WorldBuilder PRIVATE "-g" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
+
     elseif(${CMAKE_BUILD_TYPE} MATCHES "Release")
+
+      message (STATUS "")
+      message(STATUS "===== Setting up Geodynamic World Builder version ${WORLD_BUILDER_VERSION} in ${CMAKE_BUILD_TYPE} mode")
+
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
       target_compile_definitions(WorldBuilder PUBLIC "NDEBUG")
       target_compile_options(WorldBuilder PRIVATE "-O3" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
     endif()
+
   else()
+
     file(GLOB_RECURSE wb_files "${WORLD_BUILDER_SOURCE_DIR}/source/world_builder/*.cc")
     list(APPEND ASPECT_SOURCE_FILES ${wb_files})
     add_definitions(-DWB_WITH_MPI)
@@ -243,6 +337,59 @@ if(ASPECT_WITH_WORLD_BUILDER)
   endif()
 endif()
 
+
+
+# ##############################################################################
+# Configuring the ASPECT targets themselves
+# ##############################################################################
+
+message(STATUS "")
+message(STATUS "===== Configuring ASPECT build targets =============")
+
+
+
+# ##############################################################################
+# Collect source files
+
+file(GLOB_RECURSE ASPECT_SOURCE_FILES    "source/*.cc" "include/*.h")
+list(REMOVE_ITEM  ASPECT_SOURCE_FILES    ${CMAKE_CURRENT_SOURCE_DIR}/source/main.cc)
+file(GLOB_RECURSE ASPECT_UNIT_TEST_FILES "unit_tests/*.cc" "contrib/catch/catch.hpp")
+set(ASPECT_MAIN_FILE "source/main.cc")
+
+# Special treatment of some files for unity builds. We need to exclude them
+# because otherwise template class instantiations split across several
+# .cc files (for example Simulator<dim> in core.cc, helper_functions.cc,
+# solver_schemes.cc, etc. might end up in the same unity file. This would
+# lead to errors with duplicate instantiations. The only reliable option
+# is to exclude the files that instantiate the whole class.
+set(UNITY_SEPARATE_FILES
+  "source/simulator/core.cc;source/volume_of_fluid/handler.cc")
+
+foreach(_source_file ${UNITY_SEPARATE_FILES})
+  set(_full_name "${CMAKE_SOURCE_DIR}/${_source_file}")
+  set_property(SOURCE ${_full_name} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
+endforeach()
+
+
+
+# Set up include directories. Put the ASPECT header files
+# to the front of the list, whereas the 'catch' headers can
+# be preempted by the system
+include_directories(BEFORE ${CMAKE_BINARY_DIR}/include include)
+include_directories(AFTER  contrib/catch)
+
+# Generate compile_commands.json for tooling (VS Code, etc.)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
+
+# Set the name of the project and main target. If we are generating
+# ASPECT debug and release mode, we have the debug build as 'aspect'
+# and we populate a list of all targets (by default they are the same):
+set(TARGET "aspect")
+set(TARGETS "aspect")
+
+set(FORCE_COLORED_OUTPUT ON CACHE BOOL "Forces colored output when compiling with gcc and clang.")
 
 
 # load in version info and export it
@@ -590,116 +737,58 @@ if(DEAL_II_PACKAGE_VERSION VERSION_LESS 9.6.0)
   endif()
 endif()
 
-# find zlib if it is installed in a non-standard location
-set(ZLIB_DIR "" CACHE PATH "An optional hint to a ZLIB installation")
-if("${ZLIB_DIR}" STREQUAL "")
-  set(ZLIB_DIR "$ENV{ZLIB_DIR}" CACHE PATH "An optional hint to a ZLIB installation" FORCE)
-endif()
-find_package(ZLIB)
-include_directories(${ZLIB_INCLUDE_DIR})
-foreach(_T ${TARGETS})
-  target_link_libraries(${_T} ${ZLIB_LIBRARY})
-endforeach()
 
-find_package(PerpleX QUIET
-  HINTS ./contrib/perplex/install/ ../ ../../ ${PERPLEX_DIR} $ENV{PERPLEX_DIR})
+# ##############################################################################
+# Make sure we correctly link with external libraries
+# ##############################################################################
+
+# zlib
+if(${ZLIB_FOUND})
+  message(STATUS "Linking ASPECT against zlib")
+  include_directories(${ZLIB_INCLUDE_DIR})
+  foreach(_T ${TARGETS})
+    target_link_libraries(${_T} ${ZLIB_LIBRARY})
+  endforeach()
+endif()
+
+# PerpleX
 if(${PerpleX_FOUND})
-  message(STATUS "PerpleX found at ${PerpleX_INCLUDE_DIR}")
+  message(STATUS "Linking ASPECT against PerpleX")
   include_directories(${PerpleX_INCLUDE_DIR})
   foreach(_T ${TARGETS})
     target_link_libraries(${_T} ${PerpleX_LIBRARIES})
   endforeach()
-  set(ASPECT_WITH_PERPLEX ON)
-else()
-  set(ASPECT_WITH_PERPLEX OFF)
 endif()
 
-
-# Find the libdap package so that ASPECT can connect to the OPeNDAP servers
-# Author: Kodi Neumiller
-set(ASPECT_WITH_LIBDAP OFF CACHE BOOL "Check if the user wants to compile ASPECT with the libdap libraries.")
-message(STATUS "Using ASPECT_WITH_LIBDAP = '${ASPECT_WITH_LIBDAP}'")
-if(ASPECT_WITH_LIBDAP)
-  find_package(LIBDAP)
-  if(${LIBDAP_FOUND})
-    include_directories(${LIBDAP_INCLUDE_DIRS})
-    foreach(_T ${TARGETS})
-      target_link_libraries(${_T} ${LIBDAP_LIBRARIES})
-    endforeach()
-    message(STATUS "LIBDAP found at ${LIBDAP_LIBRARY}\n")
-  else()
-    message(FATAL_ERROR "LIBDAP not found. Disable ASPECT_WITH_LIBDAP or specify a hint to your installation directory with LIBDAP_DIR.")
-  endif()
+# libdap
+if(${LIBDAP_FOUND})
+  message(STATUS "Linking ASPECT against libdap")
+  include_directories(${LIBDAP_INCLUDE_DIRS})
+  foreach(_T ${TARGETS})
+    target_link_libraries(${_T} ${LIBDAP_LIBRARIES})
+  endforeach()
 endif()
 
-
-# Check for FastScape library and link it to ASPECT if requested
-set(ASPECT_WITH_FASTSCAPE OFF CACHE BOOL "Whether the user wants to compile ASPECT with the landscape evolution code FastScape, or not.")
-message(STATUS "Using ASPECT_WITH_FASTSCAPE = '${ASPECT_WITH_FASTSCAPE}'")
-if(ASPECT_WITH_FASTSCAPE)
-  find_library(FASTSCAPE NAMES fastscapelib_fortran PATHS $ENV{FASTSCAPE_DIR} ${FASTSCAPE_DIR} PATH_SUFFIXES lib NO_DEFAULT_PATH)
-  if(FASTSCAPE)
-     message(STATUS "FastScape library found at ${FASTSCAPE_DIR}")
-
-    # Get the fastscape source path so we can check the version.
-    file(STRINGS "${FASTSCAPE_DIR}/Makefile" _fastscape_makefile)
-    foreach(_line ${_fastscape_makefile})
-        if("${_line}" MATCHES "^CMAKE_SOURCE_DIR")
-          string(REPLACE "CMAKE_SOURCE_DIR = " "" FASTSCAPE_SOURCE_DIR ${_line})
-        endif()
-    endforeach()
-
-    # Now get the version from setup.py
-    message(STATUS "Parsing '${FASTSCAPE_SOURCE_DIR}/setup.py' for version information")
-    file(STRINGS "${FASTSCAPE_SOURCE_DIR}/setup.py" _fastscape_info)
-    foreach(_line ${_fastscape_info})
-        string(STRIP ${_line} _line)
-        if("${_line}" MATCHES "^version")
-          string(REGEX REPLACE "[^0-9.]" "" FASTSCAPE_VERSION ${_line})
-        endif()
-    endforeach()
-
-    # Throw an error if the version is too old.
-    if(${FASTSCAPE_VERSION} VERSION_LESS 2.8)
-      message(FATAL_ERROR "The linked FastScape version is ${FASTSCAPE_VERSION}, however at least 2.8.0 is required.")
-    endif()
-
-    foreach(_T ${TARGETS})
-      target_link_libraries(${_T} ${FASTSCAPE})
-    endforeach()
-  else()
-     message(FATAL_ERROR "Trying to link with FastScape but libfastscapelib_fortran.so was not found in ${FASTSCAPE_DIR}")
-  endif()
+# Fastscape
+if (FASTSCAPE)
+  message(STATUS "Linking ASPECT against Fastscape")
+  foreach(_T ${TARGETS})
+    target_link_libraries(${_T} ${FASTSCAPE})
+  endforeach()
 endif()
 
-
-#
-# NetCDF (c including parallel)
-#
-
-set(ASPECT_WITH_NETCDF ON CACHE BOOL "Check if the user wants to compile ASPECT with the NetCDF libraries.")
-
-if(ASPECT_WITH_NETCDF)
-  find_package(NETCDF)
-  if(${NETCDF_FOUND})
-    include_directories(${NETCDF_INCLUDE_DIRS})
-    foreach(_T ${TARGETS})
-      target_link_libraries(${_T} ${NETCDF_LIBRARIES})
-    endforeach()
-
-    message(STATUS "Using ASPECT_WITH_NETCDF = '${ASPECT_WITH_NETCDF}'")
-    message(STATUS "  NETCDF_INCLUDE_DIR: ${NETCDF_INCLUDE_DIR}")
-    message(STATUS "  NETCDF_LIBRARY: ${NETCDF_LIBRARY}")
-    message(STATUS "  NETCDF_VERSION: ${NETCDF_VERSION}")
-  else()
-    message(STATUS "NetCDF not found. Disabling ASPECT_WITH_NETCDF. You can specify a hint to your installation directory with NETCDF_DIR.")
-    set(ASPECT_WITH_NETCDF OFF CACHE BOOL "" FORCE)
-  endif()
-else()
-  message(STATUS "NetCDF support disabled.")
+# NetCDF
+if(${NETCDF_FOUND})
+  message(STATUS "Linking ASPECT against NetCDF")
+  include_directories(${NETCDF_INCLUDE_DIRS})
+  foreach(_T ${TARGETS})
+    target_link_libraries(${_T} ${NETCDF_LIBRARIES})
+  endforeach()
 endif()
+
 
 if(WORLD_BUILDER_VERSION VERSION_GREATER_EQUAL 0.6.0 AND ASPECT_WITH_WORLD_BUILDER)
+  message(STATUS "Linking ASPECT against WorldBuilder")
   if(${CMAKE_BUILD_TYPE} MATCHES "DebugRelease")
     target_include_directories(${TARGET} PUBLIC "${CMAKE_BINARY_DIR}/world_builder/include/")
     target_include_directories(${TARGET}-release PUBLIC "${CMAKE_BINARY_DIR}/world_builder_release/include/")
@@ -712,8 +801,10 @@ if(WORLD_BUILDER_VERSION VERSION_GREATER_EQUAL 0.6.0 AND ASPECT_WITH_WORLD_BUILD
 endif()
 
 
+
+# Some systems need to explicitly link to some libraries to use dlopen
 if(ASPECT_USE_SHARED_LIBS)
-  # some systems need to explicitly link to some libraries to use dlopen
+  message(STATUS "Linking ASPECT against dlopen")
   foreach(_T ${TARGETS})
     target_link_libraries(${_T} ${CMAKE_DL_LIBS})
   endforeach()
@@ -820,6 +911,60 @@ else()
 endif()
 
 
+#
+## installation
+#
+# binary:
+install(TARGETS ${TARGETS}
+  RUNTIME DESTINATION bin
+  COMPONENT runtime)
+
+# make sure we have the rpath to our dependencies set:
+
+foreach(_T ${TARGETS})
+  set_property(TARGET ${_T} PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
+endforeach()
+
+# headers:
+install(DIRECTORY include/ ${CMAKE_BINARY_DIR}/include/
+  DESTINATION include
+  COMPONENT includes
+  FILES_MATCHING PATTERN "*.h")
+
+# examples:
+set(ASPECT_INSTALL_EXAMPLES OFF CACHE BOOL "If ON all cookbooks and benchmarks will be built and installed.")
+
+if(ASPECT_INSTALL_EXAMPLES)
+  add_subdirectory(benchmarks)
+  add_subdirectory(cookbooks)
+
+  install(DIRECTORY cookbooks/
+    DESTINATION cookbooks
+    COMPONENT examples
+    FILES_MATCHING PATTERN "*")
+  install(DIRECTORY benchmarks/
+    DESTINATION benchmarks
+    COMPONENT examples
+    FILES_MATCHING PATTERN "*")
+endif()
+
+# data files:
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/
+  DESTINATION data
+  COMPONENT data)
+
+# cmake stuff:
+install(FILES ${CMAKE_BINARY_DIR}/forinstall/AspectConfig.cmake ${CMAKE_BINARY_DIR}/AspectConfigVersion.cmake
+        DESTINATION "lib/cmake/Aspect/")
+
+install(FILES ${CMAKE_BINARY_DIR}/include/aspect/revision.h DESTINATION "include/aspect/")
+
+message(STATUS "Writing configuration details into detailed.log...")
+
+
+message(STATUS "")
+MESSAGE(STATUS "===== Configuring ASPECT documentation =============")
+
 ###########################################################
 # Having configured most of the compilation phase, now also
 # deal with other parts of the system.
@@ -871,55 +1016,9 @@ add_custom_command(TARGET ${TARGET} POST_BUILD
 
 
 
-#
-## installation
-#
-# binary:
-install(TARGETS ${TARGETS}
-  RUNTIME DESTINATION bin
-  COMPONENT runtime)
+message(STATUS "")
+MESSAGE(STATUS "===== Writing final configuration =============")
 
-# make sure we have the rpath to our dependencies set:
-
-foreach(_T ${TARGETS})
-  set_property(TARGET ${_T} PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
-endforeach()
-
-# headers:
-install(DIRECTORY include/ ${CMAKE_BINARY_DIR}/include/
-  DESTINATION include
-  COMPONENT includes
-  FILES_MATCHING PATTERN "*.h")
-
-# examples:
-set(ASPECT_INSTALL_EXAMPLES OFF CACHE BOOL "If ON all cookbooks and benchmarks will be built and installed.")
-
-if(ASPECT_INSTALL_EXAMPLES)
-  add_subdirectory(benchmarks)
-  add_subdirectory(cookbooks)
-
-  install(DIRECTORY cookbooks/
-    DESTINATION cookbooks
-    COMPONENT examples
-    FILES_MATCHING PATTERN "*")
-  install(DIRECTORY benchmarks/
-    DESTINATION benchmarks
-    COMPONENT examples
-    FILES_MATCHING PATTERN "*")
-endif()
-
-# data files:
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/
-  DESTINATION data
-  COMPONENT data)
-
-# cmake stuff:
-install(FILES ${CMAKE_BINARY_DIR}/forinstall/AspectConfig.cmake ${CMAKE_BINARY_DIR}/AspectConfigVersion.cmake
-        DESTINATION "lib/cmake/Aspect/")
-
-install(FILES ${CMAKE_BINARY_DIR}/include/aspect/revision.h DESTINATION "include/aspect/")
-
-message(STATUS "Writing configuration details into detailed.log...")
 include(cmake/write_config)
 
 # print "info" if run for the first time:

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)
 
-MESSAGE(STATUS "===== Configuring ASPECT documentation =============")
-
 FIND_PACKAGE(Perl)
 
 
@@ -29,6 +27,8 @@ FIND_PACKAGE(Perl)
 
 # Step 1: Find all of the .prm files that will be used in
 #         the manual.
+message(STATUS "Finding .prm files")
+
 FILE(GLOB _doc_directories_cookbooks
      ${CMAKE_SOURCE_DIR}/cookbooks/*/doc)
 FILE(GLOB _doc_directories_benchmarks
@@ -43,6 +43,7 @@ LIST(APPEND _doc_directories
 
 
 # Step 2: Deal with images
+message(STATUS "Finding image files")
 ADD_CUSTOM_TARGET(build_images)
 
 #         We have one image file that we need to create -- the plugin
@@ -87,6 +88,7 @@ ENDIF()
 # The final target: Build it all
 #
 ################################################################
+message(STATUS "Setting up build information")
 ADD_CUSTOM_TARGET(documentation
   DEPENDS
     build_images


### PR DESCRIPTION
The cmake script has become a bit of a mess. This patch disentangles it in a substantial way, first finding and dealing with external dependencies, then configuring our own targets, then dealing with how external dependencies impact our own targets, and finally documentation. This is going to be difficult to review -- but almost all of it is really just moving things around.

For me, the cmake output now looks like this, less convoluted:
```
-- ====================================================
-- ============ Configuring ASPECT ====================
-- ====================================================
-- Setting up ASPECT for DebugRelease mode.
-- 
-- ===== Configuring external libraries ===============
-- Found deal.II version 9.6.0-pre at '/home/bangerth/p/deal.II/1/install/lib/cmake/deal.II'
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Using ASPECT_WITH_ZLIB = 'OFF'
-- Using ASPECT_WITH_LIBDAP = 'OFF'
-- Using ASPECT_WITH_FASTSCAPE = 'OFF'
CMake Warning at CMakeLists.txt:203 (find_package):
  By not providing "FindNETCDF.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "NETCDF", but
  CMake did not find one.

  Could not find a package configuration file provided by "NETCDF" with any
  of the following names:

    NETCDFConfig.cmake
    netcdf-config.cmake

  Add the installation prefix of "NETCDF" to CMAKE_PREFIX_PATH or set
  "NETCDF_DIR" to a directory containing one of the above files.  If "NETCDF"
  provides a separate development package or SDK, be sure it has been
  installed.


-- NetCDF not found. Disabling ASPECT_WITH_NETCDF. You can specify a hint to your installation directory with NETCDF_DIR.
-- Using ASPECT_WITH_WORLD_BUILDER = 'ON'
-- World Builder not found. Using internal version.
-- Found Git: /usr/bin/git (found version "2.34.1")
-- Using World Builder version 0.6.0 found at /home/bangerth/p/deal.II/1/projects/aspect/contrib/world_builder.
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- 
-- ===== Setting up Geodynamic World Builder version 0.6.0 in Debug mode
-- Looking for feenableexcept
-- Looking for feenableexcept - found
-- Looking for feclearexcept
-- Looking for feclearexcept - found
-- Using Floating Point Exceptions if in Debug mode.
-- Looking for Fortran support.
-- Looking for a Fortran compiler
-- Looking for a Fortran compiler - /usr/bin/f95
-- The Fortran compiler identification is GNU 11.4.0
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /usr/bin/f95 - skipped
-- Found Fortran support. Enabling Fortran wrapper and tests.
-- Could NOT find SWIG (missing: SWIG_EXECUTABLE SWIG_DIR) 
-- SWIG was not found, disabling python wrapper compilation.
-- Found MPI_C: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so (found version "3.1")
-- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi_cxx.so (found version "3.1")
-- Found MPI_Fortran: /usr/lib/x86_64-linux-gnu/libmpi_usempif08.so (found version "3.1")
-- Found MPI: TRUE (found version "3.1")
-- MPI found.
-- Using MPI.
-- Found Python: /usr/bin/python3.10 (found version "3.10.12") found components: Interpreter Development Development.Module Development.Embed
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11")
-- Enabling the use of ZLIB.
-- Combining source files into unity build.
-- Performing Test SUGGEST_OVERWRITE_CXX_COMPILE_FLAG
-- Performing Test SUGGEST_OVERWRITE_CXX_COMPILE_FLAG - Success
-- Performing Test NO_PLACEMENT_NEW_CXX_COMPILE_FLAG
-- Performing Test NO_PLACEMENT_NEW_CXX_COMPILE_FLAG - Success
-- Found /usr/bin/numdiff to test the difference between files.
-- 
-- ===== Setting up Geodynamic World Builder version 0.6.0 in Release mode
-- Using Floating Point Exceptions if in Debug mode.
-- Looking for Fortran support.
-- Found Fortran support. Enabling Fortran wrapper and tests.
-- Could NOT find SWIG (missing: SWIG_EXECUTABLE SWIG_DIR) 
-- SWIG was not found, disabling python wrapper compilation.
-- MPI found.
-- Using MPI.
-- Python was disabled by cmake options.
-- Enabling the use of ZLIB.
-- Combining source files into unity build.
-- 
-- ===== Configuring ASPECT build targets =============
-- Query git repository information.
CMake Deprecation Warning at CMakeLists.txt:439 (cmake_policy):
  The OLD behavior for policy CMP0037 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- Setting up test project, see tests/setup_tests.log for details.
     Found 1 tests.
-- Performing Test HAVE_DLOPEN
-- Performing Test HAVE_DLOPEN - Success
-- Enabling dynamic loading of plugins from the input file
-- Looking for C++ include link.h
-- Looking for C++ include link.h - found
-- Enabling checking of compatible deal.II library when loading plugins
-- Linking ASPECT against WorldBuilder
-- Linking ASPECT against dlopen
-- Performing Test HAVE_FP_EXCEPTIONS
-- Performing Test HAVE_FP_EXCEPTIONS - Success
-- Runtime floating point checks enabled.
-- Precompiling common header files.
-- Disabling unity build.
-- Writing configuration details into detailed.log...
-- 
-- ===== Configuring ASPECT documentation =============
-- Found Perl: /usr/bin/perl (found version "5.34.0")
-- Finding .prm files
-- Finding image files
-- Setting up build information
-- Parameter GUI not found: install and provide a hint using -D PARAMETER_GUI_DIR or set -D PARAMETER_GUI_EXECUTABLE directly.
-- 
-- ===== Writing final configuration =============
###
#
#  Project aspect set up with  deal.II-9.6.0-pre  found at
#      /home/bangerth/p/deal.II/1/install
#
#  CMAKE_BUILD_TYPE:          DebugRelease
#
#  You can now run
#      $ ninja                - to compile and link aspect
#      $ ninja debug          - to switch the build type to 'Debug'
#      $ ninja release        - to switch the build type to 'Release'
#      $ ninja debugrelease   - to switch the build type to compile both
#      $ ninja clean          - to remove the generated executable as well as
#                               all intermediate compilation files
#      $ ninja distclean      - to clean the directory from all generated
#                               files (includes clean, runclean and the removal
#                               of the generated build system)
#      $ ninja setup_tests    - enable all tests and re-run test detection
#      $ ninja indent         - fix indentation of all source files
#      $ ninja info           - to view this message again

-- Configuring done (33.0s)
-- Generating done (0.1s)
-- Build files have been written to: /home/bangerth/p/deal.II/1/projects/build
```

There are areas that remain in need of clean-up, in particular our own targets. Also, the NETCDF configuration throws an error. But this is a step forward.