### PR TITLE
update clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,29 @@
 # - modernize-concat-nested-namespaces: This is c++17 only.
 # - performance-inefficient-string-concatenation: We don't care about "a"+to_string(5)+...
 # - performance-no-automatic-move: All modern compiler perform the return value optimization and we prefer to keep things const.
+# - performance-enum-size,-performance-avoid-endl: this should not matter much
 # - modernize-avoid-bind: We use std::bind() in core.cc where replacement doesn't make sense (astyle fails to format)
 #
-Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation,-performance-no-automatic-move,-modernize-avoid-bind"
-
+Checks: >
+  -*,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  google-readability-casting,
+  modernize-*,
+  -modernize-pass-by-value,
+  -modernize-raw-string-literal,
+  -modernize-use-auto,
+  -modernize-use-override,
+  -modernize-use-default-member-init,
+  -modernize-use-transparent-functors,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  use-emplace,
+  mpi-*,
+  performance-*,
+  -performance-inefficient-string-concatenation,
+  -performance-no-automatic-move,
+  -modernize-avoid-bind,
+  -performance-enum-size,
+  -performance-avoid-endl


### PR DESCRIPTION
- use multiline formatting
- remove some checks we don't want: enum-size, avoid-endl


FYI @gassmoeller 