### PR TITLE
Convert all plugins to the use of the new Plugins::InterfaceBase class.

### DIFF
--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -52,24 +52,9 @@ namespace aspect
      * @ingroup AdiabaticConditions
      */
     template <int dim>
-    class Interface: public SimulatorAccess<dim>
+    class Interface: public SimulatorAccess<dim>, public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        ~Interface() override;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
         /**
          * Some plugins need to know whether the adiabatic conditions are
          * already calculated. Namely all plugins that are needed to create
@@ -80,14 +65,6 @@ namespace aspect
         virtual
         bool
         is_initialized () const = 0;
-
-        /**
-         * Compute the adiabatic conditions along a vertical transect of the
-         * geometry based on the given material model and other quantities.
-         * This function is called at every new timestep.
-         */
-        virtual
-        void update ();
 
         /**
          * Return the adiabatic temperature at a given point of the domain.
@@ -158,27 +135,6 @@ namespace aspect
         DEAL_II_DEPRECATED
         virtual
         void get_adiabatic_density_derivative_profile(std::vector<double> &values) const;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-
     };
 
 

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -52,37 +52,9 @@ namespace aspect
      * @ingroup BoundaryCompositions
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex boundary composition
-         * models to do an initialization step once at the beginning of each
-         * time step. An example would be a model that needs to call an
-         * external program to compute composition changes at sides.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Return the composition that is to hold at a particular position on
          * the boundary of the domain.
@@ -102,26 +74,6 @@ namespace aspect
         boundary_composition (const types::boundary_id boundary_indicator,
                               const Point<dim> &position,
                               const unsigned int compositional_field) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
     /**

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -44,23 +44,9 @@ namespace aspect
      * @ingroup BoundaryFluidPressures
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after the
-         * SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
-
         /**
          * Compute the component of the gradient of the fluid pressure
          * in the direction normal to a boundary for a list of quadrature
@@ -89,26 +75,6 @@ namespace aspect
           const std::vector<Tensor<1,dim>> &normal_vectors,
           std::vector<double> &fluid_pressure_gradient_outputs
         ) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -43,37 +43,9 @@ namespace aspect
      * @ingroup BoundaryHeatFlux
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after the
-         * SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex boundary heat flux
-         * models to do an initialization step once at the beginning of each
-         * time step. An example would be a model that needs to call an
-         * external program to compute a heat flux change at bottom.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Compute the heat flux for a list of quadrature points.
          *
@@ -95,26 +67,6 @@ namespace aspect
                    const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                    const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
                    const std::vector<Tensor<1,dim>> &normal_vectors) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -54,22 +54,9 @@ namespace aspect
      * @ingroup BoundaryTemperatures
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
         /**
          * Return the temperature that is to hold at a particular position on
          * the boundary of the domain.
@@ -107,41 +94,6 @@ namespace aspect
         virtual
         double maximal_temperature (const std::set<types::boundary_id> &fixed_boundary_ids
                                     = std::set<types::boundary_id>()) const = 0;
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex boundary temperature
-         * models to do an initialization step once at the beginning of each
-         * time step. An example would be a model that needs to call an
-         * external program to compute temperature change at bottom.
-         */
-        virtual
-        void
-        update ();
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -46,39 +46,9 @@ namespace aspect
      * @ingroup BoundaryTractions
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after the
-         * SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step.
-         * The default implementation of the function does nothing, but
-         * derived classes that need more elaborate setups for a given time
-         * step may overload the function.
-         *
-         * The point of this function is to allow complex boundary traction
-         * models to do an initialization step once at the beginning of each
-         * time step. An example would be a model that needs to call an
-         * external program to compute stresses for a set of plates.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Return the traction that is to hold at a particular position on
          * the boundary of the domain.
