### PR TITLE
Add a signal before building patches for visualization output

### DIFF
--- a/include/aspect/simulator_signals.h
+++ b/include/aspect/simulator_signals.h
@@ -27,6 +27,7 @@
 #include <aspect/parameters.h>
 
 #include <deal.II/base/parameter_handler.h>
+#include <deal.II/numerics/data_out.h>
 
 #include <boost/signals2.hpp>
 
@@ -287,6 +288,15 @@ namespace aspect
     boost::signals2::signal<void (const SimulatorAccess<dim> &,
                                   aspect::Assemblers::Manager<dim> &)>
     set_assemblers;
+
+    /**
+    * A signal that is called before the build_patches() function is called during
+    * the creation of the visualization output. This signal
+    * allows for registering functions that take a DataOut object and can for example
+    * be used to select only certain cells of the mesh to be built into patches through
+    * calling the DataOut member function set_cell_selection().
+    */
+    boost::signals2::signal<void (DataOut<dim> &)>  pre_data_out_build_patches;
   };
 
 

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -23,6 +23,7 @@
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
+#include <aspect/simulator.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/mesh_deformation/interface.h>
 #include <deal.II/fe/mapping_q1_eulerian.h>
@@ -1017,6 +1018,8 @@ namespace aspect
       const Mapping<dim> &mapping =
         (output_undeformed_mesh && dynamic_cast<const MappingQ1Eulerian<dim, LinearAlgebra::Vector>*>(&this->get_mapping())) ?
         (linear_mapping) : (this->get_mapping());
+
+      this->get_signals().pre_data_out_build_patches (data_out);
 
       // Now get everything written for the DataOut case, and record this
       // in the statistics file

--- a/tests/pre_data_out_build_patches.cc
+++ b/tests/pre_data_out_build_patches.cc
@@ -1,0 +1,45 @@
+/*
+  Copyright (C) 2022 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/simulator_signals.h>
+#include <aspect/simulator_access.h>
+
+#include <iostream>
+
+namespace aspect
+{
+  template <int dim>
+  void pre_data_out_build_patches (DataOut<dim> &)
+  {
+    std::cout << "\npre_data_out_build_patches:\n";
+  }
+
+
+  template <int dim>
+  void signal_connector (SimulatorSignals<dim> &signals)
+  {
+    std::cout << "Connecting signals" << std::endl;
+    signals.pre_data_out_build_patches.connect (&pre_data_out_build_patches<dim>);
+  }
+
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
+}

--- a/tests/pre_data_out_build_patches.prm
+++ b/tests/pre_data_out_build_patches.prm
@@ -1,0 +1,72 @@
+# A copy of stokes_solver.prm
+# to test the pre_data_out_build_patches signal
+# in visualization.cc.
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0.1
+set Start time                             = 0
+set Adiabatic surface temperature          = 0
+set Surface pressure                       = 0
+set Use years in output instead of seconds = false
+set Nonlinear solver scheme                = single Advection, single Stokes
+
+subsection Boundary temperature model
+  set List of model names = box
+  set Fixed temperature boundary indicators   = 0, 1
+end
+
+subsection Gravity model
+  set Model name = vertical
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1.2
+    set Y extent = 1
+    set Z extent = 1
+  end
+end
+
+subsection Initial temperature model
+  set Model name = perturbed box
+end
+
+subsection Material model
+  set Model name = simpler
+
+  subsection Simpler model
+    set Reference density             = 1
+    set Reference specific heat       = 1250
+    set Reference temperature         = 1
+    set Thermal conductivity          = 1e-6
+    set Thermal expansion coefficient = 2e-5
+    set Viscosity                     = 1
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 5
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = 1
+  set Zero velocity boundary indicators       = 0, 2, 3
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics
+
+  subsection Visualization
+    set List of output variables      = density, viscosity
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Number of cheap Stokes solver steps = 30
+  end
+end

--- a/tests/pre_data_out_build_patches/screen-output
+++ b/tests/pre_data_out_build_patches/screen-output
@@ -1,0 +1,29 @@
+
+Loading shared library <./libpre_data_out_build_patches.debug.so>
+
+Connecting signals
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+7 iterations.
+
+   Postprocessing:
+
+pre_data_out_build_patches:
+     Writing graphical output: output-pre_data_out_build_patches/solution/solution-00000
+     RMS, max velocity:        9e-09 m/s, 3.23e-08 m/s
+
+*** Timestep 1:  t=0.1 seconds, dt=0.1 seconds
+   Solving temperature system... 4 iterations.
+   Solving Stokes system... 8+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity: 9e-09 m/s, 3.23e-08 m/s
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/pre_data_out_build_patches/statistics
+++ b/tests/pre_data_out_build_patches/statistics
@@ -1,0 +1,15 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/s)
+# 13: Max. velocity (m/s)
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 0 37 85 38 output-pre_data_out_build_patches/solution/solution-00000 9.00076484e-09 3.23376827e-08 
+1 1.000000000000e-01 1.000000000000e-01 1024 9539 4225 4  7  9  9                                                        "" 9.00076831e-09 3.23376980e-08 


### PR DESCRIPTION
Add a signal that can modify data_out during the creation of visualization output. It can be used to for example select only part of the domain to be outputted. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
