### PR TITLE
Provide a base class for plugin manager classes.

### DIFF
--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -217,7 +217,6 @@ namespace aspect
          * A function that is called at the beginning of each time step,
          * calling the update function of the individual heating models.
          */
-        virtual
         void
         update () override;
 

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -188,6 +188,120 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm);
     };
+
+
+
+    /**
+     * A base class for "plugin manager" classes. Plugin manager classes are
+     * used in places where one can legitimately use more than one plugin of
+     * a certain kind. For example, while there can only ever be one geometry
+     * (and consequently, the Simulator class only stores a single object of
+     * type derived from GeometryModels::Interface), one can have many different
+     * postprocessor objects at the same time. In these circumstances, the
+     * Simulator class stores a Postprocess::Manager object that internally
+     * stores zero or more objects of type derived from Postprocess::Interface.
+     * Since there are many places inside ASPECT where we need these "plugin
+     * manager" classes, the current class provides some common functionality
+     * to all of these classes.
+     *
+     * The class takes as template argument the type of the derived
+     * class's interface type. Since a manager is always also a plugin
+     * (to the Simulator class) itself, the current class is derived from
+     * the `InterfaceBase` class as well.
+     */
+    template <typename InterfaceType>
+    class ManagerBase : public InterfaceBase
+    {
+      public:
+        /**
+         * A function that is called at the beginning of each time step,
+         * calling the update function of the individual heating models.
+         */
+        void
+        update ();
+
+        /**
+         * Go through the list of all plugins that have been selected
+         * in the input file (and are consequently currently active) and return
+         * true if one of them has the desired type specified by the template
+         * argument.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
+         */
+        template <typename PluginType,
+                  typename = typename std::enable_if_t<std::is_base_of<InterfaceType,PluginType>::value>>
+        bool
+        has_matching_plugin_object () const;
+
+        /**
+         * Go through the list of all plugins that have been selected
+         * in the input file (and are consequently currently active) and see
+         * if one of them has the type specified by the template
+         * argument or can be cast to that type. If so, return a reference
+         * to it. If no postprocessor is active that matches the given type,
+         * throw an exception.
+         *
+         * This function can only be called if the given template type (the first template
+         * argument) is a class derived from the Interface class in this namespace.
+         */
+        template <typename PluginType,
+                  typename = typename std::enable_if_t<std::is_base_of<InterfaceType,PluginType>::value>>
+        const PluginType &
+        get_matching_plugin_object () const;
+
+      protected:
+        /**
+         * A list of plugin objects that have been requested in the
+         * parameter file.
+         */
+        std::list<std::unique_ptr<InterfaceType>> plugin_objects;
+    };
+
+
+    template <typename InterfaceType>
+    void ManagerBase<InterfaceType>::update()
+    {
+      for (const auto &plugin : plugin_objects)
+        {
+          plugin->update();
+        }
+    }
+
+
+    template <typename InterfaceType>
+    template <typename PluginType, typename>
+    inline
+    bool
+    ManagerBase<InterfaceType>::has_matching_plugin_object () const
+    {
+      for (const auto &p : plugin_objects)
+        if (Plugins::plugin_type_matches<PluginType>(*p))
+          return true;
+      return false;
+    }
+
+
+    template <typename InterfaceType>
+    template <typename PluginType, typename>
+    inline
+    const PluginType &
+    ManagerBase<InterfaceType>::get_matching_plugin_object () const
+    {
+      AssertThrow(has_matching_plugin_object<PluginType> (),
+                  ExcMessage("You asked the object managing a collection of plugins for a "
+                             "plugin object of type <" + boost::core::demangle(typeid(PluginType).name()) + "> "
+                             "that could not be found in the current model. You need to "
+                             "activate this plugin in the input file for it to be "
+                             "available."));
+
+      for (const auto &p : plugin_objects)
+        if (Plugins::plugin_type_matches<PluginType>(*p))
+          return Plugins::get_plugin_as_type<PluginType>(*p);
+
+      // We will never get here, because we had the Assert above. Just to avoid warnings.
+      return Plugins::get_plugin_as_type<PluginType>(**(plugin_objects.begin()));
+    }
   }
 
   namespace internal

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -217,8 +217,9 @@ namespace aspect
          * A function that is called at the beginning of each time step,
          * calling the update function of the individual heating models.
          */
+        virtual
         void
-        update ();
+        update () override;
 
         /**
          * Go through the list of all plugins that have been selected

--- a/tests/find_postprocess_fail_1/screen-output
+++ b/tests/find_postprocess_fail_1/screen-output
@@ -11,17 +11,17 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage("You asked Postprocess::Manager::get_matching_postprocessor() for a " "postprocessor of type <" + boost::core::demangle(typeid(PostprocessorType).name()) + "> " "that could not be found in the current model. Activate this " "postprocessor in the input file.")' on rank 0 on processing: 
+Exception 'ExcMessage("You asked the object managing a collection of plugins for a " "plugin object of type <" + boost::core::demangle(typeid(PluginType).name()) + "> " "that could not be found in the current model. You need to " "activate this plugin in the input file for it to be " "available.")' on rank 0 on processing: 
 
-An error occurred in file <interface.h> in function
+An error occurred in file <plugins.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    has_matching_postprocessor<PostprocessorType> ()
+    has_matching_plugin_object<PluginType> ()
 Additional information: 
-    You asked Postprocess::Manager::get_matching_postprocessor() for a
-    postprocessor of type <aspect::Postprocess::PressureStatistics<2>>
-    that could not be found in the current model. Activate this
-    postprocessor in the input file.
+    You asked the object managing a collection of plugins for a plugin
+    object of type <aspect::Postprocess::PressureStatistics<2>> that could
+    not be found in the current model. You need to activate this plugin in
+    the input file for it to be available.
 
 Stacktrace:
 (rest of the output replaced by default.sh script)


### PR DESCRIPTION
This is a bit like #1807 in that it provides a base class for the various `Manager` classes. This PR also converts two of the manager class to use the common base class. The remaining ones will follow later.

Observations:
* There isn't quite as much commonality, or at least it's not as easy to refactor.
* A nuisance is that the different `Manager` classes use different names for the same functionality. For example, we have `Postprocessor::Manager<dim>::has_matching_postprocessor()` but `HeatingModels::Manager<dim>::has_matching_heating_model()`. Both do the same, but because they have different names I can't abstract them into the base class (though I have abstracted their *functionality* into the base class).