### PR TITLE
Escape backslashes in documentation

### DIFF
--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -437,7 +437,7 @@ namespace aspect
                              "The specific rate of heating due to radioactive decay (or other bulk sources "
                              "you may want to describe). This parameter corresponds to the variable "
                              "$H$ in the temperature equation stated in the manual, and the heating "
-                             "term is $\rho H$. Units: W/kg.");
+                             "term is $\\rho H$. Units: W/kg.");
         }
         prm.leave_subsection();
       }

--- a/source/heating_model/constant_heating.cc
+++ b/source/heating_model/constant_heating.cc
@@ -57,7 +57,7 @@ namespace aspect
                              "The specific rate of heating due to radioactive decay (or other bulk sources "
                              "you may want to describe). This parameter corresponds to the variable "
                              "$H$ in the temperature equation stated in the manual, and the heating "
-                             "term is $\rho H$. Units: W/kg.");
+                             "term is $\\rho H$. Units: W/kg.");
         }
         prm.leave_subsection();
       }


### PR DESCRIPTION
Found these, because they confuse the update script in #5394.