### PR TITLE
jenkins: use prebuilt tester image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,13 +29,12 @@ pipeline {
       agent
       {
         // first build a docker image for running the tests from the repo
-        dockerfile {
-          dir 'contrib/ci'
+        docker {
+          image 'geodynamics/aspect-tester:focal-dealii-9.5-v3'
           // We mount /repos into the docker image. This allows us to cache
           // the git repo by setting "advanced clone behaviors". If the
           // directory does not exist, this will be ignored.
           args '-v /repos:/repos:ro'
-          additionalBuildArgs '--pull'
         }
       }
 

--- a/contrib/ci/Dockerfile
+++ b/contrib/ci/Dockerfile
@@ -1,3 +1,0 @@
-FROM geodynamics/aspect-tester:focal-dealii-9.5-v3
-
-LABEL maintainer <rene.gassmoeller@mailbox.org>

--- a/contrib/ci/build.sh
+++ b/contrib/ci/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# This script generates a docker image for the ASPECT tester.
-# It requires a docker installation on the local machine, and the ability to
-# communicate with the docker daemon without root user privileges (see the docker
-# webpage for an explanation).
-
-docker build -t geodynamics/aspect-tester .


### PR DESCRIPTION
instead of building an (empty) image based on the image geodynamics/aspect-tester:focal-dealii-9.5-v3
we use it directly.
