### PR TITLE
Add distance weighted particle interpolator

### DIFF
--- a/doc/modules/changes/20240609_gassmoeller
+++ b/doc/modules/changes/20240609_gassmoeller
@@ -1,0 +1,8 @@
+Added: A new particle interpolator plugin 'distance weighted average' that
+computes the interpolated properties as an average of particle properties
+weighted by a distance function. This plugin is similarly accurate
+as the 'cell average' interpolator, but provides smoother results and is
+less susceptible to jumps in interpolated properties if particles move
+small distances.
+<br>
+(Rene Gassmoeller, 2024/06/09)

--- a/include/aspect/particle/interpolator/distance_weighted_average.h
+++ b/include/aspect/particle/interpolator/distance_weighted_average.h
@@ -43,9 +43,9 @@ namespace aspect
       {
         public:
           /**
-           * Update function. Called once at the beginning of each time step.
+           * Initialize function. Called once at the beginning of the model.
            */
-          void update() override;
+          void initialize() override;
 
           /**
            * Return the cell-wise evaluated particle properties at the given @p positions.
@@ -58,9 +58,10 @@ namespace aspect
 
         private:
           /**
-           * Cached information that stores for each vertex which cells it belongs to.
+           * Cached information that stores information about the grid so that we
+           * do not need to recompute it every time properties_at_points() is called.
           */
-          std::vector<std::set<typename Triangulation<dim>::active_cell_iterator>> vertex_to_cell_map;
+          std::unique_ptr<GridTools::Cache<dim>> grid_cache;
       };
     }
   }

--- a/include/aspect/particle/interpolator/distance_weighted_average.h
+++ b/include/aspect/particle/interpolator/distance_weighted_average.h
@@ -1,0 +1,69 @@
+/*
+ Copyright (C) 2024 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_interpolator_distance_weighted_average_h
+#define _aspect_particle_interpolator_distance_weighted_average_h
+
+#include <aspect/particle/interpolator/interface.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/grid/grid_tools_cache.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      /**
+       * Return the interpolated properties of all particles of the given cell using
+       * a distance weighted averaging. The weight function is a hat function.
+       *
+       * @ingroup ParticleInterpolators
+       */
+      template <int dim>
+      class DistanceWeightedAverage : public Interface<dim>, public aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Update function. Called once at the beginning of each time step.
+           */
+          void update() override;
+
+          /**
+           * Return the cell-wise evaluated particle properties at the given @p positions.
+           */
+          std::vector<std::vector<double>>
+          properties_at_points(const ParticleHandler<dim> &particle_handler,
+                               const std::vector<Point<dim>> &positions,
+                               const ComponentMask &selected_properties,
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const override;
+
+        private:
+          /**
+           * Cached information that stores for each vertex which cells it belongs to.
+          */
+          std::vector<std::set<typename Triangulation<dim>::active_cell_iterator>> vertex_to_cell_map;
+      };
+    }
+  }
+}
+
+#endif

--- a/source/particle/interpolator/distance_weighted_average.cc
+++ b/source/particle/interpolator/distance_weighted_average.cc
@@ -42,9 +42,9 @@ namespace aspect
 
       template <int dim>
       void
-      DistanceWeightedAverage<dim>::update()
+      DistanceWeightedAverage<dim>::initialize()
       {
-        vertex_to_cell_map = GridTools::vertex_to_cell_map(this->get_triangulation());
+        grid_cache = std::make_unique<GridTools::Cache<dim>>(this->get_triangulation(), this->get_mapping());
       }
 
 
@@ -71,6 +71,8 @@ namespace aspect
               cell_properties[index_positions][index_properties] = 0.0;
 
         std::set<typename Triangulation<dim>::active_cell_iterator> cell_and_neighbors;
