### PR TITLE
Call all plugin update functions

### DIFF
--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -81,6 +81,12 @@ namespace aspect
         ~Manager () override;
 
         /**
+         * Update function. Called once at the beginning of a timestep to
+         * update all plugin objects.
+        */
+        void update();
+
+        /**
          * Declare the parameters of all known initial composition plugins, as
          * well as of ones this class has itself.
          */

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -80,6 +80,12 @@ namespace aspect
         ~Manager () override;
 
         /**
+         * Update function. Called once at the beginning of a timestep to
+         * update all plugin objects.
+        */
+        void update();
+
+        /**
          * Declare the parameters of all known initial conditions plugins, as
          * well as of ones this class has itself.
          */

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -534,6 +534,13 @@ namespace aspect
           initialize ();
 
           /**
+           * Update function. This function is called once at the
+           * beginning of each timestep.
+           */
+          void
+          update ();
+
+          /**
            * Initialization function for particle properties. This function is
            * called once for each of the particles of a particle
            * collection after it was created.

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -167,6 +167,11 @@ namespace aspect
         void initialize();
 
         /**
+         * Update the particle world.
+        */
+        void update();
+
+        /**
          * Get the particle property manager for this particle world.
          *
          * @return The property manager for this world.

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -131,6 +131,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    void
+    Manager<dim>::update()
+    {
+      for (auto &initial_composition_object : initial_composition_objects)
+        initial_composition_object->update();
+    }
+
+
+
     template <int dim>
     double
     Manager<dim>::initial_composition (const Point<dim> &position,

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -121,6 +121,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    void
+    Manager<dim>::update()
+    {
+      for (auto &initial_temperature_object : initial_temperature_objects)
+        initial_temperature_object->update();
+    }
+
+
+
     template <int dim>
     double
     Manager<dim>::initial_temperature (const Point<dim> &position) const

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -349,6 +349,16 @@ namespace aspect
 
       template <int dim>
       void
+      Manager<dim>::update ()
+      {
+        for (const auto &p : property_list)
+          p->update();
+      }
+
+
+
+      template <int dim>
+      void
       Manager<dim>::initialize_one_particle (typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         if (property_information.n_components() == 0)

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -81,6 +81,20 @@ namespace aspect
       connect_to_signals(this->get_signals());
     }
 
+
+
+    template <int dim>
+    void
+    World<dim>::update()
+    {
+      generator->update();
+      integrator->update();
+      interpolator->update();
+      property_manager->update();
+    }
+
+
+
     template <int dim>
     const Property::Manager<dim> &
     World<dim>::get_property_manager() const
@@ -1336,6 +1350,7 @@ namespace aspect
       if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(interpolator.get()))
         sim->initialize_simulator (this->get_simulator());
       interpolator->parse_parameters(prm);
+      interpolator->initialize();
     }
   }
 }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -626,6 +626,7 @@ namespace aspect
     // notify different system components that we started the next time step
     // TODO: implement this for all plugins that might need it at one place.
     // Temperature BC are currently updated in compute_current_constraints
+    geometry_model->update();
     material_model->update();
     gravity_model->update();
     heating_model_manager.update();
@@ -636,6 +637,9 @@ namespace aspect
 
     if (prescribed_stokes_solution.get())
       prescribed_stokes_solution->update();
+
+    if (particle_world.get() != nullptr)
+      particle_world->update();
 
     // do the same for the traction boundary conditions and other things
     // that end up in the bilinear form. we update those that end up in


### PR DESCRIPTION
This is a follow up to #5800. In that PR all plugins inherited the canonical `update` functions from the base class to be called at the beginning of each timestep. However, not all plugin systems actually called this function at the beginning of each timestep. This PR makes sure the function is actually called for all plugin systems (I went through the systems and made sure all call the `update` function).