### PR TITLE
fix a CMake minimum version bump

### DIFF
--- a/cookbooks/tomography_based_plate_motions/plugins/CMakeLists.txt
+++ b/cookbooks/tomography_based_plate_motions/plugins/CMakeLists.txt
@@ -16,7 +16,7 @@
 # along with ASPECT; see the file LICENSE.  If not see
 # <http://www.gnu.org/licenses/>.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)
 
 FIND_PACKAGE(Aspect 2.4.0 QUIET HINTS ${Aspect_DIR} ../ ../../ $ENV{ASPECT_DIR})
 


### PR DESCRIPTION
We missed one file and it produces a warning.
