### PR TITLE
Remove unnecessary check in particle interpolator. Remove deprecated function.

### DIFF
--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -54,31 +54,6 @@ namespace aspect
            * Perform an interpolation of the properties of the particles in
            * this cell onto a vector of positions in this cell.
            * Implementations of this function must return a vector of a vector
-           * of doubles which contains a somehow computed
-           * value of all particle properties at all given positions.
-           *
-           * @param [in] particle_handler Reference to the particle handler
-           * that allows accessing the particles in the domain.
-           * @param [in] positions The vector of positions where the properties
-           * should be evaluated.
-           * @param [in] cell An optional iterator to the cell containing the
-           * particles. Not all callers will know the cell of the particles,
-           * but providing the cell when known speeds up the interpolation
-           * significantly.
-           * @return A vector with as many entries as @p positions. Every entry
-           * is a vector of interpolated particle properties at this position.
-           */
-          DEAL_II_DEPRECATED
-          virtual
-          std::vector<std::vector<double>>
-          properties_at_points(const ParticleHandler<dim> &particle_handler,
-                               const std::vector<Point<dim>> &positions,
-                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const;
-
-          /**
-           * Perform an interpolation of the properties of the particles in
-           * this cell onto a vector of positions in this cell.
-           * Implementations of this function must return a vector of a vector
            * of doubles with as many entries as positions in @p positions.
            * Each entry is a vector with as many entries as there are  particle
            * properties in this computation.
@@ -92,19 +67,20 @@ namespace aspect
            * should be evaluated.
            * @param [in] selected_properties A component mask that determines
            * which particle properties are interpolated in this function.
-           * @param [in] cell An optional iterator to the cell containing the
-           * particles. Not all callers will know the cell of the particles,
-           * but providing the cell when known speeds up the interpolation
-           * significantly.
-           * @return A vector with as many entries as @p positions. Every entry
+           * @param [in] cell An iterator to the cell containing the
+           * positions.
+           * @return A vector with as many entries as @p positions. Each entry
            * is a vector of interpolated particle properties at this position.
+           * This property vector has as many entries as there are particle
+           * properties, however entries that have not been selected in
+           * @p selected_properties are filled with signalling NaNs.
            */
           virtual
           std::vector<std::vector<double>>
           properties_at_points(const ParticleHandler<dim> &particle_handler,
                                const std::vector<Point<dim>> &positions,
                                const ComponentMask &selected_properties,
-                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell = typename parallel::distributed::Triangulation<dim>::active_cell_iterator()) const = 0;
+                               const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const = 0;
       };
 
 

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -48,32 +48,8 @@ namespace aspect
                     ExcMessage("Internal error: the particle property interpolator was "
                                "called without a specified component to interpolate."));
 
-        const Point<dim> approximated_cell_midpoint = std::accumulate (positions.begin(), positions.end(), Point<dim>())
-                                                      / static_cast<double> (positions.size());
-
-        typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
-
-        if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
-          {
-            // We can not simply use one of the points as input for find_active_cell_around_point
-            // because for vertices of mesh cells we might end up getting ghost_cells as return value
-            // instead of the local active cell. So make sure we are well in the inside of a cell.
-            Assert(positions.size() > 0,
-                   ExcMessage("The particle property interpolator was not given any "
-                              "positions to evaluate the particle cell_properties at."));
-
-
-            found_cell =
-              (GridTools::find_active_cell_around_point<> (this->get_mapping(),
-                                                           this->get_triangulation(),
-                                                           approximated_cell_midpoint)).first;
-          }
-        else
-          found_cell = cell;
-
         const typename ParticleHandler<dim>::particle_iterator_range particle_range =
