### PR TITLE
update the indexing of vector gradients following the idea of defensive programming (compiled)

### DIFF
--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -223,8 +223,8 @@ namespace aspect
 
         // get velocity gradient tensor.
         Tensor<2,dim> velocity_gradient;
-        for (unsigned int d=0; d<dim; ++d)
-          velocity_gradient[d] = gradients[d];
+        for (unsigned int i = 0; i < dim; ++i)
+          velocity_gradient[i] = gradients[this->introspection().component_indices.velocities[i]];
 
         // Calculate strain rate from velocity gradients
         const SymmetricTensor<2,dim> strain_rate = symmetrize (velocity_gradient);


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*
The previous code gradients[d] works because the indices of velocity or velocity gradient in the vector gradient are at 1 to dim th locations and so doing a for loop from 1 to dim will get the correct results. However, if in the future, someone changed the orders of "struct ComponentIndices" in aspect/include/aspect/introspection.h, then it will be a hidden bug that could be hard to debug.

### Before your first pull request:

* [x ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