@@ -98,26 +68,6 @@ namespace aspect
         boundary_traction (const types::boundary_id boundary_indicator,
                            const Point<dim> &position,
                            const Tensor<1,dim> &normal_vector) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
 
       protected:
         /**

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -52,39 +52,9 @@ namespace aspect
      * @ingroup BoundaryVelocities
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex boundary velocity
-         * models to do an initialization step once at the beginning of each
-         * time step. An example would be a model that needs to call an
-         * external program to compute positions for a set of plates.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Return the velocity that is to hold at a particular position on
          * the boundary of the domain.
@@ -101,26 +71,6 @@ namespace aspect
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
     /**

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -50,22 +50,9 @@ namespace aspect
      * @ingroup InitialTopographyModels
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
         /**
          * Return the value of the elevation at the given surface point.
          *
@@ -84,26 +71,6 @@ namespace aspect
          */
         virtual
         double max_topography () const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -56,22 +56,9 @@ namespace aspect
      * @ingroup GeometryModels
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
         /**
          * Generate a coarse mesh for the geometry described by this class.
          */
@@ -359,26 +346,6 @@ namespace aspect
         virtual
         bool
         point_is_in_domain(const Point<dim> &p) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
 
         /**
          * Collects periodic boundary constraints for the given geometry

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -44,57 +44,13 @@ namespace aspect
      * @ingroup GravityModels
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
         /**
          * Return the gravity vector as a function of position.
          */
         virtual Tensor<1,dim> gravity_vector (const Point<dim> &position) const = 0;
-
-        /**
-         * A function that is called at the beginning of each time step and
-         * that allows the implementation to update internal data structures.
-         * This is useful, for example, if you have a gravity model that
-         * depends on time, or if you have a gravity model that depends on the
-         * solution of the previous step.
-         *
-         * The default implementation of this function does nothing.
-         */
-        virtual void update();
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -53,51 +53,14 @@ namespace aspect
      * @ingroup InitialCompositions
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
         /**
          * Return the initial composition as a function of position.
          */
         virtual
         double initial_composition (const Point<dim> &position, const unsigned int n_comp) const = 0;
-
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-
     };
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -53,51 +53,14 @@ namespace aspect
      * @ingroup InitialTemperatures
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
         /**
          * Return the initial temperature as a function of position.
          */
         virtual
         double initial_temperature (const Point<dim> &position) const = 0;
-
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-
     };
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1253,7 +1253,7 @@ namespace aspect
      * @ingroup MaterialModels
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
         /**
@@ -1263,6 +1263,7 @@ namespace aspect
          * the current class.
          */
         using MaterialModelInputs = MaterialModel::MaterialModelInputs<dim>;
+
         /**
          * A typedef to import the MaterialModelOutputs name into the current
          * class. This typedef primarily exists as a backward compatibility
@@ -1270,27 +1271,6 @@ namespace aspect
          * the current class.
          */
         using MaterialModelOutputs = MaterialModel::MaterialModelOutputs<dim>;
-
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * Called at the beginning of each time step and allows the material
-         * model to update internal data structures.
-         */
-        virtual void update ();
 
         /**
          * @name Qualitative properties one can ask a material model
@@ -1327,32 +1307,6 @@ namespace aspect
         virtual
         void evaluate (const MaterialModel::MaterialModelInputs<dim> &in,
                        MaterialModel::MaterialModelOutputs<dim> &out) const = 0;
-        /**
-         * @name Functions used in dealing with run-time parameters
-         * @{
-         */
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-        /**
-         * @}
-         */
 
         /**
          * If this material model can produce additional named outputs

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -87,35 +87,9 @@ namespace aspect
      * problem with the given constraints.
      */
     template<int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         *
-         * The default implementation of this function does nothing.
-         */
-        virtual void initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step and
-         * that allows the implementation to update internal data structures.
-         * This is useful, for example, if you have mesh deformation that
-         * depends on time, or on the solution of the previous step.
-         *
-         * The default implementation of this function does nothing.
-         */
-        virtual void update();
-
-
         /**
          * A function that will be called to check whether stabilization is needed.
          */
