### PR TITLE
add separate nightly deal.II master Docker script with clang

### DIFF
--- a/.github/workflows/build_dealii_master_clang.yml
+++ b/.github/workflows/build_dealii_master_clang.yml
@@ -1,0 +1,41 @@
+name: build-dealii-master-clang
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # trigger at 1:30 am every day
+    - cron:  '30 1 * * *'
+
+concurrency:
+  group: build-dealii-master-clang
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-clang-master:
+    runs-on: ubuntu-latest
+    if: github.repository == 'geodynamics/aspect'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LOGIN }}
+
+      - name: Build and push Docker image for main
+        uses: docker/build-push-action@v5
+        with:
+          context: ./contrib/docker/tester-clang
+          cache-from: type=registry,ref=ubuntu:24.04
+          cache-to: type=inline
+          push: true
+          tags: geodynamics/aspect-tester:noble-dealii-master-clang

--- a/contrib/docker/tester-clang/Dockerfile
+++ b/contrib/docker/tester-clang/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:24.04
+
+LABEL maintainer <rene.gassmoeller@mailbox.org>
+
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && \
+  DEBIAN_FRONTEND=noninteractive apt install -yq --no-install-recommends \
+  build-essential ca-certificates file gcc g++ \
+  gfortran git libblas-dev liblapack-dev libopenmpi-dev \
+  lsb-release ninja-build numdiff openmpi-bin \
+  openmpi-common wget zlib1g-dev \
+  clang-tidy clang cmake libp4est-dev libsundials-dev \
+  mpi-default-dev trilinos-all-dev zlib1g-dev libhdf5-dev libhdf5-mpi-dev
+
+COPY local.cfg /opt/
+
+# Install deal.II with clang using candi:
+
+RUN cd /opt && \
+    git clone https://github.com/dealii/candi && \
+    cd candi && \
+    mv /opt/local.cfg . && \
+    CXX=clang++ CC=clang ./candi.sh -p /opt -j2 && \
+    rm -rf /opt/tmp
+
+# Set environment variables for this image to be used
+# by Github Actions
+ENV PATH="/opt/astyle-2.04:$PATH"
+ENV DEAL_II_DIR /opt/deal.II-master
+ENV OMPI_MCA_btl_base_warn_component_unused=0
+ENV OMPI_MCA_mpi_yield_when_idle=1
+ENV OMPI_MCA_rmaps_base_oversubscribe=1
+ENV OMPI_ALLOW_RUN_AS_ROOT=1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+WORKDIR /opt

--- a/contrib/docker/tester-clang/build.sh
+++ b/contrib/docker/tester-clang/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script generates a docker image for the ASPECT tester.
+
+docker build -t geodynamics/aspect-tester:noble-dealii-master-clang .

--- a/contrib/docker/tester-clang/local.cfg
+++ b/contrib/docker/tester-clang/local.cfg
@@ -1,0 +1,12 @@
+# Compile with debug checks, but also with optimizations to make tests run fast
+USE_DEAL_II_CMAKE_MPI_COMPILER=OFF
+BUILD_EXAMPLES=OFF
+
+DEAL_II_VERSION=master
+
+USE_64_BIT_INDICES=ON
+
+DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DCMAKE_BUILD_TYPE='DebugRelease' -DDEAL_II_CXX_FLAGS_DEBUG='-O3 -g0' -DDEAL_II_COMPONENT_EXAMPLES=OFF"
+
+# only compile deal.II, the rest of the dependencies are installed using apt
+PACKAGES="astyle dealii"


### PR DESCRIPTION
- add a clang based Docker image to be used for clang compilation and clang-tidy in the future
- add a workflow to build this image
FYI @gassmoeller 