### PR TITLE
Remove deprecated particle update function

### DIFF
--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -89,6 +89,11 @@ namespace aspect
           /**
            * Update function. This function is called every time an update is
            * request by need_update() for every particle for every property.
+           * It is obvious that
+           * this function is called a lot, so its code should be efficient.
+           * The interface provides a default implementation that does nothing,
+           * therefore derived plugins that do not require an update do not
+           * need to implement this function.
            *
            * @param [in] data_position An unsigned integer that denotes which
            * component of the particle property vector is associated with the
@@ -96,23 +101,22 @@ namespace aspect
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
-           * @param [in] position The current particle position.
-           *
            * @param [in] solution The values of the solution variables at the
            * current particle position.
            *
            * @param [in] gradients The gradients of the solution variables at
            * the current particle position.
            *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
+           * @param [in,out] particle The particle that is updated within
+           * the call of this function. The particle location can be accessed
+           * using particle->get_location() and its properties using
+           * particle->get_properties().
            */
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim>> &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim>> &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -91,7 +91,12 @@ namespace aspect
 
           /**
            * Update function. This function is called every time an update is
-           * requested by need_update() for every particle for every property.
+           * request by need_update() for every particle for every property.
+           * It is obvious that
+           * this function is called a lot, so its code should be efficient.
+           * The interface provides a default implementation that does nothing,
+           * therefore derived plugins that do not require an update do not
+           * need to implement this function.
            *
            * @param [in] data_position An unsigned integer that denotes which
            * component of the particle property vector is associated with the
@@ -99,23 +104,22 @@ namespace aspect
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
-           * @param [in] position The current particle position.
-           *
            * @param [in] solution The values of the solution variables at the
            * current particle position.
            *
            * @param [in] gradients The gradients of the solution variables at
            * the current particle position.
            *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
+           * @param [in,out] particle The particle that is updated within
+           * the call of this function. The particle location can be accessed
+           * using particle->get_location() and its properties using
+           * particle->get_properties().
            */
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim>> &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim>> &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
 
           /**
            * This function tells the particle manager that

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -160,6 +160,11 @@ namespace aspect
           /**
            * Update function. This function is called every time an update is
            * request by need_update() for every particle for every property.
+           * It is obvious that
+           * this function is called a lot, so its code should be efficient.
+           * The interface provides a default implementation that does nothing,
+           * therefore derived plugins that do not require an update do not
+           * need to implement this function.
            *
            * @param [in] data_position An unsigned integer that denotes which
            * component of the particle property vector is associated with the
@@ -167,23 +172,22 @@ namespace aspect
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
-           * @param [in] position The current particle position.
-           *
            * @param [in] solution The values of the solution variables at the
            * current particle position.
            *
            * @param [in] gradients The gradients of the solution variables at
            * the current particle position.
            *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
+           * @param [in,out] particle The particle that is updated within
+           * the call of this function. The particle location can be accessed
+           * using particle->get_location() and its properties using
+           * particle->get_properties().
            */
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim>> &gradients,
-                                        const ArrayView<double> &particle_properties) const override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim>> &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -217,31 +217,35 @@ namespace aspect
 
           /**
            * Update function. This function is called every time an update is
-           * requested by need_update() for every particle for every property.
+           * request by need_update() for every particle for every property.
+           * It is obvious that
+           * this function is called a lot, so its code should be efficient.
+           * The interface provides a default implementation that does nothing,
+           * therefore derived plugins that do not require an update do not
+           * need to implement this function.
            *
-           * @param [in] data_position. An unsigned integer that denotes which
+           * @param [in] data_position An unsigned integer that denotes which
            * component of the particle property vector is associated with the
            * current property. For properties that own several components it
            * denotes the first component of this property, all other components
            * fill consecutive entries in the @p particle_properties vector.
            *
-           * @param [in] position. The current particle position.
-           *
-           * @param [in] solution. The values of the solution variables at the
+           * @param [in] solution The values of the solution variables at the
            * current particle position.
            *
-           * @param [in] gradients. The gradients of the solution variables at
+           * @param [in] gradients The gradients of the solution variables at
            * the current particle position.
            *
-           * @param [in,out] particle_properties. The properties of the particle
-           * that is updated within the call of this function.
+           * @param [in,out] particle The particle that is updated within
+           * the call of this function. The particle location can be accessed
+           * using particle->get_location() and its properties using
+           * particle->get_properties().
            */
           void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim>> &gradients,