-          particle_handler.particles_in_cell(found_cell);
-
+          particle_handler.particles_in_cell(cell);
 
         std::vector<std::vector<double>> cell_properties(positions.size(),
                                                           std::vector<double>(n_particle_properties,
@@ -88,7 +64,7 @@ namespace aspect
           return fallback_interpolator.properties_at_points(particle_handler,
                                                             positions,
                                                             selected_properties,
-                                                            found_cell);
+                                                            cell);
 
         // Noticed that the size of matrix A is n_particles x n_matrix_columns
         // which usually is not a square matrix. Therefore, we find the
@@ -138,7 +114,7 @@ namespace aspect
         if (use_linear_least_squares_limiter.n_selected_components() != 0)
           {
             std::vector<typename parallel::distributed::Triangulation<dim>::active_cell_iterator> active_neighbors;
-            GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(found_cell, active_neighbors);
+            GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(cell, active_neighbors);
             for (const auto &active_neighbor : active_neighbors)
               {
                 if (active_neighbor->is_artificial())
@@ -153,15 +129,15 @@ namespace aspect
                       }
                   }
               }
-            if (found_cell->at_boundary())
+            if (cell->at_boundary())
               {
-                const std::vector<double> cell_average_values = fallback_interpolator.properties_at_points(particle_handler, {positions[0]}, selected_properties, found_cell)[0];
-                for (unsigned int face_id = 0; face_id < found_cell->reference_cell().n_faces(); ++face_id)
+                const std::vector<double> cell_average_values = fallback_interpolator.properties_at_points(particle_handler, {positions[0]}, selected_properties, cell)[0];
+                for (unsigned int face_id = 0; face_id < cell->reference_cell().n_faces(); ++face_id)
                   {
-                    if (found_cell->at_boundary(face_id))
+                    if (cell->at_boundary(face_id))
                       {
                         const unsigned int opposing_face_id = GeometryInfo<dim>::opposite_face[face_id];
-                        const auto &opposing_cell = found_cell->neighbor(opposing_face_id);
+                        const auto &opposing_cell = cell->neighbor(opposing_face_id);
                         if (opposing_cell.state() == IteratorState::IteratorStates::valid && opposing_cell->is_active() && opposing_cell->is_artificial() == false)
                           {
                             const auto neighbor_cell_average = fallback_interpolator.properties_at_points(particle_handler, {positions[0]}, selected_properties, opposing_cell)[0];
@@ -169,7 +145,7 @@ namespace aspect
                               {
                                 if (selected_properties[property_index] == true && use_boundary_extrapolation[property_index] == true)
                                   {
-                                    Assert(found_cell->reference_cell().is_hyper_cube() == true, ExcNotImplemented());
+                                    Assert(cell->reference_cell().is_hyper_cube() == true, ExcNotImplemented());
                                     const double expected_boundary_value = 1.5 * cell_average_values[property_index] - 0.5 * neighbor_cell_average[property_index];
                                     property_minimums[property_index] = std::min(property_minimums[property_index], expected_boundary_value);
                                     property_maximums[property_index] = std::max(property_maximums[property_index], expected_boundary_value);
@@ -192,7 +168,7 @@ namespace aspect
           return fallback_interpolator.properties_at_points(particle_handler,
                                                             positions,
                                                             selected_properties,
-                                                            found_cell);
+                                                            cell);
 
         std::vector<Vector<double>> QTb(n_particle_properties, Vector<double>(n_matrix_columns));
         std::vector<Vector<double>> c(n_particle_properties, Vector<double>(n_matrix_columns));
@@ -233,7 +209,7 @@ namespace aspect
                 std::size_t positions_index = 0;
                 for (typename std::vector<Point<dim>>::const_iterator itr = positions.begin(); itr != positions.end(); ++itr, ++positions_index)
                   {
-                    Point<dim> relative_support_point_location = this->get_mapping().transform_real_to_unit_cell(found_cell, *itr);
+                    Point<dim> relative_support_point_location = this->get_mapping().transform_real_to_unit_cell(cell, *itr);
                     double interpolated_value = c[property_index][0];
                     for (unsigned int i = 1; i < n_matrix_columns; ++i)
                       {

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -38,30 +38,8 @@ namespace aspect
                                              const ComponentMask &selected_properties,
                                              const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
-
-        if (cell == typename parallel::distributed::Triangulation<dim>::active_cell_iterator())
-          {
-            // We can not simply use one of the points as input for find_active_cell_around_point
-            // because for vertices of mesh cells we might end up getting ghost_cells as return value
-            // instead of the local active cell. So make sure we are well in the inside of a cell.
-            Assert(positions.size() > 0,
-                   ExcMessage("The particle property interpolator was not given any "
-                              "positions to evaluate the particle properties at."));
-
-            const Point<dim> approximated_cell_midpoint = std::accumulate (positions.begin(), positions.end(), Point<dim>())
-                                                          / static_cast<double> (positions.size());
-
-            found_cell =
-              (GridTools::find_active_cell_around_point<> (this->get_mapping(),
-                                                           this->get_triangulation(),
-                                                           approximated_cell_midpoint)).first;
-          }
-        else
-          found_cell = cell;
-
         const typename ParticleHandler<dim>::particle_iterator_range particle_range =
-          particle_handler.particles_in_cell(found_cell);
+          particle_handler.particles_in_cell(cell);
 
         const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
@@ -92,7 +70,7 @@ namespace aspect
         else
           {
             std::vector<typename parallel::distributed::Triangulation<dim>::active_cell_iterator> neighbors;
-            GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(found_cell,neighbors);
+            GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(cell,neighbors);
 
             unsigned int non_empty_neighbors = 0;
             for (unsigned int i=0; i<neighbors.size(); ++i)

--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -27,17 +27,6 @@ namespace aspect
   {
     namespace Interpolator
     {
-      template <int dim>
-      std::vector<std::vector<double>>
-      Interface<dim>::properties_at_points(const ParticleHandler<dim> &particle_handler,
-                                           const std::vector<Point<dim>> &positions,
-                                           const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
-      {
-        return properties_at_points(particle_handler,positions,ComponentMask(), cell);
-      }
-
-
-
 // -------------------------------- Deal with registering models and automating
 // -------------------------------- their setup and selection at run time
 

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -37,29 +37,7 @@ namespace aspect
                                                  const ComponentMask &selected_properties,
                                                  const typename parallel::distributed::Triangulation<dim>::active_cell_iterator &cell) const
       {
-        typename parallel::distributed::Triangulation<dim>::active_cell_iterator found_cell;
-
-        if (cell->state() == IteratorState::invalid)
-          {
-            // We can not simply use one of the points as input for find_active_cell_around_point
-            // because for vertices of mesh cells we might end up getting ghost_cells as return value
-            // instead of the local active cell. So make sure we are well in the inside of a cell.
-            Assert(positions.size() > 0,
-                   ExcMessage("The particle property interpolator was not given any "
-                              "positions to evaluate the particle properties at."));
-
-            const Point<dim> approximated_cell_midpoint = std::accumulate (positions.begin(), positions.end(), Point<dim>())
-                                                          / static_cast<double> (positions.size());
-
-            found_cell =
-              (GridTools::find_active_cell_around_point<> (this->get_mapping(),
-                                                           this->get_triangulation(),
-                                                           approximated_cell_midpoint)).first;
-          }
-        else
-          found_cell = cell;
-
-        const typename ParticleHandler<dim>::particle_iterator_range particle_range = particle_handler.particles_in_cell(found_cell);
+        const typename ParticleHandler<dim>::particle_iterator_range particle_range = particle_handler.particles_in_cell(cell);
 
         const unsigned int n_particles = std::distance(particle_range.begin(),particle_range.end());
         const unsigned int n_particle_properties = particle_handler.n_properties_per_particle();
@@ -91,7 +69,7 @@ namespace aspect
             else
               {
                 std::vector<typename parallel::distributed::Triangulation<dim>::active_cell_iterator> neighbors;
-                GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(found_cell,neighbors);
+                GridTools::get_active_neighbors<parallel::distributed::Triangulation<dim>>(cell,neighbors);
 
                 unsigned int nearest_neighbor_cell = numbers::invalid_unsigned_int;
                 for (unsigned int i=0; i<neighbors.size(); ++i)


### PR DESCRIPTION
It used to be possible to call the particle interpolators without knowing which cell the interpolated positions were in (e.g. when creating new particles in random locations without checking the cell first). This led to all particle interpolators having backup code in case the cell is not known. By now however, all calls to particle interpolators provide an actual cell, so it is not necessary to carry this (slow) backup code around.

Also remove a deprecated interface function that was deprecated 6 years ago.