### PR TITLE
Remove code that supports in-source builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,13 +486,6 @@ add_custom_target(setup_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "Enabling all tests ...")
 
-# Disable the ability to run all tests in an in-source build:
-if(("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}") AND ASPECT_RUN_ALL_TESTS)
-  set(ASPECT_RUN_ALL_TESTS OFF CACHE BOOL "" FORCE)
-  message(FATAL_ERROR "\nEnabling all tests is not supported in in-source builds. Please create a separate build directory!\n")
-endif()
-
-
 set(ASPECT_TEST_GENERATOR "Unix Makefiles" CACHE STRING
   "Generator to use for the test cmake project. Using ninja instead of make is not recommended.")
 


### PR DESCRIPTION
At the top of CMakeLists.txt, we already disallow in-source builds. We need not care about them further down in the file.