@@ -146,26 +120,6 @@ namespace aspect
         compute_velocity_constraints_on_boundary(const DoFHandler<dim> &mesh_deformation_dof_handler,
                                                  AffineConstraints<double> &mesh_velocity_constraints,
                                                  const std::set<types::boundary_id> &boundary_id) const;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -71,35 +71,9 @@ namespace aspect
      * @ingroup MeshRefinement
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Does nothing but is virtual so that derived classes
-         * destructors are also virtual.
-         */
-        virtual ~Interface () = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
-        /**
-         * A function that is called once at the beginning of each timestep.
-         * The default implementation of the function does nothing, but
-         * derived classes that need more elaborate setups for a given time
-         * step may overload the function.
-         *
-         * The point of this function is to allow refinement plugins to do an
-         * initialization once during each time step.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Execute this mesh refinement criterion. The default implementation
          * sets all the error indicators to zero.
@@ -126,33 +100,6 @@ namespace aspect
         virtual
         void
         tag_additional_cells () const;
-
-        /**
-         * Declare the parameters this class takes through input files.
-         * Derived classes should overload this function if they actually do
-         * take parameters; this class declares a fall-back function that does
-         * nothing, so that postprocessor classes that do not take any
-         * parameters do not have to do anything at all.
-         *
-         * This function is static (and needs to be static in derived classes)
-         * so that it can be called without creating actual objects (because
-         * declaring parameters happens before we read the input file and thus
-         * at a time when we don't even know yet which postprocessor objects
-         * we need).
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation in this class does nothing, so that
-         * derived classes that do not need any parameters do not need to
-         * implement it.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -65,28 +65,12 @@ namespace aspect
        * @ingroup ParticleGenerators
        */
       template <int dim>