+
+        const auto &vertex_to_cell_map = grid_cache->get_vertex_to_cell_map();
 
         for (const auto v : cell->vertex_indices())
           {

--- a/source/particle/interpolator/distance_weighted_average.cc
+++ b/source/particle/interpolator/distance_weighted_average.cc
@@ -1,0 +1,149 @@
+/*
+  Copyright (C) 2024 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#include <aspect/particle/interpolator/distance_weighted_average.h>
+
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/grid/grid_tools.h>
+
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      namespace internal
+      {
+        double weight (const double distance, const double interpolation_range)
+        {
+          // linear weight function (hat function)
+          return std::max(1.0 - (distance/interpolation_range),0.0);
+        }
+      }
+
+
+
+      template <int dim>
+      void
+      DistanceWeightedAverage<dim>::update()
+      {
+        vertex_to_cell_map = GridTools::vertex_to_cell_map(this->get_triangulation());
+      }
+
+
+
+      template <int dim>
+      std::vector<std::vector<double>>
+      DistanceWeightedAverage<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
+                                                         const std::vector<Point<dim>> &positions,
+                                                         const ComponentMask &selected_properties,
+                                                         const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
+      {
+        const unsigned int n_interpolate_positions = positions.size();
+        const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
+
+        // Create with signaling NaNs
+        std::vector<std::vector<double>> cell_properties(n_interpolate_positions,
+                                                          std::vector<double>(n_particle_properties,
+                                                                              numbers::signaling_nan<double>()));
+
+        // Set requested properties to 0.0
+        for (unsigned int index_positions = 0; index_positions < n_interpolate_positions; ++index_positions)
+          for (unsigned int index_properties = 0; index_properties < n_particle_properties; ++index_properties)
+            if (selected_properties[index_properties])
+              cell_properties[index_positions][index_properties] = 0.0;
+
+        std::set<typename Triangulation<dim>::active_cell_iterator> cell_and_neighbors;
+
+        for (const auto v : cell->vertex_indices())
+          {
+            const unsigned int vertex_index = cell->vertex_index(v);
+            cell_and_neighbors.insert(vertex_to_cell_map[vertex_index].begin(),
+                                      vertex_to_cell_map[vertex_index].end());
+          }
+
+        // Average over all particles that are within half a cell diameter.
+        // This distance strikes a balance between required number of particles per
+        // cell and accuracy of the interpolation. This also assumes we can find
+        // most particles within this distance in neighbor cells. If we do not find
+        // some particles in range (e.g. because the neighbor is refined) this
+        // will slightly affect the accuracy of the interpolation, but we accept that.
+        //
+        // TODO: This could be made dependent on the number of particles per cell, the more
+        // particles, the smaller the interpolation range to increase accuracy.
+        const double interpolation_range = 0.5 * cell->diameter();
+
+        std::vector<double> integrated_weight(n_interpolate_positions,0.0);
+
+        for (const auto &current_cell: cell_and_neighbors)
+          {
+            const typename ParticleHandler<dim>::particle_iterator_range particle_range =
+              particle_handler.particles_in_cell(current_cell);
+
+            for (const auto &particle: particle_range)
+              {
+                const ArrayView<const double> particle_properties = particle.get_properties();
+                unsigned int index_positions = 0;
+
+                for (const auto &interpolation_point: positions)
+                  {
+                    const double distance = particle.get_location().distance(interpolation_point);
+                    const double weight = internal::weight(distance, interpolation_range);
+
+                    for (unsigned int index_properties = 0; index_properties < particle_properties.size(); ++index_properties)
+                      if (selected_properties[index_properties])
+                        cell_properties[index_positions][index_properties] += weight * particle_properties[index_properties];
+
+                    integrated_weight[index_positions] += weight;
+                    ++index_positions;
+                  }
+              }
+          }
+
+        for (unsigned int index_positions = 0; index_positions < n_interpolate_positions; ++index_positions)
+          {
+            AssertThrow(integrated_weight[index_positions] > 0.0, ExcInternalError());
+
+            for (unsigned int index_properties = 0; index_properties < n_particle_properties; ++index_properties)
+              if (selected_properties[index_properties])
+                cell_properties[index_positions][index_properties] /= integrated_weight[index_positions];
+          }
+
+        return cell_properties;
+      }
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Particle
+  {
+    namespace Interpolator
+    {
+      ASPECT_REGISTER_PARTICLE_INTERPOLATOR(DistanceWeightedAverage,
+                                            "distance weighted average",
+                                            "Interpolates particle properties onto a vector of points using a "
+                                            "distance weighed averaging method.")
+    }
+  }
+}

--- a/tests/particle_interpolator_distance_weighted_average.prm
+++ b/tests/particle_interpolator_distance_weighted_average.prm
@@ -1,0 +1,125 @@
+# A test that performs interpolation from particle properties to
+# compositional fields that are flagged as 'particle' advected
+# fields.
+
+# MPI: 2
+
+set Dimension                              = 2
+set End time                               = 70
+set Use years in output instead of seconds = false
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent  = 0.9142
+    set Y extent  = 1.0000
+  end
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right
+  set Zero velocity boundary indicators       = bottom, top
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1010
+    set Viscosity                     = 1e2
+    set Thermal expansion coefficient = 0
+    set Density differential for compositional field 1 = -10
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+############### Parameters describing the temperature field
+# Note: The temperature plays no role in this model
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0
+  end
+end
+
+############### Parameters describing the compositional field
+# Note: The compositional field is what drives the flow
+# in this example
+
+subsection Compositional fields
+  set Number of fields = 3
+  set Names of fields = advection_field, advection_particle, advection_particle2
+  set Compositional field methods = field, particles, particles
+  set Mapped particle properties = advection_particle2:velocity [1], advection_particle:function
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  = pi=3.1415926
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02));0.0;0.0
+  end
+end
+
+subsection Discretization
+  set Use discontinuous composition discretization = true
+end
+
+############### Parameters describing the discretization
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Strategy                           = composition
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end
+
+############### Parameters describing what to do with the solution
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, composition statistics,particles
+
+  subsection Visualization
+    set Interpolate output = false
+    set Time between graphical output = 70
+  end
+
+  subsection Particles
+    set Time between data output = 70
+    set Data output format = none
+  end
+end
+
+subsection Particles
+  set List of particle properties = velocity, function, initial composition
+  set Interpolation scheme = distance weighted average
+  set Update ghost particles = true
+  set Particle generator name = random uniform
+
+  subsection Function
+    set Variable names      = x,z
+    set Function expression = 0.5*(1+tanh((0.2+0.02*cos(pi*x/0.9142)-z)/0.02))
+  end
+
+  subsection Generator
+    subsection Probability density function
+      set Variable names      = x,z
+      set Function expression = x*x*z
+      set Number of particles = 100000
+    end
+  end
+end

--- a/tests/particle_interpolator_distance_weighted_average/screen-output
+++ b/tests/particle_interpolator_distance_weighted_average/screen-output
@@ -1,0 +1,30 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 10,468 (2,178+289+1,089+2,304+2,304+2,304)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Advecting particles...  done.
+   Solving advection_field system ... 0 iterations.
+   Solving Stokes system... 12+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000181 m/s, 0.000404 m/s
+     Compositions min/max/mass:    0/1/0.1825 // 0/1/0.1828 // 0/0/0
+     Number of advected particles: 100000
+
+*** Timestep 1:  t=70 seconds, dt=70 seconds
+   Skipping temperature solve because RHS is zero.
+   Advecting particles...  done.
+   Solving advection_field system ... 5 iterations.
+   Solving Stokes system... 12+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000328 m/s, 0.000732 m/s
+     Compositions min/max/mass:    -0.007595/1.023/0.1825 // 0/1/0.1829 // -0.0002466/0.0003166/-1.013e-08
+     Number of advected particles: 100000
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/particle_interpolator_distance_weighted_average/statistics
+++ b/tests/particle_interpolator_distance_weighted_average/statistics
@@ -1,0 +1,26 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/s)
+# 14: Max. velocity (m/s)
+# 15: Minimal value for composition advection_field
+# 16: Maximal value for composition advection_field
+# 17: Global mass for composition advection_field
+# 18: Minimal value for composition advection_particle
+# 19: Maximal value for composition advection_particle
+# 20: Global mass for composition advection_particle
+# 21: Minimal value for composition advection_particle2
+# 22: Maximal value for composition advection_particle2
+# 23: Global mass for composition advection_particle2
+# 24: Number of advected particles
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 6912 0 0 11 13 13 1.81487741e-04 4.04466706e-04  0.00000000e+00 1.00000000e+00 1.82454287e-01 0.00000000e+00 9.99999998e-01 1.82788208e-01  0.00000000e+00 0.00000000e+00  0.00000000e+00 100000 
+1 7.000000000000e+01 7.000000000000e+01 256 2467 1089 6912 0 5 11 13 13 3.27581254e-04 7.32023318e-04 -7.59476083e-03 1.02334847e+00 1.82464209e-01 0.00000000e+00 9.99999998e-01 1.82936297e-01 -2.46643941e-04 3.16607900e-04 -1.01312361e-08 100000 

--- a/tests/particle_interpolator_distance_weighted_average_adaptive.prm
+++ b/tests/particle_interpolator_distance_weighted_average_adaptive.prm
@@ -1,0 +1,17 @@
+# Like particle_interpolator_distance_weighted_average.prm but
+# using adaptive refinement.
+
+# MPI: 2
+
+set Dimension                              = 2
+
+include $ASPECT_SOURCE_DIR/tests/particle_interpolator_distance_weighted_average.prm
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 2
+  set Strategy                           = composition
+  set Initial global refinement          = 2
+  set Time steps between mesh refinement = 0
+  set Coarsening fraction                = 0.05
+  set Refinement fraction                = 0.3
+end

--- a/tests/particle_interpolator_distance_weighted_average_adaptive/screen-output
+++ b/tests/particle_interpolator_distance_weighted_average_adaptive/screen-output
@@ -1,0 +1,46 @@
+
+Number of active cells: 16 (on 3 levels)
+Number of degrees of freedom: 700 (162+25+81+144+144+144)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving advection_field system ... 0 iterations.
+   Solving Stokes system... 11+0 iterations.
+
+Number of active cells: 22 (on 4 levels)
+Number of degrees of freedom: 970 (228+34+114+198+198+198)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Solving advection_field system ... 0 iterations.
+   Solving Stokes system... 16+0 iterations.
+
+Number of active cells: 28 (on 4 levels)
+Number of degrees of freedom: 1,220 (282+41+141+252+252+252)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Skipping temperature solve because RHS is zero.
+   Advecting particles...  done.
+   Solving advection_field system ... 0 iterations.
+   Solving Stokes system... 16+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000181 m/s, 0.000496 m/s
+     Compositions min/max/mass:    0/1/0.1817 // 0/1/0.1843 // 0/0/0
+     Number of advected particles: 100000
+
+*** Timestep 1:  t=70 seconds, dt=70 seconds
+   Skipping temperature solve because RHS is zero.
+   Advecting particles...  done.
+   Solving advection_field system ... 4 iterations.
+   Solving Stokes system... 14+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:            0.000224 m/s, 0.000616 m/s
+     Compositions min/max/mass:    -0.114/1.046/0.1769 // 0/1/0.1794 // -0.0003817/0.0001943/-3.557e-07
+     Number of advected particles: 100000
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/particle_interpolator_distance_weighted_average_adaptive/statistics
+++ b/tests/particle_interpolator_distance_weighted_average_adaptive/statistics
@@ -1,0 +1,26 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: RMS velocity (m/s)
+# 14: Max. velocity (m/s)
+# 15: Minimal value for composition advection_field
+# 16: Maximal value for composition advection_field
+# 17: Global mass for composition advection_field
+# 18: Minimal value for composition advection_particle
+# 19: Maximal value for composition advection_particle
+# 20: Global mass for composition advection_particle
+# 21: Minimal value for composition advection_particle2
+# 22: Maximal value for composition advection_particle2
+# 23: Global mass for composition advection_particle2
+# 24: Number of advected particles
+0 0.000000000000e+00 0.000000000000e+00 28 323 141 756 0 0 15 17 17 1.81488111e-04 4.96004522e-04  0.00000000e+00 1.00000000e+00 1.81683752e-01 0.00000000e+00 9.99999792e-01 1.84273374e-01  0.00000000e+00 0.00000000e+00  0.00000000e+00 100000 
+1 7.000000000000e+01 7.000000000000e+01 28 323 141 756 0 4 13 15 15 2.23981571e-04 6.15559291e-04 -1.13972554e-01 1.04631617e+00 1.76881740e-01 0.00000000e+00 9.99999912e-01 1.79414063e-01 -3.81681750e-04 1.94318757e-04 -3.55664526e-07 100000 


### PR DESCRIPTION
This is not ready for review.

@anne-glerum: This PR adds a new particle interpolator that interpolates between particles based on a distance weighted average (similar to what radial basis functions would do). The interpolator in its current form produces worse errors (though the same convergence rate) as the 'cell average' interpolator. However, it should be smoother and less affected by small particle movements across cell boundaries.

 This PR is currently in a very rough state, I only open this to remind myself to finish it after the hackathon.