-                                        const ArrayView<double> &particle_properties) const  override;
+          update_particle_property (const unsigned int data_position,
+                                    const Vector<double> &solution,
+                                    const std::vector<Tensor<1,dim>> &gradients,
+                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
 
           /**
            * This function tells the particle manager that

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -357,42 +357,6 @@ namespace aspect
                                     const std::vector<Tensor<1,dim>> &gradients,
                                     typename ParticleHandler<dim>::particle_iterator &particle) const;
 
-          /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           * It is obvious that
-           * this function is called a lot, so its code should be efficient.
-           * The interface provides a default implementation that does nothing,
-           * therefore derived plugins that do not require an update do not
-           * need to implement this function.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] position The current particle position.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle_properties The properties of the particle
-           * that is updated within the call of this function.
-           *
-           * @deprecated Use update_particle_property() instead.
-           */
-          DEAL_II_DEPRECATED
-          virtual
-          void
-          update_one_particle_property (const unsigned int data_position,
-                                        const Point<dim> &position,
-                                        const Vector<double> &solution,
-                                        const std::vector<Tensor<1,dim>> &gradients,
-                                        const ArrayView<double> &particle_properties) const;
 
           /**
            * Returns an enum, which determines at what times particle properties

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -87,14 +87,14 @@ namespace aspect
 
       template <int dim>
       void
-      CpoBinghamAverage<dim>::update_one_particle_property(const unsigned int data_position,
-                                                           const Point<dim> &,
-                                                           const Vector<double> &,
-                                                           const std::vector<Tensor<1,dim>> &,
-                                                           const ArrayView<double> &data) const
+      CpoBinghamAverage<dim>::update_particle_property(const unsigned int data_position,
+                                                       const Vector<double> &/*solution*/,
+                                                       const std::vector<Tensor<1,dim>> &/*gradients*/,
+                                                       typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         std::vector<double> volume_fractions_grains(n_grains);
         std::vector<Tensor<2,3>> rotation_matrices_grains(n_grains);
+        ArrayView<double> data = particle->get_properties();
         for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
           {
             // create volume fractions and rotation matrix vectors in the order that it is stored in the data array

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -140,11 +140,10 @@ namespace aspect
 
       template <int dim>
       void
-      CpoElasticTensor<dim>::update_one_particle_property(const unsigned int data_position,
-                                                          const Point<dim> &,
-                                                          const Vector<double> &,
-                                                          const std::vector<Tensor<1,dim>> &,
-                                                          const ArrayView<double> &data) const
+      CpoElasticTensor<dim>::update_particle_property(const unsigned int data_position,
+                                                      const Vector<double> &/*solution*/,
+                                                      const std::vector<Tensor<1,dim>> &/*gradients*/,
+                                                      typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         // Get a reference to the CPO particle property.
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
@@ -153,10 +152,10 @@ namespace aspect
 
         const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
                                                                             cpo_data_position,
-                                                                            data);
+                                                                            particle->get_properties());
 
         Particle::Property::CpoElasticTensor<dim>::set_elastic_tensor(data_position,
-                                                                      data,
+                                                                      particle->get_properties(),
                                                                       C_average);
 
 

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -230,11 +230,10 @@ namespace aspect
 
       template <int dim>
       void
-      CrystalPreferredOrientation<dim>::update_one_particle_property(const unsigned int data_position,
-                                                                     const Point<dim> &position,
-                                                                     const Vector<double> &solution,
-                                                                     const std::vector<Tensor<1,dim>> &gradients,
-                                                                     const ArrayView<double> &data) const
+      CrystalPreferredOrientation<dim>::update_particle_property(const unsigned int data_position,
+                                                                 const Vector<double> &solution,
+                                                                 const std::vector<Tensor<1,dim>> &gradients,
+                                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
       {
         // STEP 1: Load data and preprocess it.
 
@@ -302,6 +301,8 @@ namespace aspect
             velocity_gradient_3d[2][2] = velocity_gradient[2][2];
           }
 
+        ArrayView<double> data = particle->get_properties();
+
         for (unsigned int mineral_i = 0; mineral_i < n_minerals; ++mineral_i)
           {
 
@@ -318,7 +319,7 @@ namespace aspect
                                                            mineral_i,
                                                            strain_rate_3d,
                                                            velocity_gradient_3d,
-                                                           position,
+                                                           particle->get_location(),
                                                            temperature,
                                                            pressure,
                                                            velocity,

--- a/source/particle/property/elastic_tensor_decomposition.cc
+++ b/source/particle/property/elastic_tensor_decomposition.cc
@@ -351,15 +351,14 @@ namespace aspect
 
       template <int dim>
       void
-      ElasticTensorDecomposition<dim>::update_one_particle_property(const unsigned int data_position,
-                                                                    const Point<dim> &,
-                                                                    const Vector<double> &,
-                                                                    const std::vector<Tensor<1,dim>> &,
-                                                                    const ArrayView<double> &data) const
+      ElasticTensorDecomposition<dim>::update_particle_property(const unsigned int data_position,
+                                                                const Vector<double> &/*solution*/,
+                                                                const std::vector<Tensor<1,dim>> &/*gradients*/,
+                                                                typename ParticleHandler<dim>::particle_iterator &particle) const
       {
+        ArrayView<double> data = particle->get_properties();
         const SymmetricTensor<2,6> elastic_matrix = Particle::Property::CpoElasticTensor<dim>::get_elastic_tensor(cpo_elastic_tensor_data_position,
                                                     data);
-
 
         const SymmetricTensor<2,3> dilatation_stiffness_tensor_full = Utilities::compute_dilatation_stiffness_tensor(elastic_matrix);
         const SymmetricTensor<2,3> voigt_stiffness_tensor_full = Utilities::compute_voigt_stiffness_tensor(elastic_matrix);

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -206,36 +206,6 @@ namespace aspect
 
 
 
-      DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-      template <int dim>
-      void
-      Interface<dim>::update_particle_property (const unsigned int data_position,
-                                                const Vector<double> &solution,
-                                                const std::vector<Tensor<1,dim>> &gradients,
-                                                typename ParticleHandler<dim>::particle_iterator &particle) const
-      {
-        // call the deprecated version of this function
-        update_one_particle_property(data_position,
-                                     particle->get_location(),
-                                     solution,
-                                     gradients,
-                                     particle->get_properties());
-      }
-      DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::update_one_particle_property (const unsigned int,
-                                                    const Point<dim> &,
-                                                    const Vector<double> &,
-                                                    const std::vector<Tensor<1,dim>> &,
-                                                    const ArrayView<double> &) const
-      {}
-
-
-
       template <int dim>
       UpdateTimeFlags
       Interface<dim>::need_update () const
@@ -270,6 +240,16 @@ namespace aspect
       {
         data.resize(data.size() + n_integrator_properties, 0.0);
       }
+
+
+
+      template <int dim>
+      void
+      Interface<dim>::update_particle_property (const unsigned int /*data_position*/,
+                                                const Vector<double> &/*solution*/,
+                                                const std::vector<Tensor<1,dim>> &/*gradients*/,
+                                                typename ParticleHandler<dim>::particle_iterator &/*particle*/) const
+      {}
 
 
 


### PR DESCRIPTION
We had an outdated particle update interface function, which was deprecated 4 years ago. In order to modernize the update interface as a first step I remove this function in this PR. Unfortunately, I didnt notice during review that the CPO particle plugins use this function (I do not know why we got no deprecation warnings?). Therefore I update the use of the update function in the CPO related particle plugins as well.

The header files contain a lot of copy-pasted documentation, let me know if you want me to remove that.