### PR TITLE
Backport fix gwb clang flags.

### DIFF
--- a/contrib/world_builder/include/world_builder/bounding_box.h
+++ b/contrib/world_builder/include/world_builder/bounding_box.h
@@ -93,7 +93,7 @@ namespace WorldBuilder
    *
    * @note The majority of this class is copied from the deal.II library.
    */
-  template <int spacedim>
+  template <unsigned int spacedim>
   class BoundingBox
   {
     public:
@@ -270,7 +270,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline BoundingBox<spacedim>::BoundingBox(
     const std::pair<Point<spacedim>, Point<spacedim>>
     &boundary_points_)
@@ -286,7 +286,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   template <class Container>
   inline BoundingBox<spacedim>::BoundingBox(const Container &points)
   {
@@ -314,7 +314,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline std::pair<Point<spacedim>, Point<spacedim>> &BoundingBox<spacedim>::get_boundary_points()
   {
     return this->boundary_points;
@@ -322,7 +322,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline const std::pair<Point<spacedim>, Point<spacedim>> &BoundingBox<spacedim>::get_boundary_points() const
   {
     return this->boundary_points;
@@ -330,7 +330,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline bool
   BoundingBox<spacedim>::
   operator==(const BoundingBox<spacedim> &box) const
@@ -340,7 +340,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline bool
   BoundingBox<spacedim>::
   operator!=(const BoundingBox<spacedim> &box) const
@@ -350,7 +350,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline void
   BoundingBox<spacedim>::extend(const double amount)
   {
@@ -365,7 +365,7 @@ namespace WorldBuilder
   }
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   bool
   BoundingBox<spacedim>::point_inside(const Point<spacedim> &point,
@@ -397,7 +397,7 @@ namespace WorldBuilder
 
   }
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   bool
   BoundingBox<spacedim>::point_inside_implementation(const Point<spacedim> &p,
@@ -426,7 +426,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   void
   BoundingBox<spacedim>::merge_with(
@@ -445,7 +445,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   double
   BoundingBox<spacedim>::volume() const
   {
@@ -457,7 +457,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   double
   BoundingBox<spacedim>::lower_bound(const unsigned int direction) const
@@ -469,7 +469,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   double
   BoundingBox<spacedim>::upper_bound(const unsigned int direction) const
@@ -481,7 +481,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   Point<spacedim>
   BoundingBox<spacedim>::center() const
   {
@@ -494,7 +494,7 @@ namespace WorldBuilder
 
 
 
-  template <int spacedim>
+  template <unsigned int spacedim>
   inline
   double
   BoundingBox<spacedim>::side_length(const unsigned int direction) const

--- a/contrib/world_builder/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/continental_plate_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/continental_plate_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/continental_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/continental_plate_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/composition/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/composition/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/grains/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/grains/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/temperature/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/fault_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/fault_models/temperature/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/composition/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/mantle_layer_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/mantle_layer_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/oceanic_plate_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/oceanic_plate_models/composition/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/oceanic_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/oceanic_plate_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/plume_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/plume_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/plume_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/plume_models/grains/interface.h
@@ -30,7 +30,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/plume_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/plume_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/plume_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/plume_models/temperature/interface.h
@@ -29,7 +29,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/composition/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/composition/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/grains/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/grains/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-    template <unsigned int dim> class Point;
+  template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/interface.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/interface.h
@@ -32,7 +32,7 @@ namespace WorldBuilder
 {
   class World;
   class Parameters;
-  template <int dim> class Point;
+    template <unsigned int dim> class Point;
 
   /**
    * This class is an interface for the specific plate tectonic feature classes,

--- a/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
+++ b/contrib/world_builder/include/world_builder/features/subducting_plate_models/temperature/mass_conserving.h
@@ -133,7 +133,7 @@ namespace WorldBuilder
             ReferenceModelName reference_model_name;
             const int plate_model_summation_number = 100; // for the plate model
             bool apply_spline;
-            int spline_n_points;
+            unsigned int spline_n_points;
         };
       } // namespace Temperature
     } // namespace SubductingPlateModels

--- a/contrib/world_builder/include/world_builder/kd_tree.h
+++ b/contrib/world_builder/include/world_builder/kd_tree.h
@@ -78,7 +78,8 @@ namespace WorldBuilder
       const double &operator[](const bool y_axis) const
       {
         WBAssert(std::fabs((y_axis ? y : x) - *(&x+y_axis)) < std::numeric_limits<double>::epsilon(),
-                 "Internal error: y_axis=" << y_axis << ", x=" << x << ", y=" << y <<", *(&x+y_axis)=" << *(&x+y_axis) << ", ((bool)y_axis ? x : y) - *(&x+y_axis)=" << abs(((bool)y_axis ? x : y) - *(&x+y_axis)));
+                                  "Internal error: y_axis=" << y_axis << ", x=" << x << ", y=" << y <<", *(&x+y_axis)=" << *(&x+y_axis)
+                 << ", ((bool)y_axis ? x : y) - *(&x+y_axis)=" << fabs((y_axis ? x : y) - *(&x+y_axis)));
         return *(&x+y_axis);
       }
     };

--- a/contrib/world_builder/include/world_builder/kd_tree.h
+++ b/contrib/world_builder/include/world_builder/kd_tree.h
@@ -78,7 +78,7 @@ namespace WorldBuilder
       const double &operator[](const bool y_axis) const
       {
         WBAssert(std::fabs((y_axis ? y : x) - *(&x+y_axis)) < std::numeric_limits<double>::epsilon(),
-                                  "Internal error: y_axis=" << y_axis << ", x=" << x << ", y=" << y <<", *(&x+y_axis)=" << *(&x+y_axis)
+                 "Internal error: y_axis=" << y_axis << ", x=" << x << ", y=" << y <<", *(&x+y_axis)=" << *(&x+y_axis)
                  << ", ((bool)y_axis ? x : y) - *(&x+y_axis)=" << fabs((y_axis ? x : y) - *(&x+y_axis)));
         return *(&x+y_axis);
       }

--- a/contrib/world_builder/include/world_builder/parameters.h
+++ b/contrib/world_builder/include/world_builder/parameters.h
@@ -33,7 +33,7 @@ namespace WorldBuilder
   namespace Types
   {
     class Interface;
-    template<int dim>
+    template<unsigned int dim>
     class Point;
     class Double;
     class String;

--- a/contrib/world_builder/include/world_builder/point.h
+++ b/contrib/world_builder/include/world_builder/point.h
@@ -107,7 +107,7 @@ namespace WorldBuilder
    * implements several operations such as the computation of the l2 norm and the
    * dot product.
    */
-  template<int dim>
+  template<unsigned int dim>
   class Point
   {
     public:
@@ -463,7 +463,7 @@ namespace WorldBuilder
     return (point[0] * point[0]) + (point[1] * point[1]) + (point[2] * point[2]);
   }
 
-  template<int dim>
+  template<unsigned int dim>
   inline
   Point<dim> operator*(const double scalar, const Point<dim> &point)
   {

--- a/contrib/world_builder/include/world_builder/types/int.h
+++ b/contrib/world_builder/include/world_builder/types/int.h
@@ -60,8 +60,8 @@ namespace WorldBuilder
                           const std::string &name,
                           const std::string &documentation) const override final;
 
-        unsigned int value {0};
-        unsigned int default_value;
+        int value {0};
+        int default_value;
 
       protected:
         /**

--- a/contrib/world_builder/include/world_builder/types/point.h
+++ b/contrib/world_builder/include/world_builder/types/point.h
@@ -38,7 +38,7 @@ namespace WorldBuilder
      * the returned temperature or composition of the temperature and composition
      * functions of this class will be.
      */
-    template <int dim>
+    template <unsigned int dim>
     class Point final: public Interface
     {
       public:
@@ -124,7 +124,7 @@ namespace WorldBuilder
 
     };
 
-    template<int dim>
+    template<unsigned int dim>
     WorldBuilder::Point<dim> operator*(const double scalar, const Point<dim> &point);
   } // namespace Types
 } // namespace WorldBuilder

--- a/contrib/world_builder/include/world_builder/utilities.h
+++ b/contrib/world_builder/include/world_builder/utilities.h
@@ -142,7 +142,7 @@ namespace WorldBuilder
     /**
      * Convert point to array
      */
-    template<int dim>
+    template<unsigned int dim>
     std::array<double,dim> convert_point_to_array(const Point<dim> &point);
 
     /**
@@ -202,14 +202,14 @@ namespace WorldBuilder
         inline
         double operator() (const double x) const
         {
-          if (x >= 0 && x <= mx_size_min)
+          if (x >= 0. && x <= static_cast<double>(mx_size_min))
             {
-              const size_t idx = (size_t)x;
-              const double h = x-idx;
+              const size_t idx = static_cast<size_t>(x);
+              const double h = x-static_cast<double>(idx);
               return ((m[idx][0]*h + m[idx][1])*h + m[idx][2])*h + m[idx][3];
             }
-          const size_t idx = std::min((size_t)std::max( (int)x, (int)0),mx_size_min);
-          const double h = x-idx;
+          const size_t idx = std::min(static_cast<size_t>(std::max( static_cast<int>(x), static_cast<int>(0))),mx_size_min);
+          const double h = x-static_cast<double>(idx);
           return (m[idx][1]*h + m[idx][2])*h + m[idx][3];
         }
 
@@ -217,7 +217,7 @@ namespace WorldBuilder
         inline
         double operator() (const double x, const size_t idx, const double h) const
         {
-          return (x >= 0 && x <= mx_size_min)
+          return (x >= 0. && x <= static_cast<double>(mx_size_min))
                  ?
                  ((m[idx][0]*h + m[idx][1])*h + m[idx][2])*h + m[idx][3]
                  :
@@ -246,7 +246,7 @@ namespace WorldBuilder
         double value_outside (const size_t idx, const double h) const
         {
           WBAssert(idx <= mx_size_min, "Internal error: using value_inside outside the range of 0 to " << mx_size_min << ", but value was outside of this range: " << idx << ".");
-          WBAssert(!(idx + h >= 0 && idx + h <= 1.), "Internal error: using value_inside outside the range of 0 to " << mx_size_min << ", but value was outside of this range: " << idx + h << " (h=" << h << ", idx = " << idx << ").");
+          WBAssert(!(static_cast<double>(idx) + h >= 0 && static_cast<double>(idx) + h <= 1.), "Internal error: using value_inside outside the range of 0 to " << mx_size_min << ", but value was outside of this range: " << static_cast<double>(idx) + h << " (h=" << h << ", idx = " << idx << ").");
           return (m[idx][1]*h + m[idx][2])*h + m[idx][3];
         }
 

--- a/contrib/world_builder/source/gwb-dat/main.cc
+++ b/contrib/world_builder/source/gwb-dat/main.cc
@@ -201,10 +201,10 @@ int main(int argc, char **argv)
       properties.push_back({{1,0,0}}); // temperature
 
       for (size_t c = 0; c < compositions; ++c)
-        properties.push_back({{2,(unsigned int)c,0}}); // composition c
+        properties.push_back({{2,static_cast<unsigned int>(c),0}}); // composition c
 
       for (size_t gc = 0; gc < grain_compositions; ++gc)
-        properties.push_back({{3,(unsigned int)gc,(unsigned int)n_grains}}); // grains gc
+        properties.push_back({{3,static_cast<unsigned int>(gc),static_cast<unsigned int>(n_grains)}}); // grains gc
 
       properties.push_back({{4,0,0}}); // tag
 

--- a/contrib/world_builder/source/gwb-grid/main.cc
+++ b/contrib/world_builder/source/gwb-grid/main.cc
@@ -87,7 +87,7 @@ void filter_vtu_mesh(int dim,
                      std::vector<vtu11::DataSetData> &output_data)
 {
   output_data.resize(input_data.size());
-  const std::int64_t invalid = static_cast<std::uint64_t>(-1);
+  const std::int64_t invalid = -1;
   std::vector<std::int64_t> vertex_index_map(input_mesh.points().size(), invalid);
 
   const unsigned int n_vert_per_cell = (dim==3)?8:4;
@@ -97,27 +97,27 @@ void filter_vtu_mesh(int dim,
   for (std::size_t cellidx = 0; cellidx <n_cells; ++cellidx)
     {
       int highest_tag = -1;
-      for (unsigned int idx=cellidx*n_vert_per_cell; idx<(cellidx+1)*n_vert_per_cell; ++idx)
+      for (size_t idx=cellidx*n_vert_per_cell; idx<(cellidx+1)*n_vert_per_cell; ++idx)
         {
-          const std::int64_t src_vid = input_mesh.connectivity()[idx];
+          const std::size_t src_vid = static_cast<size_t>(input_mesh.connectivity()[idx]);
           highest_tag = std::max(highest_tag,static_cast<int>(input_data[2][src_vid]));
         }
-      if (highest_tag < 0 || include_tag[highest_tag]==false)
+      if (highest_tag < 0 || include_tag[static_cast<size_t>(highest_tag)]==false)
         continue;
 
       ++dst_cellid;
 
-      for (unsigned int idx=cellidx*n_vert_per_cell; idx<(cellidx+1)*n_vert_per_cell; ++idx)
+      for (size_t idx=cellidx*n_vert_per_cell; idx<(cellidx+1)*n_vert_per_cell; ++idx)
         {
-          const std::int64_t src_vid = input_mesh.connectivity()[idx];
+          const size_t src_vid = static_cast<size_t>(input_mesh.connectivity()[idx]);
 
           std::int64_t dst_vid = vertex_index_map[src_vid];
           if (dst_vid == invalid)
             {
-              dst_vid = output_mesh.points().size()/3;
+              dst_vid = static_cast<std::int64_t>(output_mesh.points().size()/3);
               vertex_index_map[src_vid] = dst_vid;
 
-              for (int i=0; i<3; ++i)
+              for (unsigned int i=0; i<3; ++i)
                 output_mesh.points().push_back(input_mesh.points()[src_vid*3+i]);
 
               for (unsigned int d=0; d<input_data.size(); ++d)
@@ -127,7 +127,7 @@ void filter_vtu_mesh(int dim,
           output_mesh.connectivity().push_back(dst_vid);
 
         }
-      output_mesh.offsets().push_back(dst_cellid*n_vert_per_cell);
+      output_mesh.offsets().push_back(static_cast<long int>(dst_cellid*n_vert_per_cell));
 
       output_mesh.types().push_back(input_mesh.types()[cellidx]);
     }
@@ -1519,33 +1519,33 @@ int main(int argc, char **argv)
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
           {
-            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
+            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
           }
       else
         for (size_t i = 0; i < n_cell; ++i)
           {
 
-            connectivity[i*pow_2_dim] = static_cast<int>(grid_connectivity[i][0]);
-            connectivity[i*pow_2_dim+1] = static_cast<int>(grid_connectivity[i][1]);
-            connectivity[i*pow_2_dim+2] = static_cast<int>(grid_connectivity[i][2]);
-            connectivity[i*pow_2_dim+3] = static_cast<int>(grid_connectivity[i][3]);
-            connectivity[i*pow_2_dim+4] = static_cast<int>(grid_connectivity[i][4]);
-            connectivity[i*pow_2_dim+5] = static_cast<int>(grid_connectivity[i][5]);
-            connectivity[i*pow_2_dim+6] = static_cast<int>(grid_connectivity[i][6]);
-            connectivity[i*pow_2_dim+7] = static_cast<int>(grid_connectivity[i][7]);
+            connectivity[i*pow_2_dim] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][0]);
+            connectivity[i*pow_2_dim+1] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][1]);
+            connectivity[i*pow_2_dim+2] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][2]);
+            connectivity[i*pow_2_dim+3] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][3]);
+            connectivity[i*pow_2_dim+4] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][4]);
+            connectivity[i*pow_2_dim+5] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][5]);
+            connectivity[i*pow_2_dim+6] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][6]);
+            connectivity[i*pow_2_dim+7] = static_cast<vtu11::VtkIndexType>(grid_connectivity[i][7]);
           }
       std::cout << "[5/6] Preparing to write the paraview file: stage 3 of 6, creating the offsets                              \r";
       std::cout.flush();
       std::vector<vtu11::VtkIndexType> offsets(n_cell);
       if (dim == 2)
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = static_cast<int>((i+1) * 4);
+          offsets[i] = static_cast<vtu11::VtkIndexType>((i+1) * 4);
       else
         for (size_t i = 0; i < n_cell; ++i)
-          offsets[i] = static_cast<int>((i+1) * 8);
+          offsets[i] = static_cast<vtu11::VtkIndexType>((i+1) * 8);
 
       std::cout << "[5/6] Preparing to write the paraview file: stage 4 of 6, creating the Data set info                              \r";
       std::cout.flush();
@@ -1571,8 +1571,8 @@ int main(int argc, char **argv)
 
       properties.push_back({{4,0,0}}); // tag
 
-      for (size_t c = 0; c < compositions; ++c)
-        properties.push_back({{2,(unsigned int)c,0}}); // composition c
+      for (unsigned int c = 0; c < compositions; ++c)
+        properties.push_back({{2,c,0}}); // composition c
 
 
       // compute temperature
@@ -1634,7 +1634,7 @@ int main(int argc, char **argv)
             vtu11::Vtu11UnstructuredMesh filtered_mesh {filtered_points, filtered_connectivity, filtered_offsets, filtered_types};
             std::vector<vtu11::DataSetData> filtered_data_set;
 
-            filter_vtu_mesh(dim, include_tag, mesh, data_set, filtered_mesh, filtered_data_set);
+            filter_vtu_mesh(static_cast<int>(dim), include_tag, mesh, data_set, filtered_mesh, filtered_data_set);
             vtu11::writeVtu( file_without_extension + ".filtered.vtu", filtered_mesh, dataSetInfo, filtered_data_set, vtu_output_format );
           }
 
@@ -1655,7 +1655,7 @@ int main(int argc, char **argv)
 
                 std::vector<bool> include_tag(world->feature_tags.size(), false);
                 include_tag[idx]=true;
-                filter_vtu_mesh(dim, include_tag, mesh, data_set, filtered_mesh, filtered_data_set);
+                filter_vtu_mesh(static_cast<int>(dim), include_tag, mesh, data_set, filtered_mesh, filtered_data_set);
                 const std::string filename = file_without_extension + "."+ std::to_string(idx)+".vtu";
                 vtu11::writeVtu( filename, filtered_mesh, dataSetInfo, filtered_data_set, vtu_output_format );
               }

--- a/contrib/world_builder/source/world_builder/features/continental_plate.cc
+++ b/contrib/world_builder/source/world_builder/features/continental_plate.cc
@@ -248,7 +248,7 @@ namespace WorldBuilder
                       }
                       case 4:
                       {
-                        output[entry_in_output[i_property]] = tag_index;
+                        output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                         break;
                       }
                       default:

--- a/contrib/world_builder/source/world_builder/features/fault.cc
+++ b/contrib/world_builder/source/world_builder/features/fault.cc
@@ -669,7 +669,7 @@ namespace WorldBuilder
                           }
                           case 4:
                           {
-                            output[entry_in_output[i_property]] = tag_index;
+                            output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                             break;
                           }
                           default:

--- a/contrib/world_builder/source/world_builder/features/mantle_layer.cc
+++ b/contrib/world_builder/source/world_builder/features/mantle_layer.cc
@@ -241,7 +241,7 @@ namespace WorldBuilder
                       }
                       case 4:
                       {
-                        output[entry_in_output[i_property]] = tag_index;
+                        output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                         break;
                       }
                       break;

--- a/contrib/world_builder/source/world_builder/features/oceanic_plate.cc
+++ b/contrib/world_builder/source/world_builder/features/oceanic_plate.cc
@@ -259,7 +259,7 @@ namespace WorldBuilder
                       }
                       case 4:
                       {
-                        output[entry_in_output[i_property]] = tag_index;
+                        output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                         break;
                       }
                       break;

--- a/contrib/world_builder/source/world_builder/features/plume.cc
+++ b/contrib/world_builder/source/world_builder/features/plume.cc
@@ -276,7 +276,7 @@ namespace WorldBuilder
         }
       else
         {
-          const unsigned int index = std::distance(depths.begin(), upper);
+          const unsigned int index = static_cast<unsigned int>(std::distance(depths.begin(), upper));
           const double fraction = (depth - depths[index-1]) / (depths[index] - depths[index-1]);
 
           plume_center[0] = (1-fraction) * coordinates[index-1][0] + fraction * (coordinates[index][0]);
@@ -382,7 +382,7 @@ namespace WorldBuilder
                   }
                   case 4:
                   {
-                    output[entry_in_output[i_property]] = tag_index;
+                    output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                     break;
                   }
                   default:

--- a/contrib/world_builder/source/world_builder/features/plume_models/temperature/gaussian.cc
+++ b/contrib/world_builder/source/world_builder/features/plume_models/temperature/gaussian.cc
@@ -135,7 +135,7 @@ namespace WorldBuilder
                 }
               else
                 {
-                  const unsigned int index = std::distance(depths.begin(), upper);
+                  const unsigned int index = static_cast<unsigned int>(std::distance(depths.begin(), upper));
                   const double fraction = (depth - depths[index-1]) / (depths[index] - depths[index-1]);
 
                   center_temperature_local = (1-fraction) * center_temperatures[index-1] + fraction * center_temperatures[index];

--- a/contrib/world_builder/source/world_builder/features/subducting_plate.cc
+++ b/contrib/world_builder/source/world_builder/features/subducting_plate.cc
@@ -701,7 +701,7 @@ namespace WorldBuilder
                           }
                           case 4:
                           {
-                            output[entry_in_output[i_property]] = tag_index;
+                            output[entry_in_output[i_property]] = static_cast<double>(tag_index);
                             break;
                           }
                           default:

--- a/contrib/world_builder/source/world_builder/features/subducting_plate_models/temperature/mass_conserving.cc
+++ b/contrib/world_builder/source/world_builder/features/subducting_plate_models/temperature/mass_conserving.cc
@@ -31,6 +31,7 @@
 #include "world_builder/types/one_of.h"
 #include "world_builder/types/object.h"
 #include "world_builder/types/point.h"
+#include "world_builder/types/unsigned_int.h"
 #include "world_builder/types/value_at_points.h"
 #include "world_builder/utilities.h"
 #include "world_builder/world.h"
@@ -178,7 +179,7 @@ namespace WorldBuilder
           prm.declare_entry("apply spline",  Types::Bool(false),
                             "Whether a spline should be applied on the mass conserving model.");
 
-          prm.declare_entry("number of points in spline", Types::Int(5),
+          prm.declare_entry("number of points in spline", Types::UnsignedInt(5),
                             "The number of points in the spline");
 
         }
@@ -257,7 +258,7 @@ namespace WorldBuilder
             reference_model_name = half_space_model;
 
           apply_spline = prm.get<bool>("apply spline");
-          spline_n_points = prm.get<int>("number of points in spline");
+          spline_n_points = prm.get<unsigned int>("number of points in spline");
 
           if (subducting_velocities[0].size() > 1)
             {
@@ -530,9 +531,9 @@ namespace WorldBuilder
                       const double interval_spline_distance = 1.0 / spline_n_points;
                       std::vector<double> i_temperatures (2*(spline_n_points + 1), 0.0);
 
-                      for (int i = 0; i < 2 * spline_n_points + 1; ++i)
+                      for (size_t i = 0; i < 2 * spline_n_points + 1; ++i)
                         {
-                          const double i_adjusted_distance = (i * interval_spline_distance - 1.0) * max_depth;
+                          const double i_adjusted_distance = (static_cast<double>(i) * interval_spline_distance - 1.0) * max_depth;
                           const double i_temperature = get_temperature_analytic(top_heat_content, min_temperature, background_temperature, temperature_, spreading_velocity, effective_plate_age, i_adjusted_distance);
                           i_temperatures[i] = i_temperature;
                         }

--- a/contrib/world_builder/source/world_builder/kd_tree.cc
+++ b/contrib/world_builder/source/world_builder/kd_tree.cc
@@ -36,7 +36,7 @@ namespace WorldBuilder
                         const bool y_axis)
     {
       const size_t mid=(left+right)>>1;
-      std::nth_element(nodes.begin()+left,nodes.begin()+mid,nodes.begin()+right+1,
+      std::nth_element(nodes.begin()+static_cast<long int>(left),nodes.begin()+static_cast<long int>(mid),nodes.begin()+static_cast<long int>(right)+1,
                        [y_axis](Node& i, Node& j) -> bool
       {
         return i[y_axis] < j[y_axis];

--- a/contrib/world_builder/source/world_builder/objects/bezier_curve.cc
+++ b/contrib/world_builder/source/world_builder/objects/bezier_curve.cc
@@ -313,7 +313,7 @@ namespace WorldBuilder
               const double min_squared_distance_temp = (est_min_cp_end_0*est_min_cp_end_0)+(est_min_cp_end_1*est_min_cp_end_1);
               if (min_squared_distance_temp < min_squared_distance)
                 {
-                  if (est >= -1e-8 && cp_i+est > 0 && est-1. <= 1e-8 && est-1. < cp_i)
+                  if (est >= -1e-8 && static_cast<double>(cp_i)+est > 0 && est-1. <= 1e-8 && est-1. < static_cast<double>(cp_i))
                     {
                       min_squared_distance = min_squared_distance_temp;
                       const Point<2> point_on_curve = Point<2>(a_0*est*est*est+b_0*est*est+c_0*est+d_0,a_1*est*est*est+b_1*est*est+c_1*est+d_1,cp.get_coordinate_system());
@@ -505,7 +505,7 @@ namespace WorldBuilder
 
               if (min_squared_distance_cartesian_temp < min_squared_distance)
                 {
-                  if (est >= -1e-8 && cp_i+est > 0 && est-1. <= 1e-8 && est-1. < cp_i)
+                  if (est >= -1e-8 && static_cast<double>(cp_i)+est > 0 && est-1. <= 1e-8 && est-1. < static_cast<double>(cp_i))
                     {
                       min_squared_distance = min_squared_distance_cartesian_temp;
                       const Point<2> point_on_curve = a*est*est*est+b*est*est+c*est+d;

--- a/contrib/world_builder/source/world_builder/parameters.cc
+++ b/contrib/world_builder/source/world_builder/parameters.cc
@@ -379,7 +379,7 @@ namespace WorldBuilder
                       << base + "/" + name + "/default value");
       }
 
-    return value->GetUint();
+    return value->GetInt();
   }
 
   template<>

--- a/contrib/world_builder/source/world_builder/point.cc
+++ b/contrib/world_builder/source/world_builder/point.cc
@@ -64,7 +64,7 @@ namespace WorldBuilder
 
 
 
-  template<int dim>
+  template<unsigned int dim>
   double
   Point<dim>::distance(const Point<2> &two) const
   {

--- a/contrib/world_builder/source/world_builder/types/point.cc
+++ b/contrib/world_builder/source/world_builder/types/point.cc
@@ -26,7 +26,7 @@ namespace WorldBuilder
   namespace Types
   {
 
-    template <int dim>
+    template <unsigned int dim>
     Point<dim>::Point()
       :
       value(WorldBuilder::Point<dim>(CoordinateSystem::cartesian)),
@@ -36,7 +36,7 @@ namespace WorldBuilder
       this->type_name = dim == 2 ? Types::type::Point2D : Types::type::Point3D;
     }
 
-    template <int dim>
+    template <unsigned int dim>
     Point<dim>::Point(const WorldBuilder::Point<dim> &default_value_,
                       std::string description_)
       :
@@ -47,7 +47,7 @@ namespace WorldBuilder
       this->type_name = dim == 2 ? Types::type::Point2D : Types::type::Point3D;
     }
 
-    template <int dim>
+    template <unsigned int dim>
     Point<dim>::Point(const WorldBuilder::Point<dim> &value_,
                       const WorldBuilder::Point<dim> &default_value_,
                       std::string description_)
@@ -59,7 +59,7 @@ namespace WorldBuilder
       this->type_name = dim == 2 ? Types::type::Point2D : Types::type::Point3D;
     }
 
-    template <int dim>
+    template <unsigned int dim>
     Point<dim>::Point(Point const &other)
       :
       value(other.value),
@@ -69,11 +69,11 @@ namespace WorldBuilder
       this->type_name = dim == 2 ? Types::type::Point2D : Types::type::Point3D;
     }
 
-    template <int dim>
+    template <unsigned int dim>
     Point<dim>::~Point ()
       = default;
 
-    template<int dim>
+    template<unsigned int dim>
     void
     Point<dim>::write_schema(Parameters &prm,
                              const std::string &name,
@@ -92,7 +92,7 @@ namespace WorldBuilder
     }
 
 
-    template<int dim>
+    template<unsigned int dim>
     double Point<dim>::operator*(const Point<dim> &point_) const
     {
       const std::array<double,dim> array = point_.value.get_array();
@@ -103,7 +103,7 @@ namespace WorldBuilder
     }
 
 
-    template<int dim>
+    template<unsigned int dim>
     WorldBuilder::Point<dim>
     Point<dim>::operator*(const double scalar) const
     {
@@ -114,7 +114,7 @@ namespace WorldBuilder
       return WorldBuilder::Point<dim>(array,value.get_coordinate_system());
     }
 
-    template<int dim>
+    template<unsigned int dim>
     WorldBuilder::Point<dim>
     Point<dim>::operator+(const Point<dim> &point_) const
     {
@@ -124,7 +124,7 @@ namespace WorldBuilder
       return point_tmp;
     }
 
-    template<int dim>
+    template<unsigned int dim>
     WorldBuilder::Point<dim>
     Point<dim>::operator-(const Point<dim> &point_) const
     {
@@ -137,7 +137,7 @@ namespace WorldBuilder
     /**
      * access index
      */
-    template<int dim>
+    template<unsigned int dim>
     double &
     Point<dim>::operator[](const unsigned int index)
     {
@@ -147,7 +147,7 @@ namespace WorldBuilder
     /**
      * access index
      */
-    template<int dim>
+    template<unsigned int dim>
     const double &
     Point<dim>::operator[](const unsigned int index) const
     {
@@ -158,7 +158,7 @@ namespace WorldBuilder
      * Multiplies a Types::Point<dim> with a scalr and returns a
      * WorldBuilder::Point<dim>.
      */
-    template<int dim>
+    template<unsigned int dim>
     WorldBuilder::Point<dim>
     operator*(const double scalar, const Point<dim> &point)
     {

--- a/contrib/world_builder/source/world_builder/utilities.cc
+++ b/contrib/world_builder/source/world_builder/utilities.cc
@@ -1190,7 +1190,7 @@ namespace WorldBuilder
 
               // Need to convert to unsigned int, because MPI_Bcast does not support
               // size_t or const unsigned int
-              unsigned int invalid_file_size = -1;
+              int invalid_file_size = -1;
 
               if (!filestream)
                 {
@@ -1218,7 +1218,7 @@ namespace WorldBuilder
 
               data_string = datastream.str();
               WBAssertThrow(static_cast<long int>(data_string.size()) < std::numeric_limits<int>::max(),
-                            "File to large to be send with MPI.");
+                            "File is too large to be send with MPI.");
               filesize = static_cast<int>(data_string.size());
 
               // Distribute data_size and data across processes

--- a/contrib/world_builder/source/world_builder/utilities.cc
+++ b/contrib/world_builder/source/world_builder/utilities.cc
@@ -296,7 +296,7 @@ namespace WorldBuilder
     }
 
 
-    template<int dim>
+    template<unsigned int dim>
     std::array<double,dim>
     convert_point_to_array(const Point<dim> &point_)
     {
@@ -621,9 +621,9 @@ namespace WorldBuilder
 
               if (!bool_cartesian)
                 {
-                  const double normal = std::fabs(point_list[i_section_min_distance+(int)(std::round(fraction_CPL_P1P2))][0]-check_point_surface_2d[0]);
-                  const double plus   = std::fabs(point_list[i_section_min_distance+(int)(std::round(fraction_CPL_P1P2))][0]-(check_point_surface_2d[0]+2*Consts::PI));
-                  const double min    = std::fabs(point_list[i_section_min_distance+(int)(std::round(fraction_CPL_P1P2))][0]-(check_point_surface_2d[0]-2*Consts::PI));
+                  const double normal = std::fabs(point_list[i_section_min_distance+static_cast<size_t>((std::round(fraction_CPL_P1P2)))][0]-check_point_surface_2d[0]);
+                  const double plus   = std::fabs(point_list[i_section_min_distance+static_cast<size_t>((std::round(fraction_CPL_P1P2)))][0]-(check_point_surface_2d[0]+2*Consts::PI));
+                  const double min    = std::fabs(point_list[i_section_min_distance+static_cast<size_t>((std::round(fraction_CPL_P1P2)))][0]-(check_point_surface_2d[0]-2*Consts::PI));
 
                   // find out whether the check point, checkpoint + 2pi or check point -2 pi is closest to the point list.
                   if (plus < normal)
@@ -1178,21 +1178,19 @@ namespace WorldBuilder
       MPI_Initialized(&mpi_initialized);
       if (mpi_initialized != 0)
         {
-          const unsigned int invalid_unsigned_int = static_cast<unsigned int>(-1);
-
           const MPI_Comm comm = MPI_COMM_WORLD;
-          int my_rank = invalid_unsigned_int;
+          int my_rank = 0;
           MPI_Comm_rank(comm, &my_rank);
           if (my_rank == 0)
             {
-              std::size_t filesize;
+              uint64_t filesize;
               std::ifstream filestream;
               filestream.open(filename.c_str());
               WBAssertThrow (filestream.is_open(), std::string("Could not open file <") + filename + ">.");
 
               // Need to convert to unsigned int, because MPI_Bcast does not support
               // size_t or const unsigned int
-              unsigned int invalid_file_size = invalid_unsigned_int;
+              unsigned int invalid_file_size = -1;
 
               if (!filestream)
                 {
@@ -1220,6 +1218,8 @@ namespace WorldBuilder
 
               data_string = datastream.str();
               filesize = data_string.size();
+              WBAssertThrow(filesize < std::numeric_limits<uint64_t>::max(),
+                            "File to large to be send with MPI.");
 
               // Distribute data_size and data across processes
               int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
@@ -1227,7 +1227,7 @@ namespace WorldBuilder
 
               // Receive and store data
               ierr = MPI_Bcast(&data_string[0],
-                               filesize,
+                               static_cast<int>(filesize),
                                MPI_CHAR,
                                0,
                                comm);
@@ -1236,13 +1236,13 @@ namespace WorldBuilder
           else
             {
               // Prepare for receiving data
-              unsigned int filesize = 0;
+              int filesize = 0;
               int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
               WBAssertThrow(ierr == 0, "MPI_Bcast failed.");
-              WBAssertThrow(filesize != invalid_unsigned_int,
+              WBAssertThrow(filesize != -1,
                             std::string("Could not open file <") + filename + ">.");
 
-              data_string.resize(filesize);
+              data_string.resize(static_cast<size_t>(filesize));
 
               // Receive and store data
               ierr = MPI_Bcast(&data_string[0],

--- a/contrib/world_builder/source/world_builder/utilities.cc
+++ b/contrib/world_builder/source/world_builder/utilities.cc
@@ -1183,7 +1183,7 @@ namespace WorldBuilder
           MPI_Comm_rank(comm, &my_rank);
           if (my_rank == 0)
             {
-              uint64_t filesize;
+              int filesize;
               std::ifstream filestream;
               filestream.open(filename.c_str());
               WBAssertThrow (filestream.is_open(), std::string("Could not open file <") + filename + ">.");
@@ -1217,9 +1217,9 @@ namespace WorldBuilder
                 }
 
               data_string = datastream.str();
-              filesize = data_string.size();
-              WBAssertThrow(filesize < std::numeric_limits<uint64_t>::max(),
+              WBAssertThrow(static_cast<long int>(data_string.size()) < std::numeric_limits<int>::max(),
                             "File to large to be send with MPI.");
+              filesize = static_cast<int>(data_string.size());
 
               // Distribute data_size and data across processes
               int ierr = MPI_Bcast(&filesize, 1, MPI_UNSIGNED, 0, comm);
@@ -1227,7 +1227,7 @@ namespace WorldBuilder
 
               // Receive and store data
               ierr = MPI_Bcast(&data_string[0],
-                               static_cast<int>(filesize),
+                               filesize,
                                MPI_CHAR,
                                0,
                                comm);

--- a/contrib/world_builder/source/world_builder/world.cc
+++ b/contrib/world_builder/source/world_builder/world.cc
@@ -251,7 +251,7 @@ namespace WorldBuilder
     const int local_seed = prm.get<int>("random number seed");
 
     if (local_seed>=0)
-      random_number_engine.seed(local_seed+MPI_RANK);
+      random_number_engine.seed(static_cast<unsigned int>(local_seed+MPI_RANK));
 
     /**
      * Now load the features. Some features use for example temperature values,
@@ -445,7 +445,7 @@ namespace WorldBuilder
                 const unsigned int composition_number,
                 size_t number_of_grains) const
   {
-    return WorldBuilder::grains(properties(point, depth, {{{3,composition_number,(unsigned int)number_of_grains}}}),(unsigned int)number_of_grains,0);
+    return WorldBuilder::grains(properties(point, depth, {{{3,composition_number,static_cast<unsigned int>(number_of_grains)}}}),static_cast<unsigned int>(number_of_grains),0);
   }
 
   WorldBuilder::grains
@@ -454,7 +454,7 @@ namespace WorldBuilder
                 const unsigned int composition_number,
                 size_t number_of_grains) const
   {
-    return WorldBuilder::grains(properties(point, depth, {{{3,composition_number,(unsigned int)number_of_grains}}}),(unsigned int)number_of_grains,0);
+    return WorldBuilder::grains(properties(point, depth, {{{3,composition_number,static_cast<unsigned int>(number_of_grains)}}}),static_cast<unsigned int>(number_of_grains),0);
   }
 
   std::mt19937 &

--- a/contrib/world_builder/tests/unit_tests/unit_test_world_builder.cc
+++ b/contrib/world_builder/tests/unit_tests/unit_test_world_builder.cc
@@ -3862,9 +3862,9 @@ TEST_CASE("WorldBuilder Parameters")
   CHECK_THROWS_WITH(prm.get("value at points non existent",additional_points), Contains("internal error: could not retrieve"));
   std::pair<std::vector<double>,std::vector<double>> v_at_p_one_value = prm.get("one value at points one value",additional_points);
 
-  approval_tests.emplace_back((double)v_at_p_one_value.first.size());
-  approval_tests.emplace_back((double)v_at_p_one_value.first[0]);
-  approval_tests.emplace_back((double)v_at_p_one_value.second.size());
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_value.first.size()));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_value.first[0]));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_value.second.size()));
 
   {
     const Objects::Surface surface(v_at_p_one_value);
@@ -3872,19 +3872,19 @@ TEST_CASE("WorldBuilder Parameters")
   }
   std::pair<std::vector<double>,std::vector<double>> v_at_p_one_array_value = prm.get("array value at points one value",additional_points);
 
-  approval_tests.emplace_back((double)v_at_p_one_array_value.first.size());
-  approval_tests.emplace_back((double)v_at_p_one_array_value.first[0]);
-  approval_tests.emplace_back((double)v_at_p_one_array_value.second.size());
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_array_value.first.size()));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_array_value.first[0]));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_one_array_value.second.size()));
 
   std::pair<std::vector<double>,std::vector<double>> v_at_p_full_default = prm.get("value at points",additional_points);
 
-  approval_tests.emplace_back((double)v_at_p_full_default.first.size());
-  approval_tests.emplace_back((double)v_at_p_full_default.first[0]);
-  approval_tests.emplace_back((double)v_at_p_full_default.second.size());
+  approval_tests.emplace_back(static_cast<double>(v_at_p_full_default.first.size()));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_full_default.first[0]));
+  approval_tests.emplace_back(static_cast<double>(v_at_p_full_default.second.size()));
 
   std::pair<std::vector<double>,std::vector<double>> v_at_p_dap = prm.get("value at points default ap",additional_points);
 
-  approval_tests.emplace_back((double)v_at_p_dap.first.size());
+  approval_tests.emplace_back(static_cast<double>(v_at_p_dap.first.size()));
   approval_tests.emplace_back(v_at_p_dap.first[0]);
   approval_tests.emplace_back(v_at_p_dap.first[1]);
   approval_tests.emplace_back(v_at_p_dap.first[2]);
@@ -3892,7 +3892,7 @@ TEST_CASE("WorldBuilder Parameters")
   approval_tests.emplace_back(v_at_p_dap.first[4]);
   approval_tests.emplace_back(v_at_p_dap.first[5]);
   approval_tests.emplace_back(v_at_p_dap.first[6]);
-  approval_tests.emplace_back((double)v_at_p_dap.second.size());
+  approval_tests.emplace_back(static_cast<double>(v_at_p_dap.second.size()));
   approval_tests.emplace_back(v_at_p_dap.second[0]);
   approval_tests.emplace_back(v_at_p_dap.second[1]);
   approval_tests.emplace_back(v_at_p_dap.second[2]);
@@ -3971,15 +3971,15 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<unsigned int> v_int = prm.get_vector<unsigned int>("now existent unsigned int vector");
-  approval_tests.emplace_back((double)v_int.size());
-  approval_tests.emplace_back((double)v_int[0]);
-  approval_tests.emplace_back((double)v_int[1]);
+  approval_tests.emplace_back(static_cast<double>(v_int.size()));
+  approval_tests.emplace_back(static_cast<double>(v_int[0]));
+  approval_tests.emplace_back(static_cast<double>(v_int[1]));
 
   v_int = prm.get_vector<unsigned int>("unsigned int array");
-  approval_tests.emplace_back((double)v_int.size());
-  approval_tests.emplace_back((double)v_int[0]);
-  approval_tests.emplace_back((double)v_int[1]);
-  approval_tests.emplace_back((double)v_int[2]);
+  approval_tests.emplace_back(static_cast<double>(v_int.size()));
+  approval_tests.emplace_back(static_cast<double>(v_int[0]));
+  approval_tests.emplace_back(static_cast<double>(v_int[1]));
+  approval_tests.emplace_back(static_cast<double>(v_int[2]));
 
   CHECK_THROWS_WITH(prm.get_vector<size_t>("non existent unsigned int vector"),
                     Contains("internal error: could not retrieve the minItems value"));
@@ -3987,15 +3987,15 @@ TEST_CASE("WorldBuilder Parameters")
 
 
   std::vector<size_t> v_size_t = prm.get_vector<size_t>("now existent unsigned int vector");
-  approval_tests.emplace_back((double)v_size_t.size());
-  approval_tests.emplace_back((double)v_size_t[0]);
-  approval_tests.emplace_back((double)v_size_t[1]);
+  approval_tests.emplace_back(static_cast<double>(v_size_t.size()));
+  approval_tests.emplace_back(static_cast<double>(v_size_t[0]));
+  approval_tests.emplace_back(static_cast<double>(v_size_t[1]));
 
   v_size_t = prm.get_vector<size_t>("unsigned int array");
-  approval_tests.emplace_back((double)v_size_t.size());
-  approval_tests.emplace_back((double)v_size_t[0]);
-  approval_tests.emplace_back((double)v_size_t[1]);
-  approval_tests.emplace_back((double)v_size_t[2]);
+  approval_tests.emplace_back(static_cast<double>(v_size_t.size()));
+  approval_tests.emplace_back(static_cast<double>(v_size_t[0]));
+  approval_tests.emplace_back(static_cast<double>(v_size_t[1]));
+  approval_tests.emplace_back(static_cast<double>(v_size_t[2]));
 
 
   CHECK_THROWS_WITH(prm.get_vector<size_t>("non existent unsigned int vector"),
@@ -4010,18 +4010,18 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<bool> v_bool = prm.get_vector<bool>("now existent bool vector");
-  approval_tests.emplace_back((double)v_bool.size());
-  approval_tests.emplace_back((double)v_bool[0]);
-  approval_tests.emplace_back((double)v_bool[1]);
+  approval_tests.emplace_back(static_cast<double>(v_bool.size()));
+  approval_tests.emplace_back(static_cast<double>(v_bool[0]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[1]));
 
   v_bool = prm.get_vector<bool>("bool array");
-  approval_tests.emplace_back((double)v_bool.size());
-  approval_tests.emplace_back((double)v_bool[0]);
-  approval_tests.emplace_back((double)v_bool[1]);
-  approval_tests.emplace_back((double)v_bool[2]);
-  approval_tests.emplace_back((double)v_bool[3]);
-  approval_tests.emplace_back((double)v_bool[4]);
-  approval_tests.emplace_back((double)v_bool[1]);
+  approval_tests.emplace_back(static_cast<double>(v_bool.size()));
+  approval_tests.emplace_back(static_cast<double>(v_bool[0]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[1]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[2]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[3]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[4]));
+  approval_tests.emplace_back(static_cast<double>(v_bool[1]));
 
   CHECK_THROWS_WITH(prm.get_vector<bool>("bool array nob"),
                     Contains("IsBool()"));
@@ -4039,7 +4039,7 @@ TEST_CASE("WorldBuilder Parameters")
   prm.leave_subsection();
 
   std::vector<double> v_double = prm.get_vector<double>("now existent double vector");
-  approval_tests.emplace_back((double)v_double.size());
+  approval_tests.emplace_back(static_cast<double>(v_double.size()));
   approval_tests.emplace_back(v_double[0]);
   approval_tests.emplace_back(v_double[1]);
 
@@ -4047,7 +4047,7 @@ TEST_CASE("WorldBuilder Parameters")
                     Contains("Could not convert values of /string array into Point<2>, because it could not convert the sub-elements into doubles."));
 
   v_double = prm.get_vector<double>("double array");
-  approval_tests.emplace_back((double)v_double.size());
+  approval_tests.emplace_back(static_cast<double>(v_double.size()));
   approval_tests.emplace_back(v_double[0]);
   approval_tests.emplace_back(v_double[1]);
   approval_tests.emplace_back(v_double[2]);
@@ -4056,7 +4056,7 @@ TEST_CASE("WorldBuilder Parameters")
                     Contains("Could not convert values of /point<2> array nan/0 into a Point<2> array, because it could not convert the sub-elements into doubles."));
 
   std::vector<std::array<std::array<double,3>,3> > v_3x3_array = prm.get_vector<std::array<std::array<double,3>,3> >("vector of 3x3 arrays");
-  approval_tests.emplace_back((double)v_3x3_array.size());
+  approval_tests.emplace_back(static_cast<double>(v_3x3_array.size()));
   approval_tests.emplace_back(v_3x3_array[0][0][0]);
   approval_tests.emplace_back(v_3x3_array[0][0][1]);
   approval_tests.emplace_back(v_3x3_array[0][0][2]);
@@ -4078,14 +4078,14 @@ TEST_CASE("WorldBuilder Parameters")
   approval_tests.emplace_back(v_3x3_array[1][2][2]);
 
   std::vector<std::vector<Point<2> > > v_v_p2 = prm.get_vector<std::vector<Point<2>>>("vector of vectors of points<2>");
-  approval_tests.emplace_back((double)v_v_p2.size());
-  approval_tests.emplace_back((double)v_v_p2[0].size());
+  approval_tests.emplace_back(static_cast<double>(v_v_p2.size()));
+  approval_tests.emplace_back(static_cast<double>(v_v_p2[0].size()));
   approval_tests.emplace_back(v_v_p2[0][0][0]);
   approval_tests.emplace_back(v_v_p2[0][0][1]);
   approval_tests.emplace_back(v_v_p2[0][1][0]);
   approval_tests.emplace_back(v_v_p2[0][1][1]);
 
-  approval_tests.emplace_back((double)v_v_p2[1].size());
+  approval_tests.emplace_back(static_cast<double>(v_v_p2[1].size()));
   approval_tests.emplace_back(v_v_p2[1][0][0]);
   approval_tests.emplace_back(v_v_p2[1][0][1]);
   approval_tests.emplace_back(v_v_p2[1][1][0]);
@@ -4099,11 +4099,11 @@ TEST_CASE("WorldBuilder Parameters")
 
 
   std::pair<std::vector<double>,std::vector<double>> value_at_array = prm.get_value_at_array("value at array full");
-  approval_tests.emplace_back((double)value_at_array.first.size());
+  approval_tests.emplace_back(static_cast<double>(value_at_array.first.size()));
   approval_tests.emplace_back(value_at_array.first[0]);
   approval_tests.emplace_back(value_at_array.first[1]);
 
-  approval_tests.emplace_back((double)value_at_array.second.size());
+  approval_tests.emplace_back(static_cast<double>(value_at_array.second.size()));
   approval_tests.emplace_back(value_at_array.second[0]);
   approval_tests.emplace_back(value_at_array.second[1]);
   approval_tests.emplace_back(value_at_array.second[2]);
@@ -4112,33 +4112,33 @@ TEST_CASE("WorldBuilder Parameters")
 
 
   std::pair<std::vector<double>,std::vector<double>> double_value_at_array = prm.get_value_at_array("one value at points one value");
-  approval_tests.emplace_back((double)double_value_at_array.first.size());
+  approval_tests.emplace_back(static_cast<double>(double_value_at_array.first.size()));
   approval_tests.emplace_back(double_value_at_array.first[0]);
-  approval_tests.emplace_back((double)double_value_at_array.second.size());
+  approval_tests.emplace_back(static_cast<double>(double_value_at_array.second.size()));
   approval_tests.emplace_back(double_value_at_array.second[0]);
 
   std::pair<std::vector<double>,std::vector<double>> default_value_at_array = prm.get_value_at_array("value at array");
-  approval_tests.emplace_back((double)default_value_at_array.first.size());
+  approval_tests.emplace_back(static_cast<double>(default_value_at_array.first.size()));
   approval_tests.emplace_back(default_value_at_array.first[0]);
-  approval_tests.emplace_back((double)default_value_at_array.second.size());
+  approval_tests.emplace_back(static_cast<double>(default_value_at_array.second.size()));
   approval_tests.emplace_back(default_value_at_array.second[0]);
 
   std::vector<std::vector<double>> vector_for_vector_or_double = prm.get_vector_or_double("vector for vector or double");
-  approval_tests.emplace_back((double)vector_for_vector_or_double.size());
-  approval_tests.emplace_back((double)vector_for_vector_or_double[0].size());
-  approval_tests.emplace_back((double)vector_for_vector_or_double[0][0]);
-  approval_tests.emplace_back((double)vector_for_vector_or_double[0][1]);
-  approval_tests.emplace_back((double)vector_for_vector_or_double[0][2]);
-  approval_tests.emplace_back((double)vector_for_vector_or_double[0][3]);
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double.size()));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[0].size()));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[0][0]));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[0][1]));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[0][2]));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[0][3]));
 
-  approval_tests.emplace_back((double)vector_for_vector_or_double[1].size());
-  approval_tests.emplace_back((double)vector_for_vector_or_double[1][0]);
-  approval_tests.emplace_back((double)vector_for_vector_or_double[1][1]);
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[1].size()));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[1][0]));
+  approval_tests.emplace_back(static_cast<double>(vector_for_vector_or_double[1][1]));
 
   std::vector<std::vector<double>> double_for_vector_or_double = prm.get_vector_or_double("one value at points one value");
-  approval_tests.emplace_back((double)double_for_vector_or_double.size());
-  approval_tests.emplace_back((double)double_for_vector_or_double[0].size());
-  approval_tests.emplace_back((double)double_for_vector_or_double[0][0]);
+  approval_tests.emplace_back(static_cast<double>(double_for_vector_or_double.size()));
+  approval_tests.emplace_back(static_cast<double>(double_for_vector_or_double[0].size()));
+  approval_tests.emplace_back(static_cast<double>(double_for_vector_or_double[0][0]));
   /*CHECK_THROWS_WITH(prm.get_vector<std::string>("non existent string vector"),
                     Contains("internal error: could not retrieve the default value at"));
 
@@ -4936,8 +4936,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -4960,8 +4960,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-4); // practically zero
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-5);
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.insert( approval_tests.end(), std::begin(distance_from_planes.closest_trench_point.get_array()),
@@ -4986,8 +4986,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5013,8 +5013,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5039,8 +5039,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5067,8 +5067,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5094,8 +5094,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.depth_reference_surface) > 1e-12 ? distance_from_planes.depth_reference_surface : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5122,8 +5122,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5149,8 +5149,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   // The old method for slabs can not provide the corners when out of bounds and returns a nan. The new method can do this,
@@ -5173,8 +5173,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.insert( approval_tests.end(), std::begin(distance_from_planes.closest_trench_point.get_array()), std::end(distance_from_planes.closest_trench_point.get_array()));
@@ -5199,8 +5199,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   // The old method for slabs can not provide the corners when out of bounds and returns a nan. The new method can do this,
@@ -5223,8 +5223,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14); // practically zero
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5253,8 +5253,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
   approval_tests.emplace_back(distance_from_planes.closest_trench_point.get_array()[0]);
@@ -5282,8 +5282,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -5308,8 +5308,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -5334,8 +5334,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // add coordinate
@@ -5370,8 +5370,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-12);
 
   // different angle
@@ -5404,8 +5404,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane)<1e-10);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check interpolation 1 (in the middle of a segment with 22.5 degree and a segment with 45)
@@ -5429,8 +5429,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check interpolation 2 (at the end of the segment at 45 degree)
@@ -5454,8 +5454,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation with 90 degree angles for simplicity
@@ -5500,8 +5500,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation first segment center 2
@@ -5525,8 +5525,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation first segment center 3
@@ -5550,8 +5550,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -5577,8 +5577,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -5605,8 +5605,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 2
@@ -5630,8 +5630,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 3
@@ -5655,8 +5655,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -5682,8 +5682,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // Now check the end of the second segment, each segment should have a length of 50.
@@ -5708,8 +5708,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 2
@@ -5733,8 +5733,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // practically zero
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // check length interpolation second segment center 3
@@ -5758,8 +5758,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -5785,8 +5785,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   ApprovalTests::Approvals::verifyAll("TITLE", approval_tests);
 }
@@ -5879,8 +5879,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -5905,8 +5905,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about 5 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -5931,8 +5931,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about -5 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -5958,8 +5958,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -5984,8 +5984,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about -10 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -6014,8 +6014,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   // where the check point has angle 0. This means that the distanceAlongPlate is zero.
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -6041,8 +6041,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -6072,8 +6072,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -6098,8 +6098,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -6138,8 +6138,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 11
@@ -6163,8 +6163,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 12
@@ -6188,8 +6188,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.depth_reference_surface);
 
@@ -6215,8 +6215,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 14
@@ -6254,8 +6254,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 15
@@ -6279,8 +6279,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 16
@@ -6304,8 +6304,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about -1 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 16
@@ -6329,8 +6329,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about -1 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 17
@@ -6354,8 +6354,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -6380,8 +6380,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about 1 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 19
@@ -6405,8 +6405,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about 1 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -6445,8 +6445,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 21
@@ -6470,8 +6470,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 21
@@ -6495,8 +6495,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test 22
@@ -6520,8 +6520,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test start 45 degree 1
@@ -6562,8 +6562,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about -7.3 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test change reference point 1
@@ -6591,8 +6591,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test change reference point 2
@@ -6616,8 +6616,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be about 2.3 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test angle interpolation 1
@@ -6659,8 +6659,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 1
@@ -6701,8 +6701,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 2
@@ -6726,8 +6726,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 3
@@ -6751,8 +6751,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 4
@@ -6778,8 +6778,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) ); // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -6804,8 +6804,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) > 1e-12 ? distance_from_planes.distance_from_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 6
@@ -6843,8 +6843,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-10); // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
   // curve test reverse angle 6
@@ -6869,8 +6869,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
   // curve test reverse angle 6
@@ -6895,8 +6895,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-10);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-10);
 
 
@@ -6922,8 +6922,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane)< 1e-10);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -6950,8 +6950,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(fabs(distance_from_planes.distance_from_plane)); // checked that it should be small positive this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 9
@@ -6976,8 +6976,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked that it should be small negative this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // curve test reverse angle 10
@@ -7002,8 +7002,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -7029,8 +7029,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 2
@@ -7054,8 +7054,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 3
@@ -7079,8 +7079,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 4
@@ -7104,8 +7104,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // global_x_list test 5
@@ -7129,8 +7129,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane)); // checked that it should be about 0 this with a drawing
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-12);
 
 
@@ -7156,8 +7156,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes ca
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
   ApprovalTests::Approvals::verifyAll("TITLE", approval_tests);
 }
@@ -7222,8 +7222,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_section) < 1e-14);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
@@ -7248,8 +7248,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14); // practically zero
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) < 1e-14);
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
@@ -7278,8 +7278,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_from_plane));
   approval_tests.emplace_back(std::isinf(distance_from_planes.distance_along_plane));
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
@@ -7303,8 +7303,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
 
@@ -7337,8 +7337,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(distance_from_planes.distance_from_plane); // checked it with a geometric drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) < 1e-14); // checked it with a geometric drawing
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) < 1e-14);
 
 
@@ -7361,8 +7361,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_from_plane) < 1e-14);  // checked it with a geometric drawing
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // checked it with a geometric drawing
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers
 
   // spherical curve test 1
@@ -7397,8 +7397,8 @@ TEST_CASE("WorldBuilder Utilities function: distance_point_from_curved_planes sp
   approval_tests.emplace_back(distance_from_planes.distance_from_plane);  // see comment at the top of the test
   approval_tests.emplace_back(std::fabs(distance_from_planes.distance_along_plane) > 1e-12 ? distance_from_planes.distance_along_plane : 0.); // to make sure the approval test have the same characters for very small numbers // see comment at the top of the test
   approval_tests.emplace_back(distance_from_planes.fraction_of_section);
-  approval_tests.emplace_back((double)distance_from_planes.section);
-  approval_tests.emplace_back((double)distance_from_planes.segment);
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.section));
+  approval_tests.emplace_back(static_cast<double>(distance_from_planes.segment));
   approval_tests.emplace_back(std::fabs(distance_from_planes.fraction_of_segment) > 1e-12 ? distance_from_planes.fraction_of_segment : 0.); // to make sure the approval test have the same characters for very small numbers*/
   ApprovalTests::Approvals::verifyAll("TITLE", approval_tests);
 }
@@ -7743,3 +7743,38 @@ TEST_CASE("WorldBuilder Utilities function: calculate_ridge_distance_and_spreadi
   ApprovalTests::Approvals::verifyAll("TITLE", approval_tests);
 }
 
+
+TEST_CASE("WorldBuilder Utilities function: calculate_effective_trench_and_plate_ages")
+{
+  std::vector<double> approval_tests;
+
+  // test 1:  trivial case, spreading velocity = subducting velocity and no ridge migration
+  const std::vector<double> ridge_parameters_1 = {4.75299e-10, 1.04512e+06, 4.75299e-10, 0.0}; // m/s, m, m/s, s
+  const double distance_along_plane_1 = 1000e3;
+  std::vector<double> result1 = Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_1, distance_along_plane_1);
+
+  approval_tests.emplace_back(result1[0]); // age at trench
+  approval_tests.emplace_back(result1[1]); // effective plate age
+
+  // test 2:  2 * spreading velocity = subducting velocity and no ridge migration, trench retreating
+  std::vector<double> ridge_parameters_2 = {4.75299e-10, 1.04512e+06, 9.50598e-10, 0.0}; // m/s, m, m/s, s
+  const double distance_along_plane_2 = 1000e3;
+  std::vector<double> result2 = Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_2, distance_along_plane_2);
+
+  approval_tests.emplace_back(result2[0]); // age at trench
+  approval_tests.emplace_back(result2[1]); // effective plate age
+
+  ApprovalTests::Approvals::verifyAll("TITLE", approval_tests);
+
+  // test 3: negative subducting velocity triggers error
+  std::vector<double> ridge_parameters_3 = {4.75299e-10, 1.04512e+06, -9.50598e-10, 0.0}; // m/s, m, m/s, s
+  const double distance_along_plane_3 = 1000e3;
+  CHECK_THROWS_WITH(Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_3, distance_along_plane_3),
+                    Contains("The subducting velocity is less than 0."));
+
+  // test 4:  subducting velocity is too small, causing negative trench age at subducting initiation
+  std::vector<double> ridge_parameters_4 = {4.75299e-10, 1.04512e+06, 9.50598e-11, 0.0}; // m/s, m, m/s, s
+  const double distance_along_plane_4 = 1000e3;
+  CHECK_THROWS_WITH(Utilities::calculate_effective_trench_and_plate_ages(ridge_parameters_4, distance_along_plane_4),
+                    Contains("The age of trench at subducting initiation is less than 0. "));
+}


### PR DESCRIPTION
This is a backport of https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/739, which applies the fixes for the stricter clang flags. I did this by hand more or less, so hopefully I didn't miss anything. 

@tjhei can you run this with your clang aspect version? 