-      class Interface : public SimulatorAccess<dim>
+      class Interface : public SimulatorAccess<dim>, public Plugins::InterfaceBase
       {
         public:
-          /**
-           * Constructor. Initializes the random number generator.
-           */
-          Interface ();
-
-          /**
-           * Destructor. Made virtual so that derived classes can be created
-           * and destroyed through pointers to the base class.
-           */
-          ~Interface () override = default;
-
-          /**
-           * Initialization function. This function is called once at the
-           * beginning of the program after parse_parameters is run and after
-           * the SimulatorAccess (if applicable) is initialized.
-           */
           virtual
           void
-          initialize ();
+          initialize () override;
 
           /**
            * Generate particles. Every derived class
@@ -131,27 +115,6 @@ namespace aspect
           std::pair<Particles::internal::LevelInd,Particle<dim>>
           generate_particle (const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell,
                              const types::particle_index id);
-
-
-          /**
-           * Declare the parameters this class takes through input files. The
-           * default implementation of this function does not describe any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          static
-          void
-          declare_parameters (ParameterHandler &prm);
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           * The default implementation of this function does not read any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          virtual
-          void
-          parse_parameters (ParameterHandler &prm);
 
         protected:
           /**

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -44,23 +44,9 @@ namespace aspect
        * @ingroup ParticleIntegrators
        */
       template <int dim>
-      class Interface
+      class Interface : public Plugins::InterfaceBase
       {
         public:
-          /**
-           * Destructor. Made virtual so that derived classes can be created
-           * and destroyed through pointers to the base class.
-           */
-          virtual ~Interface () = default;
-
-          /**
-           * Initialization function. This function is called once at the
-           * beginning of the program after parse_parameters is run.
-           */
-          virtual
-          void
-          initialize ();
-
           /**
            * Perform an integration step of moving the particles of one cell
            * by the specified timestep dt. Implementations of this function
@@ -158,27 +144,6 @@ namespace aspect
           void *
           write_data(const typename ParticleHandler<dim>::particle_iterator &particle,
                      void *data) const;
-
-
-          /**
-           * Declare the parameters this class takes through input files. The
-           * default implementation of this function does not describe any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          static
-          void
-          declare_parameters (ParameterHandler &prm);
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           * The default implementation of this function does not read any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          virtual
-          void
-          parse_parameters (ParameterHandler &prm);
       };
 
 

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -47,15 +47,9 @@ namespace aspect
        * @ingroup ParticleInterpolators
        */
       template <int dim>
-      class Interface
+      class Interface : public Plugins::InterfaceBase
       {
         public:
-          /**
-           * Destructor. Made virtual so that derived classes can be created
-           * and destroyed through pointers to the base class.
-           */
-          virtual ~Interface () = default;
-
           /**
            * Perform an interpolation of the properties of the particles in
            * this cell onto a vector of positions in this cell.
@@ -111,26 +105,6 @@ namespace aspect
                                const std::vector<Point<dim>> &positions,
                                const ComponentMask &selected_properties,
                                const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const = 0;
-
-          /**
-           * Declare the parameters this class takes through input files. The
-           * default implementation of this function does not describe any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          static
-          void
-          declare_parameters (ParameterHandler &prm);
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           * The default implementation of this function does not read any
-           * parameters. Consequently, derived classes do not have to overload
-           * this function if they do not take any runtime parameters.
-           */
-          virtual
-          void
-          parse_parameters (ParameterHandler &prm);
       };
 
 

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -305,23 +305,9 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class Interface
+      class Interface : public Plugins::InterfaceBase
       {
         public:
-          /**
-           * Destructor. Made virtual so that derived classes can be created
-           * and destroyed through pointers to the base class.
-           */
-          virtual ~Interface () = default;
-
-          /**
-           * Initialization function. This function is called once at the
-           * beginning of the program after parse_parameters is run.
-           */
-          virtual
-          void
-          initialize ();
-
           /**
            * Initialization function. This function is called once at the
            * creation of every particle for every property to initialize its
@@ -470,34 +456,6 @@ namespace aspect
           virtual
           std::vector<std::pair<std::string, unsigned int>>
           get_property_information() const = 0;
-
-
-          /**
-           * Declare the parameters this class takes through input files.
-           * Derived classes should overload this function if they actually do
-           * take parameters; this class declares a fall-back function that
-           * does nothing, so that property classes that do not take any
-           * parameters do not have to do anything at all.
-           *
-           * This function is static (and needs to be static in derived
-           * classes) so that it can be called without creating actual objects
-           * (because declaring parameters happens before we read the input
-           * file and thus at a time when we don't even know yet which
-           * property objects we need).
-           */
-          static
-          void
-          declare_parameters (ParameterHandler &prm);
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           * The default implementation in this class does nothing, so that
-           * derived classes that do not need any parameters do not need to
-           * implement it.
-           */
-          virtual
-          void
-          parse_parameters (ParameterHandler &prm);
       };
 
       /**

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -134,7 +134,7 @@ namespace aspect
          * Destructor. Made virtual to enforce that derived classes also have
          * virtual destructors.
          */
-        virtual ~InterfaceBase();
+        virtual ~InterfaceBase() = default;
 
         /**
          * Initialization function. This function is called once at the

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -117,6 +117,16 @@ namespace aspect
     using namespace dealii;
 
 
+    /**
+     * A base class for all plugin systems. The class ensures that a
+     * common set of functions is declared as `virtual` (namely, the
+     * destructor, `initialize()`, `update()`, and
+     * `parse_parameters()`) and implemented with empty bodies so that
+     * derived interface classes do not have to declare these
+     * functions themselves. Furthermore, the class provides an empty,
+     * `static` function `declare_parameters()` that derived classes
+     * can re-implement to declare their parameters.
+     */
     class InterfaceBase
     {
       public:
@@ -128,7 +138,7 @@ namespace aspect
 
         /**
          * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
+         * beginning of the program after parse_parameters() is run and after
          * the SimulatorAccess (if applicable) is initialized.
          *
          * The default implementation of this function does nothing, but

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -68,26 +68,9 @@ namespace aspect
      * @ingroup Postprocessing
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Does nothing but is virtual so that derived classes
-         * destructors are also virtual.
-         */
-        virtual ~Interface () = default;
-
-        /**
-         * Initialize function.
-         */
-        virtual void initialize ();
-
-        /**
-         * Update function. This should be called before each postprocessor
-         * is run and allows an opportunity to prepare/update temporary data
-         */
-        virtual void update ();
-
         /**
          * Execute this postprocessor. Derived classes will implement this
          * function to do whatever they want to do to evaluate the solution at
@@ -108,33 +91,6 @@ namespace aspect
         virtual
         std::pair<std::string,std::string>
         execute (TableHandler &statistics) = 0;
-
-        /**
-         * Declare the parameters this class takes through input files.
-         * Derived classes should overload this function if they actually do
-         * take parameters; this class declares a fall-back function that does
-         * nothing, so that postprocessor classes that do not take any
-         * parameters do not have to do anything at all.
-         *
-         * This function is static (and needs to be static in derived classes)
-         * so that it can be called without creating actual objects (because
-         * declaring parameters happens before we read the input file and thus
-         * at a time when we don't even know yet which postprocessor objects
-         * we need).
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation in this class does nothing, so that
-         * derived classes that do not need any parameters do not need to
-         * implement it.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
 
         /**
          * A function that is used to indicate to the postprocessor manager which

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -121,7 +121,7 @@ namespace aspect
        * @ingroup Visualization
        */
       template <int dim>
-      class Interface
+      class Interface : public Plugins::InterfaceBase
       {
         public:
           /**
@@ -146,22 +146,6 @@ namespace aspect
           explicit Interface (const std::string &physical_units = "");
 
           /**
-           * Destructor. Does nothing but is virtual so that derived classes
-           * destructors are also virtual.
-           */
-          virtual ~Interface () = default;
-
-          /**
-           * Initialize function.
-           */
-          virtual void initialize ();
-
-          /**
-           * Update any temporary information needed by the visualization postprocessor.
-           */
-          virtual void update();
-
-          /**
            * Return the string representation of the physical units that a
            * derived class has provided to the constructor of this class.
            *
@@ -175,33 +159,6 @@ namespace aspect
           virtual
           std::string
           get_physical_units () const;
-
-          /**
-           * Declare the parameters this class takes through input files.
-           * Derived classes should overload this function if they actually do
-           * take parameters; this class declares a fall-back function that
-           * does nothing, so that postprocessor classes that do not take any
-           * parameters do not have to do anything at all.
-           *
-           * This function is static (and needs to be static in derived
-           * classes) so that it can be called without creating actual objects
-           * (because declaring parameters happens before we read the input
-           * file and thus at a time when we don't even know yet which
-           * postprocessor objects we need).
-           */
-          static
-          void
-          declare_parameters (ParameterHandler &prm);
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           * The default implementation in this class does nothing, so that
-           * derived classes that do not need any parameters do not need to
-           * implement it.
-           */
-          virtual
-          void
-          parse_parameters (ParameterHandler &prm);
 
           /**
            * A function that is used to indicate to the postprocessor manager which

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -53,38 +53,9 @@ namespace aspect
      * @ingroup PrescribedStokesSolution
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         *
-         * The point of this function is to allow complex prescribed Stokes
-         * solutions to do an initialization step once at the beginning of each
-         * time step. An example would be a time-dependent prescribed velocity.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Given a position @p p, fill in desired velocity and pressure at
          * that point into @p value, which will have dim+1 components. In @p
@@ -93,27 +64,6 @@ namespace aspect
          */
         virtual
         void stokes_solution (const Point<dim> &p, Vector<double> &value) const = 0;
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
-
     };
 
 

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -532,14 +532,9 @@ namespace aspect
      * which equation is solved.
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor
-         */
-        virtual ~Interface () = default;
-
         /**
          * Execute this assembler object. This function performs the primary work
          * of an assembler. More precisely, it uses information for the current

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -62,22 +62,9 @@ namespace aspect
      * @ingroup TerminationCriteria
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Does nothing but is virtual so that derived classes'
-         * destructors are also virtual.
-         */
-        virtual ~Interface () = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual void initialize ();
-
         /**
          * Execute evaluation of the termination criterion.
          *
@@ -111,33 +98,6 @@ namespace aspect
          * argument put into this function.
          */
         virtual double check_for_last_time_step (const double time_step) const;
-
-        /**
-         * Declare the parameters this class takes through input files.
-         * Derived classes should overload this function if they actually do
-         * take parameters; this class declares a fall-back function that does
-         * nothing, so that classes that do not take any parameters do not
-         * have to do anything at all.
-         *
-         * This function is static (and needs to be static in derived classes)
-         * so that it can be called without creating actual objects (because
-         * declaring parameters happens before we read the input file and thus
-         * at a time when we don't even know yet which plugin objects we
-         * need).
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation in this class does nothing, so that
-         * derived classes that do not need any parameters do not need to
-         * implement it.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -89,34 +89,9 @@ namespace aspect
      * @ingroup TimeStepping
      */
     template <int dim>
-    class Interface
+    class Interface : public Plugins::InterfaceBase
     {
       public:
-        /**
-         * Destructor. Made virtual to enforce that derived classes also have
-         * virtual destructors.
-         */
-        virtual ~Interface() = default;
-
-        /**
-         * Initialization function. This function is called once at the
-         * beginning of the program after parse_parameters is run and after
-         * the SimulatorAccess (if applicable) is initialized.
-         */
-        virtual
-        void
-        initialize ();
-
-        /**
-         * A function that is called at the beginning of each time step. The
-         * default implementation of the function does nothing, but derived
-         * classes that need more elaborate setups for a given time step may
-         * overload the function.
-         */
-        virtual
-        void
-        update ();
-
         /**
          * Execute the logic of the plugin.
          *
@@ -144,26 +119,6 @@ namespace aspect
         virtual
         std::pair<Reaction, double>
         determine_reaction(const TimeStepInfo &info);
-
-        /**
-         * Declare the parameters this class takes through input files. The
-         * default implementation of this function does not describe any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        static
-        void
-        declare_parameters (ParameterHandler &prm);
-
-        /**
-         * Read the parameters this class declares from the parameter file.
-         * The default implementation of this function does not read any
-         * parameters. Consequently, derived classes do not have to overload
-         * this function if they do not take any runtime parameters.
-         */
-        virtual
-        void
-        parse_parameters (ParameterHandler &prm);
     };
 
 

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -33,35 +33,6 @@ namespace aspect
   namespace AdiabaticConditions
   {
     template <int dim>
-    Interface<dim>::~Interface ()
-      = default;
-
-    template <int dim>
-    void
-    Interface<dim>::
-    initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    update ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
     void Interface<dim>::get_adiabatic_temperature_profile(std::vector<double> &values) const
     {
       const unsigned int num_slices = values.size();

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -36,36 +36,6 @@ namespace aspect
 {
   namespace BoundaryComposition
   {
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-
     // ------------------------------ Manager -----------------------------
     // -------------------------------- Deal with registering boundary_composition models and automating
     // -------------------------------- their setup and selection at run time

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -33,24 +33,6 @@ namespace aspect
 {
   namespace BoundaryFluidPressure
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &/*prm*/)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &/*prm*/)
-    {}
-
-
 // -------------------------------- Deal with registering models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -33,29 +33,6 @@ namespace aspect
 {
   namespace BoundaryHeatFlux
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (ParameterHandler &/*prm*/)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (ParameterHandler &/*prm*/)
-    {}
-
-
 // -------------------------------- Deal with registering models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -36,34 +36,6 @@ namespace aspect
 {
   namespace BoundaryTemperature
   {
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
     // ------------------------------ Manager -----------------------------
     // -------------------------------- Deal with registering boundary_temperature models and automating
     // -------------------------------- their setup and selection at run time

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -34,35 +34,6 @@ namespace aspect
   namespace BoundaryTraction
   {
     template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
     Manager<dim>::~Manager()
       = default;
 

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -33,34 +33,6 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
     // ------------------------------ Manager -----------------------------
     // -------------------------------- Deal with registering boundary_velocity models and automating
     // -------------------------------- their setup and selection at run time

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -31,24 +31,6 @@ namespace aspect
 {
   namespace InitialTopographyModel
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
 // -------------------------------- Deal with registering initial topography models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -32,13 +32,6 @@ namespace aspect
   namespace GeometryModel
   {
     template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
     std::map<std::string,types::boundary_id>
     Interface<dim>::get_symbolic_boundary_names_map() const
     {
@@ -128,21 +121,6 @@ namespace aspect
                           "not been implemented in this geometry model."));
       return Point<dim>();
     }
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
 
 
     /* --------- functions to translate between symbolic and numeric boundary indicators ------ */

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -33,29 +33,6 @@ namespace aspect
 {
   namespace GravityModel
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
 // -------------------------------- Deal with registering gravity models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -33,26 +33,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
     // ------------------------------ Manager -----------------------------
     // ------------------------------ Deal with registering initial composition models and automating
     // ------------------------------ their setup and selection at run time

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -32,26 +32,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
     // ------------------------------ Manager -----------------------------
     // -------------------------------- Deal with registering initial_temperature models and automating
     // -------------------------------- their setup and selection at run time

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -73,34 +73,6 @@ namespace aspect
 
 
 
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &)
-    {}
-
-
 // -------------------------------- Deal with registering material models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -155,20 +155,6 @@ namespace aspect
   namespace MeshDeformation
   {
     template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
     bool
     Interface<dim>::needs_surface_stabilization () const
     {
@@ -194,21 +180,6 @@ namespace aspect
     compute_velocity_constraints_on_boundary(const DoFHandler<dim> &/*mesh_deformation_dof_handler*/,
                                              AffineConstraints<double> &/*mesh_velocity_constraints*/,
                                              const std::set<types::boundary_id> &/*boundary_id*/) const
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (ParameterHandler &)
     {}
 
 

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -33,18 +33,6 @@ namespace aspect
 
     template <int dim>
     void
-    Interface<dim>::initialize ()
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-    template <int dim>
-    void
     Interface<dim>::execute (Vector<float> &error_indicators) const
     {
       for (float &error_indicator : error_indicators)
@@ -55,19 +43,6 @@ namespace aspect
     template <int dim>
     void
     Interface<dim>::tag_additional_cells () const
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::declare_parameters (ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (ParameterHandler &)
     {}
 
 

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -32,12 +32,6 @@ namespace aspect
     namespace Generator
     {
       template <int dim>
-      Interface<dim>::Interface()
-        = default;
-
-
-
-      template <int dim>
       void
       Interface<dim>::initialize ()
       {
@@ -188,20 +182,6 @@ namespace aspect
 
         return std::make_pair(cellid, new_particle);
       }
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::declare_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::parse_parameters (ParameterHandler &)
-      {}
 
 
 // -------------------------------- Deal with registering models and automating

--- a/source/particle/integrator/interface.cc
+++ b/source/particle/integrator/interface.cc
@@ -30,27 +30,6 @@ namespace aspect
     namespace Integrator
     {
       template <int dim>
-      void
-      Interface<dim>::initialize ()
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::declare_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::parse_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
       bool
       Interface<dim>::new_integration_step()
       {

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -38,20 +38,6 @@ namespace aspect
 
 
 
-      template <int dim>
-      void
-      Interface<dim>::declare_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::parse_parameters (ParameterHandler &)
-      {}
-
-
-
 // -------------------------------- Deal with registering models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -200,13 +200,6 @@ namespace aspect
 
       template <int dim>
       void
-      Interface<dim>::initialize ()
-      {}
-
-
-
-      template <int dim>
-      void
       Interface<dim>::initialize_one_particle_property (const Point<dim> &,
                                                         std::vector<double> &) const
       {}
@@ -267,20 +260,6 @@ namespace aspect
       {
         return interpolate;
       }
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::declare_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::parse_parameters (ParameterHandler &)
-      {}
 
 
 

--- a/source/plugins.cc
+++ b/source/plugins.cc
@@ -24,11 +24,6 @@ namespace aspect
 {
   namespace Plugins
   {
-    InterfaceBase::~InterfaceBase ()
-    {}
-
-
-
     void
     InterfaceBase::initialize ()
     {}

--- a/source/postprocess/interface.cc
+++ b/source/postprocess/interface.cc
@@ -31,35 +31,6 @@ namespace aspect
   {
 // ------------------------------ Interface -----------------------------
 
-
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::declare_parameters (ParameterHandler &)
-    {}
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (ParameterHandler &)
-    {}
-
-
-
     template <int dim>
     std::list<std::string>
     Interface<dim>::required_other_postprocessors() const

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -244,39 +244,11 @@ namespace aspect
 
 
       template <int dim>
-      void
-      Interface<dim>::initialize ()
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::update ()
-      {}
-
-
-
-      template <int dim>
       std::string
       Interface<dim>::get_physical_units () const
       {
         return physical_units;
       }
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::declare_parameters (ParameterHandler &)
-      {}
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::parse_parameters (ParameterHandler &)
-      {}
 
 
 

--- a/source/prescribed_stokes_solution/interface.cc
+++ b/source/prescribed_stokes_solution/interface.cc
@@ -28,31 +28,6 @@ namespace aspect
 {
   namespace PrescribedStokesSolution
   {
-    template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::update ()
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    declare_parameters (dealii::ParameterHandler &/*prm*/)
-    {}
-
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (dealii::ParameterHandler &/*prm*/)
-    {}
-
-
 // -------------------------------- Deal with registering prescribed_stokes_solution models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -32,25 +32,10 @@ namespace aspect
 // ------------------------------ Interface -----------------------------
 
     template <int dim>
-    void
-    Interface<dim>::initialize ()
-    {}
-
-    template <int dim>
-    void
-    Interface<dim>::declare_parameters (ParameterHandler &)
-    {}
-
-    template <int dim>
     double Interface<dim>::check_for_last_time_step (const double time_step) const
     {
       return time_step;
     }
-
-    template <int dim>
-    void
-    Interface<dim>::parse_parameters (ParameterHandler &)
-    {}
 
 
 

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -37,48 +37,12 @@ namespace aspect
 
 
 
-
-    template <int dim>
-    void
-    Interface<dim>::
-    initialize ()
-    {
-    }
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    update ()
-    {
-    }
-
-
     template <int dim>
     std::pair<Reaction, double>
     Interface<dim>::
     determine_reaction (const TimeStepInfo & /*info*/)
     {
       return std::make_pair<Reaction, double>(Reaction::advance, std::numeric_limits<double>::max());
-    }
-
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::declare_parameters (ParameterHandler &/*prm*/)
-    {
-    }
-
-
-
-    template <int dim>
-    void
-    Interface<dim>::
-    parse_parameters (ParameterHandler &/*prm*/)
-    {
     }
 
 


### PR DESCRIPTION
This is the follow-up to #1807 that converts all plugins I could find to derive from the abstract base class. It allows removing almost all function declarations of boiler-plate functions in the plugin declarations because they are now provided by the base class.

I will rebase once #1807 is merged.