### PR TITLE
Backport GWB crash fix if min and max are the same.

### DIFF
--- a/contrib/world_builder/source/world_builder/features/continental_plate_models/temperature/linear.cc
+++ b/contrib/world_builder/source/world_builder/features/continental_plate_models/temperature/linear.cc
@@ -128,9 +128,9 @@ namespace WorldBuilder
                                                             this->world->specific_heat) * max_depth_local_local);
                     }
 
-                  const double new_temperature = top_temperature_local +
-                                                 (depth - min_depth_local) *
-                                                 ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local));
+                  const double new_temperature = top_temperature_local + (max_depth_local_local - min_depth_local_local < 10.0*std::numeric_limits<double>::epsilon() ? 0.0 :
+                                                        (depth - min_depth_local) *
+                                                        ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local)));
 
                   WBAssert(!std::isnan(new_temperature), "Temperature is not a number: " << new_temperature
                            << ", based on a temperature model with the name " << this->name);

--- a/contrib/world_builder/source/world_builder/features/mantle_layer_models/temperature/linear.cc
+++ b/contrib/world_builder/source/world_builder/features/mantle_layer_models/temperature/linear.cc
@@ -127,9 +127,9 @@ namespace WorldBuilder
 
                     }
 
-                  const double new_temperature =  top_temperature_local +
-                                                  (depth - min_depth_local_local) *
-                                                  ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local));
+                  const double new_temperature =  top_temperature_local + (max_depth_local_local - min_depth_local_local < 10.0*std::numeric_limits<double>::epsilon() ? 0.0 :
+                                                                           (depth - min_depth_local_local) *
+                                                                           ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local)));
 
                   return apply_operation(operation,temperature_,new_temperature);
                 }

--- a/contrib/world_builder/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
+++ b/contrib/world_builder/source/world_builder/features/oceanic_plate_models/temperature/linear.cc
@@ -125,9 +125,9 @@ namespace WorldBuilder
                                                             this->world->specific_heat) * max_depth_local_local);
                     }
 
-                  const double new_temperature =  top_temperature_local +
-                                                  (depth - min_depth_local_local) *
-                                                  ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local));
+                  const double new_temperature =  top_temperature_local + (max_depth_local_local - min_depth_local_local < 10.0*std::numeric_limits<double>::epsilon() ? 0.0 :
+                                                         (depth - min_depth_local_local) *
+                                                         ((bottom_temperature_local - top_temperature_local) / (max_depth_local_local - min_depth_local_local)));
 
                   return apply_operation(operation,temperature_,new_temperature);
                 }


### PR DESCRIPTION
This is backporting a fix made in the GWB to prevent a crash when min and max are the same in the linear temperature model. See https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/704 for more info.

@cedrict