### PR TITLE
Backport world builder sprintf to snprintf

### DIFF
--- a/contrib/world_builder/include/doctest/doctest.h
+++ b/contrib/world_builder/include/doctest/doctest.h
@@ -4151,7 +4151,7 @@ namespace doctest
 #define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
   String toString(type in) {                                                                     \
     char buf[64];                                                                              \
-    std::sprintf(buf, fmt, in);                                                                \
+    std::snprintf(buf, sizeof( buf ), fmt, in);                                                                \
     return buf;                                                                                \
   }
 


### PR DESCRIPTION
resolves issue https://github.com/GeodynamicWorldBuilder/WorldBuilder/issues/731 in ASPECT. Changing sprintf to snprintf. This was resovled in https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/704 in the world builder.