### PR TITLE
Add documentation on grain size model

### DIFF
--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -216,8 +216,12 @@ namespace aspect
                        const std::vector<double>                          &pressures,
                        const std::vector<unsigned int>                    &phase_indices) const
     {
-      // we want to iterate over the grain size evolution here, as we solve in fact an ordinary differential equation
-      // and it is not correct to use the starting grain size (and introduces instabilities)
+      // We want to iterate over the grain size evolution here, as we solve in fact an ordinary differential equation
+      // and it is not correct to use the starting grain size (and introduces instabilities).
+      // We assume that the strain rate is constant across all substeps for the ODE (within one advection step).
+      // Even though this assumption may not always be the most accurate (compared to assuming a constant stress),
+      // it leads to a more stable behavior because it implies that a reduction in grain size leads to less work
+      // being done by dislocation creep, so that the grain size reduction rate is lower in the next substep.
       std::vector<std::vector<double>> reaction_terms (in.n_evaluation_points(), std::vector<double>(this->n_compositional_fields(), 0.0));
 
       // Set up a vector that tells us which phase transition has been crossed for each point we are evaluating.

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -217,7 +217,7 @@ namespace aspect
                        const std::vector<unsigned int>                    &phase_indices) const
     {
       // We want to iterate over the grain size evolution here, as we solve in fact an ordinary differential equation
-      // and it is not correct to use the starting grain size (and introduces instabilities).
+      // and it is not correct to use the starting grain size (and it introduces instabilities).
       // We assume that the strain rate is constant across all substeps for the ODE (within one advection step).
       // Even though this assumption may not always be the most accurate (compared to assuming a constant stress),
       // it leads to a more stable behavior because it implies that a reduction in grain size leads to less work

--- a/tests/grain_size_friction_heating.prm
+++ b/tests/grain_size_friction_heating.prm
@@ -1,5 +1,5 @@
 # A test for the grain size material model similar to
-# damage-rheology-strain. The only difference is the activation of shear
+# grain_size_strain.prm. The only difference is the activation of shear
 # heating. In the grain size model, a fraction of the energy dissipated by
 # dislocation creep increases the surface area of grains.
 


### PR DESCRIPTION
During the hackathon, we discussed that it might be more accurate to keep the stress constant in the substeps we do for grain size evolution, rather than keeping the strain rate constant. I still think this is true, but only if the grain size reduction small. For large grain size reduction, keeping the stress constant can lead to a runaway effect: We have a large stress, this reduces the grain size by a lot and leads to a lower viscosity. Usually, a lower viscosity would also mean a lower stress, but keeping the stress constant overestimates the grain size reduction. This effect is especially bad at boundaries where we prescribe the velocity (in other words, the strain rate). 

I tested this both with the grain_size_strain test and with an application model similar to the grain)size_ridge model, and I am attaching two images here to show what I mean. 

For small rates of grain size change, the "new" (constant stress) method is slightly more accurate.
![grain-size-ridge-traction](https://github.com/geodynamics/aspect/assets/7517347/6fabf631-4988-4369-aa8f-d504b2972738)

For large rates of grain size change, the "new" (constant stress) method can leads to a completely wrong result.
![grain-size-ridge-traction_original](https://github.com/geodynamics/aspect/assets/7517347/5b43fb99-d77b-401f-aa18-07f4b91589e4)

Therefore, I think it's better to keep the old method, and I am documenting this in the grain_size_change function.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.

For completeness, below is the prm I used for the test case. 

```
# This is a test for the grain size evolutionn in a realistic
# model setup, in this case, the grain_size_ridge cookbook.
# We make the problem more well-posed

include $ASPECT_SOURCE_DIR/cookbooks/grain_size_ridge/grain_size_ridge.prm

set End time                    = 20000
set Nonlinear solver tolerance  = 1e-5
set Maximum time step           = 50
set Output directory            = grain-size-ridge-ode-50

set Maximum first time step                = 1e300
set Maximum relative increase in time step = 10


subsection Solver parameters
  subsection Stokes solver parameters
    set GMRES solver restart length = 200
    set Number of cheap Stokes solver steps = 5000
    set Stokes solver type = block GMG
    set Linear solver tolerance = 1e-8
  end
end


subsection Mesh refinement
  set Initial global refinement = 4
  set Initial adaptive refinement = 2
  set Minimum refinement level = 4
  set Time steps between mesh refinement = 0
  set Strategy = minimum refinement function

  subsection Minimum refinement function
    set Coordinate system  = cartesian
    set Variable names      = x,y
    set Function expression = if(x*x+(y-200000)*(y-200000) < 60000*60000, 6, 4)
    set Function expression = if((y-200000)*(y-200000) < 60000*60000, 6, 4)
  end
end


subsection Geometry model
  set Model name = box
  subsection Box
    set X extent  = 410000
    set Y extent  = 200000
    set X repetitions = 2
    set Y repetitions = 1
  end
end


subsection Boundary velocity model
  set Tangential velocity boundary indicators = left, top
  set Prescribed velocity boundary indicators = bottom x: function, right y:function

  subsection Function
    set Variable names      = x,y
    set Function expression = 0; 0     #0.05*0.5*(1.0+tanh(0.00005*(y-140000))); 0
  end
end



subsection Boundary traction model
  set Prescribed traction boundary indicators = right x:initial lithostatic pressure, bottom y:initial lithostatic pressure

  subsection Initial lithostatic pressure
    set Representative point         = 60000, 0
    set Number of integration points = 10000
  end
end



# Larger conductivity to make up for the smaller model domain.
subsection Material model
  set Material averaging = harmonic average only viscosity
  subsection Grain size model
    set Thermal conductivity  = 20
    set Maximum viscosity     = 1e23
    set Work fraction for boundary area change      = 0.5
  end
end


subsection Initial temperature model
  set List of model names = adiabatic
  subsection Adiabatic
    set Age bottom boundary layer   = 0.0
    set Top boundary layer age model = function

    subsection Age function
      set Function expression = max((x-10000) / 0.05, 0)
    end
  end
end


# Make the grain size constant everywhere.
subsection Initial composition model
  set Model name = function
  subsection Function
    set Function expression = 5e-3
    set Variable names      = x,y
  end
end


subsection Postprocess
  set List of postprocessors = composition statistics, velocity statistics, mass flux statistics, particles

  subsection Particles
    set Number of particles = 500000
    set Minimum particles per cell = 40
    set Maximum particles per cell = 640
    set Time between data output = 1e100
    set Data output format       = none
  end

  subsection Visualization
    set List of output variables      = material properties, nonadiabatic temperature, nonadiabatic pressure, strain rate, named additional outputs, shear stress
  end
end
```