### PR TITLE
Refactor defect correction and newton solver to standardize methods and output

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -680,8 +680,8 @@ namespace aspect
        * number of iterations is reached. This can greatly improve the
        * convergence rate for particularly nonlinear viscosities.
        *
-       * @param use_newton_iterations Sets whether this should function as a defect
-       * correction iterations (use_newton_iterations = false) or as a Newton iteration
+       * @param use_newton_iterations Sets whether this function should only use defect
+       * correction iterations (use_newton_iterations = false) or also use Newton iterations
        * (use_newton_iterations = true).
        *
        * This function is implemented in
@@ -701,8 +701,8 @@ namespace aspect
        * number of iterations is reached. This can greatly improve the
        * convergence rate for particularly nonlinear viscosities.
        *
-       * @param use_newton_iterations Sets whether this should function as a defect
-       * correction iterations (use_newton_iterations = false) or as a Newton iteration
+       * @param use_newton_iterations Sets whether this function should only use defect
+       * correction iterations (use_newton_iterations = false) or also use Newton iterations
        * (use_newton_iterations = true).
        *
        * This function is implemented in

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -680,10 +680,14 @@ namespace aspect
        * number of iterations is reached. This can greatly improve the
        * convergence rate for particularly nonlinear viscosities.
        *
+       * @param use_newton_iterations Sets whether this should function as a defect
+       * correction iterations (use_newton_iterations = false) or as a Newton iteration
+       * (use_newton_iterations = true).
+       *
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_iterated_advection_and_newton_stokes ();
+      void solve_iterated_advection_and_newton_stokes (bool use_newton_iterations);
 
       /**
        * This function implements one scheme for the various
@@ -697,10 +701,14 @@ namespace aspect
        * number of iterations is reached. This can greatly improve the
        * convergence rate for particularly nonlinear viscosities.
        *
+       * @param use_newton_iterations Sets whether this should function as a defect
+       * correction iterations (use_newton_iterations = false) or as a Newton iteration
+       * (use_newton_iterations = true).
+       *
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_single_advection_and_iterated_newton_stokes ();
+      void solve_single_advection_and_iterated_newton_stokes (bool use_newton_iterations);
 
       /**
        * This function implements one scheme for the various

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1902,13 +1902,13 @@ namespace aspect
 
         case NonlinearSolver::iterated_Advection_and_Newton_Stokes:
         {
-          solve_iterated_advection_and_newton_stokes();
+          solve_iterated_advection_and_newton_stokes(/*use_newton_iterations =*/ true);
           break;
         }
 
         case NonlinearSolver::single_Advection_iterated_Newton_Stokes:
         {
-          solve_single_advection_and_iterated_newton_stokes();
+          solve_single_advection_and_iterated_newton_stokes(/*use_newton_iterations =*/ true);
           break;
         }
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -976,7 +976,7 @@ namespace aspect
         // write the residual output in the same order as the solutions
         pcout << "      Relative nonlinear residuals (temperature"
               << (introspection.n_compositional_fields > 0 ? ", compositional fields" : "")
-              << ", Stokes system):" << relative_temperature_residual;
+              << ", Stokes system): " << relative_temperature_residual;
         for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
           pcout << ", " << relative_composition_residual[c];
         pcout << ", " << relative_nonlinear_stokes_residual;
@@ -1167,7 +1167,7 @@ namespace aspect
         // write the residual output in the same order as the solutions
         pcout << "      Relative nonlinear residuals (temperature"
               << (introspection.n_compositional_fields > 0 ? ", compositional fields" : "")
-              << ", Stokes system):" << relative_temperature_residual;
+              << ", Stokes system): " << relative_temperature_residual;
         for (unsigned int c=0; c<introspection.n_compositional_fields; ++c)
           pcout << ", " << relative_composition_residual[c];
         pcout << ", " << dcr.residual/dcr.initial_residual << std::endl;

--- a/tests/compute-no-normal-flux-constraints/screen-output
+++ b/tests/compute-no-normal-flux-constraints/screen-output
@@ -7,10 +7,12 @@ Number of degrees of freedom: 1,836 (1,122+153+561)
    Initial Newton Stokes residual = 2.98201e+13, v = 2.98201e+13, p = 0
 
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 2.98201e+13
+      Newton system information: Norm of the rhs: 2.98201e+13
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.95854e-12, norm of the rhs: 58.4038, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 58.4038, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 1.95854e-12
 
 
    Postprocessing:
@@ -27,7 +29,8 @@ Number of degrees of freedom: 1,836 (1,122+153+561)
    Initial Newton Stokes residual = 1.83248e+13, v = 1.83248e+13, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.52443e-12, norm of the rhs: 64.5845
+      Newton system information: Norm of the rhs: 64.5845
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 3.52443e-12
 
 
    Postprocessing:

--- a/tests/continental_extension/screen-output
+++ b/tests/continental_extension/screen-output
@@ -15,7 +15,8 @@ Number of mesh deformation degrees of freedom: 462
    Initial Newton Stokes residual = 2.88429e+14, v = 2.79119e+14, p = 7.26906e+13
 
    Solving Stokes system... 0+56 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 2.88429e+14
+      Newton system information: Norm of the rhs: 2.88429e+14
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -33,7 +34,8 @@ Number of mesh deformation degrees of freedom: 462
    Initial Newton Stokes residual = 1.57637e+14, v = 1.57164e+14, p = 1.21967e+13
 
    Solving Stokes system... 0+21 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.149257, norm of the rhs: 2.35285e+13
+      Newton system information: Norm of the rhs: 2.35285e+13
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.149257
 
 
    Postprocessing:

--- a/tests/dc_Picard_compressible/screen-output
+++ b/tests/dc_Picard_compressible/screen-output
@@ -8,16 +8,20 @@ Number of degrees of freedom: 53,952 (25,344+3,264+12,672+12,672)
    Initial Newton Stokes residual = 3.96803e+15, v = 3.96803e+15, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 3.96803e+15
+      Newton system information: Norm of the rhs: 3.96803e+15
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.000373076, norm of the rhs: 1.48038e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.48038e+12, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.000373076
 
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 6.9755e-05, norm of the rhs: 2.7679e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.7679e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 6.9755e-05
 
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 7.99759e-06, norm of the rhs: 3.17347e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.17347e+10, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 7.99759e-06
 
 
    Postprocessing:

--- a/tests/free_surface_iterated_IMPES/screen-output
+++ b/tests/free_surface_iterated_IMPES/screen-output
@@ -8,12 +8,12 @@ Number of mesh deformation degrees of freedom: 1,394
    Solving mesh displacement system... 0 iterations.
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.45124e-16, 0.00104778
+      Relative nonlinear residuals (temperature, Stokes system): 2.45124e-16, 0.00104778
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00104778
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.45124e-16, 3.59962e-11
+      Relative nonlinear residuals (temperature, Stokes system): 2.45124e-16, 3.59962e-11
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.59962e-11
 
 
@@ -26,12 +26,12 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 0 iterations.
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19446e-16, 0.000806375
+      Relative nonlinear residuals (temperature, Stokes system): 2.19446e-16, 0.000806375
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000806375
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.19446e-16, 5.22562e-11
+      Relative nonlinear residuals (temperature, Stokes system): 2.19446e-16, 5.22562e-11
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.22562e-11
 
 
@@ -58,22 +58,22 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 0+25 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.320951, 0.00144364
+      Relative nonlinear residuals (temperature, Stokes system): 0.320951, 0.00144364
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.320951
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+20 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00829076, 5.72382e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0.00829076, 5.72382e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00829076
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.43963e-05, 1.6247e-08
+      Relative nonlinear residuals (temperature, Stokes system): 2.43963e-05, 1.6247e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.43963e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+2 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.70131e-08, 1.74103e-10
+      Relative nonlinear residuals (temperature, Stokes system): 6.70131e-08, 1.74103e-10
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.70131e-08
 
 
@@ -85,22 +85,22 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 9 iterations.
    Solving Stokes system... 0+29 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.419186, 0.00677762
+      Relative nonlinear residuals (temperature, Stokes system): 0.419186, 0.00677762
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.419186
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+24 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0194066, 1.40055e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0.0194066, 1.40055e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0194066
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+17 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.79182e-05, 4.10079e-08
+      Relative nonlinear residuals (temperature, Stokes system): 5.79182e-05, 4.10079e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.79182e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.43516e-07, 1.61706e-10
+      Relative nonlinear residuals (temperature, Stokes system): 1.43516e-07, 1.61706e-10
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.43516e-07
 
 
@@ -112,22 +112,22 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+25 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0847437, 0.00181183
+      Relative nonlinear residuals (temperature, Stokes system): 0.0847437, 0.00181183
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0847437
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 0+21 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0048184, 3.52043e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0.0048184, 3.52043e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0048184
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 0+13 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.04072e-05, 7.4745e-09
+      Relative nonlinear residuals (temperature, Stokes system): 1.04072e-05, 7.4745e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.04072e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.88609e-08, 6.35965e-11
+      Relative nonlinear residuals (temperature, Stokes system): 1.88609e-08, 6.35965e-11
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.88609e-08
 
 
@@ -139,17 +139,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+26 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0275512, 0.000988103
+      Relative nonlinear residuals (temperature, Stokes system): 0.0275512, 0.000988103
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0275512
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 0+21 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00239853, 1.73869e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0.00239853, 1.73869e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00239853
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 0+11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.54917e-06, 3.94504e-09
+      Relative nonlinear residuals (temperature, Stokes system): 5.54917e-06, 3.94504e-09
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.54917e-06
 
 
@@ -161,17 +161,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+25 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.019331, 0.000130973
+      Relative nonlinear residuals (temperature, Stokes system): 0.019331, 0.000130973
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.019331
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 0+18 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000506481, 3.62159e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0.000506481, 3.62159e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000506481
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.23065e-06, 8.65112e-10
+      Relative nonlinear residuals (temperature, Stokes system): 1.23065e-06, 8.65112e-10
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.23065e-06
 
 
@@ -186,17 +186,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+26 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0120717, 6.58442e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0.0120717, 6.58442e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0120717
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 0+17 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000249238, 1.75391e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0.000249238, 1.75391e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000249238
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.91221e-07, 4.13331e-10
+      Relative nonlinear residuals (temperature, Stokes system): 5.91221e-07, 4.13331e-10
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.91221e-07
 
 
@@ -208,17 +208,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+25 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00838215, 3.31867e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0.00838215, 3.31867e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00838215
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+17 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000127077, 8.7942e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.000127077, 8.7942e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000127077
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.96048e-07, 2.04552e-10
+      Relative nonlinear residuals (temperature, Stokes system): 2.96048e-07, 2.04552e-10
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.96048e-07
 
 
@@ -230,17 +230,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+24 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00622733, 1.70895e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0.00622733, 1.70895e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00622733
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+16 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.01307e-05, 4.07523e-08
+      Relative nonlinear residuals (temperature, Stokes system): 6.01307e-05, 4.07523e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.01307e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+5 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.3875e-07, 9.9688e-11
+      Relative nonlinear residuals (temperature, Stokes system): 1.3875e-07, 9.9688e-11
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.3875e-07
 
 
@@ -252,17 +252,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00489473, 9.21671e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0.00489473, 9.21671e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00489473
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+16 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.34711e-05, 2.23078e-08
+      Relative nonlinear residuals (temperature, Stokes system): 3.34711e-05, 2.23078e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.34711e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.53124e-08, 5.45534e-11
+      Relative nonlinear residuals (temperature, Stokes system): 7.53124e-08, 5.45534e-11
       Relative nonlinear residual (total system) after nonlinear iteration 3: 7.53124e-08
 
 
@@ -274,17 +274,17 @@ Number of mesh deformation degrees of freedom: 1,466
    Solving mesh displacement system... 5 iterations.
    Solving temperature system... 8 iterations.
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00400255, 5.37243e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0.00400255, 5.37243e-06
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00400255
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 0+16 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.57868e-05, 1.02615e-08
+      Relative nonlinear residuals (temperature, Stokes system): 1.57868e-05, 1.02615e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.57868e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.57585e-08, 2.8558e-11
+      Relative nonlinear residuals (temperature, Stokes system): 3.57585e-08, 2.8558e-11
       Relative nonlinear residual (total system) after nonlinear iteration 3: 3.57585e-08
 
 

--- a/tests/grain_size_plunge/screen-output
+++ b/tests/grain_size_plunge/screen-output
@@ -5,260 +5,260 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 5e+12
+      Newton system information: Norm of the rhs: 5e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.839327, norm of the rhs: 4.19663e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.19663e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.839327
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.839327
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.704451, norm of the rhs: 3.52226e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.52226e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.704451
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.704451
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.556303, norm of the rhs: 2.78152e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.78152e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.556303
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.556303
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.418266, norm of the rhs: 2.09133e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.09133e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.418266
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.418266
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.303134, norm of the rhs: 1.51567e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.51567e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.303134
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.303134
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.213981, norm of the rhs: 1.06991e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.06991e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.213981
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.213981
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.148296, norm of the rhs: 7.41481e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.41481e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.148296
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.148296
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.101484, norm of the rhs: 5.07421e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.07421e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.101484
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.101484
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.0688553, norm of the rhs: 3.44277e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.44277e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0688553
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0688553
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.0464471, norm of the rhs: 2.32236e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.32236e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0464471
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0464471
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.0312095, norm of the rhs: 1.56048e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.56048e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0312095
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0312095
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.0209161, norm of the rhs: 1.04581e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.04581e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0209161
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0209161
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.0139931, norm of the rhs: 6.99657e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.99657e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0139931
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.0139931
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00935066, norm of the rhs: 4.67533e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.67533e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00935066
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00935066
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00624353, norm of the rhs: 3.12176e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.12176e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00624353
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00624353
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.00416669, norm of the rhs: 2.08335e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.08335e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00416669
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00416669
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.00277973, norm of the rhs: 1.38986e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.38986e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00277973
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.00277973
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.00185401, norm of the rhs: 9.27006e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.27006e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00185401
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.00185401
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.00123639, norm of the rhs: 6.18195e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.18195e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00123639
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.00123639
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.00082443, norm of the rhs: 4.12215e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.12215e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00082443
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.00082443
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.000549696, norm of the rhs: 2.74848e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.74848e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000549696
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000549696
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000366497, norm of the rhs: 1.83249e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.83249e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000366497
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000366497
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000244347, norm of the rhs: 1.22173e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.22173e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000244347
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000244347
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000162904, norm of the rhs: 8.14522e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.14522e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000162904
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000162904
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.000108606, norm of the rhs: 5.43029e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.43029e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000108606
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000108606
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 7.24052e-05, norm of the rhs: 3.62026e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.62026e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 7.24052e-05
       Relative nonlinear residual (total system) after nonlinear iteration 27: 7.24052e-05
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 4.82707e-05, norm of the rhs: 2.41354e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.41354e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 4.82707e-05
       Relative nonlinear residual (total system) after nonlinear iteration 28: 4.82707e-05
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 3.21807e-05, norm of the rhs: 1.60904e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.60904e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 3.21807e-05
       Relative nonlinear residual (total system) after nonlinear iteration 29: 3.21807e-05
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 2.14539e-05, norm of the rhs: 1.0727e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.0727e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 2.14539e-05
       Relative nonlinear residual (total system) after nonlinear iteration 30: 2.14539e-05
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 1.43027e-05, norm of the rhs: 7.15134e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.15134e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 1.43027e-05
       Relative nonlinear residual (total system) after nonlinear iteration 31: 1.43027e-05
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.10201e-16, 1.58051e-16
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 9.53514e-06, norm of the rhs: 4.76757e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.76757e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 9.53514e-06
       Relative nonlinear residual (total system) after nonlinear iteration 32: 9.53514e-06
 
 
@@ -272,20 +272,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 1:  t=10 years, dt=10 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0, 0.00130736
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.81353, norm of the rhs: 4.06765e+12
+      Newton system information: Norm of the rhs: 4.06765e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00130736, 0.81353
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.81353
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.46417e-16, 3.39288e-06
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.23785e-06, norm of the rhs: 2.11893e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.11893e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.46417e-16, 3.39288e-06, 4.23785e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.23785e-06
 
 
@@ -298,20 +298,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 2:  t=20.1 years, dt=10.1 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.07453e-16, 2.28817e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813544, norm of the rhs: 4.06772e+12
+      Newton system information: Norm of the rhs: 4.06772e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.07453e-16, 2.28817e-06, 0.813544
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813544
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.46692e-16, 2.70691e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.94377e-07, norm of the rhs: 2.47189e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.47189e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.46692e-16, 2.70691e-09, 4.94377e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 4.94377e-07
 
 
@@ -324,20 +324,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 3:  t=30.301 years, dt=10.201 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 7.33458e-17, 3.11984e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.81355, norm of the rhs: 4.06775e+12
+      Newton system information: Norm of the rhs: 4.06775e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-17, 3.11984e-06, 0.81355
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.81355
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0, 6.94872e-10
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.34395e-06, norm of the rhs: 1.17197e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.17197e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.94872e-10, 2.34395e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.34395e-06
 
 
@@ -350,20 +350,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 4:  t=40.604 years, dt=10.303 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 7.33458e-16, 3.45764e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813549, norm of the rhs: 4.06774e+12
+      Newton system information: Norm of the rhs: 4.06774e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-16, 3.45764e-06, 0.813549
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813549
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 7.33458e-16, 1.15975e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.872e-06, norm of the rhs: 9.35999e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.35999e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-16, 1.15975e-09, 1.872e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.872e-06
 
 
@@ -376,20 +376,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 5:  t=51.0101 years, dt=10.406 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 9.39284e-16, 3.62082e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813545, norm of the rhs: 4.06772e+12
+      Newton system information: Norm of the rhs: 4.06772e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.39284e-16, 3.62082e-06, 0.813545
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813545
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 9.39284e-16, 4.83175e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 6.20147e-07, norm of the rhs: 3.10074e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.10074e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.39284e-16, 4.83175e-09, 6.20147e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 6.20147e-07
 
 
@@ -402,20 +402,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 6:  t=61.5202 years, dt=10.5101 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.31205e-15, 3.71788e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813542, norm of the rhs: 4.06771e+12
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.31205e-15, 3.71788e-06, 0.813542
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813542
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.18266e-15, 7.50958e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.86323e-07, norm of the rhs: 1.43161e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.43161e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18266e-15, 7.50958e-09, 2.86323e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.86323e-07
 
 
@@ -428,20 +428,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 7:  t=72.1354 years, dt=10.6152 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.28093e-15, 3.79005e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813541, norm of the rhs: 4.06771e+12
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.28093e-15, 3.79005e-06, 0.813541
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813541
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.25333e-15, 8.3844e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.3416e-07, norm of the rhs: 2.6708e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.6708e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25333e-15, 8.3844e-09, 5.3416e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 5.3416e-07
 
 
@@ -454,20 +454,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 8:  t=82.8567 years, dt=10.7214 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.44474e-15, 3.85507e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813542, norm of the rhs: 4.06771e+12
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44474e-15, 3.85507e-06, 0.813542
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813542
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.51028e-15, 8.06395e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.48656e-07, norm of the rhs: 1.74328e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.74328e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51028e-15, 8.06395e-09, 3.48656e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.48656e-07
 
 
@@ -480,20 +480,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 9:  t=93.6853 years, dt=10.8286 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.67415e-15, 3.92039e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813543, norm of the rhs: 4.06771e+12
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67415e-15, 3.92039e-06, 0.813543
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813543
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.64006e-15, 7.48312e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 7.16875e-08, norm of the rhs: 358438, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 358438, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.64006e-15, 7.48312e-09, 7.16875e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 7.16875e-08
 
 
@@ -506,20 +506,20 @@ Number of degrees of freedom: 40 (18+4+9+9)
 *** Timestep 10:  t=100 years, dt=6.31473 years
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.51955e-15, 1.46266e-06
    Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.813543, norm of the rhs: 4.06771e+12
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51955e-15, 1.46266e-06, 0.813543
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813543
 
    Solving temperature system... 0 iterations.
    Solving grain_size system ... 1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.34038e-15, 1.6689e-09
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.99234e-08, norm of the rhs: 199617, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 199617, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.34038e-15, 1.6689e-09, 3.99234e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.99234e-08
 
 

--- a/tests/iterated_advection_and_defect_correction_Stokes/screen-output
+++ b/tests/iterated_advection_and_defect_correction_Stokes/screen-output
@@ -5,18 +5,18 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.23157e-16, 1.69854e-16
    Initial Newton Stokes residual = 8.98822e+07, v = 8.98822e+07, p = 0
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 8.98822e+07
+      Newton system information: Norm of the rhs: 8.98822e+07
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.23157e-16, 1.69854e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving porosity system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.23157e-16, 1.69854e-16
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.78399e-06, norm of the rhs: 160.349, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 160.349, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.23157e-16, 1.69854e-16, 1.78399e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 1.78399e-06
 
 
@@ -25,39 +25,39 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 1:  t=13251 years, dt=13251 years
    Solving temperature system... 14 iterations.
    Solving porosity system ... 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.108621, 0.0574656
    Initial Newton Stokes residual = 4.55548e+07, v = 4.55548e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.131943, norm of the rhs: 6.01064e+06
+      Newton system information: Norm of the rhs: 6.01064e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.108621, 0.0574656, 0.131943
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.131943
 
    Solving temperature system... 12 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.00439982, 0.00233772
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.07455e-05, norm of the rhs: 489.51, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 489.51, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00439982, 0.00233772, 1.07455e-05
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00439982
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 9 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000396861, 0.000195744
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 6.81227e-07, norm of the rhs: 31.0332, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 31.0332, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000396861, 0.000195744, 6.81227e-07
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000396861
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.84532e-05, 1.26813e-05
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.6966e-08, norm of the rhs: 2.13953, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.13953, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.84532e-05, 1.26813e-05, 4.6966e-08
       Relative nonlinear residual (total system) after nonlinear iteration 4: 2.84532e-05
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.94777e-06, 8.27759e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.2021e-09, norm of the rhs: 0.145871, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.145871, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.94777e-06, 8.27759e-07, 3.2021e-09
       Relative nonlinear residual (total system) after nonlinear iteration 5: 1.94777e-06
 
 
@@ -66,32 +66,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 2:  t=26110 years, dt=12859.1 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.0238436, 0.0169551
    Initial Newton Stokes residual = 4.59713e+07, v = 4.59713e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0286638, norm of the rhs: 1.31771e+06
+      Newton system information: Norm of the rhs: 1.31771e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0238436, 0.0169551, 0.0286638
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0286638
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.00117973, 0.000466825
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.98173e-06, norm of the rhs: 91.1028, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 91.1028, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00117973, 0.000466825, 1.98173e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00117973
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 5.84697e-05, 2.11044e-05
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 8.89678e-08, norm of the rhs: 4.08996, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.08996, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.84697e-05, 2.11044e-05, 8.89678e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.84697e-05
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.26382e-06, 9.2893e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 3.68935e-09, norm of the rhs: 0.169604, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.169604, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.26382e-06, 9.2893e-07, 3.68935e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 2.26382e-06
 
 
@@ -100,32 +100,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 3:  t=38522.2 years, dt=12412.2 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.0138162, 0.00624635
    Initial Newton Stokes residual = 4.6349e+07, v = 4.6349e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0183946, norm of the rhs: 852573
+      Newton system information: Norm of the rhs: 852573
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0138162, 0.00624635, 0.0183946
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0183946
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.00058268, 0.000227609
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.1397e-06, norm of the rhs: 52.8239, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 52.8239, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00058268, 0.000227609, 1.1397e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00058268
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.51761e-05, 1.0078e-05
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.66963e-08, norm of the rhs: 2.16433, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.16433, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.51761e-05, 1.0078e-05, 4.66963e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.51761e-05
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 9.97362e-07, 3.91322e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.91793e-09, norm of the rhs: 0.0888943, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0888943, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.97362e-07, 3.91322e-07, 1.91793e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 9.97362e-07
 
 
@@ -134,32 +134,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 4:  t=50507 years, dt=11984.8 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.0150813, 0.00660991
    Initial Newton Stokes residual = 4.68088e+07, v = 4.68088e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0205456, norm of the rhs: 961713
+      Newton system information: Norm of the rhs: 961713
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0150813, 0.00660991, 0.0205456
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0205456
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000493175, 0.000165154
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.11742e-06, norm of the rhs: 52.305, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 52.305, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000493175, 0.000165154, 1.11742e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000493175
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 9 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 2.01895e-05, 7.22591e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.42317e-08, norm of the rhs: 2.07043, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.07043, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.01895e-05, 7.22591e-06, 4.42317e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.01895e-05
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 7.53626e-07, 2.52268e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.65699e-09, norm of the rhs: 0.0775619, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0775619, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.53626e-07, 2.52268e-07, 1.65699e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 7.53626e-07
 
 
@@ -168,32 +168,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 5:  t=62100 years, dt=11593 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.015807, 0.00760231
    Initial Newton Stokes residual = 4.72906e+07, v = 4.72906e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0218472, norm of the rhs: 1.03317e+06
+      Newton system information: Norm of the rhs: 1.03317e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015807, 0.00760231, 0.0218472
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0218472
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000506738, 0.000148158
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.21725e-06, norm of the rhs: 57.5646, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 57.5646, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000506738, 0.000148158, 1.21725e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000506738
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.98661e-05, 6.14287e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.70502e-08, norm of the rhs: 2.22503, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.22503, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.98661e-05, 6.14287e-06, 4.70502e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.98661e-05
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 7.29098e-07, 2.02145e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.72535e-09, norm of the rhs: 0.0815927, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0815927, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.29098e-07, 2.02145e-07, 1.72535e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 7.29098e-07
 
 
@@ -202,32 +202,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 6:  t=73010.9 years, dt=10910.9 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.0154389, 0.00778622
    Initial Newton Stokes residual = 4.78013e+07, v = 4.78013e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0219443, norm of the rhs: 1.04897e+06
+      Newton system information: Norm of the rhs: 1.04897e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0154389, 0.00778622, 0.0219443
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0219443
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000498388, 0.000134536
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.25537e-06, norm of the rhs: 60.0081, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 60.0081, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000498388, 0.000134536, 1.25537e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000498388
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.84671e-05, 5.21399e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.56201e-08, norm of the rhs: 2.1807, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1807, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.84671e-05, 5.21399e-06, 4.56201e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.84671e-05
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 6.83519e-07, 1.68699e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.71888e-09, norm of the rhs: 0.0821648, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0821648, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.83519e-07, 1.68699e-07, 1.71888e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.83519e-07
 
 
@@ -236,32 +236,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 7:  t=83267.4 years, dt=10256.5 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.015111, 0.0075949
    Initial Newton Stokes residual = 4.84317e+07, v = 4.84317e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0219795, norm of the rhs: 1.0645e+06
+      Newton system information: Norm of the rhs: 1.0645e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015111, 0.0075949, 0.0219795
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0219795
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000470207, 0.000124161
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.27632e-06, norm of the rhs: 61.8144, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 61.8144, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000470207, 0.000124161, 1.27632e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000470207
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.70636e-05, 4.61672e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.38714e-08, norm of the rhs: 2.12476, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.12476, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.70636e-05, 4.61672e-06, 4.38714e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.70636e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 6.49554e-07, 1.56802e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.76195e-09, norm of the rhs: 0.0853343, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0853343, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.49554e-07, 1.56802e-07, 1.76195e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.49554e-07
 
 
@@ -270,32 +270,32 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 8:  t=92948.5 years, dt=9681.09 years
    Solving temperature system... 13 iterations.
    Solving porosity system ... 12 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.015232, 0.00733279
    Initial Newton Stokes residual = 4.92949e+07, v = 4.92949e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0220619, norm of the rhs: 1.08754e+06
+      Newton system information: Norm of the rhs: 1.08754e+06
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.015232, 0.00733279, 0.0220619
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0220619
 
    Solving temperature system... 11 iterations.
    Solving porosity system ... 10 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000426919, 0.000115961
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.26357e-06, norm of the rhs: 62.2875, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 62.2875, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000426919, 0.000115961, 1.26357e-06
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000426919
 
    Solving temperature system... 9 iterations.
    Solving porosity system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.53177e-05, 4.14595e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.20256e-08, norm of the rhs: 2.07165, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.07165, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.53177e-05, 4.14595e-06, 4.20256e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 1.53177e-05
 
    Solving temperature system... 7 iterations.
    Solving porosity system ... 6 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 6.08983e-07, 1.51654e-07
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.80383e-09, norm of the rhs: 0.0889198, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0889198, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.08983e-07, 1.51654e-07, 1.80383e-09
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.08983e-07
 
 
@@ -304,25 +304,25 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
 *** Timestep 9:  t=100000 years, dt=7051.49 years
    Solving temperature system... 12 iterations.
    Solving porosity system ... 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.0103042, 0.00480105
    Initial Newton Stokes residual = 5.01672e+07, v = 5.01672e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.014726, norm of the rhs: 738759
+      Newton system information: Norm of the rhs: 738759
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0103042, 0.00480105, 0.014726
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.014726
 
    Solving temperature system... 10 iterations.
    Solving porosity system ... 9 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.000205135, 5.87355e-05
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 6.95895e-07, norm of the rhs: 34.9111, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 34.9111, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000205135, 5.87355e-05, 6.95895e-07
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000205135
 
    Solving temperature system... 8 iterations.
    Solving porosity system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 5.77068e-06, 1.59923e-06
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.73586e-08, norm of the rhs: 0.870833, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.870833, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 5.77068e-06, 1.59923e-06, 1.73586e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 5.77068e-06
 
 

--- a/tests/mesh_deformation_gmg_2d_spherical_shell/screen-output
+++ b/tests/mesh_deformation_gmg_2d_spherical_shell/screen-output
@@ -11,7 +11,7 @@ Number of mesh deformation degrees of freedom: 480
    Solving mesh displacement system... 0 iterations.
    Solving temperature system... 12 iterations.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1, 0.146653
+      Relative nonlinear residuals (temperature, Stokes system): 1, 0.146653
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 

--- a/tests/newton_postprocess_nonlinear/screen-output
+++ b/tests/newton_postprocess_nonlinear/screen-output
@@ -14,7 +14,8 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+46 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 4.43603e+13
+      Newton system information: Norm of the rhs: 4.43603e+13
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Postprocessing:
      Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/1/4.712e+09 // 0/1/5.104e+09 // 0/1/1.834e+08
@@ -23,7 +24,8 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+62 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0197899, norm of the rhs: 8.77888e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.77888e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0197899
 
    Postprocessing:
      Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/1/4.712e+09 // 0/1/5.104e+09 // 0/1/1.834e+08
@@ -33,7 +35,8 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0146001, norm of the rhs: 6.47665e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.47665e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0146001
 
    Postprocessing:
      Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/1/4.712e+09 // 0/1/5.104e+09 // 0/1/1.834e+08
@@ -43,7 +46,8 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0134023, norm of the rhs: 5.9453e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.9453e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.0134023
 
    Postprocessing:
      Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/1/4.712e+09 // 0/1/5.104e+09 // 0/1/1.834e+08
@@ -53,7 +57,8 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+4 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0137113, norm of the rhs: 6.08238e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.08238e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 0.0137113
 
    Postprocessing:
      Compositions min/max/mass: 0/0/0 // 0/0/0 // 0/0/0 // 0/1/4.712e+09 // 0/1/5.104e+09 // 0/1/1.834e+08

--- a/tests/no_Advection_iterated_defect_correction_Stokes/screen-output
+++ b/tests/no_Advection_iterated_defect_correction_Stokes/screen-output
@@ -6,10 +6,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 8.98822e+07, v = 8.98822e+07, p = 0
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 8.98822e+07
+      Newton system information: Norm of the rhs: 8.98822e+07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.78399e-06, norm of the rhs: 160.349, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 160.349, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 1.78399e-06
 
 
    Postprocessing:
@@ -18,7 +20,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.51401e+07, v = 4.51401e+07, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.55226e-06, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 3.55226e-06
 
 
    Postprocessing:
@@ -27,7 +30,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -36,7 +40,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -45,7 +50,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -54,7 +60,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -63,7 +70,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -72,7 +80,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:
@@ -81,7 +90,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 2.35296e+09, v = 2.35296e+09, p = 0
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.81478e-08, norm of the rhs: 160.349
+      Newton system information: Norm of the rhs: 160.349
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.81478e-08
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes/screen-output
@@ -10,54 +10,72 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.85171e+12
+      Newton system information: Norm of the rhs: 1.85171e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.168536, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.1208e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.168536
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.168536
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.147371, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.72888e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.147371
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.147371
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0974617, norm of the rhs: 1.80471e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.80471e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0974617
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0974617
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0440614, norm of the rhs: 8.15888e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.15888e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0440614
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0440614
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0183817, norm of the rhs: 3.40375e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.40375e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0183817
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0183817
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.0175076, norm of the rhs: 3.2419e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.2419e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0175076
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0175076
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.0149885, norm of the rhs: 2.77544e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.77544e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0149885
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0149885
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.0100808, norm of the rhs: 1.86667e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.86667e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0100808
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0100808
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -65,13 +83,17 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 33+0 iterations.
    Line search iteration 0, with norm of the rhs 2.6406e+10 and going to 1.86646e+10, relative residual: 0.0142603
    Line search iteration 1, with norm of the rhs 2.0374e+10 and going to 1.86652e+10, relative residual: 0.0110028
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.00966049, norm of the rhs: 1.78884e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.78884e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00966049
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.00966049
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.00496681, norm of the rhs: 9.19707e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.19707e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00496681
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.00496681
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -80,7 +102,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 0, with norm of the rhs 2.01479e+10 and going to 9.19613e+09, relative residual: 0.0108807
    Line search iteration 1, with norm of the rhs 1.81507e+10 and going to 9.19644e+09, relative residual: 0.00980213
    Line search iteration 2, with norm of the rhs 1.04057e+10 and going to 9.19664e+09, relative residual: 0.00561953
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.0046555, norm of the rhs: 8.62063e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.62063e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0046555
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0046555
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -90,7 +114,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 1, with norm of the rhs 1.04074e+10 and going to 8.62004e+09, relative residual: 0.00562044
    Line search iteration 2, with norm of the rhs 9.15217e+09 and going to 8.62023e+09, relative residual: 0.00494256
    Line search iteration 3, with norm of the rhs 8.69763e+09 and going to 8.62036e+09, relative residual: 0.00469709
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.00463344, norm of the rhs: 8.57977e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.57977e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00463344
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.00463344
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -101,68 +127,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 2, with norm of the rhs 1.05905e+10 and going to 8.5794e+09, relative residual: 0.0057193
    Line search iteration 3, with norm of the rhs 9.31394e+09 and going to 8.57953e+09, relative residual: 0.00502992
    Line search iteration 4, with norm of the rhs 8.89761e+09 and going to 8.57961e+09, relative residual: 0.00480508
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.00471616, norm of the rhs: 8.73294e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.73294e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00471616
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00471616
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00422593, norm of the rhs: 7.82518e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.82518e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00422593
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00422593
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00368914, norm of the rhs: 6.8312e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.8312e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00368914
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00368914
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 57+0 iterations.
    Line search iteration 0, with norm of the rhs 8.79794e+09 and going to 6.83052e+09, relative residual: 0.00475126
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.00284676, norm of the rhs: 5.27137e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.27137e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00284676
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00284676
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.0011049, norm of the rhs: 2.04596e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.04596e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0011049
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.0011049
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 6.21526e-05, norm of the rhs: 1.15088e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.15088e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.21526e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 6.21526e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 118+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 8.59545e-06, norm of the rhs: 1.59163e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.59163e+07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.59545e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 8.59545e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 136+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.98872e-06, norm of the rhs: 3.68252e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.68252e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.98872e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.98872e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.98333e-07, norm of the rhs: 367255, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 367255, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.98333e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 1.98333e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0370936. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 169+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 7.24243e-09, norm of the rhs: 13410.9, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 13410.9, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.24243e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 7.24243e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.00079132. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 365+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 1.23136e-10, norm of the rhs: 228.011, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 228.011, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.23136e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 1.23136e-10
 
 
    Postprocessing:
@@ -177,31 +225,41 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.38053e-10, norm of the rhs: 185.072
+      Newton system information: Norm of the rhs: 185.072
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.38053e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.38053e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 468+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.77595e-10, norm of the rhs: 198.673, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 198.673, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.77595e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77595e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 522+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.32515e-10, norm of the rhs: 183.167, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 183.167, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.32515e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.32515e-10
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 5.11422e-10, norm of the rhs: 175.911, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 175.911, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.11422e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 5.11422e-10
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
    Line search iteration 0, with norm of the rhs 180.258 and going to 175.893, relative residual: 5.24057e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 4.46412e-10, norm of the rhs: 153.55, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 153.55, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.46412e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 4.46412e-10
 
 
    Postprocessing:
@@ -215,17 +273,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.63902e-10, norm of the rhs: 193.963
+      Newton system information: Norm of the rhs: 193.963
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.63902e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.63902e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 490+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.48167e-10, norm of the rhs: 188.55, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 188.55, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.48167e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.48167e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 483+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.38734e-10, norm of the rhs: 185.306, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 185.306, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.38734e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.38734e-10
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
@@ -233,7 +297,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 203.801 and going to 185.287, relative residual: 5.92504e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.52938e-10, norm of the rhs: 155.795, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 155.795, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.52938e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.52938e-10
 
 
    Postprocessing:
@@ -248,17 +314,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.97097e-10, norm of the rhs: 205.381
+      Newton system information: Norm of the rhs: 205.381
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.97097e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.97097e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 473+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.35008e-10, norm of the rhs: 184.024, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 184.024, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.35008e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.35008e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 527+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.00341e-10, norm of the rhs: 172.1, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 172.1, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.00341e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.00341e-10
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
@@ -266,7 +338,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
    Line search iteration 0, with norm of the rhs 184.127 and going to 172.082, relative residual: 5.35307e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.95426e-10, norm of the rhs: 170.409, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 170.409, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.95426e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.95426e-10
 
 
    Postprocessing:
@@ -280,12 +354,16 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.69279e-10, norm of the rhs: 230.209
+      Newton system information: Norm of the rhs: 230.209
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.69279e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.69279e-10
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 384+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.9895e-10, norm of the rhs: 171.621, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 171.621, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.9895e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.9895e-10
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_GMG/screen-output
@@ -9,49 +9,69 @@ Number of degrees of freedom: 54,148 (33,282+4,225+16,641)
    Initial Newton Stokes residual = 9.30238e+11, v = 9.30238e+11, p = 0
 
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 9.30238e+11
+      Newton system information: Norm of the rhs: 9.30238e+11
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0898569, norm of the rhs: 8.35883e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.35883e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0898569
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0898569
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0116342, norm of the rhs: 1.08226e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.08226e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0116342
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0116342
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.42172e-05, norm of the rhs: 1.32253e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.32253e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.42172e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.42172e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.44318e-10, norm of the rhs: 320.297, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 320.297, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.44318e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.44318e-10
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.860345. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 2.077e-07, norm of the rhs: 193210, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 193210, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.077e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.077e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 1.41114e-08, norm of the rhs: 13127, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 13127, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.41114e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.41114e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.03278e-08, norm of the rhs: 9607.32, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9607.32, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.03278e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.03278e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 7.78722e-09, norm of the rhs: 7243.97, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7243.97, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.78722e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 7.78722e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 6.73131e-09, norm of the rhs: 6261.72, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6261.72, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.73131e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 6.73131e-09
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_deviator/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_deviator/screen-output
@@ -10,89 +10,117 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.85171e+12
+      Newton system information: Norm of the rhs: 1.85171e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.168536, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.1208e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.168536
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.168536
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.147371, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.72888e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.147371
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.147371
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0974578, norm of the rhs: 1.80463e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.80463e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0974578
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0974578
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0431877, norm of the rhs: 7.9971e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.9971e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0431877
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0431877
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0108825, norm of the rhs: 2.01512e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.01512e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0108825
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0108825
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.00923796, norm of the rhs: 1.7106e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.7106e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00923796
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.00923796
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.00752721, norm of the rhs: 1.39382e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.39382e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00752721
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.00752721
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
    Line search iteration 0, with norm of the rhs 1.41869e+10 and going to 1.3937e+10, relative residual: 0.00766154
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.00552443, norm of the rhs: 1.02296e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.02296e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00552443
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.00552443
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 36+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.00521038, norm of the rhs: 9.64809e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.64809e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00521038
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.00521038
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
    Line search iteration 0, with norm of the rhs 1.20899e+10 and going to 9.6472e+09, relative residual: 0.00652908
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.00499094, norm of the rhs: 9.24175e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.24175e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00499094
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.00499094
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 46+0 iterations.
    Line search iteration 0, with norm of the rhs 1.08096e+10 and going to 9.24083e+09, relative residual: 0.00583763
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.00429779, norm of the rhs: 7.95825e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.95825e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00429779
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.00429779
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
    Line search iteration 0, with norm of the rhs 1.00989e+10 and going to 7.95746e+09, relative residual: 0.00545382
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.00425155, norm of the rhs: 7.87262e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.87262e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00425155
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.00425155
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
    Line search iteration 0, with norm of the rhs 8.4978e+09 and going to 7.87183e+09, relative residual: 0.00458917
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.00338802, norm of the rhs: 6.27362e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.27362e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00338802
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00338802
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -100,59 +128,77 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 35+0 iterations.
    Line search iteration 0, with norm of the rhs 8.1799e+09 and going to 6.27299e+09, relative residual: 0.00441749
    Line search iteration 1, with norm of the rhs 6.34591e+09 and going to 6.2732e+09, relative residual: 0.00342706
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00217786, norm of the rhs: 4.03275e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.03275e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00217786
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00217786
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 55+0 iterations.
    Line search iteration 0, with norm of the rhs 4.47104e+09 and going to 4.03229e+09, relative residual: 0.00241455
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00178257, norm of the rhs: 3.3008e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.3008e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00178257
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00178257
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
    Line search iteration 0, with norm of the rhs 3.83044e+09 and going to 3.30053e+09, relative residual: 0.0020686
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.00155184, norm of the rhs: 2.87355e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.87355e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00155184
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00155184
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.00138475, norm of the rhs: 2.56416e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.56416e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00138475
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.00138475
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.00135299, norm of the rhs: 2.50535e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.50535e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00135299
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.00135299
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
    Line search iteration 0, with norm of the rhs 3.16937e+09 and going to 2.50498e+09, relative residual: 0.00171159
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.00121551, norm of the rhs: 2.25077e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.25077e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00121551
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.00121551
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.00104694, norm of the rhs: 1.93862e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.93862e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00104694
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.00104694
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 66+0 iterations.
    Line search iteration 0, with norm of the rhs 2.61695e+09 and going to 1.93843e+09, relative residual: 0.00141326
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.000975318, norm of the rhs: 1.806e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.806e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000975318
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000975318
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000855908, norm of the rhs: 1.58489e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.58489e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000855908
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000855908
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -160,31 +206,41 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 50+0 iterations.
    Line search iteration 0, with norm of the rhs 2.32523e+09 and going to 1.58474e+09, relative residual: 0.00125572
    Line search iteration 1, with norm of the rhs 1.58971e+09 and going to 1.58479e+09, relative residual: 0.000858512
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000122788, norm of the rhs: 2.27367e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.27367e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000122788
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000122788
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 66+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 6.08336e-06, norm of the rhs: 1.12646e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.12646e+07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.08336e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 6.08336e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 88+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 1.1559e-06, norm of the rhs: 2.14039e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.14039e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.1559e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 1.1559e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 121+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 1.14768e-07, norm of the rhs: 212516, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 212516, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.14768e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 1.14768e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 2.06164e-05. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 450+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 1.1074e-10, norm of the rhs: 205.058, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 205.058, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.1074e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 1.1074e-10
 
 
    Postprocessing:
@@ -199,7 +255,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.83981e-10, norm of the rhs: 166.473
+      Newton system information: Norm of the rhs: 166.473
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.83981e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.83981e-10
 
 
    Postprocessing:
@@ -213,7 +271,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 8.99022e-11, norm of the rhs: 166.473
+      Newton system information: Norm of the rhs: 166.473
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.99022e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 8.99022e-11
 
 
    Postprocessing:
@@ -228,7 +288,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 8.99022e-11, norm of the rhs: 166.473
+      Newton system information: Norm of the rhs: 166.473
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.99022e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 8.99022e-11
 
 
    Postprocessing:
@@ -242,7 +304,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 8.99022e-11, norm of the rhs: 166.473
+      Newton system information: Norm of the rhs: 166.473
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.99022e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 8.99022e-11
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_line_search/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_line_search/screen-output
@@ -10,270 +10,360 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.85171e+12
+      Newton system information: Norm of the rhs: 1.85171e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.168536, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.1208e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.168536
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.168536
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.147371, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.72888e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.147371
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.147371
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0974617, norm of the rhs: 1.80471e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.80471e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0974617
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0974617
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0440614, norm of the rhs: 8.15888e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.15888e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0440614
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0440614
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0183817, norm of the rhs: 3.40375e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.40375e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0183817
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0183817
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.0175076, norm of the rhs: 3.2419e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.2419e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0175076
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0175076
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.0149885, norm of the rhs: 2.77544e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.77544e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0149885
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0149885
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.0100808, norm of the rhs: 1.86667e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.86667e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0100808
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0100808
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.0142603, norm of the rhs: 2.6406e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.6406e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0142603
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0142603
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.0118277, norm of the rhs: 2.19014e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.19014e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0118277
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0118277
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.0145843, norm of the rhs: 2.70058e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.70058e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0145843
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0145843
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.0168684, norm of the rhs: 3.12354e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.12354e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0168684
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0168684
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.0205652, norm of the rhs: 3.80806e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.80806e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0205652
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.0205652
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.0243809, norm of the rhs: 4.51462e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.51462e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0243809
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.0243809
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.0292729, norm of the rhs: 5.42048e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.42048e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0292729
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.0292729
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.0347142, norm of the rhs: 6.42805e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.42805e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0347142
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.0347142
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.0408851, norm of the rhs: 7.57072e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.57072e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0408851
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.0408851
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.0475514, norm of the rhs: 8.80513e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.80513e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0475514
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.0475514
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.0543145, norm of the rhs: 1.00575e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.00575e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0543145
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.0543145
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.0624779, norm of the rhs: 1.15691e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.15691e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0624779
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.0624779
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.0705683, norm of the rhs: 1.30672e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.30672e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0705683
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.0705683
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.0905814, norm of the rhs: 1.6773e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.6773e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0905814
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.0905814
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.0986532, norm of the rhs: 1.82677e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.82677e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0986532
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.0986532
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.112401, norm of the rhs: 2.08134e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.08134e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.112401
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.112401
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.112173, norm of the rhs: 2.07711e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.07711e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.112173
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.112173
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.128595, norm of the rhs: 2.3812e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.3812e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.128595
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.128595
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.138005, norm of the rhs: 2.55545e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.55545e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.138005
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.138005
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.15478, norm of the rhs: 2.86607e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.86607e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.15478
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.15478
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.171083, norm of the rhs: 3.16795e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.16795e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.171083
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.171083
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 0.201436, norm of the rhs: 3.73001e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.73001e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.201436
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 0.201436
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 0.231603, norm of the rhs: 4.28862e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.28862e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.231603
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 0.231603
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 0.268619, norm of the rhs: 4.97404e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.97404e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.268619
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 0.268619
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 34: 0.317074, norm of the rhs: 5.87128e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.87128e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.317074
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 0.317074
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 35: 0.379338, norm of the rhs: 7.02423e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.02423e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.379338
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 0.379338
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 36: 0.45898, norm of the rhs: 8.49896e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.49896e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.45898
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 0.45898
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 37: 0.551802, norm of the rhs: 1.02178e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.02178e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.551802
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 0.551802
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 38: 0.667045, norm of the rhs: 1.23517e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.23517e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.667045
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 0.667045
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 39: 0.815975, norm of the rhs: 1.51095e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.51095e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.815975
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 0.815975
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 40: 0.995442, norm of the rhs: 1.84327e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.84327e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.995442
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 0.995442
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 41: 1.22619, norm of the rhs: 2.27055e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.27055e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.22619
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 1.22619
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 42: 1.42094, norm of the rhs: 2.63116e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.63116e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.42094
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 1.42094
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 43: 1.62745, norm of the rhs: 3.01356e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.01356e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.62745
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 1.62745
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 44: 1.91582, norm of the rhs: 3.54753e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.54753e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.91582
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 1.91582
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 45: 2.08364, norm of the rhs: 3.85829e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.85829e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.08364
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 2.08364
 
 
    Postprocessing:
@@ -288,270 +378,360 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 61+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.91224, norm of the rhs: 3.85367e+12
+      Newton system information: Norm of the rhs: 3.85367e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.91224
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.91224
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.276328, norm of the rhs: 2.72191e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.72191e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.276328
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.276328
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 59+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.149988, norm of the rhs: 1.47743e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47743e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.149988
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.149988
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.387023, norm of the rhs: 3.81229e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.81229e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.387023
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.387023
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.244797, norm of the rhs: 2.41133e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.41133e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.244797
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.244797
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.427038, norm of the rhs: 4.20646e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.20646e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.427038
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.427038
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.299158, norm of the rhs: 2.9468e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.9468e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.299158
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.299158
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.488236, norm of the rhs: 4.80927e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.80927e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.488236
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.488236
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.423599, norm of the rhs: 4.17258e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.17258e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.423599
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.423599
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.612191, norm of the rhs: 6.03026e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.03026e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.612191
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.612191
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.63414, norm of the rhs: 6.24647e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.24647e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.63414
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.63414
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.85626, norm of the rhs: 8.43442e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.43442e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.85626
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.85626
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.979251, norm of the rhs: 9.64592e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.64592e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.979251
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.979251
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.24954, norm of the rhs: 1.23083e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.23083e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.24954
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.24954
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.47482, norm of the rhs: 1.45274e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.45274e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.47482
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.47482
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.87889, norm of the rhs: 1.85076e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.85076e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.87889
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.87889
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 2.25895, norm of the rhs: 2.22513e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.22513e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.25895
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 2.25895
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.88186, norm of the rhs: 2.83872e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.83872e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.88186
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 2.88186
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 3.11564, norm of the rhs: 3.069e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.069e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.11564
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 3.11564
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 3.21579, norm of the rhs: 3.16765e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.16765e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.21579
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 3.21579
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 4.03528, norm of the rhs: 3.97487e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.97487e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.03528
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 4.03528
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 4.25817, norm of the rhs: 4.19443e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.19443e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.25817
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 4.25817
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 4.94714, norm of the rhs: 4.87308e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.87308e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.94714
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 4.94714
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 5.16247, norm of the rhs: 5.08518e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.08518e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.16247
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 5.16247
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 5.56852, norm of the rhs: 5.48516e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.48516e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.56852
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 5.56852
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 6.03399, norm of the rhs: 5.94367e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.94367e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.03399
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 6.03399
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 5.94777, norm of the rhs: 5.85874e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.85874e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.94777
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 5.94777
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 6.36234, norm of the rhs: 6.2671e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.2671e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.36234
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 6.36234
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 6.75776, norm of the rhs: 6.6566e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.6566e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.75776
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 6.75776
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 7.02442, norm of the rhs: 6.91927e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.91927e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.02442
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 7.02442
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 7.38221, norm of the rhs: 7.2717e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.2717e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.38221
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 7.38221
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 7.63591, norm of the rhs: 7.52161e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.52161e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.63591
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 7.63591
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 8.0168, norm of the rhs: 7.89679e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.89679e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.0168
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 8.0168
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 34: 8.37284, norm of the rhs: 8.2475e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.2475e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.37284
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 8.37284
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 35: 8.33276, norm of the rhs: 8.20803e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.20803e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.33276
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 8.33276
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 36: 8.59513, norm of the rhs: 8.46647e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.46647e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.59513
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 8.59513
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 37: 8.92672, norm of the rhs: 8.79309e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.79309e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.92672
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 8.92672
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 38: 9.01243, norm of the rhs: 8.87751e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.87751e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.01243
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 9.01243
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 39: 9.25949, norm of the rhs: 9.12087e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.12087e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.25949
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 9.25949
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 40: 9.44475, norm of the rhs: 9.30336e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.30336e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.44475
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 9.44475
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 41: 9.21008, norm of the rhs: 9.07221e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.07221e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.21008
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 9.21008
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 42: 9.35182, norm of the rhs: 9.21182e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.21182e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.35182
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 9.35182
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 43: 9.87574, norm of the rhs: 9.7279e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.7279e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.87574
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 9.87574
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 44: 9.60482, norm of the rhs: 9.46104e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.46104e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.60482
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 9.60482
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 45: 9.60144, norm of the rhs: 9.45771e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.45771e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.60144
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 9.60144
 
 
    Postprocessing:
@@ -565,270 +745,360 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 60+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.46591, norm of the rhs: 1.60684e+13
+      Newton system information: Norm of the rhs: 1.60684e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.46591
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.46591
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.156449, norm of the rhs: 5.62905e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.62905e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.156449
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.156449
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 66+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0823825, norm of the rhs: 2.96413e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.96413e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0823825
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0823825
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.214426, norm of the rhs: 7.71508e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.71508e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.214426
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.214426
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.186462, norm of the rhs: 6.70891e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.70891e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.186462
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.186462
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.240788, norm of the rhs: 8.66359e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.66359e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.240788
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.240788
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.213966, norm of the rhs: 7.69853e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.69853e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.213966
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.213966
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.293715, norm of the rhs: 1.05679e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.05679e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.293715
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.293715
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.263507, norm of the rhs: 9.48103e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.48103e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.263507
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.263507
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.390625, norm of the rhs: 1.40548e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.40548e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.390625
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.390625
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.406812, norm of the rhs: 1.46372e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.46372e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.406812
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.406812
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.570234, norm of the rhs: 2.05171e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.05171e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.570234
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.570234
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.669102, norm of the rhs: 2.40744e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.40744e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.669102
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.669102
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.828213, norm of the rhs: 2.97992e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.97992e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.828213
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.828213
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.02427, norm of the rhs: 3.68532e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.68532e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.02427
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.02427
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.30768, norm of the rhs: 4.70505e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.70505e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.30768
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.30768
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.48477, norm of the rhs: 5.34222e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.34222e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.48477
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 1.48477
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.43721, norm of the rhs: 5.17111e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.17111e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.43721
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 1.43721
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 1.58122, norm of the rhs: 5.68926e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.68926e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.58122
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 1.58122
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.89318, norm of the rhs: 6.81169e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.81169e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.89318
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 1.89318
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.95705, norm of the rhs: 7.0415e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.0415e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.95705
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.95705
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 2.10296, norm of the rhs: 7.56646e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.56646e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.10296
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 2.10296
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 2.18587, norm of the rhs: 7.86479e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.86479e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.18587
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 2.18587
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 2.27089, norm of the rhs: 8.17068e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.17068e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.27089
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 2.27089
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 2.24502, norm of the rhs: 8.07762e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.07762e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.24502
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 2.24502
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.43467, norm of the rhs: 8.75997e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.75997e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.43467
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 2.43467
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.42944, norm of the rhs: 8.74116e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.74116e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.42944
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 2.42944
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 2.60075, norm of the rhs: 9.35754e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.35754e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.60075
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 2.60075
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 2.57132, norm of the rhs: 9.25166e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.25166e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.57132
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 2.57132
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 2.51932, norm of the rhs: 9.06457e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.06457e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.51932
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 2.51932
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 2.55855, norm of the rhs: 9.20569e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.20569e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.55855
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 2.55855
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 2.62534, norm of the rhs: 9.44602e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.44602e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.62534
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 2.62534
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 2.60842, norm of the rhs: 9.38514e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.38514e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.60842
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 2.60842
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 34: 2.67123, norm of the rhs: 9.61111e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.61111e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.67123
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 2.67123
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 35: 2.65489, norm of the rhs: 9.55232e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.55232e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.65489
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 2.65489
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 36: 2.76088, norm of the rhs: 9.93369e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.93369e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.76088
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 2.76088
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 37: 2.66981, norm of the rhs: 9.60602e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.60602e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.66981
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 2.66981
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 38: 2.72714, norm of the rhs: 9.81227e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.81227e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.72714
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 2.72714
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 39: 2.74161, norm of the rhs: 9.86434e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.86434e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.74161
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 2.74161
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 40: 2.74626, norm of the rhs: 9.88108e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.88108e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.74626
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 2.74626
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 41: 2.75131, norm of the rhs: 9.89926e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.89926e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.75131
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 2.75131
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 42: 2.87223, norm of the rhs: 1.03343e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.03343e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.87223
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 2.87223
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 43: 2.86637, norm of the rhs: 1.03132e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.03132e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.86637
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 2.86637
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 44: 2.86187, norm of the rhs: 1.02971e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.02971e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.86187
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 2.86187
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 45: 2.87177, norm of the rhs: 1.03327e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.03327e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.87177
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 2.87177
 
 
    Postprocessing:
@@ -843,270 +1113,360 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.22087, norm of the rhs: 1.95525e+13
+      Newton system information: Norm of the rhs: 1.95525e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.22087
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.22087
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.154062, norm of the rhs: 5.76973e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.76973e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.154062
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.154062
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 60+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.081147, norm of the rhs: 3.03901e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.03901e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.081147
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.081147
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.190778, norm of the rhs: 7.14479e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.14479e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.190778
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.190778
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.167733, norm of the rhs: 6.28171e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.28171e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.167733
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.167733
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.218817, norm of the rhs: 8.19486e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.19486e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.218817
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.218817
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.183841, norm of the rhs: 6.88496e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.88496e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.183841
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.183841
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.285717, norm of the rhs: 1.07003e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.07003e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.285717
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.285717
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.258234, norm of the rhs: 9.67106e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.67106e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.258234
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.258234
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.378119, norm of the rhs: 1.41608e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.41608e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.378119
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.378119
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.393535, norm of the rhs: 1.47382e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.47382e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.393535
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.393535
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.550545, norm of the rhs: 2.06183e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.06183e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.550545
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.550545
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.649669, norm of the rhs: 2.43306e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.43306e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.649669
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.649669
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.908633, norm of the rhs: 3.4029e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.4029e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.908633
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.908633
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.07376, norm of the rhs: 4.02131e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.02131e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.07376
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.07376
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.25049, norm of the rhs: 4.68318e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.68318e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.25049
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.25049
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.35051, norm of the rhs: 5.05777e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.05777e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.35051
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 1.35051
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.5067, norm of the rhs: 5.64272e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.64272e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.5067
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 1.5067
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 1.54853, norm of the rhs: 5.79936e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.79936e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.54853
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 1.54853
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.82214, norm of the rhs: 6.82405e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.82405e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.82214
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 1.82214
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.7681, norm of the rhs: 6.62167e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.62167e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.7681
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.7681
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.90683, norm of the rhs: 7.14123e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.14123e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.90683
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 1.90683
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 2.00929, norm of the rhs: 7.52495e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.52495e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.00929
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 2.00929
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 2.11297, norm of the rhs: 7.91321e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.91321e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.11297
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 2.11297
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 2.02698, norm of the rhs: 7.59118e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.59118e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.02698
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 2.02698
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.18268, norm of the rhs: 8.17428e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.17428e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.18268
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 2.18268
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.3745, norm of the rhs: 8.89269e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.89269e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.3745
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 2.3745
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 2.23131, norm of the rhs: 8.35642e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.35642e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.23131
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 2.23131
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 2.25572, norm of the rhs: 8.44783e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.44783e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.25572
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 2.25572
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 2.33195, norm of the rhs: 8.73332e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.73332e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.33195
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 2.33195
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 2.34388, norm of the rhs: 8.778e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.778e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.34388
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 2.34388
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 2.35423, norm of the rhs: 8.81675e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.81675e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.35423
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 2.35423
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 2.31547, norm of the rhs: 8.67158e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.67158e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.31547
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 2.31547
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 34: 2.34945, norm of the rhs: 8.79886e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.79886e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.34945
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 2.34945
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 35: 2.5106, norm of the rhs: 9.40238e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.40238e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.5106
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 2.5106
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 36: 2.39522, norm of the rhs: 8.97028e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.97028e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.39522
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 2.39522
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 37: 2.376, norm of the rhs: 8.89829e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.89829e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.376
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 2.376
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 38: 2.51676, norm of the rhs: 9.42546e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.42546e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.51676
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 2.51676
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 39: 2.44816, norm of the rhs: 9.16853e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.16853e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.44816
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 2.44816
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 40: 2.47317, norm of the rhs: 9.26221e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.26221e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.47317
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 2.47317
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 41: 2.49085, norm of the rhs: 9.32842e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.32842e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.49085
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 2.49085
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 42: 2.45273, norm of the rhs: 9.18563e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.18563e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.45273
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 2.45273
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 43: 2.51719, norm of the rhs: 9.42706e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.42706e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.51719
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 2.51719
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 44: 2.58822, norm of the rhs: 9.69308e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.69308e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.58822
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 2.58822
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 45: 2.60284, norm of the rhs: 9.74784e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.74784e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.60284
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 2.60284
 
 
    Postprocessing:
@@ -1120,270 +1480,360 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.01053, norm of the rhs: 1.86532e+13
+      Newton system information: Norm of the rhs: 1.86532e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.01053
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.01053
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 51+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.151327, norm of the rhs: 5.63362e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.63362e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.151327
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.151327
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 69+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0796891, norm of the rhs: 2.96667e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.96667e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0796891
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0796891
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.191051, norm of the rhs: 7.11245e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.11245e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.191051
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.191051
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.157821, norm of the rhs: 5.87535e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.87535e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.157821
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.157821
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.219948, norm of the rhs: 8.18822e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.18822e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.219948
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.219948
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.267141, norm of the rhs: 9.94515e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.94515e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.267141
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.267141
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.28369, norm of the rhs: 1.05612e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.05612e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.28369
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.28369
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.320326, norm of the rhs: 1.19251e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.19251e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.320326
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.320326
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.39023, norm of the rhs: 1.45275e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.45275e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.39023
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.39023
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.458856, norm of the rhs: 1.70823e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.70823e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.458856
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.458856
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.569476, norm of the rhs: 2.12005e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.12005e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.569476
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.569476
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.696523, norm of the rhs: 2.59302e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.59302e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.696523
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.696523
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.855824, norm of the rhs: 3.18606e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.18606e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.855824
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.855824
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.17768, norm of the rhs: 4.38425e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.38425e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.17768
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.17768
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.34049, norm of the rhs: 4.99037e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.99037e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.34049
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.34049
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 1.60578, norm of the rhs: 5.97801e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.97801e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.60578
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 1.60578
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.38191, norm of the rhs: 5.14457e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.14457e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.38191
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 1.38191
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 1.60289, norm of the rhs: 5.96724e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.96724e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.60289
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 1.60289
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 1.66452, norm of the rhs: 6.19667e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.19667e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.66452
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 1.66452
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.84531, norm of the rhs: 6.86974e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.86974e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.84531
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.84531
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.84773, norm of the rhs: 6.87875e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.87875e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.84773
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 1.84773
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 2.01192, norm of the rhs: 7.48997e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.48997e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.01192
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 2.01192
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 2.16403, norm of the rhs: 8.05624e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.05624e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.16403
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 2.16403
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 2.09802, norm of the rhs: 7.81053e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.81053e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.09802
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 2.09802
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.26175, norm of the rhs: 8.42004e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.42004e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.26175
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 2.26175
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 2.29971, norm of the rhs: 8.56135e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.56135e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.29971
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 2.29971
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 2.2287, norm of the rhs: 8.29703e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.29703e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.2287
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 2.2287
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 2.35926, norm of the rhs: 8.78307e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.78307e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.35926
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 2.35926
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 2.46197, norm of the rhs: 9.16543e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.16543e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.46197
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 2.46197
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 31: 2.35562, norm of the rhs: 8.76951e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.76951e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.35562
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 2.35562
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 32: 2.66448, norm of the rhs: 9.91934e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.91934e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.66448
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 2.66448
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 33: 2.46636, norm of the rhs: 9.18177e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.18177e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.46636
+      Relative nonlinear residual (total system) after nonlinear iteration 33: 2.46636
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 34: 2.44342, norm of the rhs: 9.09638e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.09638e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.44342
+      Relative nonlinear residual (total system) after nonlinear iteration 34: 2.44342
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 35: 2.55496, norm of the rhs: 9.51162e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.51162e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.55496
+      Relative nonlinear residual (total system) after nonlinear iteration 35: 2.55496
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 36: 2.64416, norm of the rhs: 9.84368e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.84368e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.64416
+      Relative nonlinear residual (total system) after nonlinear iteration 36: 2.64416
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 37: 2.55811, norm of the rhs: 9.52334e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.52334e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.55811
+      Relative nonlinear residual (total system) after nonlinear iteration 37: 2.55811
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 38: 2.62059, norm of the rhs: 9.75593e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.75593e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.62059
+      Relative nonlinear residual (total system) after nonlinear iteration 38: 2.62059
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 39: 2.76832, norm of the rhs: 1.03059e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.03059e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.76832
+      Relative nonlinear residual (total system) after nonlinear iteration 39: 2.76832
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 40: 2.72391, norm of the rhs: 1.01406e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.01406e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.72391
+      Relative nonlinear residual (total system) after nonlinear iteration 40: 2.72391
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 41: 2.70894, norm of the rhs: 1.00849e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.00849e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.70894
+      Relative nonlinear residual (total system) after nonlinear iteration 41: 2.70894
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 42: 2.83016, norm of the rhs: 1.05361e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.05361e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.83016
+      Relative nonlinear residual (total system) after nonlinear iteration 42: 2.83016
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 43: 2.74798, norm of the rhs: 1.02302e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.02302e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.74798
+      Relative nonlinear residual (total system) after nonlinear iteration 43: 2.74798
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 44: 2.75952, norm of the rhs: 1.02732e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.02732e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.75952
+      Relative nonlinear residual (total system) after nonlinear iteration 44: 2.75952
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 45: 2.83731, norm of the rhs: 1.05628e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.05628e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.83731
+      Relative nonlinear residual (total system) after nonlinear iteration 45: 2.83731
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles/screen-output
@@ -11,19 +11,25 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.85171e+12
+      Newton system information: Norm of the rhs: 1.85171e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.168536, norm of the rhs: 3.1208e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.1208e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.168536
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.168536
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 93+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.147371, norm of the rhs: 2.72888e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.72888e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.147371
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.147371
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -31,42 +37,54 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0974617, norm of the rhs: 1.80471e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.80471e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0974617
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0974617
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.0440614, norm of the rhs: 8.15888e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.15888e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0440614
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.0440614
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.0183817, norm of the rhs: 3.40375e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.40375e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0183817
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0183817
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.0175076, norm of the rhs: 3.2419e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.2419e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0175076
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0175076
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.0149885, norm of the rhs: 2.77544e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.77544e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0149885
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.0149885
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.0100808, norm of the rhs: 1.86667e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.86667e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0100808
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0100808
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -75,14 +93,18 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 33+0 iterations.
    Line search iteration 0, with norm of the rhs 2.6406e+10 and going to 1.86646e+10, relative residual: 0.0142603
    Line search iteration 1, with norm of the rhs 2.0374e+10 and going to 1.86652e+10, relative residual: 0.0110028
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.00966049, norm of the rhs: 1.78884e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.78884e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00966049
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.00966049
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.00496681, norm of the rhs: 9.19707e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.19707e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00496681
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.00496681
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -92,7 +114,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 0, with norm of the rhs 2.01479e+10 and going to 9.19613e+09, relative residual: 0.0108807
    Line search iteration 1, with norm of the rhs 1.81507e+10 and going to 9.19644e+09, relative residual: 0.00980213
    Line search iteration 2, with norm of the rhs 1.04057e+10 and going to 9.19664e+09, relative residual: 0.00561953
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.0046555, norm of the rhs: 8.62063e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.62063e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0046555
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0046555
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -103,7 +127,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 1, with norm of the rhs 1.04074e+10 and going to 8.62004e+09, relative residual: 0.00562044
    Line search iteration 2, with norm of the rhs 9.15217e+09 and going to 8.62023e+09, relative residual: 0.00494256
    Line search iteration 3, with norm of the rhs 8.69763e+09 and going to 8.62036e+09, relative residual: 0.00469709
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.00463344, norm of the rhs: 8.57977e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.57977e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00463344
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.00463344
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -115,21 +141,27 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 2, with norm of the rhs 1.05905e+10 and going to 8.5794e+09, relative residual: 0.0057193
    Line search iteration 3, with norm of the rhs 9.31394e+09 and going to 8.57953e+09, relative residual: 0.00502992
    Line search iteration 4, with norm of the rhs 8.89761e+09 and going to 8.57961e+09, relative residual: 0.00480508
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.00471616, norm of the rhs: 8.73294e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.73294e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00471616
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00471616
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.00422593, norm of the rhs: 7.82518e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.82518e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00422593
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00422593
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.00368914, norm of the rhs: 6.8312e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.8312e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00368914
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00368914
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -137,56 +169,72 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 57+0 iterations.
    Line search iteration 0, with norm of the rhs 8.79794e+09 and going to 6.83052e+09, relative residual: 0.00475126
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.00284676, norm of the rhs: 5.27137e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.27137e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00284676
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00284676
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.0011049, norm of the rhs: 2.04596e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.04596e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0011049
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.0011049
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 6.21526e-05, norm of the rhs: 1.15088e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.15088e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.21526e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 6.21526e-05
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 118+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 8.59545e-06, norm of the rhs: 1.59163e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.59163e+07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.59545e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 8.59545e-06
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 136+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.98872e-06, norm of the rhs: 3.68252e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.68252e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.98872e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.98872e-06
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.98333e-07, norm of the rhs: 367255, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 367255, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.98333e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 1.98333e-07
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.0370936. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 169+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 7.24243e-09, norm of the rhs: 13410.9, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 13410.9, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.24243e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 7.24243e-09
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    The linear solver tolerance is set to 0.00079132. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 365+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 1.23136e-10, norm of the rhs: 228.011, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 228.011, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.23136e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 1.23136e-10
 
 
    Postprocessing:
@@ -203,19 +251,25 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.38053e-10, norm of the rhs: 185.072
+      Newton system information: Norm of the rhs: 185.072
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.38053e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.38053e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 468+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.77595e-10, norm of the rhs: 198.673, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 198.673, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.77595e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.77595e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 522+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.32515e-10, norm of the rhs: 183.167, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 183.167, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.32515e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.32515e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -223,7 +277,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 5.11422e-10, norm of the rhs: 175.911, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 175.911, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.11422e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 5.11422e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -231,7 +287,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
    Line search iteration 0, with norm of the rhs 180.258 and going to 175.893, relative residual: 5.24057e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 4.46412e-10, norm of the rhs: 153.55, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 153.55, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.46412e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 4.46412e-10
 
 
    Postprocessing:
@@ -247,19 +305,25 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.63902e-10, norm of the rhs: 193.963
+      Newton system information: Norm of the rhs: 193.963
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.63902e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.63902e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 490+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.48167e-10, norm of the rhs: 188.55, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 188.55, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.48167e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.48167e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 483+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.38734e-10, norm of the rhs: 185.306, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 185.306, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.38734e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.38734e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -268,7 +332,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 203.801 and going to 185.287, relative residual: 5.92504e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.52938e-10, norm of the rhs: 155.795, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 155.795, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.52938e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.52938e-10
 
 
    Postprocessing:
@@ -285,19 +351,25 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.97097e-10, norm of the rhs: 205.381
+      Newton system information: Norm of the rhs: 205.381
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.97097e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.97097e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 473+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.35008e-10, norm of the rhs: 184.024, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 184.024, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.35008e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.35008e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 527+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.00341e-10, norm of the rhs: 172.1, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 172.1, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.00341e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.00341e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
@@ -306,7 +378,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
    Line search iteration 0, with norm of the rhs 184.127 and going to 172.082, relative residual: 5.35307e-10
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 4.95426e-10, norm of the rhs: 170.409, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 170.409, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.95426e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 4.95426e-10
 
 
    Postprocessing:
@@ -322,13 +396,17 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.69279e-10, norm of the rhs: 230.209
+      Newton system information: Norm of the rhs: 230.209
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.69279e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.69279e-10
 
    Skipping temperature solve because RHS is zero.
    Advecting particles...  done.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 384+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.9895e-10, norm of the rhs: 171.621, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 171.621, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.9895e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.9895e-10
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_dc_picard_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_dc_picard_Stokes_GMG/screen-output
@@ -9,34 +9,44 @@ Number of degrees of freedom: 54,148 (33,282+4,225+16,641)
    Initial Newton Stokes residual = 9.30238e+11, v = 9.30238e+11, p = 0
 
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 9.30238e+11
+      Newton system information: Norm of the rhs: 9.30238e+11
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0898569, norm of the rhs: 8.35883e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.35883e+10, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0898569
 
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0116342, norm of the rhs: 1.08226e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.08226e+10, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.0116342
 
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.42172e-05, norm of the rhs: 1.32253e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.32253e+07, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 1.42172e-05
 
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.44318e-10, norm of the rhs: 320.297, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 320.297, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 3.44318e-10
 
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 6.26778e-09, norm of the rhs: 5830.53, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5830.53, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 6.26778e-09
 
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.60125e-09, norm of the rhs: 4280.26, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4280.26, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 4.60125e-09
 
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 4.59332e-09, norm of the rhs: 4272.88, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4272.88, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 4.59332e-09
 
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 4.33674e-09, norm of the rhs: 4034.2, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4034.2, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 4.33674e-09
 
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.3978e-09, norm of the rhs: 4091, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4091, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 4.3978e-09
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
@@ -7,502 +7,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.181517
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.181517
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.181517
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.169214
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.169214
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.169214
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.147761
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.147761
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.147761
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.123682
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.123682
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.123682
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0988719
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0988719
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.0988719
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0935533
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0935533
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.0935533
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.21706
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.21706
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.21706
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0540917
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0540917
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.0540917
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0449582
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0449582
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0449582
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0308627
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0308627
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0308627
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0205446
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0205446
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0205446
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0136714
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0136714
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0136714
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00974486
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00974486
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.00974486
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00745989
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00745989
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00745989
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00625425
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00625425
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00625425
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00562199
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00562199
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00562199
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00534598
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00534598
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.00534598
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00528586
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00528586
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.00528586
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00538654
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00538654
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.00538654
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00562696
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00562696
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.00562696
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00601444
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00601444
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.00601444
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00657781
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00657781
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.00657781
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0073725
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0073725
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.0073725
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00849356
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00849356
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.00849356
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0101053
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0101053
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.0101053
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0125059
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0125059
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.0125059
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0162819
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0162819
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.0162819
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0227294
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0227294
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.0227294
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0352607
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0352607
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.0352607
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0659507
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0659507
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.0659507
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.119332
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.119332
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.119332
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.708792
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.708792
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.708792
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00535025
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00535025
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.00535025
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0152389
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0152389
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.0152389
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00875104
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00875104
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.00875104
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0038305
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0038305
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.0038305
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00150606
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00150606
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.00150606
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000562059
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000562059
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.000562059
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000204226
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000204226
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.000204226
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.32118e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.32118e-05
       Relative nonlinear residual (total system) after nonlinear iteration 41: 7.32118e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.61034e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.61034e-05
       Relative nonlinear residual (total system) after nonlinear iteration 42: 2.61034e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.32716e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.32716e-06
       Relative nonlinear residual (total system) after nonlinear iteration 43: 9.32716e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.53111e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.53111e-06
       Relative nonlinear residual (total system) after nonlinear iteration 44: 3.53111e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.49142e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.49142e-06
       Relative nonlinear residual (total system) after nonlinear iteration 45: 2.49142e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.38948e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.38948e-06
       Relative nonlinear residual (total system) after nonlinear iteration 46: 4.38948e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.80007e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.80007e-06
       Relative nonlinear residual (total system) after nonlinear iteration 47: 8.80007e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.77739e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.77739e-05
       Relative nonlinear residual (total system) after nonlinear iteration 48: 1.77739e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.59288e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.59288e-05
       Relative nonlinear residual (total system) after nonlinear iteration 49: 3.59288e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.26614e-05
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.26614e-05
       Relative nonlinear residual (total system) after nonlinear iteration 50: 7.26614e-05
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000147042
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000147042
       Relative nonlinear residual (total system) after nonlinear iteration 51: 0.000147042
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000297547
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000297547
       Relative nonlinear residual (total system) after nonlinear iteration 52: 0.000297547
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000602769
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000602769
       Relative nonlinear residual (total system) after nonlinear iteration 53: 0.000602769
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00121951
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00121951
       Relative nonlinear residual (total system) after nonlinear iteration 54: 0.00121951
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00247522
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00247522
       Relative nonlinear residual (total system) after nonlinear iteration 55: 0.00247522
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00499565
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00499565
       Relative nonlinear residual (total system) after nonlinear iteration 56: 0.00499565
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0101977
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0101977
       Relative nonlinear residual (total system) after nonlinear iteration 57: 0.0101977
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0203539
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0203539
       Relative nonlinear residual (total system) after nonlinear iteration 58: 0.0203539
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0423179
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0423179
       Relative nonlinear residual (total system) after nonlinear iteration 59: 0.0423179
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 53+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0783926
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0783926
       Relative nonlinear residual (total system) after nonlinear iteration 60: 0.0783926
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.136252
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.136252
       Relative nonlinear residual (total system) after nonlinear iteration 61: 0.136252
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 58+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.193701
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.193701
       Relative nonlinear residual (total system) after nonlinear iteration 62: 0.193701
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 66+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.586702
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.586702
       Relative nonlinear residual (total system) after nonlinear iteration 63: 0.586702
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 61+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.335499
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.335499
       Relative nonlinear residual (total system) after nonlinear iteration 64: 0.335499
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 64+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.406904
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.406904
       Relative nonlinear residual (total system) after nonlinear iteration 65: 0.406904
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 62+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.203101
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.203101
       Relative nonlinear residual (total system) after nonlinear iteration 66: 0.203101
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 63+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.249553
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.249553
       Relative nonlinear residual (total system) after nonlinear iteration 67: 0.249553
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 69+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.276423
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.276423
       Relative nonlinear residual (total system) after nonlinear iteration 68: 0.276423
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.752096
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.752096
       Relative nonlinear residual (total system) after nonlinear iteration 69: 0.752096
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.616
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.616
       Relative nonlinear residual (total system) after nonlinear iteration 70: 0.616
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.267297
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.267297
       Relative nonlinear residual (total system) after nonlinear iteration 71: 0.267297
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.302853
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.302853
       Relative nonlinear residual (total system) after nonlinear iteration 72: 0.302853
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.460346
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.460346
       Relative nonlinear residual (total system) after nonlinear iteration 73: 0.460346
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.608138
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.608138
       Relative nonlinear residual (total system) after nonlinear iteration 74: 0.608138
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.349953
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.349953
       Relative nonlinear residual (total system) after nonlinear iteration 75: 0.349953
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.34468
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.34468
       Relative nonlinear residual (total system) after nonlinear iteration 76: 0.34468
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.374952
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.374952
       Relative nonlinear residual (total system) after nonlinear iteration 77: 0.374952
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.371241
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.371241
       Relative nonlinear residual (total system) after nonlinear iteration 78: 0.371241
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.528773
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.528773
       Relative nonlinear residual (total system) after nonlinear iteration 79: 0.528773
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.347623
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.347623
       Relative nonlinear residual (total system) after nonlinear iteration 80: 0.347623
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.364593
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.364593
       Relative nonlinear residual (total system) after nonlinear iteration 81: 0.364593
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.428894
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.428894
       Relative nonlinear residual (total system) after nonlinear iteration 82: 0.428894
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.627593
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.627593
       Relative nonlinear residual (total system) after nonlinear iteration 83: 0.627593
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 85+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.324755
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.324755
       Relative nonlinear residual (total system) after nonlinear iteration 84: 0.324755
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.327113
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.327113
       Relative nonlinear residual (total system) after nonlinear iteration 85: 0.327113
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.374718
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.374718
       Relative nonlinear residual (total system) after nonlinear iteration 86: 0.374718
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 66+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.392145
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.392145
       Relative nonlinear residual (total system) after nonlinear iteration 87: 0.392145
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 69+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.366132
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.366132
       Relative nonlinear residual (total system) after nonlinear iteration 88: 0.366132
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.385103
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.385103
       Relative nonlinear residual (total system) after nonlinear iteration 89: 0.385103
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.408646
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.408646
       Relative nonlinear residual (total system) after nonlinear iteration 90: 0.408646
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.380425
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.380425
       Relative nonlinear residual (total system) after nonlinear iteration 91: 0.380425
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.330497
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.330497
       Relative nonlinear residual (total system) after nonlinear iteration 92: 0.330497
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.351215
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.351215
       Relative nonlinear residual (total system) after nonlinear iteration 93: 0.351215
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.363534
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.363534
       Relative nonlinear residual (total system) after nonlinear iteration 94: 0.363534
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.491261
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.491261
       Relative nonlinear residual (total system) after nonlinear iteration 95: 0.491261
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.293537
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.293537
       Relative nonlinear residual (total system) after nonlinear iteration 96: 0.293537
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.425608
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.425608
       Relative nonlinear residual (total system) after nonlinear iteration 97: 0.425608
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.329871
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.329871
       Relative nonlinear residual (total system) after nonlinear iteration 98: 0.329871
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.355883
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.355883
       Relative nonlinear residual (total system) after nonlinear iteration 99: 0.355883
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.319654
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.319654
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.319654
 
 
@@ -515,502 +515,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=1 seconds, dt=1 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.315356
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.315356
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.315356
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.341148
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.341148
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.341148
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.349084
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.349084
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.349084
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.391622
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.391622
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.391622
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.634024
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.634024
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.634024
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.364141
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.364141
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.364141
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.372336
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.372336
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.372336
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.360255
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.360255
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.360255
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.415609
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.415609
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.415609
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.33708
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.33708
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.33708
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.45369
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.45369
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.45369
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.366954
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.366954
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.366954
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.404904
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.404904
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.404904
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.343578
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.343578
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.343578
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 67+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.330476
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.330476
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.330476
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.526024
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.526024
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.526024
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.349389
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.349389
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.349389
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.419386
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.419386
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.419386
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.598331
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.598331
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.598331
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.43063
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.43063
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.43063
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.3364
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.3364
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.3364
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.565555
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.565555
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.565555
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.529767
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.529767
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.529767
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.509845
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.509845
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.509845
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 86+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.380818
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.380818
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.380818
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.338482
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.338482
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.338482
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.70155
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.70155
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.70155
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.368909
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.368909
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.368909
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.483675
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.483675
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.483675
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.390357
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.390357
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.390357
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.326792
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.326792
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.326792
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 69+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.336083
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.336083
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.336083
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 67+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.36671
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.36671
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.36671
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.525474
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.525474
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.525474
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.411581
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.411581
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.411581
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.365448
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.365448
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.365448
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.443401
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.443401
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.443401
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.546671
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.546671
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.546671
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.408135
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.408135
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.408135
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.37737
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.37737
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.37737
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.339352
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.339352
       Relative nonlinear residual (total system) after nonlinear iteration 41: 0.339352
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.355708
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.355708
       Relative nonlinear residual (total system) after nonlinear iteration 42: 0.355708
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.307401
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.307401
       Relative nonlinear residual (total system) after nonlinear iteration 43: 0.307401
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.596907
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.596907
       Relative nonlinear residual (total system) after nonlinear iteration 44: 0.596907
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.334564
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.334564
       Relative nonlinear residual (total system) after nonlinear iteration 45: 0.334564
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.298844
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.298844
       Relative nonlinear residual (total system) after nonlinear iteration 46: 0.298844
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.387627
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.387627
       Relative nonlinear residual (total system) after nonlinear iteration 47: 0.387627
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.606219
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.606219
       Relative nonlinear residual (total system) after nonlinear iteration 48: 0.606219
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.402061
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.402061
       Relative nonlinear residual (total system) after nonlinear iteration 49: 0.402061
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.450665
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.450665
       Relative nonlinear residual (total system) after nonlinear iteration 50: 0.450665
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.344714
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.344714
       Relative nonlinear residual (total system) after nonlinear iteration 51: 0.344714
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.44976
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.44976
       Relative nonlinear residual (total system) after nonlinear iteration 52: 0.44976
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.522356
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.522356
       Relative nonlinear residual (total system) after nonlinear iteration 53: 0.522356
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.498839
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.498839
       Relative nonlinear residual (total system) after nonlinear iteration 54: 0.498839
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.326617
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.326617
       Relative nonlinear residual (total system) after nonlinear iteration 55: 0.326617
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.324656
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.324656
       Relative nonlinear residual (total system) after nonlinear iteration 56: 0.324656
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.396008
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.396008
       Relative nonlinear residual (total system) after nonlinear iteration 57: 0.396008
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.504159
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.504159
       Relative nonlinear residual (total system) after nonlinear iteration 58: 0.504159
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.341495
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.341495
       Relative nonlinear residual (total system) after nonlinear iteration 59: 0.341495
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.357069
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.357069
       Relative nonlinear residual (total system) after nonlinear iteration 60: 0.357069
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.373719
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.373719
       Relative nonlinear residual (total system) after nonlinear iteration 61: 0.373719
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.404615
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.404615
       Relative nonlinear residual (total system) after nonlinear iteration 62: 0.404615
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.479898
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.479898
       Relative nonlinear residual (total system) after nonlinear iteration 63: 0.479898
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.403627
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.403627
       Relative nonlinear residual (total system) after nonlinear iteration 64: 0.403627
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.30091
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.30091
       Relative nonlinear residual (total system) after nonlinear iteration 65: 0.30091
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.397341
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.397341
       Relative nonlinear residual (total system) after nonlinear iteration 66: 0.397341
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.404171
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.404171
       Relative nonlinear residual (total system) after nonlinear iteration 67: 0.404171
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.428316
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.428316
       Relative nonlinear residual (total system) after nonlinear iteration 68: 0.428316
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.307058
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.307058
       Relative nonlinear residual (total system) after nonlinear iteration 69: 0.307058
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.361237
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.361237
       Relative nonlinear residual (total system) after nonlinear iteration 70: 0.361237
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.383777
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.383777
       Relative nonlinear residual (total system) after nonlinear iteration 71: 0.383777
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.350255
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.350255
       Relative nonlinear residual (total system) after nonlinear iteration 72: 0.350255
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.339339
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.339339
       Relative nonlinear residual (total system) after nonlinear iteration 73: 0.339339
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.511131
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.511131
       Relative nonlinear residual (total system) after nonlinear iteration 74: 0.511131
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.381307
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.381307
       Relative nonlinear residual (total system) after nonlinear iteration 75: 0.381307
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.541578
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.541578
       Relative nonlinear residual (total system) after nonlinear iteration 76: 0.541578
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.305402
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.305402
       Relative nonlinear residual (total system) after nonlinear iteration 77: 0.305402
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.448634
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.448634
       Relative nonlinear residual (total system) after nonlinear iteration 78: 0.448634
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.481512
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.481512
       Relative nonlinear residual (total system) after nonlinear iteration 79: 0.481512
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.331057
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.331057
       Relative nonlinear residual (total system) after nonlinear iteration 80: 0.331057
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.328848
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.328848
       Relative nonlinear residual (total system) after nonlinear iteration 81: 0.328848
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.397004
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.397004
       Relative nonlinear residual (total system) after nonlinear iteration 82: 0.397004
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.319585
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.319585
       Relative nonlinear residual (total system) after nonlinear iteration 83: 0.319585
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.480221
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.480221
       Relative nonlinear residual (total system) after nonlinear iteration 84: 0.480221
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.332511
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.332511
       Relative nonlinear residual (total system) after nonlinear iteration 85: 0.332511
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.324765
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.324765
       Relative nonlinear residual (total system) after nonlinear iteration 86: 0.324765
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.680959
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.680959
       Relative nonlinear residual (total system) after nonlinear iteration 87: 0.680959
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.364203
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.364203
       Relative nonlinear residual (total system) after nonlinear iteration 88: 0.364203
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.363092
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.363092
       Relative nonlinear residual (total system) after nonlinear iteration 89: 0.363092
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.371239
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.371239
       Relative nonlinear residual (total system) after nonlinear iteration 90: 0.371239
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.330993
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.330993
       Relative nonlinear residual (total system) after nonlinear iteration 91: 0.330993
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.296263
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.296263
       Relative nonlinear residual (total system) after nonlinear iteration 92: 0.296263
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.347442
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.347442
       Relative nonlinear residual (total system) after nonlinear iteration 93: 0.347442
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.355022
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.355022
       Relative nonlinear residual (total system) after nonlinear iteration 94: 0.355022
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.523397
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.523397
       Relative nonlinear residual (total system) after nonlinear iteration 95: 0.523397
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.305985
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.305985
       Relative nonlinear residual (total system) after nonlinear iteration 96: 0.305985
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.464491
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.464491
       Relative nonlinear residual (total system) after nonlinear iteration 97: 0.464491
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.419461
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.419461
       Relative nonlinear residual (total system) after nonlinear iteration 98: 0.419461
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.361815
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.361815
       Relative nonlinear residual (total system) after nonlinear iteration 99: 0.361815
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.436628
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.436628
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.436628
 
 
@@ -1022,502 +1022,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=2 seconds, dt=1 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.438537
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.438537
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.438537
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.373544
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.373544
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.373544
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.532023
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.532023
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.532023
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.461235
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.461235
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.461235
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.369594
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.369594
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.369594
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.338593
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.338593
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.338593
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.299875
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.299875
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.299875
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.332375
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.332375
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.332375
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.350475
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.350475
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.350475
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.4905
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.4905
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.4905
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.334597
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.334597
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.334597
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.269474
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.269474
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.269474
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.319811
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.319811
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.319811
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.276432
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.276432
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.276432
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.321082
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.321082
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.321082
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.314542
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.314542
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.314542
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.380502
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.380502
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.380502
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.31544
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.31544
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.31544
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.544154
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.544154
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.544154
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.374905
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.374905
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.374905
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.445858
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.445858
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.445858
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.654294
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.654294
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.654294
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.308783
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.308783
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.308783
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.336371
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.336371
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.336371
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.311312
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.311312
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.311312
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.399869
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.399869
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.399869
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.337574
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.337574
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.337574
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.401622
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.401622
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.401622
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.337017
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.337017
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.337017
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.413611
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.413611
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.413611
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.412714
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.412714
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.412714
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.45222
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.45222
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.45222
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.36499
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.36499
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.36499
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.781144
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.781144
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.781144
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.316416
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.316416
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.316416
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.302329
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.302329
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.302329
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.431412
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.431412
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.431412
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.326831
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.326831
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.326831
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.37676
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.37676
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.37676
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.318059
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.318059
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.318059
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.473362
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.473362
       Relative nonlinear residual (total system) after nonlinear iteration 41: 0.473362
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.35212
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.35212
       Relative nonlinear residual (total system) after nonlinear iteration 42: 0.35212
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.404034
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.404034
       Relative nonlinear residual (total system) after nonlinear iteration 43: 0.404034
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.13744
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.13744
       Relative nonlinear residual (total system) after nonlinear iteration 44: 1.13744
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 67+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.34355
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.34355
       Relative nonlinear residual (total system) after nonlinear iteration 45: 0.34355
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.46228
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.46228
       Relative nonlinear residual (total system) after nonlinear iteration 46: 0.46228
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.506863
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.506863
       Relative nonlinear residual (total system) after nonlinear iteration 47: 0.506863
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.444259
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.444259
       Relative nonlinear residual (total system) after nonlinear iteration 48: 0.444259
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.455981
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.455981
       Relative nonlinear residual (total system) after nonlinear iteration 49: 0.455981
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.420263
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.420263
       Relative nonlinear residual (total system) after nonlinear iteration 50: 0.420263
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.340774
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.340774
       Relative nonlinear residual (total system) after nonlinear iteration 51: 0.340774
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.384768
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.384768
       Relative nonlinear residual (total system) after nonlinear iteration 52: 0.384768
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.336369
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.336369
       Relative nonlinear residual (total system) after nonlinear iteration 53: 0.336369
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.433124
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.433124
       Relative nonlinear residual (total system) after nonlinear iteration 54: 0.433124
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.285592
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.285592
       Relative nonlinear residual (total system) after nonlinear iteration 55: 0.285592
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.262654
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.262654
       Relative nonlinear residual (total system) after nonlinear iteration 56: 0.262654
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.607425
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.607425
       Relative nonlinear residual (total system) after nonlinear iteration 57: 0.607425
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.388913
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.388913
       Relative nonlinear residual (total system) after nonlinear iteration 58: 0.388913
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 83+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.592297
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.592297
       Relative nonlinear residual (total system) after nonlinear iteration 59: 0.592297
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.327955
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.327955
       Relative nonlinear residual (total system) after nonlinear iteration 60: 0.327955
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.568731
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.568731
       Relative nonlinear residual (total system) after nonlinear iteration 61: 0.568731
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.3727
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.3727
       Relative nonlinear residual (total system) after nonlinear iteration 62: 0.3727
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.388006
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.388006
       Relative nonlinear residual (total system) after nonlinear iteration 63: 0.388006
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.349619
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.349619
       Relative nonlinear residual (total system) after nonlinear iteration 64: 0.349619
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.637352
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.637352
       Relative nonlinear residual (total system) after nonlinear iteration 65: 0.637352
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.484504
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.484504
       Relative nonlinear residual (total system) after nonlinear iteration 66: 0.484504
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.293257
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.293257
       Relative nonlinear residual (total system) after nonlinear iteration 67: 0.293257
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.313726
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.313726
       Relative nonlinear residual (total system) after nonlinear iteration 68: 0.313726
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.349911
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.349911
       Relative nonlinear residual (total system) after nonlinear iteration 69: 0.349911
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 68+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.373335
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.373335
       Relative nonlinear residual (total system) after nonlinear iteration 70: 0.373335
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.357483
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.357483
       Relative nonlinear residual (total system) after nonlinear iteration 71: 0.357483
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.300935
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.300935
       Relative nonlinear residual (total system) after nonlinear iteration 72: 0.300935
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.390235
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.390235
       Relative nonlinear residual (total system) after nonlinear iteration 73: 0.390235
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.347605
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.347605
       Relative nonlinear residual (total system) after nonlinear iteration 74: 0.347605
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.391934
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.391934
       Relative nonlinear residual (total system) after nonlinear iteration 75: 0.391934
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.366626
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.366626
       Relative nonlinear residual (total system) after nonlinear iteration 76: 0.366626
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 71+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.379474
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.379474
       Relative nonlinear residual (total system) after nonlinear iteration 77: 0.379474
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.386301
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.386301
       Relative nonlinear residual (total system) after nonlinear iteration 78: 0.386301
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 69+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.365581
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.365581
       Relative nonlinear residual (total system) after nonlinear iteration 79: 0.365581
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.409355
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.409355
       Relative nonlinear residual (total system) after nonlinear iteration 80: 0.409355
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.640851
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.640851
       Relative nonlinear residual (total system) after nonlinear iteration 81: 0.640851
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.950159
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.950159
       Relative nonlinear residual (total system) after nonlinear iteration 82: 0.950159
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.575087
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.575087
       Relative nonlinear residual (total system) after nonlinear iteration 83: 0.575087
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 82+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.373754
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.373754
       Relative nonlinear residual (total system) after nonlinear iteration 84: 0.373754
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 85+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.370122
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.370122
       Relative nonlinear residual (total system) after nonlinear iteration 85: 0.370122
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 79+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.355995
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.355995
       Relative nonlinear residual (total system) after nonlinear iteration 86: 0.355995
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.670811
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.670811
       Relative nonlinear residual (total system) after nonlinear iteration 87: 0.670811
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 74+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.327039
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.327039
       Relative nonlinear residual (total system) after nonlinear iteration 88: 0.327039
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 85+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.28343
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.28343
       Relative nonlinear residual (total system) after nonlinear iteration 89: 0.28343
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 70+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.279819
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.279819
       Relative nonlinear residual (total system) after nonlinear iteration 90: 0.279819
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.412499
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.412499
       Relative nonlinear residual (total system) after nonlinear iteration 91: 0.412499
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 73+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.389132
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.389132
       Relative nonlinear residual (total system) after nonlinear iteration 92: 0.389132
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.485971
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.485971
       Relative nonlinear residual (total system) after nonlinear iteration 93: 0.485971
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.389243
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.389243
       Relative nonlinear residual (total system) after nonlinear iteration 94: 0.389243
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.357245
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.357245
       Relative nonlinear residual (total system) after nonlinear iteration 95: 0.357245
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 80+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.416123
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.416123
       Relative nonlinear residual (total system) after nonlinear iteration 96: 0.416123
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 75+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.421765
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.421765
       Relative nonlinear residual (total system) after nonlinear iteration 97: 0.421765
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 78+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.39021
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.39021
       Relative nonlinear residual (total system) after nonlinear iteration 98: 0.39021
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 76+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.355874
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.355874
       Relative nonlinear residual (total system) after nonlinear iteration 99: 0.355874
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.321945
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.321945
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.321945
 
 

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes/screen-output
@@ -10,17 +10,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.2855e-06, norm of the rhs: 2.1946e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1946e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.2855e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.2855e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21045e-06, norm of the rhs: 1.4765e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4765e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.21045e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.21045e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
@@ -29,7 +35,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 22+0 iterations.
    Line search iteration 0, with norm of the rhs 3.68051e+11 and going to 1.47636e+11, relative residual: 5.51002e-06
    Line search iteration 1, with norm of the rhs 2.83623e+11 and going to 1.47641e+11, relative residual: 4.24607e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.21318e-06, norm of the rhs: 8.10366e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.10366e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.21318e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.21318e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -37,7 +45,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 17+0 iterations.
    Line search iteration 0, with norm of the rhs 1.79849e+11 and going to 8.10285e+10, relative residual: 2.69249e-06
    Line search iteration 1, with norm of the rhs 1.1785e+11 and going to 8.10312e+10, relative residual: 1.76432e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.46951e-07, norm of the rhs: 5.65735e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.65735e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.46951e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.46951e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -45,7 +55,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 9.28386e+10 and going to 5.65678e+10, relative residual: 1.38987e-06
    Line search iteration 1, with norm of the rhs 6.95112e+10 and going to 5.65697e+10, relative residual: 1.04064e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 5.65941e-07, norm of the rhs: 3.78029e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.78029e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.65941e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 5.65941e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -53,7 +65,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 6.53014e+10 and going to 3.77992e+10, relative residual: 9.77616e-07
    Line search iteration 1, with norm of the rhs 5.57306e+10 and going to 3.78004e+10, relative residual: 8.34332e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.10691e-07, norm of the rhs: 2.74328e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.74328e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.10691e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 4.10691e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -61,49 +75,65 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 23+0 iterations.
    Line search iteration 0, with norm of the rhs 4.02269e+10 and going to 2.74301e+10, relative residual: 6.0223e-07
    Line search iteration 1, with norm of the rhs 3.55541e+10 and going to 2.7431e+10, relative residual: 5.32274e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.97118e-07, norm of the rhs: 2.65261e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.65261e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.97118e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.97118e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.2311e-07, norm of the rhs: 8.22331e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.22331e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.2311e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.2311e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 7.38641e-08, norm of the rhs: 4.93387e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.93387e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.38641e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 7.38641e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 6.79933e-09, norm of the rhs: 4.54172e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.54172e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.79933e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 6.79933e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0171838. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 4.25061e-10, norm of the rhs: 2.83926e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.83926e+07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.25061e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 4.25061e-10
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 9.04206e-11, norm of the rhs: 6.03979e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.03979e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.04206e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 9.04206e-11
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 2.1858e-11, norm of the rhs: 1.46004e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.46004e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.1858e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 2.1858e-11
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.99343e-12, norm of the rhs: 333544, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 333544, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.99343e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 4.99343e-12
 
 
    Postprocessing:
@@ -118,12 +148,16 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.64043e-12, norm of the rhs: 304758
+      Newton system information: Norm of the rhs: 304758
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.64043e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 6.64043e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1000+376 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 8.85049e-13, norm of the rhs: 40618.7, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 40618.7, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.85049e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.85049e-13
 
 
    Postprocessing:
@@ -137,12 +171,16 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.79029e-12, norm of the rhs: 265741
+      Newton system information: Norm of the rhs: 265741
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.79029e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.79029e-12
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.80973e-13, norm of the rhs: 22073.9, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 22073.9, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.80973e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.80973e-13
 
 
    Postprocessing:
@@ -157,7 +195,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1.77325e-12, norm of the rhs: 81382
+      Newton system information: Norm of the rhs: 81382
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.77325e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.77325e-12
 
 
    Postprocessing:
@@ -171,7 +211,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.08587e-12, norm of the rhs: 141623
+      Newton system information: Norm of the rhs: 141623
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.08587e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 3.08587e-12
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
@@ -9,123 +9,183 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 6.67966e+16, v = 4.5894e+16, p = 4.85338e+16
 
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.35346e-06, norm of the rhs: 2.90796e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.90796e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.35346e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.35346e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 3.1599e-06, norm of the rhs: 2.11071e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.11071e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.1599e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 3.1599e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 2.35971e-06, norm of the rhs: 1.5762e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.5762e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.35971e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 2.35971e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.65319e-06, norm of the rhs: 1.10427e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.10427e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.65319e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.65319e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.12565e-06, norm of the rhs: 7.51896e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.51896e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.12565e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.12565e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 7.44479e-07, norm of the rhs: 4.97287e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.97287e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.44479e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 7.44479e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 4.80363e-07, norm of the rhs: 3.20866e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.20866e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.80363e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 4.80363e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 3.04842e-07, norm of the rhs: 2.03624e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.03624e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.04842e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 3.04842e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.9292e-07, norm of the rhs: 1.28864e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.28864e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.9292e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.9292e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.23156e-07, norm of the rhs: 8.22644e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.22644e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.23156e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.23156e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 7.91864e-08, norm of the rhs: 5.28938e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.28938e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.91864e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 7.91864e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 5.11317e-08, norm of the rhs: 3.41543e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.41543e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.11317e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 5.11317e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 3.31344e-08, norm of the rhs: 2.21327e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.21327e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.31344e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 3.31344e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 2.15421e-08, norm of the rhs: 1.43894e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.43894e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.15421e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 2.15421e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.4045e-08, norm of the rhs: 9.3816e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.3816e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.4045e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.4045e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 9.17852e-09, norm of the rhs: 6.13094e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.13094e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.17852e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 9.17852e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 6.00984e-09, norm of the rhs: 4.01437e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.01437e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.00984e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 6.00984e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 3.94146e-09, norm of the rhs: 2.63276e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.63276e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.94146e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 3.94146e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 2.58852e-09, norm of the rhs: 1.72905e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.72905e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.58852e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 2.58852e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 1.70204e-09, norm of the rhs: 1.1369e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.1369e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.70204e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 1.70204e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 1.12033e-09, norm of the rhs: 7.48343e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.48343e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.12033e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 1.12033e-09
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 7.38133e-10, norm of the rhs: 4.93048e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.93048e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.38133e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 7.38133e-10
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 4.86735e-10, norm of the rhs: 3.25122e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.25122e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.86735e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 4.86735e-10
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 3.21206e-10, norm of the rhs: 2.14555e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.14555e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.21206e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 3.21206e-10
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 2.12119e-10, norm of the rhs: 1.41688e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.41688e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.12119e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 2.12119e-10
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 1.40168e-10, norm of the rhs: 9.36273e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.36273e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.40168e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 1.40168e-10
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 9.2676e-11, norm of the rhs: 6.19045e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.19045e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.2676e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 9.2676e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 6.13075e-11, norm of the rhs: 4.09513e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.09513e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.13075e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 6.13075e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 4.05757e-11, norm of the rhs: 2.71032e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.71032e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.05757e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 4.05757e-11
 
 
    Postprocessing:
@@ -138,27 +198,39 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 4.58943e+16, v = 4.58941e+16, p = 1.36197e+14
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.90556e-11, norm of the rhs: 2.71032e+06
+      Newton system information: Norm of the rhs: 2.71032e+06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.90556e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.90556e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.91022e-11, norm of the rhs: 1.79457e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.79457e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.91022e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.91022e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.59006e-11, norm of the rhs: 1.18869e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.18869e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.59006e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.59006e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.71622e-11, norm of the rhs: 787649, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 787649, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.71622e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.71622e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.13757e-11, norm of the rhs: 522078, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 522078, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.13757e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.13757e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 1000+83 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.54233e-12, norm of the rhs: 346150, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 346150, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.54233e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.54233e-12
 
 
    Postprocessing:
@@ -171,23 +243,33 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 4.58943e+16, v = 4.58941e+16, p = 1.36198e+14
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.39915e-11, norm of the rhs: 2.01896e+06
+      Newton system information: Norm of the rhs: 2.01896e+06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.39915e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.39915e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.91101e-11, norm of the rhs: 1.33599e+06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.33599e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.91101e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.91101e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.92714e-11, norm of the rhs: 884448, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 884448, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.92714e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.92714e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.27632e-11, norm of the rhs: 585758, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 585758, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.27632e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.27632e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.45601e-12, norm of the rhs: 388083, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 388083, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.45601e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.45601e-12
 
 
    Postprocessing:
@@ -200,19 +282,27 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 4.58943e+16, v = 4.58941e+16, p = 1.36198e+14
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.44536e-11, norm of the rhs: 1.12228e+06
+      Newton system information: Norm of the rhs: 1.12228e+06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.44536e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.44536e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.62101e-11, norm of the rhs: 743953, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 743953, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.62101e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 1.62101e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.07486e-11, norm of the rhs: 493302, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 493302, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.07486e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.07486e-11
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 7.12905e-12, norm of the rhs: 327183, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 327183, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.12905e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 7.12905e-12
 
 
    Postprocessing:
@@ -225,7 +315,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 4.58943e+16, v = 4.58941e+16, p = 1.36198e+14
 
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.81003e-12, norm of the rhs: 266648
+      Newton system information: Norm of the rhs: 266648
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.81003e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 5.81003e-12
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_derivative/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_derivative/screen-output
@@ -10,92 +10,128 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.2855e-06, norm of the rhs: 2.1946e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1946e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.2855e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.2855e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21045e-06, norm of the rhs: 1.4765e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4765e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.21045e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.21045e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 65+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.60827e-06, norm of the rhs: 1.07427e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.07427e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.60827e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.60827e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 81+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.12884e-06, norm of the rhs: 7.54024e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.54024e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.12884e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.12884e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 98+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.66437e-07, norm of the rhs: 5.11954e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.11954e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.66437e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.66437e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 103+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.90984e-07, norm of the rhs: 3.27961e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.27961e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.90984e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 4.90984e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 100+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.0257e-07, norm of the rhs: 2.02106e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.02106e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.0257e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.0257e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 99+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.85512e-07, norm of the rhs: 1.23916e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.23916e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.85512e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.85512e-07
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 97+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 9.32982e-08, norm of the rhs: 6.23201e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.23201e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.32982e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 9.32982e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 117+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 4.86656e-08, norm of the rhs: 3.2507e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.2507e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.86656e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 4.86656e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 129+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.83471e-08, norm of the rhs: 1.89349e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.89349e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.83471e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.83471e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 132+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 1.67665e-08, norm of the rhs: 1.11994e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.11994e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.67665e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 1.67665e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 134+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.00253e-08, norm of the rhs: 6.69658e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.69658e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.00253e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.00253e-08
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 134+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 6.0403e-09, norm of the rhs: 4.03472e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.03472e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.0403e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 6.0403e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 135+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 3.66075e-09, norm of the rhs: 2.44526e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.44526e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.66075e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 3.66075e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 135+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 2.22946e-09, norm of the rhs: 1.48921e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.48921e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.22946e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 2.22946e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 134+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.36357e-09, norm of the rhs: 9.10817e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.10817e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.36357e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 1.36357e-09
 
 
    Postprocessing:
@@ -110,12 +146,16 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1.9846e-09, norm of the rhs: 9.10817e+07
+      Newton system information: Norm of the rhs: 9.10817e+07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.9846e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.9846e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 95+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 7.6905e-10, norm of the rhs: 3.5295e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.5295e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.6905e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.6905e-10
 
 
    Postprocessing:
@@ -129,7 +169,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.67676e-10, norm of the rhs: 2.14636e+07
+      Newton system information: Norm of the rhs: 2.14636e+07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.67676e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.67676e-10
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_derivative_EW/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_derivative_EW/screen-output
@@ -10,114 +10,152 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.2855e-06, norm of the rhs: 2.1946e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1946e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.2855e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.2855e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.29543e-06, norm of the rhs: 1.53327e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.53327e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.29543e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.29543e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.70026e-06, norm of the rhs: 1.13572e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.13572e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.70026e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.70026e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.16734e-06, norm of the rhs: 7.79746e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.79746e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.16734e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.16734e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.7562e-07, norm of the rhs: 5.18088e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.18088e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.7562e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.7562e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.89599e-07, norm of the rhs: 3.27036e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.27036e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.89599e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 4.89599e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.0082e-07, norm of the rhs: 2.00938e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.00938e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.0082e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.0082e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.85625e-07, norm of the rhs: 1.23991e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.23991e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.85625e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.85625e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 9.31004e-08, norm of the rhs: 6.2188e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.2188e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.31004e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 9.31004e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 4.94388e-08, norm of the rhs: 3.30235e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.30235e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.94388e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 4.94388e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.82126e-08, norm of the rhs: 1.88451e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.88451e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.82126e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.82126e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 1.68454e-08, norm of the rhs: 1.12522e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.12522e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.68454e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 1.68454e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.00362e-08, norm of the rhs: 6.70387e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.70387e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.00362e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.00362e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 6.06282e-09, norm of the rhs: 4.04976e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.04976e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.06282e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 6.06282e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 3.72672e-09, norm of the rhs: 2.48932e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.48932e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.72672e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 3.72672e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 2.26362e-09, norm of the rhs: 1.51203e+08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.51203e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.26362e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 2.26362e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 1.39546e-09, norm of the rhs: 9.32123e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.32123e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.39546e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 1.39546e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 8.62561e-10, norm of the rhs: 5.76162e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.76162e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.62561e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 8.62561e-10
 
 
    Postprocessing:
@@ -132,12 +170,16 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1.24072e-09, norm of the rhs: 5.69421e+07
+      Newton system information: Norm of the rhs: 5.69421e+07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.24072e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1.24072e-09
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 96+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 5.32975e-10, norm of the rhs: 2.44605e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.44605e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.32975e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.32975e-10
 
 
    Postprocessing:
@@ -151,7 +193,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 2.0198e-10, norm of the rhs: 9.26971e+06
+      Newton system information: Norm of the rhs: 9.26971e+06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.0198e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 2.0198e-10
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_deviator/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_deviator/screen-output
@@ -10,17 +10,23 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.28123e-06, norm of the rhs: 2.19175e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.19175e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.28123e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.28123e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.20787e-06, norm of the rhs: 1.47478e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47478e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.20787e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.20787e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
@@ -29,7 +35,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 22+0 iterations.
    Line search iteration 0, with norm of the rhs 3.68956e+11 and going to 1.47464e+11, relative residual: 5.52356e-06
    Line search iteration 1, with norm of the rhs 2.80121e+11 and going to 1.47468e+11, relative residual: 4.19363e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.16208e-06, norm of the rhs: 7.76231e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.76231e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.16208e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.16208e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -37,7 +45,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 17+0 iterations.
    Line search iteration 0, with norm of the rhs 1.76854e+11 and going to 7.76153e+10, relative residual: 2.64765e-06
    Line search iteration 1, with norm of the rhs 1.12687e+11 and going to 7.76179e+10, relative residual: 1.68702e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 7.38892e-07, norm of the rhs: 4.93555e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.93555e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.38892e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 7.38892e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -45,7 +55,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 9.51029e+10 and going to 4.93505e+10, relative residual: 1.42377e-06
    Line search iteration 1, with norm of the rhs 7.06535e+10 and going to 4.93522e+10, relative residual: 1.05774e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 4.55786e-07, norm of the rhs: 3.0445e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.0445e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.55786e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 4.55786e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -53,7 +65,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 6.50053e+10 and going to 3.0442e+10, relative residual: 9.73182e-07
    Line search iteration 1, with norm of the rhs 5.48843e+10 and going to 3.0443e+10, relative residual: 8.21663e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 3.13911e-07, norm of the rhs: 2.09682e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.09682e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.13911e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 3.13911e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -62,7 +76,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Line search iteration 0, with norm of the rhs 3.70029e+10 and going to 2.09661e+10, relative residual: 5.53963e-07
    Line search iteration 1, with norm of the rhs 3.46837e+10 and going to 2.09668e+10, relative residual: 5.19243e-07
    Line search iteration 2, with norm of the rhs 2.36955e+10 and going to 2.09673e+10, relative residual: 3.5474e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 2.85349e-07, norm of the rhs: 1.90604e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.90604e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.85349e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 2.85349e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -70,43 +86,57 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 25+0 iterations.
    Line search iteration 0, with norm of the rhs 2.24692e+10 and going to 1.90585e+10, relative residual: 3.36382e-07
    Line search iteration 1, with norm of the rhs 2.15097e+10 and going to 1.90591e+10, relative residual: 3.22018e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 2.7485e-07, norm of the rhs: 1.83591e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.83591e+10, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.7485e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 2.7485e-07
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.8851e-08, norm of the rhs: 3.26308e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.26308e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.8851e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 4.8851e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.30685e-08, norm of the rhs: 1.5409e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.5409e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.30685e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 2.30685e-08
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.27128e-09, norm of the rhs: 1.51714e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.51714e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.27128e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.27128e-09
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0109027. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.27497e-11, norm of the rhs: 4.19147e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.19147e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.27497e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.27497e-11
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 6.34683e-12, norm of the rhs: 423947, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 423947, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.34683e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 6.34683e-12
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.0856437. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 40+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 5.72055e-13, norm of the rhs: 38211.3, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 38211.3, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.72055e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 5.72055e-13
 
 
    Postprocessing:
@@ -121,7 +151,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.42444e-13, norm of the rhs: 20305.6
+      Newton system information: Norm of the rhs: 20305.6
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.42444e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.42444e-13
 
 
    Postprocessing:
@@ -135,7 +167,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.42445e-13, norm of the rhs: 20305.6
+      Newton system information: Norm of the rhs: 20305.6
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.42445e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.42445e-13
 
 
    Postprocessing:
@@ -150,7 +184,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.42445e-13, norm of the rhs: 20305.6
+      Newton system information: Norm of the rhs: 20305.6
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.42445e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.42445e-13
 
 
    Postprocessing:
@@ -164,7 +200,9 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 4.42445e-13, norm of the rhs: 20305.6
+      Newton system information: Norm of the rhs: 20305.6
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.42445e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 4.42445e-13
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_line_search/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_line_search/screen-output
@@ -10,180 +10,240 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.2855e-06, norm of the rhs: 2.1946e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1946e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.2855e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.2855e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21045e-06, norm of the rhs: 1.4765e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4765e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.21045e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.21045e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 5.51002e-06, norm of the rhs: 3.68051e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.68051e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.51002e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 5.51002e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 6.28573e-06, norm of the rhs: 4.19866e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.19866e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.28573e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 6.28573e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.05347e-06, norm of the rhs: 4.71148e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.71148e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.05347e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.05347e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 5.99448e-06, norm of the rhs: 4.00411e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.00411e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.99448e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 5.99448e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 9.44688e-06, norm of the rhs: 6.3102e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.3102e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.44688e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 9.44688e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 9.21033e-06, norm of the rhs: 6.15219e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.15219e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.21033e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 9.21033e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.33644e-05, norm of the rhs: 8.92699e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.92699e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.33644e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.33644e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.59894e-05, norm of the rhs: 1.06804e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.06804e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.59894e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.59894e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.0282e-05, norm of the rhs: 1.35477e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.35477e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.0282e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.0282e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 2.4128e-05, norm of the rhs: 1.61167e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.61167e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.4128e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 2.4128e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 3.08461e-05, norm of the rhs: 2.06042e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.06042e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.08461e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 3.08461e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 3.74938e-05, norm of the rhs: 2.50446e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.50446e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.74938e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 3.74938e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 4.71222e-05, norm of the rhs: 3.14761e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.14761e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.71222e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 4.71222e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 5.59419e-05, norm of the rhs: 3.73673e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.73673e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.59419e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 5.59419e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 5.6693e-05, norm of the rhs: 3.7869e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.7869e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.6693e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 5.6693e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 7.03235e-05, norm of the rhs: 4.69737e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.69737e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.03235e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 7.03235e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 6.97434e-05, norm of the rhs: 4.65863e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.65863e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.97434e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 6.97434e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 8.18277e-05, norm of the rhs: 5.46581e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.46581e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.18277e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 8.18277e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 8.46837e-05, norm of the rhs: 5.65659e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.65659e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.46837e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 8.46837e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 9.9158e-05, norm of the rhs: 6.62342e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.62342e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.9158e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 9.9158e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000100845, norm of the rhs: 6.73611e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.73611e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000100845
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000100845
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000103, norm of the rhs: 6.88008e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.88008e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000103
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000103
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.00011546, norm of the rhs: 7.71232e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.71232e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00011546
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.00011546
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.000123425, norm of the rhs: 8.24437e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.24437e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000123425
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000123425
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.000118571, norm of the rhs: 7.92013e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.92013e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000118571
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000118571
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.000122679, norm of the rhs: 8.19454e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.19454e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000122679
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000122679
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.000127152, norm of the rhs: 8.49333e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.49333e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000127152
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000127152
 
 
    Postprocessing:
@@ -198,180 +258,240 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000184833, norm of the rhs: 8.48277e+12
+      Newton system information: Norm of the rhs: 8.48277e+12
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000184833
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000184833
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 8.91846e-06, norm of the rhs: 4.09306e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.09306e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.91846e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.91846e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 52+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.97479e-06, norm of the rhs: 2.28314e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.28314e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.97479e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.97479e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 8.64815e-06, norm of the rhs: 3.969e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.969e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.64815e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.64815e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.5086e-06, norm of the rhs: 3.90496e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.90496e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.5086e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.5086e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.02743e-05, norm of the rhs: 4.71532e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.71532e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.02743e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.02743e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 8.72775e-06, norm of the rhs: 4.00554e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.00554e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.72775e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 8.72775e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.32202e-05, norm of the rhs: 6.06733e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.06733e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.32202e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.32202e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.28054e-05, norm of the rhs: 5.87696e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.87696e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.28054e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.28054e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.78632e-05, norm of the rhs: 8.1982e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.1982e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.78632e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.78632e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.0695e-05, norm of the rhs: 9.49784e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.49784e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.0695e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 2.0695e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.68332e-05, norm of the rhs: 1.23149e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.23149e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.68332e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.68332e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 3.15611e-05, norm of the rhs: 1.44847e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.44847e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.15611e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 3.15611e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.0371e-05, norm of the rhs: 1.8528e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.8528e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.0371e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 4.0371e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.92267e-05, norm of the rhs: 2.25922e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.25922e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.92267e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 4.92267e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 6.14673e-05, norm of the rhs: 2.821e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.821e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.14673e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 6.14673e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 7.60246e-05, norm of the rhs: 3.48909e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.48909e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.60246e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 7.60246e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 8.24449e-05, norm of the rhs: 3.78375e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.78375e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.24449e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 8.24449e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 9.58196e-05, norm of the rhs: 4.39757e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.39757e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.58196e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 9.58196e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.000101421, norm of the rhs: 4.65464e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.65464e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000101421
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000101421
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.000119825, norm of the rhs: 5.49927e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.49927e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000119825
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000119825
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.00011973, norm of the rhs: 5.49491e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.49491e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00011973
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.00011973
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000138367, norm of the rhs: 6.35023e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.35023e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000138367
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000138367
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000132584, norm of the rhs: 6.08485e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.08485e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000132584
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000132584
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000143229, norm of the rhs: 6.57338e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.57338e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000143229
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000143229
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.00016115, norm of the rhs: 7.39586e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.39586e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00016115
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.00016115
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.000162336, norm of the rhs: 7.45029e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.45029e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000162336
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000162336
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.000165025, norm of the rhs: 7.57368e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.57368e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000165025
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000165025
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.000179245, norm of the rhs: 8.2263e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.2263e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000179245
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000179245
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.000182844, norm of the rhs: 8.3915e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.3915e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000182844
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000182844
 
 
    Postprocessing:
@@ -385,180 +505,240 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000318113, norm of the rhs: 1.45994e+13
+      Newton system information: Norm of the rhs: 1.45994e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000318113
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000318113
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 9.03497e-06, norm of the rhs: 4.1465e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.1465e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.03497e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.03497e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.92637e-06, norm of the rhs: 2.2609e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.2609e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.92637e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.92637e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 8.30645e-06, norm of the rhs: 3.81215e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.81215e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.30645e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.30645e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.33969e-06, norm of the rhs: 3.82741e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.82741e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.33969e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.33969e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 9.81347e-06, norm of the rhs: 4.50378e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.50378e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.81347e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 9.81347e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 7.90753e-06, norm of the rhs: 3.62907e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.62907e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.90753e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 7.90753e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.23634e-05, norm of the rhs: 5.67405e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.67405e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.23634e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.23634e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.1575e-05, norm of the rhs: 5.31224e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.31224e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.1575e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.1575e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.70744e-05, norm of the rhs: 7.83611e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.83611e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.70744e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.70744e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.87392e-05, norm of the rhs: 8.60016e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.60016e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.87392e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.87392e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.5292e-05, norm of the rhs: 1.16075e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.16075e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.5292e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.5292e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 2.96891e-05, norm of the rhs: 1.36255e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.36255e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.96891e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 2.96891e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 3.81901e-05, norm of the rhs: 1.75269e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.75269e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.81901e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 3.81901e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.61685e-05, norm of the rhs: 2.11885e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.11885e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.61685e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 4.61685e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 5.80535e-05, norm of the rhs: 2.6643e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.6643e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.80535e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 5.80535e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 7.16873e-05, norm of the rhs: 3.29001e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.29001e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.16873e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 7.16873e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.813e-05, norm of the rhs: 3.58569e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.58569e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.813e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 7.813e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 9.83046e-05, norm of the rhs: 4.51158e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.51158e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.83046e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 9.83046e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 9.64964e-05, norm of the rhs: 4.4286e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.4286e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.64964e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 9.64964e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.000112394, norm of the rhs: 5.15818e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.15818e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000112394
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000112394
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.000120826, norm of the rhs: 5.54518e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.54518e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000120826
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000120826
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000137367, norm of the rhs: 6.30432e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.30432e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000137367
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000137367
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000140831, norm of the rhs: 6.4633e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.4633e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000140831
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000140831
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000149476, norm of the rhs: 6.86002e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.86002e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000149476
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000149476
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.000168218, norm of the rhs: 7.72017e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.72017e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000168218
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000168218
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.000164408, norm of the rhs: 7.54533e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.54533e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000164408
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000164408
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.00016896, norm of the rhs: 7.75424e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.75424e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00016896
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.00016896
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.000177425, norm of the rhs: 8.14272e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.14272e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000177425
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000177425
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.000179495, norm of the rhs: 8.23772e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.23772e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000179495
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000179495
 
 
    Postprocessing:
@@ -573,180 +753,240 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00029802, norm of the rhs: 1.36775e+13
+      Newton system information: Norm of the rhs: 1.36775e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00029802
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00029802
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 9.26657e-06, norm of the rhs: 4.25284e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.25284e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.26657e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.26657e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 59+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.11446e-06, norm of the rhs: 2.34726e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.34726e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.11446e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.11446e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 8.73997e-06, norm of the rhs: 4.01117e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.01117e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.73997e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.73997e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 9.01619e-06, norm of the rhs: 4.13793e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.13793e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.01619e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.01619e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.05514e-05, norm of the rhs: 4.84251e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.84251e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.05514e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.05514e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 9.50788e-06, norm of the rhs: 4.36359e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.36359e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.50788e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 9.50788e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.36085e-05, norm of the rhs: 6.24557e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.24557e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.36085e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.36085e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.34419e-05, norm of the rhs: 6.16911e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.16911e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.34419e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.34419e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.87978e-05, norm of the rhs: 8.62718e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.62718e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.87978e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.87978e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.19098e-05, norm of the rhs: 1.00554e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.00554e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.19098e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 2.19098e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.83347e-05, norm of the rhs: 1.30041e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.30041e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.83347e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.83347e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 3.3148e-05, norm of the rhs: 1.52131e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.52131e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.3148e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 3.3148e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.23712e-05, norm of the rhs: 1.9446e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.9446e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.23712e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 4.23712e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 5.14094e-05, norm of the rhs: 2.35941e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.35941e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.14094e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 5.14094e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 6.42456e-05, norm of the rhs: 2.94852e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.94852e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.42456e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 6.42456e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 8.22446e-05, norm of the rhs: 3.77458e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.77458e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.22446e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 8.22446e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 7.87213e-05, norm of the rhs: 3.61287e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.61287e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.87213e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 7.87213e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 9.75476e-05, norm of the rhs: 4.4769e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.4769e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.75476e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 9.75476e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 9.91086e-05, norm of the rhs: 4.54854e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.54854e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.91086e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 9.91086e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.000118599, norm of the rhs: 5.44306e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.44306e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000118599
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000118599
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.000117842, norm of the rhs: 5.40828e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.40828e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000117842
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000117842
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000128666, norm of the rhs: 5.90506e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.90506e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000128666
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000128666
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000138396, norm of the rhs: 6.35162e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.35162e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000138396
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000138396
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000150445, norm of the rhs: 6.90459e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.90459e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000150445
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000150445
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.00015245, norm of the rhs: 6.99663e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.99663e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00015245
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.00015245
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.000170723, norm of the rhs: 7.83526e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.83526e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000170723
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000170723
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.000166034, norm of the rhs: 7.62004e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.62004e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000166034
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000166034
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.000178526, norm of the rhs: 8.19337e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.19337e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000178526
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000178526
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.000181009, norm of the rhs: 8.30731e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.30731e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000181009
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000181009
 
 
    Postprocessing:
@@ -760,180 +1000,240 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000303471, norm of the rhs: 1.39276e+13
+      Newton system information: Norm of the rhs: 1.39276e+13
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000303471
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000303471
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 9.35546e-06, norm of the rhs: 4.29362e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.29362e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.35546e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 9.35546e-06
 
    Skipping temperature solve because RHS is zero.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 55+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 5.1146e-06, norm of the rhs: 2.34731e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.34731e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.1146e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 5.1146e-06
 
    Skipping temperature solve because RHS is zero.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 9.20586e-06, norm of the rhs: 4.22497e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.22497e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.20586e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 9.20586e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 9.66791e-06, norm of the rhs: 4.43702e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.43702e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.66791e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.66791e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.03262e-05, norm of the rhs: 4.73913e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.73913e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.03262e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 1.03262e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 9.33217e-06, norm of the rhs: 4.28293e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.28293e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.33217e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 9.33217e-06
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.37418e-05, norm of the rhs: 6.30671e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.30671e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.37418e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.37418e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.33416e-05, norm of the rhs: 6.12302e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.12302e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.33416e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.33416e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.91707e-05, norm of the rhs: 8.79825e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.79825e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.91707e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.91707e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 2.16937e-05, norm of the rhs: 9.95619e+11, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.95619e+11, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.16937e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 2.16937e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 2.85685e-05, norm of the rhs: 1.31113e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.31113e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.85685e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 2.85685e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 3.34648e-05, norm of the rhs: 1.53585e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.53585e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.34648e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 3.34648e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.37243e-05, norm of the rhs: 2.0067e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.0067e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.37243e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 4.37243e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 5.19225e-05, norm of the rhs: 2.38295e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.38295e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.19225e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 5.19225e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 6.56069e-05, norm of the rhs: 3.01098e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.01098e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.56069e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 6.56069e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 8.51655e-05, norm of the rhs: 3.90861e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.90861e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.51655e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 8.51655e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 8.16867e-05, norm of the rhs: 3.74895e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.74895e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.16867e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 8.16867e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 9.71983e-05, norm of the rhs: 4.46085e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.46085e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.71983e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 9.71983e-05
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.000106917, norm of the rhs: 4.90688e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.90688e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000106917
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000106917
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.000119459, norm of the rhs: 5.48247e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.48247e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000119459
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000119459
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.000126783, norm of the rhs: 5.81861e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.81861e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000126783
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000126783
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.000135421, norm of the rhs: 6.21503e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.21503e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000135421
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000135421
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.000133774, norm of the rhs: 6.13948e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.13948e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000133774
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000133774
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.000147324, norm of the rhs: 6.76132e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.76132e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000147324
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000147324
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.000158349, norm of the rhs: 7.26731e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.26731e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000158349
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000158349
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.000168045, norm of the rhs: 7.71229e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.71229e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000168045
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000168045
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.000167738, norm of the rhs: 7.69821e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.69821e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000167738
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000167738
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.000182145, norm of the rhs: 8.3594e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.3594e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000182145
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000182145
 
    Skipping temperature solve because RHS is zero.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.000183823, norm of the rhs: 8.43643e+12, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.43643e+12, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000183823
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000183823
 
 
    Postprocessing:

--- a/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
@@ -7,502 +7,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.0133231
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.0133231
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0133231
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.2508e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.2508e-07
       Relative nonlinear residual (total system) after nonlinear iteration 3: 2.2508e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.06471e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.06471e-07
       Relative nonlinear residual (total system) after nonlinear iteration 4: 2.06471e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.65733e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.65733e-07
       Relative nonlinear residual (total system) after nonlinear iteration 5: 1.65733e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.09111e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.09111e-07
       Relative nonlinear residual (total system) after nonlinear iteration 6: 1.09111e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.00406e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.00406e-08
       Relative nonlinear residual (total system) after nonlinear iteration 7: 9.00406e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.27507e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.27507e-07
       Relative nonlinear residual (total system) after nonlinear iteration 8: 1.27507e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.06584e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.06584e-07
       Relative nonlinear residual (total system) after nonlinear iteration 9: 4.06584e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.74948e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.74948e-07
       Relative nonlinear residual (total system) after nonlinear iteration 10: 1.74948e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.13873e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.13873e-08
       Relative nonlinear residual (total system) after nonlinear iteration 11: 9.13873e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.72289e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.72289e-08
       Relative nonlinear residual (total system) after nonlinear iteration 12: 5.72289e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.61037e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.61037e-08
       Relative nonlinear residual (total system) after nonlinear iteration 13: 3.61037e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.67495e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.67495e-08
       Relative nonlinear residual (total system) after nonlinear iteration 14: 2.67495e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.20586e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.20586e-08
       Relative nonlinear residual (total system) after nonlinear iteration 15: 2.20586e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.05502e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.05502e-08
       Relative nonlinear residual (total system) after nonlinear iteration 16: 2.05502e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.06209e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.06209e-08
       Relative nonlinear residual (total system) after nonlinear iteration 17: 2.06209e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.29302e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.29302e-08
       Relative nonlinear residual (total system) after nonlinear iteration 18: 2.29302e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.75549e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.75549e-08
       Relative nonlinear residual (total system) after nonlinear iteration 19: 2.75549e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.64299e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.64299e-08
       Relative nonlinear residual (total system) after nonlinear iteration 20: 3.64299e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.49643e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.49643e-08
       Relative nonlinear residual (total system) after nonlinear iteration 21: 5.49643e-08
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.06565e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.06565e-07
       Relative nonlinear residual (total system) after nonlinear iteration 22: 1.06565e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.89601e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 2.89601e-07
       Relative nonlinear residual (total system) after nonlinear iteration 23: 2.89601e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.96481e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.96481e-07
       Relative nonlinear residual (total system) after nonlinear iteration 24: 8.96481e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 3.94583e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.94583e-07
       Relative nonlinear residual (total system) after nonlinear iteration 25: 3.94583e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.76915e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.76915e-07
       Relative nonlinear residual (total system) after nonlinear iteration 26: 4.76915e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.75751e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.75751e-07
       Relative nonlinear residual (total system) after nonlinear iteration 27: 5.75751e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.70668e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.70668e-07
       Relative nonlinear residual (total system) after nonlinear iteration 28: 4.70668e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.40771e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.40771e-07
       Relative nonlinear residual (total system) after nonlinear iteration 29: 5.40771e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.80092e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.80092e-07
       Relative nonlinear residual (total system) after nonlinear iteration 30: 5.80092e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.575e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.575e-07
       Relative nonlinear residual (total system) after nonlinear iteration 31: 5.575e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.95536e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.95536e-07
       Relative nonlinear residual (total system) after nonlinear iteration 32: 5.95536e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.22643e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.22643e-07
       Relative nonlinear residual (total system) after nonlinear iteration 33: 6.22643e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.17355e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.17355e-07
       Relative nonlinear residual (total system) after nonlinear iteration 34: 5.17355e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.31601e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.31601e-07
       Relative nonlinear residual (total system) after nonlinear iteration 35: 4.31601e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.23617e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.23617e-06
       Relative nonlinear residual (total system) after nonlinear iteration 36: 1.23617e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.41881e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.41881e-07
       Relative nonlinear residual (total system) after nonlinear iteration 37: 8.41881e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.74847e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.74847e-07
       Relative nonlinear residual (total system) after nonlinear iteration 38: 4.74847e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.23098e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.23098e-07
       Relative nonlinear residual (total system) after nonlinear iteration 39: 6.23098e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 25+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.09285e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.09285e-06
       Relative nonlinear residual (total system) after nonlinear iteration 40: 1.09285e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.43342e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.43342e-07
       Relative nonlinear residual (total system) after nonlinear iteration 41: 7.43342e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.91667e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.91667e-07
       Relative nonlinear residual (total system) after nonlinear iteration 42: 4.91667e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 24+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.80935e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.80935e-07
       Relative nonlinear residual (total system) after nonlinear iteration 43: 5.80935e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.05305e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.05305e-07
       Relative nonlinear residual (total system) after nonlinear iteration 44: 7.05305e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.72427e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.72427e-07
       Relative nonlinear residual (total system) after nonlinear iteration 45: 5.72427e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.53306e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.53306e-07
       Relative nonlinear residual (total system) after nonlinear iteration 46: 6.53306e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.08149e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.08149e-07
       Relative nonlinear residual (total system) after nonlinear iteration 47: 5.08149e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.58795e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.58795e-07
       Relative nonlinear residual (total system) after nonlinear iteration 48: 6.58795e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.79573e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.79573e-07
       Relative nonlinear residual (total system) after nonlinear iteration 49: 7.79573e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.85076e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.85076e-07
       Relative nonlinear residual (total system) after nonlinear iteration 50: 4.85076e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.88696e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.88696e-07
       Relative nonlinear residual (total system) after nonlinear iteration 51: 6.88696e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.23496e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.23496e-07
       Relative nonlinear residual (total system) after nonlinear iteration 52: 6.23496e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.3131e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.3131e-07
       Relative nonlinear residual (total system) after nonlinear iteration 53: 9.3131e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 4.63704e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 4.63704e-07
       Relative nonlinear residual (total system) after nonlinear iteration 54: 4.63704e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.70493e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.70493e-07
       Relative nonlinear residual (total system) after nonlinear iteration 55: 6.70493e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.10727e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.10727e-06
       Relative nonlinear residual (total system) after nonlinear iteration 56: 1.10727e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.80373e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.80373e-07
       Relative nonlinear residual (total system) after nonlinear iteration 57: 5.80373e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.26864e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.26864e-07
       Relative nonlinear residual (total system) after nonlinear iteration 58: 7.26864e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.78613e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.78613e-07
       Relative nonlinear residual (total system) after nonlinear iteration 59: 5.78613e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.33309e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.33309e-07
       Relative nonlinear residual (total system) after nonlinear iteration 60: 6.33309e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.60912e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.60912e-07
       Relative nonlinear residual (total system) after nonlinear iteration 61: 6.60912e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.97979e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.97979e-07
       Relative nonlinear residual (total system) after nonlinear iteration 62: 7.97979e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.15456e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.15456e-07
       Relative nonlinear residual (total system) after nonlinear iteration 63: 7.15456e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.19807e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.19807e-07
       Relative nonlinear residual (total system) after nonlinear iteration 64: 5.19807e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.20503e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.20503e-07
       Relative nonlinear residual (total system) after nonlinear iteration 65: 6.20503e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.6569e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.6569e-07
       Relative nonlinear residual (total system) after nonlinear iteration 66: 6.6569e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.67325e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.67325e-07
       Relative nonlinear residual (total system) after nonlinear iteration 67: 6.67325e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.95268e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.95268e-07
       Relative nonlinear residual (total system) after nonlinear iteration 68: 5.95268e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.90618e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.90618e-07
       Relative nonlinear residual (total system) after nonlinear iteration 69: 9.90618e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.30706e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.30706e-07
       Relative nonlinear residual (total system) after nonlinear iteration 70: 8.30706e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.03704e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.03704e-07
       Relative nonlinear residual (total system) after nonlinear iteration 71: 6.03704e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.06353e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.06353e-07
       Relative nonlinear residual (total system) after nonlinear iteration 72: 5.06353e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.49831e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.49831e-06
       Relative nonlinear residual (total system) after nonlinear iteration 73: 1.49831e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.68648e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.68648e-07
       Relative nonlinear residual (total system) after nonlinear iteration 74: 8.68648e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.0845e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.0845e-07
       Relative nonlinear residual (total system) after nonlinear iteration 75: 6.0845e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.41999e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.41999e-07
       Relative nonlinear residual (total system) after nonlinear iteration 76: 7.41999e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.48919e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.48919e-07
       Relative nonlinear residual (total system) after nonlinear iteration 77: 6.48919e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.42084e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.42084e-07
       Relative nonlinear residual (total system) after nonlinear iteration 78: 5.42084e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 9.50374e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 9.50374e-07
       Relative nonlinear residual (total system) after nonlinear iteration 79: 9.50374e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.11572e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.11572e-07
       Relative nonlinear residual (total system) after nonlinear iteration 80: 5.11572e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.7407e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.7407e-07
       Relative nonlinear residual (total system) after nonlinear iteration 81: 5.7407e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.50358e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.50358e-07
       Relative nonlinear residual (total system) after nonlinear iteration 82: 7.50358e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.16925e-06
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1.16925e-06
       Relative nonlinear residual (total system) after nonlinear iteration 83: 1.16925e-06
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.41733e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.41733e-07
       Relative nonlinear residual (total system) after nonlinear iteration 84: 5.41733e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.87805e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.87805e-07
       Relative nonlinear residual (total system) after nonlinear iteration 85: 5.87805e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.88583e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.88583e-07
       Relative nonlinear residual (total system) after nonlinear iteration 86: 5.88583e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.53788e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.53788e-07
       Relative nonlinear residual (total system) after nonlinear iteration 87: 6.53788e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.05915e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.05915e-07
       Relative nonlinear residual (total system) after nonlinear iteration 88: 8.05915e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.13099e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.13099e-07
       Relative nonlinear residual (total system) after nonlinear iteration 89: 6.13099e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 8.02404e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.02404e-07
       Relative nonlinear residual (total system) after nonlinear iteration 90: 8.02404e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.79801e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.79801e-07
       Relative nonlinear residual (total system) after nonlinear iteration 91: 5.79801e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.17539e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.17539e-07
       Relative nonlinear residual (total system) after nonlinear iteration 92: 6.17539e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.5661e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.5661e-07
       Relative nonlinear residual (total system) after nonlinear iteration 93: 5.5661e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.43116e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.43116e-07
       Relative nonlinear residual (total system) after nonlinear iteration 94: 6.43116e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.5828e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.5828e-07
       Relative nonlinear residual (total system) after nonlinear iteration 95: 5.5828e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.61485e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 7.61485e-07
       Relative nonlinear residual (total system) after nonlinear iteration 96: 7.61485e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.67091e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.67091e-07
       Relative nonlinear residual (total system) after nonlinear iteration 97: 5.67091e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.9604e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.9604e-07
       Relative nonlinear residual (total system) after nonlinear iteration 98: 6.9604e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.37753e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 6.37753e-07
       Relative nonlinear residual (total system) after nonlinear iteration 99: 6.37753e-07
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.69791e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0, 5.69791e-07
       Relative nonlinear residual (total system) after nonlinear iteration 100: 5.69791e-07
 
 
@@ -515,502 +515,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=1 seconds, dt=1 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000511399
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000511399
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000511399
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000428633
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000428633
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000428633
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000461641
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000461641
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000461641
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000381555
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000381555
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000381555
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000399874
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000399874
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000399874
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000372136
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000372136
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000372136
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000509647
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000509647
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000509647
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000352658
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000352658
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000352658
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000369593
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000369593
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.000369593
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000495265
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000495265
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.000495265
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000433279
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000433279
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.000433279
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000404609
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000404609
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.000404609
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000419633
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000419633
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.000419633
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000554985
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000554985
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.000554985
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000290616
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000290616
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.000290616
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000434132
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000434132
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.000434132
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000359344
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000359344
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.000359344
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000373972
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000373972
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.000373972
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00122886
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00122886
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.00122886
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000458297
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000458297
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000458297
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000538917
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000538917
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000538917
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00038265
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00038265
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.00038265
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000428
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000428
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000428
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000646919
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000646919
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000646919
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000473317
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000473317
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000473317
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000556353
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000556353
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000556353
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000388969
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000388969
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000388969
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000352484
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000352484
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000352484
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000375959
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000375959
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000375959
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000362963
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000362963
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000362963
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000398179
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000398179
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.000398179
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000614299
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000614299
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.000614299
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000395629
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000395629
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.000395629
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000603461
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000603461
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.000603461
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000407919
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000407919
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.000407919
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000428538
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000428538
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.000428538
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00051835
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00051835
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.00051835
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000464945
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000464945
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.000464945
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000640149
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000640149
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.000640149
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000513962
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000513962
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.000513962
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000414235
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000414235
       Relative nonlinear residual (total system) after nonlinear iteration 41: 0.000414235
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000898174
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000898174
       Relative nonlinear residual (total system) after nonlinear iteration 42: 0.000898174
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000400076
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000400076
       Relative nonlinear residual (total system) after nonlinear iteration 43: 0.000400076
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000439889
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000439889
       Relative nonlinear residual (total system) after nonlinear iteration 44: 0.000439889
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000531897
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000531897
       Relative nonlinear residual (total system) after nonlinear iteration 45: 0.000531897
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000355711
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000355711
       Relative nonlinear residual (total system) after nonlinear iteration 46: 0.000355711
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000479785
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000479785
       Relative nonlinear residual (total system) after nonlinear iteration 47: 0.000479785
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000323806
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000323806
       Relative nonlinear residual (total system) after nonlinear iteration 48: 0.000323806
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000404799
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000404799
       Relative nonlinear residual (total system) after nonlinear iteration 49: 0.000404799
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00033022
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00033022
       Relative nonlinear residual (total system) after nonlinear iteration 50: 0.00033022
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000422626
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000422626
       Relative nonlinear residual (total system) after nonlinear iteration 51: 0.000422626
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000354518
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000354518
       Relative nonlinear residual (total system) after nonlinear iteration 52: 0.000354518
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000329852
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000329852
       Relative nonlinear residual (total system) after nonlinear iteration 53: 0.000329852
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000425466
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000425466
       Relative nonlinear residual (total system) after nonlinear iteration 54: 0.000425466
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00035948
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00035948
       Relative nonlinear residual (total system) after nonlinear iteration 55: 0.00035948
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000471906
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000471906
       Relative nonlinear residual (total system) after nonlinear iteration 56: 0.000471906
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000317894
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000317894
       Relative nonlinear residual (total system) after nonlinear iteration 57: 0.000317894
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00071187
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00071187
       Relative nonlinear residual (total system) after nonlinear iteration 58: 0.00071187
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000514002
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000514002
       Relative nonlinear residual (total system) after nonlinear iteration 59: 0.000514002
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000428898
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000428898
       Relative nonlinear residual (total system) after nonlinear iteration 60: 0.000428898
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000536625
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000536625
       Relative nonlinear residual (total system) after nonlinear iteration 61: 0.000536625
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 35+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000788849
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000788849
       Relative nonlinear residual (total system) after nonlinear iteration 62: 0.000788849
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000415816
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000415816
       Relative nonlinear residual (total system) after nonlinear iteration 63: 0.000415816
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000469073
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000469073
       Relative nonlinear residual (total system) after nonlinear iteration 64: 0.000469073
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000473118
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000473118
       Relative nonlinear residual (total system) after nonlinear iteration 65: 0.000473118
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000468025
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000468025
       Relative nonlinear residual (total system) after nonlinear iteration 66: 0.000468025
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000368423
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000368423
       Relative nonlinear residual (total system) after nonlinear iteration 67: 0.000368423
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000422923
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000422923
       Relative nonlinear residual (total system) after nonlinear iteration 68: 0.000422923
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000429147
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000429147
       Relative nonlinear residual (total system) after nonlinear iteration 69: 0.000429147
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000456725
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000456725
       Relative nonlinear residual (total system) after nonlinear iteration 70: 0.000456725
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000347616
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000347616
       Relative nonlinear residual (total system) after nonlinear iteration 71: 0.000347616
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000495317
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000495317
       Relative nonlinear residual (total system) after nonlinear iteration 72: 0.000495317
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00042544
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00042544
       Relative nonlinear residual (total system) after nonlinear iteration 73: 0.00042544
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00044527
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00044527
       Relative nonlinear residual (total system) after nonlinear iteration 74: 0.00044527
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000711862
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000711862
       Relative nonlinear residual (total system) after nonlinear iteration 75: 0.000711862
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00053328
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00053328
       Relative nonlinear residual (total system) after nonlinear iteration 76: 0.00053328
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000363452
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000363452
       Relative nonlinear residual (total system) after nonlinear iteration 77: 0.000363452
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000433155
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000433155
       Relative nonlinear residual (total system) after nonlinear iteration 78: 0.000433155
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00045512
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00045512
       Relative nonlinear residual (total system) after nonlinear iteration 79: 0.00045512
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000537527
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000537527
       Relative nonlinear residual (total system) after nonlinear iteration 80: 0.000537527
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000522574
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000522574
       Relative nonlinear residual (total system) after nonlinear iteration 81: 0.000522574
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000484755
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000484755
       Relative nonlinear residual (total system) after nonlinear iteration 82: 0.000484755
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000405839
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000405839
       Relative nonlinear residual (total system) after nonlinear iteration 83: 0.000405839
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000466735
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000466735
       Relative nonlinear residual (total system) after nonlinear iteration 84: 0.000466735
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000543753
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000543753
       Relative nonlinear residual (total system) after nonlinear iteration 85: 0.000543753
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000507766
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000507766
       Relative nonlinear residual (total system) after nonlinear iteration 86: 0.000507766
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000553454
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000553454
       Relative nonlinear residual (total system) after nonlinear iteration 87: 0.000553454
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000450505
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000450505
       Relative nonlinear residual (total system) after nonlinear iteration 88: 0.000450505
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000414262
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000414262
       Relative nonlinear residual (total system) after nonlinear iteration 89: 0.000414262
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000503809
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000503809
       Relative nonlinear residual (total system) after nonlinear iteration 90: 0.000503809
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000369413
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000369413
       Relative nonlinear residual (total system) after nonlinear iteration 91: 0.000369413
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000378349
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000378349
       Relative nonlinear residual (total system) after nonlinear iteration 92: 0.000378349
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000378539
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000378539
       Relative nonlinear residual (total system) after nonlinear iteration 93: 0.000378539
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000406464
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000406464
       Relative nonlinear residual (total system) after nonlinear iteration 94: 0.000406464
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00045843
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00045843
       Relative nonlinear residual (total system) after nonlinear iteration 95: 0.00045843
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000415453
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000415453
       Relative nonlinear residual (total system) after nonlinear iteration 96: 0.000415453
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00035339
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00035339
       Relative nonlinear residual (total system) after nonlinear iteration 97: 0.00035339
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000723986
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000723986
       Relative nonlinear residual (total system) after nonlinear iteration 98: 0.000723986
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000574332
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000574332
       Relative nonlinear residual (total system) after nonlinear iteration 99: 0.000574332
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000442183
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000442183
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.000442183
 
 
@@ -1022,502 +1022,502 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 2:  t=2 seconds, dt=1 seconds
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00113819
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00113819
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00113819
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000498086
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000498086
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000498086
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000456495
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000456495
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000456495
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000371851
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000371851
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000371851
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000468317
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000468317
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000468317
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000502122
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000502122
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000502122
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000574043
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000574043
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000574043
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000395974
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000395974
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000395974
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000447493
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000447493
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.000447493
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000435554
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000435554
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.000435554
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000412264
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000412264
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.000412264
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000552704
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000552704
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.000552704
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000398947
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000398947
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.000398947
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000432013
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000432013
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.000432013
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000418657
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000418657
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.000418657
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000374455
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000374455
       Relative nonlinear residual (total system) after nonlinear iteration 16: 0.000374455
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00185041
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00185041
       Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00185041
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000389735
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000389735
       Relative nonlinear residual (total system) after nonlinear iteration 18: 0.000389735
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000338104
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000338104
       Relative nonlinear residual (total system) after nonlinear iteration 19: 0.000338104
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000517801
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000517801
       Relative nonlinear residual (total system) after nonlinear iteration 20: 0.000517801
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000347317
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000347317
       Relative nonlinear residual (total system) after nonlinear iteration 21: 0.000347317
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000377198
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000377198
       Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000377198
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000527851
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000527851
       Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000527851
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000485712
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000485712
       Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000485712
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000376493
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000376493
       Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000376493
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000448075
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000448075
       Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000448075
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000382756
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000382756
       Relative nonlinear residual (total system) after nonlinear iteration 27: 0.000382756
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000381336
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000381336
       Relative nonlinear residual (total system) after nonlinear iteration 28: 0.000381336
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000319846
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000319846
       Relative nonlinear residual (total system) after nonlinear iteration 29: 0.000319846
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000370729
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000370729
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000370729
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000351357
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000351357
       Relative nonlinear residual (total system) after nonlinear iteration 31: 0.000351357
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000761343
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000761343
       Relative nonlinear residual (total system) after nonlinear iteration 32: 0.000761343
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000689792
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000689792
       Relative nonlinear residual (total system) after nonlinear iteration 33: 0.000689792
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000460704
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000460704
       Relative nonlinear residual (total system) after nonlinear iteration 34: 0.000460704
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000414999
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000414999
       Relative nonlinear residual (total system) after nonlinear iteration 35: 0.000414999
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000746203
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000746203
       Relative nonlinear residual (total system) after nonlinear iteration 36: 0.000746203
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000565524
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000565524
       Relative nonlinear residual (total system) after nonlinear iteration 37: 0.000565524
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00058437
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00058437
       Relative nonlinear residual (total system) after nonlinear iteration 38: 0.00058437
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000508855
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000508855
       Relative nonlinear residual (total system) after nonlinear iteration 39: 0.000508855
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000369408
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000369408
       Relative nonlinear residual (total system) after nonlinear iteration 40: 0.000369408
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00038767
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00038767
       Relative nonlinear residual (total system) after nonlinear iteration 41: 0.00038767
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00045177
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00045177
       Relative nonlinear residual (total system) after nonlinear iteration 42: 0.00045177
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000395332
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000395332
       Relative nonlinear residual (total system) after nonlinear iteration 43: 0.000395332
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 34+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000342157
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000342157
       Relative nonlinear residual (total system) after nonlinear iteration 44: 0.000342157
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000298193
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000298193
       Relative nonlinear residual (total system) after nonlinear iteration 45: 0.000298193
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000431053
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000431053
       Relative nonlinear residual (total system) after nonlinear iteration 46: 0.000431053
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000567063
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000567063
       Relative nonlinear residual (total system) after nonlinear iteration 47: 0.000567063
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000638695
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000638695
       Relative nonlinear residual (total system) after nonlinear iteration 48: 0.000638695
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000585488
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000585488
       Relative nonlinear residual (total system) after nonlinear iteration 49: 0.000585488
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000347432
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000347432
       Relative nonlinear residual (total system) after nonlinear iteration 50: 0.000347432
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000340807
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000340807
       Relative nonlinear residual (total system) after nonlinear iteration 51: 0.000340807
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000415525
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000415525
       Relative nonlinear residual (total system) after nonlinear iteration 52: 0.000415525
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000586187
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000586187
       Relative nonlinear residual (total system) after nonlinear iteration 53: 0.000586187
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000539773
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000539773
       Relative nonlinear residual (total system) after nonlinear iteration 54: 0.000539773
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000392038
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000392038
       Relative nonlinear residual (total system) after nonlinear iteration 55: 0.000392038
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000445949
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000445949
       Relative nonlinear residual (total system) after nonlinear iteration 56: 0.000445949
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000401098
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000401098
       Relative nonlinear residual (total system) after nonlinear iteration 57: 0.000401098
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000388302
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000388302
       Relative nonlinear residual (total system) after nonlinear iteration 58: 0.000388302
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000357453
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000357453
       Relative nonlinear residual (total system) after nonlinear iteration 59: 0.000357453
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000391413
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000391413
       Relative nonlinear residual (total system) after nonlinear iteration 60: 0.000391413
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000537293
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000537293
       Relative nonlinear residual (total system) after nonlinear iteration 61: 0.000537293
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00060952
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00060952
       Relative nonlinear residual (total system) after nonlinear iteration 62: 0.00060952
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000483777
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000483777
       Relative nonlinear residual (total system) after nonlinear iteration 63: 0.000483777
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000353228
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000353228
       Relative nonlinear residual (total system) after nonlinear iteration 64: 0.000353228
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00044531
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00044531
       Relative nonlinear residual (total system) after nonlinear iteration 65: 0.00044531
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000527248
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000527248
       Relative nonlinear residual (total system) after nonlinear iteration 66: 0.000527248
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000565921
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000565921
       Relative nonlinear residual (total system) after nonlinear iteration 67: 0.000565921
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000349687
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000349687
       Relative nonlinear residual (total system) after nonlinear iteration 68: 0.000349687
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000470358
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000470358
       Relative nonlinear residual (total system) after nonlinear iteration 69: 0.000470358
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000464479
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000464479
       Relative nonlinear residual (total system) after nonlinear iteration 70: 0.000464479
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000409365
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000409365
       Relative nonlinear residual (total system) after nonlinear iteration 71: 0.000409365
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000405426
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000405426
       Relative nonlinear residual (total system) after nonlinear iteration 72: 0.000405426
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000490729
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000490729
       Relative nonlinear residual (total system) after nonlinear iteration 73: 0.000490729
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000407486
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000407486
       Relative nonlinear residual (total system) after nonlinear iteration 74: 0.000407486
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000457707
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000457707
       Relative nonlinear residual (total system) after nonlinear iteration 75: 0.000457707
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000547728
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000547728
       Relative nonlinear residual (total system) after nonlinear iteration 76: 0.000547728
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000562175
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000562175
       Relative nonlinear residual (total system) after nonlinear iteration 77: 0.000562175
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000497577
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000497577
       Relative nonlinear residual (total system) after nonlinear iteration 78: 0.000497577
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00032297
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00032297
       Relative nonlinear residual (total system) after nonlinear iteration 79: 0.00032297
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 33+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00116143
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00116143
       Relative nonlinear residual (total system) after nonlinear iteration 80: 0.00116143
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 32+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000484155
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000484155
       Relative nonlinear residual (total system) after nonlinear iteration 81: 0.000484155
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000327423
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000327423
       Relative nonlinear residual (total system) after nonlinear iteration 82: 0.000327423
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000441683
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000441683
       Relative nonlinear residual (total system) after nonlinear iteration 83: 0.000441683
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000324236
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000324236
       Relative nonlinear residual (total system) after nonlinear iteration 84: 0.000324236
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000367713
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000367713
       Relative nonlinear residual (total system) after nonlinear iteration 85: 0.000367713
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000342342
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000342342
       Relative nonlinear residual (total system) after nonlinear iteration 86: 0.000342342
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000441138
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000441138
       Relative nonlinear residual (total system) after nonlinear iteration 87: 0.000441138
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000463628
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000463628
       Relative nonlinear residual (total system) after nonlinear iteration 88: 0.000463628
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000410632
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000410632
       Relative nonlinear residual (total system) after nonlinear iteration 89: 0.000410632
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000413083
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000413083
       Relative nonlinear residual (total system) after nonlinear iteration 90: 0.000413083
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000410576
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000410576
       Relative nonlinear residual (total system) after nonlinear iteration 91: 0.000410576
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000475341
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000475341
       Relative nonlinear residual (total system) after nonlinear iteration 92: 0.000475341
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000460573
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000460573
       Relative nonlinear residual (total system) after nonlinear iteration 93: 0.000460573
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000394495
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000394495
       Relative nonlinear residual (total system) after nonlinear iteration 94: 0.000394495
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000395975
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000395975
       Relative nonlinear residual (total system) after nonlinear iteration 95: 0.000395975
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 26+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000465911
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000465911
       Relative nonlinear residual (total system) after nonlinear iteration 96: 0.000465911
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00056262
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.00056262
       Relative nonlinear residual (total system) after nonlinear iteration 97: 0.00056262
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000476508
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000476508
       Relative nonlinear residual (total system) after nonlinear iteration 98: 0.000476508
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000533619
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000533619
       Relative nonlinear residual (total system) after nonlinear iteration 99: 0.000533619
 
    Skipping temperature solve because RHS is zero.
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.000499731
+      Relative nonlinear residuals (temperature, Stokes system): 0, 0.000499731
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.000499731
 
 

--- a/tests/nonlinear_channel_flow_velocities_single_advection_Newton_Stokes/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_single_advection_Newton_Stokes/screen-output
@@ -10,15 +10,18 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 37+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 6.67966e+16
+      Newton system information: Norm of the rhs: 6.67966e+16
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 50+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.2855e-06, norm of the rhs: 2.1946e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.1946e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.2855e-06
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 54+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21045e-06, norm of the rhs: 1.4765e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4765e+11, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 2.21045e-06
 
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
@@ -26,70 +29,82 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Solving Stokes system... 22+0 iterations.
    Line search iteration 0, with norm of the rhs 3.68051e+11 and going to 1.47636e+11, relative residual: 5.51002e-06
    Line search iteration 1, with norm of the rhs 2.83623e+11 and going to 1.47641e+11, relative residual: 4.24607e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.21318e-06, norm of the rhs: 8.10366e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.10366e+10, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 1.21318e-06
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
    Line search iteration 0, with norm of the rhs 1.79849e+11 and going to 8.10285e+10, relative residual: 2.69249e-06
    Line search iteration 1, with norm of the rhs 1.1785e+11 and going to 8.10312e+10, relative residual: 1.76432e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.46951e-07, norm of the rhs: 5.65735e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.65735e+10, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 8.46951e-07
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 9.28386e+10 and going to 5.65678e+10, relative residual: 1.38987e-06
    Line search iteration 1, with norm of the rhs 6.95112e+10 and going to 5.65697e+10, relative residual: 1.04064e-06
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 5.65941e-07, norm of the rhs: 3.78029e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.78029e+10, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 5.65941e-07
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 21+0 iterations.
    Line search iteration 0, with norm of the rhs 6.53014e+10 and going to 3.77992e+10, relative residual: 9.77616e-07
    Line search iteration 1, with norm of the rhs 5.57306e+10 and going to 3.78004e+10, relative residual: 8.34332e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.10691e-07, norm of the rhs: 2.74328e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.74328e+10, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 4.10691e-07
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
    Line search iteration 0, with norm of the rhs 4.02269e+10 and going to 2.74301e+10, relative residual: 6.0223e-07
    Line search iteration 1, with norm of the rhs 3.55541e+10 and going to 2.7431e+10, relative residual: 5.32274e-07
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.97118e-07, norm of the rhs: 2.65261e+10, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.65261e+10, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 3.97118e-07
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.2311e-07, norm of the rhs: 8.22331e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.22331e+09, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 1.2311e-07
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 7.38641e-08, norm of the rhs: 4.93387e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.93387e+09, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 7.38641e-08
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 27+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 6.79933e-09, norm of the rhs: 4.54172e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.54172e+08, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 11: 6.79933e-09
 
    The linear solver tolerance is set to 0.0171838. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 4.25061e-10, norm of the rhs: 2.83926e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.83926e+07, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 12: 4.25061e-10
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 9.04206e-11, norm of the rhs: 6.03979e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.03979e+06, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 13: 9.04206e-11
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 2.1858e-11, norm of the rhs: 1.46004e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.46004e+06, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 14: 2.1858e-11
 
    The linear solver tolerance is set to 0.1. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 29+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.99343e-12, norm of the rhs: 333544, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 333544, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 15: 4.99343e-12
 
 
    Postprocessing:
@@ -104,11 +119,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 6.64043e-12, norm of the rhs: 304758
+      Newton system information: Norm of the rhs: 304758
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 6.64043e-12
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 1000+376 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 8.85049e-13, norm of the rhs: 40618.7, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 40618.7, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.85049e-13
 
 
    Postprocessing:
@@ -122,11 +139,13 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 5.79029e-12, norm of the rhs: 265741
+      Newton system information: Norm of the rhs: 265741
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 5.79029e-12
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 92+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.80973e-13, norm of the rhs: 22073.9, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 22073.9, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.80973e-13
 
 
    Postprocessing:
@@ -141,7 +160,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1.77325e-12, norm of the rhs: 81382
+      Newton system information: Norm of the rhs: 81382
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.77325e-12
 
 
    Postprocessing:
@@ -155,7 +175,8 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 3.08587e-12, norm of the rhs: 141623
+      Newton system information: Norm of the rhs: 141623
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 3.08587e-12
 
 
    Postprocessing:

--- a/tests/nonlinear_solver_history/screen-output
+++ b/tests/nonlinear_solver_history/screen-output
@@ -8,12 +8,12 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.59443e-16, 2.078e-05
+      Relative nonlinear residuals (temperature, Stokes system): 1.59443e-16, 2.078e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.078e-05
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.59443e-16, 3.99261e-13
+      Relative nonlinear residuals (temperature, Stokes system): 1.59443e-16, 3.99261e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.99261e-13
 
 
@@ -29,7 +29,7 @@ number of nonlinear iterations: 2. State: 1.
 *** Timestep 1:  t=0.1 seconds, dt=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 3.50453e-08, 7.39415e-13
+      Relative nonlinear residuals (temperature, Stokes system): 3.50453e-08, 7.39415e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 3.50453e-08
 
 

--- a/tests/periodic_compressible/screen-output
+++ b/tests/periodic_compressible/screen-output
@@ -6,17 +6,17 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 30+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58886e-16, 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.58886e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 31+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.55733e-16, 0.0690827
+      Relative nonlinear residuals (temperature, Stokes system): 1.55733e-16, 0.0690827
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0690827
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 28+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.58353e-16, 0.0147308
+      Relative nonlinear residuals (temperature, Stokes system): 1.58353e-16, 0.0147308
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0147308
 
 

--- a/tests/prescribed_dilation_newton/screen-output
+++ b/tests/prescribed_dilation_newton/screen-output
@@ -9,10 +9,14 @@ Number of degrees of freedom: 948 (578+81+289)
    Initial Newton Stokes residual = 997.366, v = 432.304, p = 898.806
 
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 997.366
+      Newton system information: Norm of the rhs: 997.366
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Nonlinear residual reduction has been very large (3.48956e-13); skipping Stokes solve
+      Relative nonlinear residuals (temperature, Stokes system): 0, 3.48956e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.48956e-13
 
 
    Postprocessing:
@@ -28,10 +32,14 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 898.181, v = 601.449, p = 667.075
 
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 898.181
+      Newton system information: Norm of the rhs: 898.181
+      Relative nonlinear residuals (temperature, Stokes system): 0, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Nonlinear residual reduction has been very large (8.38532e-13); skipping Stokes solve
+      Relative nonlinear residuals (temperature, Stokes system): 0, 8.38532e-13
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.38532e-13
 
 
    Postprocessing:

--- a/tests/prescribed_dilation_newton_singleadvection/screen-output
+++ b/tests/prescribed_dilation_newton_singleadvection/screen-output
@@ -9,9 +9,11 @@ Number of degrees of freedom: 948 (578+81+289)
    Initial Newton Stokes residual = 997.366, v = 432.304, p = 898.806
 
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 997.366
+      Newton system information: Norm of the rhs: 997.366
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Nonlinear residual reduction has been very large (3.48956e-13); skipping Stokes solve
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.48956e-13
 
 
    Postprocessing:
@@ -27,9 +29,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 898.181, v = 601.449, p = 667.075
 
    Solving Stokes system... 0+22 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 898.181
+      Newton system information: Norm of the rhs: 898.181
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Nonlinear residual reduction has been very large (8.38532e-13); skipping Stokes solve
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.38532e-13
 
 
    Postprocessing:

--- a/tests/single_Advection_iterated_defect_correction_Stokes/screen-output
+++ b/tests/single_Advection_iterated_defect_correction_Stokes/screen-output
@@ -8,10 +8,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 8.98822e+07, v = 8.98822e+07, p = 0
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 8.98822e+07
+      Newton system information: Norm of the rhs: 8.98822e+07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.78399e-06, norm of the rhs: 160.349, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 160.349, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 1.78399e-06
 
 
    Postprocessing:
@@ -22,10 +24,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.55548e+07, v = 4.55548e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.131943, norm of the rhs: 6.01064e+06
+      Newton system information: Norm of the rhs: 6.01064e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.131943
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.98704e-06, norm of the rhs: 136.074, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 136.074, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 2.98704e-06
 
 
    Postprocessing:
@@ -36,10 +40,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.59292e+07, v = 4.59292e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.030083, norm of the rhs: 1.38169e+06
+      Newton system information: Norm of the rhs: 1.38169e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.030083
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 7.86108e-07, norm of the rhs: 36.1053, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 36.1053, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 7.86108e-07
 
 
    Postprocessing:
@@ -50,10 +56,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.62984e+07, v = 4.62984e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0198092, norm of the rhs: 917134
+      Newton system information: Norm of the rhs: 917134
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0198092
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.3084e-07, norm of the rhs: 15.3174, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 15.3174, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.3084e-07
 
 
    Postprocessing:
@@ -64,10 +72,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.67525e+07, v = 4.67525e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.021423, norm of the rhs: 1.00158e+06
+      Newton system information: Norm of the rhs: 1.00158e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.021423
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.5713e-07, norm of the rhs: 16.6967, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 16.6967, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.5713e-07
 
 
    Postprocessing:
@@ -78,10 +88,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.72245e+07, v = 4.72245e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0225197, norm of the rhs: 1.06348e+06
+      Newton system information: Norm of the rhs: 1.06348e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0225197
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.67864e-07, norm of the rhs: 17.3722, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 17.3722, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.67864e-07
 
 
    Postprocessing:
@@ -92,10 +104,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.77163e+07, v = 4.77163e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0227451, norm of the rhs: 1.08531e+06
+      Newton system information: Norm of the rhs: 1.08531e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0227451
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.57934e-07, norm of the rhs: 17.0793, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 17.0793, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.57934e-07
 
 
    Postprocessing:
@@ -106,10 +120,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.83119e+07, v = 4.83119e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0228267, norm of the rhs: 1.1028e+06
+      Newton system information: Norm of the rhs: 1.1028e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0228267
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.6055e-07, norm of the rhs: 17.4189, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 17.4189, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.6055e-07
 
 
    Postprocessing:
@@ -120,10 +136,12 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.91279e+07, v = 4.91279e+07, p = 0
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0229566, norm of the rhs: 1.12781e+06
+      Newton system information: Norm of the rhs: 1.12781e+06
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0229566
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.76787e-07, norm of the rhs: 18.5107, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 18.5107, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.76787e-07
 
 
    Postprocessing:
@@ -134,13 +152,16 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
    Initial Newton Stokes residual = 4.99014e+07, v = 4.99014e+07, p = 0
 
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0142211, norm of the rhs: 709653
+      Newton system information: Norm of the rhs: 709653
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0142211
 
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.36684e-05, norm of the rhs: 682.073, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 682.073, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 1.36684e-05
 
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.06845e-07, norm of the rhs: 5.3317, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.3317, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 1.06845e-07
 
 
    Postprocessing:

--- a/tests/sol_cx_newton_crash/screen-output
+++ b/tests/sol_cx_newton_crash/screen-output
@@ -9,9 +9,11 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0172385, v = 0.0172385, p = 0
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 0.0172385
+      Newton system information: Norm of the rhs: 0.0172385
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Nonlinear residual reduction has been very large (8.73223e-10); skipping Stokes solve
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.73223e-10
 
 
    Postprocessing:

--- a/tests/spiegelman_fail_test/screen-output
+++ b/tests/spiegelman_fail_test/screen-output
@@ -11,13 +11,17 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 7.75879e+15
+      Newton system information: Norm of the rhs: 7.75879e+15
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.184271, norm of the rhs: 1.42972e+15, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.42972e+15, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.184271
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.184271
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
@@ -25,14 +29,18 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.121011, norm of the rhs: 9.38898e+14, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.38898e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.121011
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.121011
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    The linear solver tolerance is set to 0.82638. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0556899, norm of the rhs: 4.32086e+14, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.32086e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.0556899
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0556899
 
 
    Postprocessing:
@@ -48,13 +56,17 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0505531, norm of the rhs: 4.35071e+14
+      Newton system information: Norm of the rhs: 4.35071e+14
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.24412e-13, 0.0505531
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0505531
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.025017, norm of the rhs: 2.15302e+14, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.15302e+14, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.24412e-13, 0.025017
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.025017
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
@@ -62,14 +74,18 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0158695, norm of the rhs: 1.36576e+14, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.36576e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.75875e-13, 0.0158695
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0158695
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.00971022, norm of the rhs: 8.35682e+13, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.35682e+13, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.86622e-13, 0.00971022
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00971022
 
 
    Postprocessing:

--- a/tests/steinberger_projected_density_dcPicard/screen-output
+++ b/tests/steinberger_projected_density_dcPicard/screen-output
@@ -7,47 +7,47 @@ Number of degrees of freedom: 5,223 (1,666+225+833+833+833+833)
    Solving composition system ... 0 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16
    Initial Newton Stokes residual = 1.22791e+14, v = 1.22791e+14, p = 0
 
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.22791e+14
+      Newton system information: Norm of the rhs: 1.22791e+14
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving composition system ... 0 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0182306, norm of the rhs: 2.23856e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.23856e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16, 0.0182306
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0182306
 
    Solving temperature system... 0 iterations.
    Solving composition system ... 0 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000534843, norm of the rhs: 6.56739e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.56739e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16, 0.000534843
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000534843
 
    Solving temperature system... 0 iterations.
    Solving composition system ... 0 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.32183e-05, norm of the rhs: 1.62309e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.62309e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16, 1.32183e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.32183e-05
 
    Solving temperature system... 0 iterations.
    Solving composition system ... 0 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.64653e-07, norm of the rhs: 4.47762e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.47762e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.71633e-16, 1.61486e-16, 0, 1.56133e-16, 3.64653e-07
       Relative nonlinear residual (total system) after nonlinear iteration 5: 3.64653e-07
 
 
@@ -63,47 +63,47 @@ Number of degrees of freedom: 5,223 (1,666+225+833+833+833+833)
    Solving composition system ... 11 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 11 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.00377681, 0.0202636, 0, 0.0108039
    Initial Newton Stokes residual = 8.39912e+13, v = 8.31745e+13, p = 1.16846e+13
 
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.177774, norm of the rhs: 1.49315e+13
+      Newton system information: Norm of the rhs: 1.49315e+13
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00377681, 0.0202636, 0, 0.0108039, 0.177774
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.177774
 
    Solving temperature system... 11 iterations.
    Solving composition system ... 9 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 9 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 0.00012418, 0.000414973, 0, 0.000193229
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00303934, norm of the rhs: 2.55278e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.55278e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.00012418, 0.000414973, 0, 0.000193229, 0.00303934
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00303934
 
    Solving temperature system... 10 iterations.
    Solving composition system ... 8 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 8 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 6.8685e-06, 3.11445e-05, 0, 1.43921e-05
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000264707, norm of the rhs: 2.2233e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.2233e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.8685e-06, 3.11445e-05, 0, 1.43921e-05, 0.000264707
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000264707
 
    Solving temperature system... 8 iterations.
    Solving composition system ... 7 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 7 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 6.11361e-07, 2.60566e-06, 0, 1.38988e-06
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.19295e-05, norm of the rhs: 1.00197e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.00197e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 6.11361e-07, 2.60566e-06, 0, 1.38988e-06, 1.19295e-05
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.19295e-05
 
    Solving temperature system... 7 iterations.
    Solving composition system ... 6 iterations.
    Copying properties into prescribed compositional field density_field... done.
    Solving another_field system ... 5 iterations.
-      Relative nonlinear residuals (temperature, compositional fields): 4.31558e-08, 1.25138e-07, 0, 8.13074e-08
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.11146e-06, norm of the rhs: 9.33525e+07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.33525e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.31558e-08, 1.25138e-07, 0, 8.13074e-08, 1.11146e-06
       Relative nonlinear residual (total system) after nonlinear iteration 5: 1.11146e-06
 
 

--- a/tests/stokes_residual/screen-output
+++ b/tests/stokes_residual/screen-output
@@ -5,12 +5,12 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74991e-16, 2.07408e-05
+      Relative nonlinear residuals (temperature, Stokes system): 1.74991e-16, 2.07408e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.07408e-05
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74991e-16, 8.6296e-13
+      Relative nonlinear residuals (temperature, Stokes system): 1.74991e-16, 8.6296e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 8.6296e-13
 
 
@@ -24,7 +24,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.1 seconds, dt=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.24912e-08, 2.85462e-13
+      Relative nonlinear residuals (temperature, Stokes system): 1.24912e-08, 2.85462e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.24912e-08
 
 

--- a/tests/stokes_residual_cheap/screen-output
+++ b/tests/stokes_residual_cheap/screen-output
@@ -5,12 +5,12 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+14 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74991e-16, 2.07408e-05
+      Relative nonlinear residuals (temperature, Stokes system): 1.74991e-16, 2.07408e-05
       Relative nonlinear residual (total system) after nonlinear iteration 1: 2.07408e-05
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+1 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.74991e-16, 3.68832e-13
+      Relative nonlinear residuals (temperature, Stokes system): 1.74991e-16, 3.68832e-13
       Relative nonlinear residual (total system) after nonlinear iteration 2: 3.68832e-13
 
 
@@ -24,7 +24,7 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
 *** Timestep 1:  t=0.1 seconds, dt=0.1 seconds
    Solving temperature system... 4 iterations.
    Solving Stokes system... 0+3 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.24912e-08, 2.75721e-13
+      Relative nonlinear residuals (temperature, Stokes system): 1.24912e-08, 2.75721e-13
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.24912e-08
 
 

--- a/tests/tosi_benchmark/screen-output
+++ b/tests/tosi_benchmark/screen-output
@@ -7,7 +7,7 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Solving temperature system... 0 iterations.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.28118e-16, 5.67797e-07
+      Relative nonlinear residuals (temperature, Stokes system): 1.28118e-16, 5.67797e-07
       Relative nonlinear residual (total system) after nonlinear iteration 1: 5.67797e-07
 
 
@@ -23,77 +23,77 @@ Number of degrees of freedom: 268 (162+25+81)
 *** Timestep 1:  t=0.005 seconds, dt=0.005 seconds
    Solving temperature system... 6 iterations.
    Solving Stokes system... 39+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.000215717, 1.72999e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.000215717, 1.72999e-08
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000215717
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 41+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.0203668, 1.03951e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.0203668, 1.03951e-08
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0203668
 
    Solving temperature system... 12 iterations.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.088188, 3.50268e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.088188, 3.50268e-08
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.088188
 
    Solving temperature system... 24 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.264121, 4.28707e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.264121, 4.28707e-08
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.264121
 
    Solving temperature system... 25 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.261383, 9.19044e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0.261383, 9.19044e-07
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.261383
 
    Solving temperature system... 13 iterations.
    Solving Stokes system... 43+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.291524, 8.98347e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.291524, 8.98347e-08
       Relative nonlinear residual (total system) after nonlinear iteration 6: 0.291524
 
    Solving temperature system... 24 iterations.
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.543386, 8.5032e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.543386, 8.5032e-08
       Relative nonlinear residual (total system) after nonlinear iteration 7: 0.543386
 
    Solving temperature system... 27 iterations.
    Solving Stokes system... 45+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.217424, 8.85483e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.217424, 8.85483e-08
       Relative nonlinear residual (total system) after nonlinear iteration 8: 0.217424
 
    Solving temperature system... 20 iterations.
    Solving Stokes system... 44+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.215224, 3.3807e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.215224, 3.3807e-08
       Relative nonlinear residual (total system) after nonlinear iteration 9: 0.215224
 
    Solving temperature system... 27 iterations.
    Solving Stokes system... 49+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.285143, 2.67423e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0.285143, 2.67423e-07
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.285143
 
    Solving temperature system... 20 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.275683, 5.19457e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.275683, 5.19457e-08
       Relative nonlinear residual (total system) after nonlinear iteration 11: 0.275683
 
    Solving temperature system... 26 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.335992, 6.49983e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.335992, 6.49983e-08
       Relative nonlinear residual (total system) after nonlinear iteration 12: 0.335992
 
    Solving temperature system... 22 iterations.
    Solving Stokes system... 48+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.287894, 5.04515e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.287894, 5.04515e-08
       Relative nonlinear residual (total system) after nonlinear iteration 13: 0.287894
 
    Solving temperature system... 24 iterations.
    Solving Stokes system... 47+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.231104, 4.40945e-08
+      Relative nonlinear residuals (temperature, Stokes system): 0.231104, 4.40945e-08
       Relative nonlinear residual (total system) after nonlinear iteration 14: 0.231104
 
    Solving temperature system... 27 iterations.
    Solving Stokes system... 46+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0.457178, 1.34928e-07
+      Relative nonlinear residuals (temperature, Stokes system): 0.457178, 1.34928e-07
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.457178
 
 

--- a/tests/tosi_benchmark_gmg_dc_picard_solver/screen-output
+++ b/tests/tosi_benchmark_gmg_dc_picard_solver/screen-output
@@ -9,28 +9,36 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 1.97927, v = 1.97927, p = 0
 
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.97927
+      Newton system information: Norm of the rhs: 1.97927
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00662148, norm of the rhs: 0.0131057, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0131057, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00662148
 
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00090009, norm of the rhs: 0.00178152, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00178152, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00090009
 
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000131035, norm of the rhs: 0.000259354, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000259354, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.000131035
 
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.9738e-05, norm of the rhs: 3.90667e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.90667e-05, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 1.9738e-05
 
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.03324e-06, norm of the rhs: 6.00361e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.00361e-06, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 3.03324e-06
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.72157e-07, norm of the rhs: 9.34527e-07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.34527e-07, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 4.72157e-07
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 7.44201e-08, norm of the rhs: 1.47297e-07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47297e-07, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 7.44201e-08
 
 
    Postprocessing:
@@ -46,94 +54,124 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0373897, v = 0.0373897, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.205101, norm of the rhs: 0.00766867
+      Newton system information: Norm of the rhs: 0.00766867
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.205101
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00960573, norm of the rhs: 0.000359155, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000359155, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00960573
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00178143, norm of the rhs: 6.66072e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.66072e-05, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00178143
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000331184, norm of the rhs: 1.23829e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.23829e-05, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.000331184
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 6.24971e-05, norm of the rhs: 2.33675e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.33675e-06, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 6.24971e-05
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.19504e-05, norm of the rhs: 4.46824e-07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.46824e-07, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 1.19504e-05
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.33587e-06, norm of the rhs: 8.73374e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.73374e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 2.33587e-06
 
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 6.02797e-07, norm of the rhs: 2.25384e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.25384e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 6.02797e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 4.07026e-07, norm of the rhs: 1.52186e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52186e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 4.07026e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.94507e-07, norm of the rhs: 1.47505e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47505e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 3.94507e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 3.84717e-07, norm of the rhs: 1.43845e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.43845e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 11: 3.84717e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 3.85777e-07, norm of the rhs: 1.44241e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.44241e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 12: 3.85777e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 4.07127e-07, norm of the rhs: 1.52224e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52224e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 13: 4.07127e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 4.21781e-07, norm of the rhs: 1.57703e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.57703e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 14: 4.21781e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 4.23459e-07, norm of the rhs: 1.5833e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.5833e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 15: 4.23459e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 3.95146e-07, norm of the rhs: 1.47744e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47744e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 16: 3.95146e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 4.01607e-07, norm of the rhs: 1.5016e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.5016e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 17: 4.01607e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 4.10662e-07, norm of the rhs: 1.53545e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.53545e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 18: 4.10662e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 3.90089e-07, norm of the rhs: 1.45853e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.45853e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 19: 3.90089e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 3.87199e-07, norm of the rhs: 1.44772e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.44772e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 20: 3.87199e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 3.9138e-07, norm of the rhs: 1.46336e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.46336e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 21: 3.9138e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 4.03144e-07, norm of the rhs: 1.50734e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.50734e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 22: 4.03144e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 3.83211e-07, norm of the rhs: 1.43281e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.43281e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 23: 3.83211e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 3.99365e-07, norm of the rhs: 1.49321e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.49321e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 24: 3.99365e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 3.91755e-07, norm of the rhs: 1.46476e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.46476e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 25: 3.91755e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 3.99297e-07, norm of the rhs: 1.49296e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.49296e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 26: 3.99297e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 3.8894e-07, norm of the rhs: 1.45423e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.45423e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 27: 3.8894e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 4.1016e-07, norm of the rhs: 1.53357e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.53357e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 28: 4.1016e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 4.08136e-07, norm of the rhs: 1.52601e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52601e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 29: 4.08136e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 3.86817e-07, norm of the rhs: 1.4463e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4463e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 30: 3.86817e-07
 
 
    Postprocessing:
@@ -147,94 +185,124 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0463712, v = 0.0463712, p = 0
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0219036, norm of the rhs: 0.00101569
+      Newton system information: Norm of the rhs: 0.00101569
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0219036
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00105964, norm of the rhs: 4.9137e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.9137e-05, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00105964
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000205472, norm of the rhs: 9.528e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.528e-06, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.000205472
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 3.99034e-05, norm of the rhs: 1.85037e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.85037e-06, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 3.99034e-05
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 7.87501e-06, norm of the rhs: 3.65174e-07, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.65174e-07, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 5: 7.87501e-06
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 1.60132e-06, norm of the rhs: 7.42551e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 7.42551e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 6: 1.60132e-06
 
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 4.46593e-07, norm of the rhs: 2.07091e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.07091e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 7: 4.46593e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.28981e-07, norm of the rhs: 1.52552e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52552e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 8: 3.28981e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 3.21311e-07, norm of the rhs: 1.48996e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.48996e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 9: 3.21311e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.28644e-07, norm of the rhs: 1.52396e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52396e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 3.28644e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 3.17213e-07, norm of the rhs: 1.47095e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47095e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 11: 3.17213e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 3.40126e-07, norm of the rhs: 1.5772e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.5772e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 12: 3.40126e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 3.10018e-07, norm of the rhs: 1.43759e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.43759e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 13: 3.10018e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 3.27075e-07, norm of the rhs: 1.51669e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.51669e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 14: 3.27075e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 3.02897e-07, norm of the rhs: 1.40457e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.40457e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 15: 3.02897e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 2.9737e-07, norm of the rhs: 1.37894e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.37894e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 16: 2.9737e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 3.20724e-07, norm of the rhs: 1.48723e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.48723e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 17: 3.20724e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 2.98451e-07, norm of the rhs: 1.38395e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.38395e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 18: 2.98451e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 3.15692e-07, norm of the rhs: 1.4639e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.4639e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 19: 3.15692e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 3.18518e-07, norm of the rhs: 1.47701e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47701e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 20: 3.18518e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 3.11242e-07, norm of the rhs: 1.44326e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.44326e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 21: 3.11242e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 3.18568e-07, norm of the rhs: 1.47724e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47724e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 22: 3.18568e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 3.27835e-07, norm of the rhs: 1.52021e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52021e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 23: 3.27835e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 3.20128e-07, norm of the rhs: 1.48447e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.48447e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 24: 3.20128e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 3.17496e-07, norm of the rhs: 1.47227e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.47227e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 25: 3.17496e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 3.28633e-07, norm of the rhs: 1.52391e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52391e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 26: 3.28633e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 3.35513e-07, norm of the rhs: 1.55581e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.55581e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 27: 3.35513e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 3.35533e-07, norm of the rhs: 1.55591e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.55591e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 28: 3.35533e-07
 
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 3.23839e-07, norm of the rhs: 1.50168e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.50168e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 29: 3.23839e-07
 
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 3.28075e-07, norm of the rhs: 1.52132e-08, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.52132e-08, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 30: 3.28075e-07
 
 
    Postprocessing:

--- a/tests/tosi_benchmark_gmg_newton_solver/screen-output
+++ b/tests/tosi_benchmark_gmg_newton_solver/screen-output
@@ -9,49 +9,69 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 1.97927, v = 1.97927, p = 0
 
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.97927
+      Newton system information: Norm of the rhs: 1.97927
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00662148, norm of the rhs: 0.0131057, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0131057, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 0.00662148
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00662148
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00090009, norm of the rhs: 0.00178152, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00178152, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 0.00090009
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00090009
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000131035, norm of the rhs: 0.000259354, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000259354, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 0.000131035
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000131035
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 1.9738e-05, norm of the rhs: 3.90667e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.90667e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 1.9738e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 1.9738e-05
 
    Solving temperature system... 0 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.0535e-06, norm of the rhs: 6.04371e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.04371e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 3.0535e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.0535e-06
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 7.11486e-07, norm of the rhs: 1.40822e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.40822e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 7.11486e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 7.11486e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.83164e-07, norm of the rhs: 3.6253e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.6253e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 1.83164e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.83164e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.14514e-07, norm of the rhs: 2.26653e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.26653e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 1.14514e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.14514e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.16406e-08, norm of the rhs: 6.26253e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.26253e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.65584e-16, 3.16406e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 3.16406e-08
 
 
    Postprocessing:
@@ -67,149 +87,209 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0373897, v = 0.0373897, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.205101, norm of the rhs: 0.00766867
+      Newton system information: Norm of the rhs: 0.00766867
+      Relative nonlinear residuals (temperature, Stokes system): 0.00302562, 0.205101
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.205101
 
    Solving temperature system... 20 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0613292, norm of the rhs: 0.00229309, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00229309, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.0029653, 0.0613292
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0613292
 
    Solving temperature system... 22 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.072235, norm of the rhs: 0.00270085, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00270085, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00309101, 0.072235
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.072235
 
    Solving temperature system... 23 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0871575, norm of the rhs: 0.0032588, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0032588, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00368689, 0.0871575
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0871575
 
    Solving temperature system... 25 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.113004, norm of the rhs: 0.0042252, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0042252, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00547346, 0.113004
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.113004
 
    Solving temperature system... 28 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.517621, norm of the rhs: 0.0193537, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0193537, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00941542, 0.517621
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.517621
 
    Solving temperature system... 28 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.453701, norm of the rhs: 0.0169638, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0169638, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00312169, 0.453701
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.453701
 
    Solving temperature system... 31 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.688641, norm of the rhs: 0.0257481, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0257481, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0105347, 0.688641
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.688641
 
    Solving temperature system... 34 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.834308, norm of the rhs: 0.0311946, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0311946, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0141869, 0.834308
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.834308
 
    Solving temperature system... 39 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 0.624436, norm of the rhs: 0.0233475, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0233475, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0176193, 0.624436
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.624436
 
    Solving temperature system... 44 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.915911, norm of the rhs: 0.0342457, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0342457, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0200326, 0.915911
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.915911
 
    Solving temperature system... 45 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.866792, norm of the rhs: 0.0324091, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0324091, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0106816, 0.866792
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.866792
 
    Solving temperature system... 46 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.633119, norm of the rhs: 0.0236722, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0236722, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00693642, 0.633119
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.633119
 
    Solving temperature system... 48 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 0.754743, norm of the rhs: 0.0282196, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0282196, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0147421, 0.754743
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.754743
 
    Solving temperature system... 55 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 1.06488, norm of the rhs: 0.0398157, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0398157, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.015341, 1.06488
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 1.06488
 
    Solving temperature system... 53 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 0.523066, norm of the rhs: 0.0195573, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0195573, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00520999, 0.523066
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.523066
 
    Solving temperature system... 59 iterations.
    The linear solver tolerance is set to 0.752853. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 0.611218, norm of the rhs: 0.0228533, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0228533, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.013067, 0.611218
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.611218
 
    Solving temperature system... 58 iterations.
    The linear solver tolerance is set to 0.631703. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 0.249519, norm of the rhs: 0.00932946, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00932946, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0047781, 0.249519
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.249519
 
    Solving temperature system... 60 iterations.
    The linear solver tolerance is set to 0.843463. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 0.333025, norm of the rhs: 0.0124517, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0124517, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0059026, 0.333025
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.333025
 
    Solving temperature system... 58 iterations.
    The linear solver tolerance is set to 0.759229. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 20: 0.285927, norm of the rhs: 0.0106908, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0106908, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00230886, 0.285927
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.285927
 
    Solving temperature system... 60 iterations.
    The linear solver tolerance is set to 0.640381. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 21: 0.179076, norm of the rhs: 0.00669562, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00669562, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0028849, 0.179076
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.179076
 
    Solving temperature system... 59 iterations.
    The linear solver tolerance is set to 0.486196. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 22: 0.08716, norm of the rhs: 0.00325889, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00325889, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00245028, 0.08716
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.08716
 
    Solving temperature system... 58 iterations.
    The linear solver tolerance is set to 0.311351. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 23: 0.0218205, norm of the rhs: 0.000815862, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.000815862, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00135467, 0.0218205
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.0218205
 
    Solving temperature system... 57 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 24: 0.0400442, norm of the rhs: 0.00149724, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00149724, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000677439, 0.0400442
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.0400442
 
    Solving temperature system... 51 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 25: 0.0365618, norm of the rhs: 0.00136704, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00136704, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000135265, 0.0365618
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.0365618
 
    Solving temperature system... 53 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 26: 0.0231141, norm of the rhs: 0.000864231, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.000864231, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000197202, 0.0231141
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.0231141
 
    Solving temperature system... 54 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 27: 0.0142141, norm of the rhs: 0.000531462, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.000531462, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000274905, 0.0142141
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 0.0142141
 
    Solving temperature system... 54 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 28: 0.00571762, norm of the rhs: 0.00021378, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.00021378, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000247457, 0.00571762
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 0.00571762
 
    Solving temperature system... 52 iterations.
    The linear solver tolerance is set to 0.835179. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 29: 0.00825791, norm of the rhs: 0.000308761, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.000308761, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.000151079, 0.00825791
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 0.00825791
 
    Solving temperature system... 48 iterations.
    The linear solver tolerance is set to 0.7472. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 30: 0.00596191, norm of the rhs: 0.000222914, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.000222914, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.20742e-05, 0.00596191
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 0.00596191
 
 
    Postprocessing:
@@ -223,64 +303,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.23659, v = 0.23659, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0299712, norm of the rhs: 0.0070909
+      Newton system information: Norm of the rhs: 0.0070909
+      Relative nonlinear residuals (temperature, Stokes system): 0.000341504, 0.0299712
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0299712
 
    Solving temperature system... 9 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0030256, norm of the rhs: 0.000715828, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000715828, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.000103544, 0.0030256
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0030256
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00137788, norm of the rhs: 0.000325993, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000325993, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.36259e-05, 0.00137788
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00137788
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000622064, norm of the rhs: 0.000147174, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000147174, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 3.88748e-06, 0.000622064
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000622064
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.000280485, norm of the rhs: 6.63599e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.63599e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.35624e-06, 0.000280485
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000280485
 
    Solving temperature system... 6 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.000240054, norm of the rhs: 5.67943e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.67943e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.05124e-07, 0.000240054
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000240054
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.000201723, norm of the rhs: 4.77256e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.77256e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.09198e-08, 0.000201723
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000201723
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.000152952, norm of the rhs: 3.61869e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.61869e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.12689e-08, 0.000152952
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000152952
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 7.35484e-05, norm of the rhs: 1.74008e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.74008e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 7.90867e-08, 7.35484e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 7.35484e-05
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.34288e-05, norm of the rhs: 7.90892e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.90892e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.10733e-07, 3.34288e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 3.34288e-05
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 4.61632e-06, norm of the rhs: 1.09218e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.09218e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.4216e-08, 4.61632e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 4.61632e-06
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 5.90151e-07, norm of the rhs: 1.39624e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.39624e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.09212e-09, 5.90151e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 5.90151e-07
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.00984757. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.50205e-08, norm of the rhs: 1.53832e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.53832e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.29269e-10, 6.50205e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.50205e-08
 
 
    Postprocessing:
@@ -294,64 +400,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.246448, v = 0.246448, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00452039, norm of the rhs: 0.00111404
+      Newton system information: Norm of the rhs: 0.00111404
+      Relative nonlinear residuals (temperature, Stokes system): 0.000267726, 0.00452039
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00452039
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.000377256, norm of the rhs: 9.2974e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.2974e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.09799e-05, 0.000377256
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000377256
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000171944, norm of the rhs: 4.23752e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.23752e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 6.65492e-07, 0.000171944
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000171944
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 7.87629e-05, norm of the rhs: 1.94109e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.94109e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.99947e-07, 7.87629e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 7.87629e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.62024e-05, norm of the rhs: 8.92201e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 8.92201e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 7.86187e-08, 3.62024e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.62024e-05
 
    Solving temperature system... 4 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.12872e-05, norm of the rhs: 7.71067e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.71067e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.16867e-08, 3.12872e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.12872e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.11628e-05, norm of the rhs: 5.21552e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.21552e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.54103e-09, 2.11628e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.11628e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.4719e-05, norm of the rhs: 3.62747e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.62747e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.83977e-09, 1.4719e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.4719e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 7.77361e-06, norm of the rhs: 1.91579e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.91579e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.26286e-09, 7.77361e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 7.77361e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.74472e-06, norm of the rhs: 9.22878e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.22878e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.93619e-09, 3.74472e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 3.74472e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.11283e-06, norm of the rhs: 2.74254e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.74254e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.26094e-09, 1.11283e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.11283e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 1.01251e-07, norm of the rhs: 2.49532e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.49532e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.02724e-10, 1.01251e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 1.01251e-07
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.216102. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.30779e-08, norm of the rhs: 1.55454e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.55454e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.07861e-10, 6.30779e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.30779e-08
 
 
    Postprocessing:
@@ -365,59 +497,83 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.25508, v = 0.25508, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00500802, norm of the rhs: 0.00127744
+      Newton system information: Norm of the rhs: 0.00127744
+      Relative nonlinear residuals (temperature, Stokes system): 0.000328388, 0.00500802
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00500802
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.000384706, norm of the rhs: 9.81308e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 9.81308e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.34347e-05, 0.000384706
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.000384706
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000178661, norm of the rhs: 4.55728e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.55728e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 6.25686e-07, 0.000178661
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000178661
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 8.36906e-05, norm of the rhs: 2.13478e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.13478e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.80811e-07, 8.36906e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 8.36906e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 3.93959e-05, norm of the rhs: 1.00491e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.00491e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 7.43239e-08, 3.93959e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 3.93959e-05
 
    Solving temperature system... 4 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.34511e-05, norm of the rhs: 8.5327e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.5327e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.1057e-08, 3.34511e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.34511e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.15538e-05, norm of the rhs: 5.49793e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.49793e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.19732e-09, 2.15538e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.15538e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.38538e-05, norm of the rhs: 3.53383e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.53383e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.0633e-08, 1.38538e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.38538e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.19757e-06, norm of the rhs: 1.58087e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.58087e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.80417e-09, 6.19757e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 6.19757e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.4411e-06, norm of the rhs: 3.67595e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.67595e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.59119e-09, 1.4411e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.4411e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 3.80669e-07, norm of the rhs: 9.71008e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 9.71008e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.94077e-10, 3.80669e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 3.80669e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 7.92575e-08, norm of the rhs: 2.0217e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.0217e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.39307e-10, 7.92575e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 7.92575e-08
 
 
    Postprocessing:
@@ -431,59 +587,83 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.258084, v = 0.258084, p = 0
 
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00121107, norm of the rhs: 0.000312557
+      Newton system information: Norm of the rhs: 0.000312557
+      Relative nonlinear residuals (temperature, Stokes system): 7.89747e-05, 0.00121107
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.00121107
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 8.96499e-05, norm of the rhs: 2.31372e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.31372e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.40639e-06, 8.96499e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 8.96499e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 4.1659e-05, norm of the rhs: 1.07515e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.07515e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 4.92976e-08, 4.1659e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 4.1659e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.95643e-05, norm of the rhs: 5.04923e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.04923e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.52742e-08, 1.95643e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.95643e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 9.24386e-06, norm of the rhs: 2.38569e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.38569e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 6.40508e-09, 9.24386e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 9.24386e-06
 
    Solving temperature system... 3 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 8.08388e-06, norm of the rhs: 2.08632e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.08632e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.69668e-09, 8.08388e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 8.08388e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 6.3176e-06, norm of the rhs: 1.63047e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.63047e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.29542e-10, 6.3176e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 6.3176e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 4.27742e-06, norm of the rhs: 1.10393e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.10393e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.92225e-10, 4.27742e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 4.27742e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.41739e-06, norm of the rhs: 3.65806e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.65806e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.6944e-10, 1.41739e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.41739e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.43305e-07, norm of the rhs: 1.1441e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.1441e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.06592e-10, 4.43305e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 4.43305e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.03352e-07, norm of the rhs: 2.66735e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.66735e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.02508e-10, 1.03352e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.03352e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.267582. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 5.91755e-08, norm of the rhs: 1.52722e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.52722e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.97107e-11, 5.91755e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 5.91755e-08
 
 
    Postprocessing:

--- a/tests/tosi_benchmark_newton_solver/screen-output
+++ b/tests/tosi_benchmark_newton_solver/screen-output
@@ -9,44 +9,62 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 1.97927, v = 1.97927, p = 0
 
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.97927
+      Newton system information: Norm of the rhs: 1.97927
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00668806, norm of the rhs: 0.0132375, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0132375, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.00668806
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00668806
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000915217, norm of the rhs: 0.00181146, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00181146, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.000915217
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000915217
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000134144, norm of the rhs: 0.000265506, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000265506, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.000134144
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000134144
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 2.0343e-05, norm of the rhs: 4.02643e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.02643e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 2.0343e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.0343e-05
 
    Solving temperature system... 0 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.16631e-06, norm of the rhs: 6.26699e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.26699e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 3.16631e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.16631e-06
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 7.76452e-07, norm of the rhs: 1.53681e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.53681e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 7.76452e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 7.76452e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.61044e-07, norm of the rhs: 3.18749e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.18749e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 1.61044e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.61044e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.24353e-08, norm of the rhs: 1.23576e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.23576e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 6.24353e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 6.24353e-08
 
 
    Postprocessing:
@@ -62,74 +80,104 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0376294, v = 0.0376294, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.206943, norm of the rhs: 0.00778715
+      Newton system information: Norm of the rhs: 0.00778715
+      Relative nonlinear residuals (temperature, Stokes system): 0.00303534, 0.206943
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.206943
 
    Solving temperature system... 20 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0628274, norm of the rhs: 0.00236416, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00236416, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00302796, 0.0628274
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0628274
 
    Solving temperature system... 22 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0755701, norm of the rhs: 0.00284366, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00284366, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00322397, 0.0755701
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0755701
 
    Solving temperature system... 23 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0934953, norm of the rhs: 0.00351818, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00351818, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00395164, 0.0934953
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0934953
 
    Solving temperature system... 25 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.124946, norm of the rhs: 0.00470164, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00470164, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00608165, 0.124946
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.124946
 
    Solving temperature system... 29 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.442669, norm of the rhs: 0.0166574, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0166574, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0107998, 0.442669
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.442669
 
    Solving temperature system... 31 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.707475, norm of the rhs: 0.0266219, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0266219, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0106113, 0.707475
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.707475
 
    Solving temperature system... 34 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.87946, norm of the rhs: 0.0330936, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0330936, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0143743, 0.87946
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.87946
 
    Solving temperature system... 39 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.675169, norm of the rhs: 0.0254063, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0254063, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0185613, 0.675169
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.675169
 
    Solving temperature system... 44 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.01788, norm of the rhs: 0.0383021, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0383021, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0218163, 1.01788
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.01788
 
    Solving temperature system... 46 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.967785, norm of the rhs: 0.0364172, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0364172, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0114146, 0.967785
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.967785
 
    Solving temperature system... 47 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.704853, norm of the rhs: 0.0265232, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0265232, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00757486, 0.704853
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.704853
 
    Solving temperature system... 51 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.816485, norm of the rhs: 0.0307239, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0307239, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0160711, 0.816485
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.816485
 
    Solving temperature system... 59 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.11987, norm of the rhs: 0.04214, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.04214, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0169127, 1.11987
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.11987
 
    Solving temperature system... 57 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.506494, norm of the rhs: 0.0190591, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0190591, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0060702, 0.506494
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.506494
 
 
    Postprocessing:
@@ -143,64 +191,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.220152, v = 0.220152, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0788964, norm of the rhs: 0.0173692
+      Newton system information: Norm of the rhs: 0.0173692
+      Relative nonlinear residuals (temperature, Stokes system): 0.000821948, 0.0788964
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0788964
 
    Solving temperature system... 9 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00309473, norm of the rhs: 0.000681312, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000681312, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.0118e-05, 0.00309473
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00309473
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00141483, norm of the rhs: 0.000311479, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000311479, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.17667e-05, 0.00141483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00141483
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000662546, norm of the rhs: 0.000145861, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000145861, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 3.01048e-06, 0.000662546
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000662546
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.000314356, norm of the rhs: 6.92063e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.92063e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.65952e-07, 0.000314356
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000314356
 
    Solving temperature system... 6 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.000267007, norm of the rhs: 5.87821e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.87821e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.37721e-07, 0.000267007
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000267007
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.000194743, norm of the rhs: 4.28732e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.28732e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.18927e-08, 0.000194743
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000194743
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.000124587, norm of the rhs: 2.74282e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.74282e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 7.95218e-08, 0.000124587
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000124587
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 5.94879e-05, norm of the rhs: 1.30964e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.30964e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.11788e-08, 5.94879e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 5.94879e-05
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 2.39184e-05, norm of the rhs: 5.26569e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.26569e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.84554e-08, 2.39184e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 2.39184e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 7.03114e-06, norm of the rhs: 1.54792e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.54792e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.63899e-09, 7.03114e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 7.03114e-06
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 6.40433e-07, norm of the rhs: 1.40993e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.40993e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.68331e-09, 6.40433e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 6.40433e-07
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.00562201. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.76967e-08, norm of the rhs: 1.49036e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.49036e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.21326e-10, 6.76967e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.76967e-08
 
 
    Postprocessing:
@@ -214,64 +288,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.226633, v = 0.226633, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0662477, norm of the rhs: 0.0150139
+      Newton system information: Norm of the rhs: 0.0150139
+      Relative nonlinear residuals (temperature, Stokes system): 0.000242648, 0.0662477
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0662477
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00131214, norm of the rhs: 0.000297374, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000297374, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.64281e-05, 0.00131214
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00131214
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000483968, norm of the rhs: 0.000109683, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000109683, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.5998e-06, 0.000483968
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000483968
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000199138, norm of the rhs: 4.51314e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.51314e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 4.94132e-07, 0.000199138
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000199138
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.92161e-05, norm of the rhs: 2.02194e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.02194e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.32636e-07, 8.92161e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.92161e-05
 
    Solving temperature system... 4 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.8185e-05, norm of the rhs: 1.77193e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.77193e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.20845e-08, 7.8185e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.8185e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 5.86263e-05, norm of the rhs: 1.32867e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.32867e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.17045e-09, 5.86263e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 5.86263e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.46495e-05, norm of the rhs: 7.85273e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.85273e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.52935e-09, 3.46495e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.46495e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.58692e-05, norm of the rhs: 3.59649e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.59649e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.0379e-08, 1.58692e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.58692e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 5.04292e-06, norm of the rhs: 1.14289e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.14289e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.08988e-09, 5.04292e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 5.04292e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.4251e-06, norm of the rhs: 3.22975e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.22975e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.25362e-09, 1.4251e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.4251e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 1.64218e-07, norm of the rhs: 3.72174e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.72174e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.16704e-10, 1.64218e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 1.64218e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.0863885. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.44128e-08, norm of the rhs: 1.45981e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.45981e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.10694e-10, 6.44128e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.44128e-08
 
 
    Postprocessing:
@@ -285,59 +385,83 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.229717, v = 0.229717, p = 0
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000698263, norm of the rhs: 0.000160403
+      Newton system information: Norm of the rhs: 0.000160403
+      Relative nonlinear residuals (temperature, Stokes system): 3.77877e-05, 0.000698263
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000698263
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.91512e-05, norm of the rhs: 1.12909e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.12909e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 4.34351e-07, 4.91512e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.91512e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21545e-05, norm of the rhs: 5.08927e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.08927e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.39104e-08, 2.21545e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.21545e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.01965e-05, norm of the rhs: 2.34231e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.34231e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 6.76747e-09, 1.01965e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.01965e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 4.76415e-06, norm of the rhs: 1.09441e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.09441e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.34604e-09, 4.76415e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 4.76415e-06
 
    Solving temperature system... 2 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.78351e-06, norm of the rhs: 8.69139e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.69139e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.61886e-10, 3.78351e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.78351e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.94361e-06, norm of the rhs: 6.76198e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.76198e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.72537e-10, 2.94361e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.94361e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.62874e-06, norm of the rhs: 3.74149e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.74149e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.94421e-10, 1.62874e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.62874e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 9.92136e-07, norm of the rhs: 2.27911e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.27911e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.16442e-10, 9.92136e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 9.92136e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.82691e-07, norm of the rhs: 1.10882e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.10882e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.08698e-11, 4.82691e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 4.82691e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.25392e-07, norm of the rhs: 2.88047e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.88047e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.40199e-11, 1.25392e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.25392e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.195909. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 7.09626e-08, norm of the rhs: 1.63013e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.63013e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.20111e-11, 7.09626e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 7.09626e-08
 
 
    Postprocessing:

--- a/tests/tosi_benchmark_newton_solver_full_A/screen-output
+++ b/tests/tosi_benchmark_newton_solver_full_A/screen-output
@@ -9,44 +9,62 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 1.97927, v = 1.97927, p = 0
 
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.97927
+      Newton system information: Norm of the rhs: 1.97927
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 18+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00668806, norm of the rhs: 0.0132375, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.0132375, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.00668806
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00668806
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000915217, norm of the rhs: 0.00181146, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00181146, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.000915217
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000915217
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000134144, norm of the rhs: 0.000265506, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000265506, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 0.000134144
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000134144
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 2.0343e-05, norm of the rhs: 4.02643e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.02643e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 2.0343e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 2.0343e-05
 
    Solving temperature system... 0 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.16631e-06, norm of the rhs: 6.26699e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.26699e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 3.16631e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.16631e-06
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 7.76452e-07, norm of the rhs: 1.53681e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.53681e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 7.76452e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 7.76452e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.61044e-07, norm of the rhs: 3.18749e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.18749e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 1.61044e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.61044e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.24353e-08, norm of the rhs: 1.23576e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.23576e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.6005e-16, 6.24353e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 6.24353e-08
 
 
    Postprocessing:
@@ -62,74 +80,104 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.0376294, v = 0.0376294, p = 0
 
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.206943, norm of the rhs: 0.00778715
+      Newton system information: Norm of the rhs: 0.00778715
+      Relative nonlinear residuals (temperature, Stokes system): 0.00303534, 0.206943
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.206943
 
    Solving temperature system... 20 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0628274, norm of the rhs: 0.00236416, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00236416, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00302796, 0.0628274
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0628274
 
    Solving temperature system... 22 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.0755701, norm of the rhs: 0.00284366, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00284366, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00322397, 0.0755701
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0755701
 
    Solving temperature system... 23 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.0934953, norm of the rhs: 0.00351818, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00351818, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00395164, 0.0934953
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0934953
 
    Solving temperature system... 25 iterations.
    Solving Stokes system... 23+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.124946, norm of the rhs: 0.00470164, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00470164, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 0.00608165, 0.124946
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.124946
 
    Solving temperature system... 29 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.442669, norm of the rhs: 0.0166574, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0166574, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0107998, 0.442669
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.442669
 
    Solving temperature system... 31 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.707475, norm of the rhs: 0.0266219, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0266219, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0106113, 0.707475
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.707475
 
    Solving temperature system... 34 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.87946, norm of the rhs: 0.0330936, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0330936, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0143743, 0.87946
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.87946
 
    Solving temperature system... 39 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 0.675169, norm of the rhs: 0.0254063, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0254063, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0185613, 0.675169
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.675169
 
    Solving temperature system... 44 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 1.01788, norm of the rhs: 0.0383021, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0383021, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0218163, 1.01788
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 1.01788
 
    Solving temperature system... 46 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 0.967785, norm of the rhs: 0.0364172, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0364172, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0114146, 0.967785
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.967785
 
    Solving temperature system... 47 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 0.704853, norm of the rhs: 0.0265232, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0265232, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.00757486, 0.704853
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.704853
 
    Solving temperature system... 51 iterations.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 0.816485, norm of the rhs: 0.0307239, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0307239, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0160711, 0.816485
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.816485
 
    Solving temperature system... 59 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 9+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.11987, norm of the rhs: 0.04214, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.04214, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0169127, 1.11987
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.11987
 
    Solving temperature system... 57 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 0.506494, norm of the rhs: 0.0190591, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 0.0190591, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 0.0060702, 0.506494
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.506494
 
 
    Postprocessing:
@@ -143,64 +191,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.220152, v = 0.220152, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0788964, norm of the rhs: 0.0173692
+      Newton system information: Norm of the rhs: 0.0173692
+      Relative nonlinear residuals (temperature, Stokes system): 0.000821948, 0.0788964
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0788964
 
    Solving temperature system... 9 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00309473, norm of the rhs: 0.000681312, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000681312, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.0118e-05, 0.00309473
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00309473
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00141483, norm of the rhs: 0.000311479, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000311479, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.17667e-05, 0.00141483
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.00141483
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000662546, norm of the rhs: 0.000145861, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000145861, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 3.01048e-06, 0.000662546
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000662546
 
    Solving temperature system... 7 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 0.000314356, norm of the rhs: 6.92063e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.92063e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.65952e-07, 0.000314356
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000314356
 
    Solving temperature system... 6 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 0.000267007, norm of the rhs: 5.87821e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.87821e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 3.37721e-07, 0.000267007
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.000267007
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 0.000194743, norm of the rhs: 4.28732e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4.28732e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.18927e-08, 0.000194743
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.000194743
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 0.000124587, norm of the rhs: 2.74282e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.74282e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 7.95218e-08, 0.000124587
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.000124587
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 5.94879e-05, norm of the rhs: 1.30964e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.30964e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.11788e-08, 5.94879e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 5.94879e-05
 
    Solving temperature system... 5 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 2.39184e-05, norm of the rhs: 5.26569e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.26569e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.84554e-08, 2.39184e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 2.39184e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 7.03114e-06, norm of the rhs: 1.54792e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.54792e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.63899e-09, 7.03114e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 7.03114e-06
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 6+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 6.40433e-07, norm of the rhs: 1.40993e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.40993e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.68331e-09, 6.40433e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 6.40433e-07
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.00562201. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.76967e-08, norm of the rhs: 1.49036e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.49036e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.21326e-10, 6.76967e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.76967e-08
 
 
    Postprocessing:
@@ -214,64 +288,90 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.226633, v = 0.226633, p = 0
 
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0662477, norm of the rhs: 0.0150139
+      Newton system information: Norm of the rhs: 0.0150139
+      Relative nonlinear residuals (temperature, Stokes system): 0.000242648, 0.0662477
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0662477
 
    Solving temperature system... 8 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00131214, norm of the rhs: 0.000297374, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000297374, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.64281e-05, 0.00131214
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.00131214
 
    Solving temperature system... 6 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.000483968, norm of the rhs: 0.000109683, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.000109683, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.5998e-06, 0.000483968
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.000483968
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000199138, norm of the rhs: 4.51314e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4.51314e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 4.94132e-07, 0.000199138
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000199138
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.92161e-05, norm of the rhs: 2.02194e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.02194e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 1.32636e-07, 8.92161e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.92161e-05
 
    Solving temperature system... 4 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 1+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 7.8185e-05, norm of the rhs: 1.77193e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.77193e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.20845e-08, 7.8185e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 7.8185e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 5.86263e-05, norm of the rhs: 1.32867e-05, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.32867e-05, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.17045e-09, 5.86263e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 5.86263e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 3.46495e-05, norm of the rhs: 7.85273e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.85273e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 4.52935e-09, 3.46495e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 3.46495e-05
 
    Solving temperature system... 4 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 1.58692e-05, norm of the rhs: 3.59649e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.59649e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.0379e-08, 1.58692e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 1.58692e-05
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 5.04292e-06, norm of the rhs: 1.14289e-06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.14289e-06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 5.08988e-09, 5.04292e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 5.04292e-06
 
    Solving temperature system... 3 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.4251e-06, norm of the rhs: 3.22975e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.22975e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.25362e-09, 1.4251e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.4251e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.150979. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 1.64218e-07, norm of the rhs: 3.72174e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.72174e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.16704e-10, 1.64218e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 1.64218e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.0863885. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 7+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.44128e-08, norm of the rhs: 1.45981e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.45981e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.10694e-10, 6.44128e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.44128e-08
 
 
    Postprocessing:
@@ -285,59 +385,83 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
    Initial Newton Stokes residual = 0.229717, v = 0.229717, p = 0
 
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.000698263, norm of the rhs: 0.000160403
+      Newton system information: Norm of the rhs: 0.000160403
+      Relative nonlinear residuals (temperature, Stokes system): 3.77877e-05, 0.000698263
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000698263
 
    Solving temperature system... 5 iterations.
    Solving Stokes system... 22+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.91512e-05, norm of the rhs: 1.12909e-05, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.12909e-05, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 4.34351e-07, 4.91512e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.91512e-05
 
    Solving temperature system... 4 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 2.21545e-05, norm of the rhs: 5.08927e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 5.08927e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.39104e-08, 2.21545e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 2.21545e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.01965e-05, norm of the rhs: 2.34231e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.34231e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 6.76747e-09, 1.01965e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.01965e-05
 
    Solving temperature system... 3 iterations.
    Solving Stokes system... 21+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 4.76415e-06, norm of the rhs: 1.09441e-06, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.09441e-06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 2.34604e-09, 4.76415e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 4.76415e-06
 
    Solving temperature system... 2 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.9. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 2+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 3.78351e-06, norm of the rhs: 8.69139e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 8.69139e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 8.61886e-10, 3.78351e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 3.78351e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 3+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 2.94361e-06, norm of the rhs: 6.76198e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.76198e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.72537e-10, 2.94361e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 2.94361e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.62874e-06, norm of the rhs: 3.74149e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.74149e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.94421e-10, 1.62874e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.62874e-06
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.639983. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 9.92136e-07, norm of the rhs: 2.27911e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.27911e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.16442e-10, 9.92136e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 9.92136e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.485706. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 4+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 4.82691e-07, norm of the rhs: 1.10882e-07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.10882e-07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 6.08698e-11, 4.82691e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 4.82691e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.310843. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 5+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 1.25392e-07, norm of the rhs: 2.88047e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 2.88047e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.40199e-11, 1.25392e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 1.25392e-07
 
    Solving temperature system... 2 iterations.
    The linear solver tolerance is set to 0.195909. Stabilization Preconditioner is SPD and A block is SPD.
    Solving Stokes system... 8+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 7.09626e-08, norm of the rhs: 1.63013e-08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.63013e-08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 2.20111e-11, 7.09626e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 7.09626e-08
 
 
    Postprocessing:

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -17,19 +17,19 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 182+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 1
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 1
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 94+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 0.172827
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 0.172827
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.172827
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 85+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 0.0233251
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 0.0233251
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0233251
 
 

--- a/tests/traction_multiple_model/screen-output
+++ b/tests/traction_multiple_model/screen-output
@@ -16,17 +16,17 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
    Solving Stokes system... 61+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 0.102074
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 0.102074
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.102074
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 42+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 0.337213
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 0.337213
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.337213
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 38+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.73824e-16, 0.133364
+      Relative nonlinear residuals (temperature, Stokes system): 1.73824e-16, 0.133364
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.133364
 
 

--- a/tests/transform_fault_behn_2007/screen-output
+++ b/tests/transform_fault_behn_2007/screen-output
@@ -5,12 +5,12 @@ Number of degrees of freedom: 49,097 (35,547+1,701+11,849)
 *** Timestep 0:  t=0 years, dt=0 years
    Solving temperature system... 0 iterations.
    Solving Stokes system... 19+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.42842e-16, 0.000543298
+      Relative nonlinear residuals (temperature, Stokes system): 4.42842e-16, 0.000543298
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.000543298
 
    Solving temperature system... 0 iterations.
    Solving Stokes system... 0+0 iterations.
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 4.42842e-16, 2.21486e-11
+      Relative nonlinear residuals (temperature, Stokes system): 4.42842e-16, 2.21486e-11
       Relative nonlinear residual (total system) after nonlinear iteration 2: 2.21486e-11
 
 

--- a/tests/visco_plastic_gerya_2019_vp/screen-output
+++ b/tests/visco_plastic_gerya_2019_vp/screen-output
@@ -11,11 +11,13 @@ Number of degrees of freedom: 6,023 (2,178+289+289+1,089+1,089+1,089)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 72+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 2.74998e+13
+      Newton system information: Norm of the rhs: 2.74998e+13
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 77+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.0943178, norm of the rhs: 2.59373e+12, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.59373e+12, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0943178
 
 
    Postprocessing:

--- a/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
+++ b/tests/visco_plastic_newton_nonlinear_channelflow/screen-output
@@ -8,107 +8,145 @@ Number of degrees of freedom: 268 (162+25+81)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.64574e+16
+      Newton system information: Norm of the rhs: 1.64574e+16
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.77637e-05, norm of the rhs: 6.21492e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.21492e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 3.77637e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.77637e-05
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.95095e-05, norm of the rhs: 3.21076e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.21076e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.95095e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 1.95095e-05
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 1.1184e-05, norm of the rhs: 1.8406e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.8406e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.1184e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 1.1184e-05
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 5: 8.04578e-06, norm of the rhs: 1.32413e+11, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.32413e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 8.04578e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 8.04578e-06
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 6: 2.41936e-06, norm of the rhs: 3.98164e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.98164e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 2.41936e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 2.41936e-06
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 7: 1.60467e-06, norm of the rhs: 2.64088e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 2.64088e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.60467e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 1.60467e-06
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 17+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 8: 1.02053e-06, norm of the rhs: 1.67952e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.67952e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.02053e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 1.02053e-06
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 9: 6.40802e-07, norm of the rhs: 1.05459e+10, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 1.05459e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 6.40802e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 6.40802e-07
 
    Solving temperature system... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 16+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 10: 3.99636e-07, norm of the rhs: 6.57697e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 6.57697e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 3.99636e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 3.99636e-07
 
    Solving temperature system... 0 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 11: 4.48107e-07, norm of the rhs: 7.37469e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 7.37469e+09, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 4.48107e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 4.48107e-07
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 12: 3.7409e-08, norm of the rhs: 6.15655e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 6.15655e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 3.7409e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 3.7409e-08
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 13: 6.72188e-09, norm of the rhs: 1.10625e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.10625e+08, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 6.72188e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 6.72188e-09
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 14: 1.98864e-09, norm of the rhs: 3.27279e+07, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 3.27279e+07, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.98864e-09
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 1.98864e-09
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 15: 3.53014e-10, norm of the rhs: 5.8097e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5.8097e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 3.53014e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 3.53014e-10
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 16: 1.01431e-10, norm of the rhs: 1.66929e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.66929e+06, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.01431e-10
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 1.01431e-10
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 17: 2.22072e-11, norm of the rhs: 365473, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 365473, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 2.22072e-11
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 2.22072e-11
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 12+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 18: 5.71001e-12, norm of the rhs: 93972, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 93972, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 5.71001e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 5.71001e-12
 
    Solving temperature system... 0 iterations.
    The linear solver tolerance is set to 0.01. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 19: 1.34123e-12, norm of the rhs: 22073.3, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 22073.3, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, Stokes system): 9.54579e-17, 1.34123e-12
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 1.34123e-12
 
 
    Postprocessing:

--- a/tests/visco_plastic_vep_brick_extension/screen-output
+++ b/tests/visco_plastic_vep_brick_extension/screen-output
@@ -12,11 +12,13 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.09752e+12
+      Newton system information: Norm of the rhs: 1.09752e+12
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 2.42185e-15, norm of the rhs: 0.00265803, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 0.00265803, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 2.42185e-15
 
 
    Postprocessing:
@@ -34,11 +36,13 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0426595, norm of the rhs: 4.68235e+10
+      Newton system information: Norm of the rhs: 4.68235e+10
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0426595
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 3.96267e-09, norm of the rhs: 4349.46, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 4349.46, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 3.96267e-09
 
 
    Postprocessing:
@@ -56,12 +60,14 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00445133, norm of the rhs: 4.89317e+09
+      Newton system information: Norm of the rhs: 4.89317e+09
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00445133
 
    Switching from defect correction form of Picard to the Newton solver scheme.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.47139e-09, norm of the rhs: 4915.22, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 4915.22, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.47139e-09
 
 
    Postprocessing:
@@ -79,12 +85,14 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00271194, norm of the rhs: 2.98346e+09
+      Newton system information: Norm of the rhs: 2.98346e+09
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00271194
 
    Switching from defect correction form of Picard to the Newton solver scheme.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 4.82809e-09, norm of the rhs: 5311.48, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 5311.48, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 4.82809e-09
 
 
    Postprocessing:
@@ -102,22 +110,26 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 10+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.00195672, norm of the rhs: 2.15473e+09
+      Newton system information: Norm of the rhs: 2.15473e+09
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00195672
 
    Switching from defect correction form of Picard to the Newton solver scheme.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 1.46543e-06, norm of the rhs: 1.61372e+06, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.61372e+06, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 1.46543e-06
 
    The linear solver tolerance is set to 1e-07. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 1.20186e-07, norm of the rhs: 132349, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 132349, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 1.20186e-07
 
    The linear solver tolerance is set to 1e-07. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 13+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 2.42598e-08, norm of the rhs: 26714.8, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 26714.8, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 2.42598e-08
 
 
    Postprocessing:
@@ -135,22 +147,26 @@ Number of mesh deformation degrees of freedom: 252
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 11+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 0.0261004, norm of the rhs: 2.85334e+10
+      Newton system information: Norm of the rhs: 2.85334e+10
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0261004
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 2: 0.00351397, norm of the rhs: 3.84152e+09, newton_derivative_scaling_factor: 0
+      Newton system information: Norm of the rhs: 3.84152e+09, Derivative scaling factor: 0
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.00351397
 
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 1e-07. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 15+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 3: 0.00122331, norm of the rhs: 1.33734e+09, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.33734e+09, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 3: 0.00122331
 
    The linear solver tolerance is set to 1e-07. Stabilization Preconditioner is SPD and A block is SPD.
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 14+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 4: 0.000137637, norm of the rhs: 1.50467e+08, newton_derivative_scaling_factor: 1
+      Newton system information: Norm of the rhs: 1.50467e+08, Derivative scaling factor: 1
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.000137637
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield_plastic_damper/screen-output
+++ b/tests/visco_plastic_yield_plastic_damper/screen-output
@@ -11,7 +11,8 @@ Number of degrees of freedom: 1,607 (578+81+81+289+289+289)
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system... 20+0 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 1.60155e+13
+      Newton system information: Norm of the rhs: 1.60155e+13
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:

--- a/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
@@ -8,7 +8,8 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Initial Newton Stokes residual = 4.4124e+12, v = 2.00464e+12, p = 3.93073e+12
 
    Solving Stokes system... 0+7 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 1, norm of the rhs: 4.4124e+12
+      Newton system information: Norm of the rhs: 4.4124e+12
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
    Postprocessing:
@@ -25,7 +26,8 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
    Initial Newton Stokes residual = 1.8223e+13, v = 1.81808e+13, p = 1.24042e+12
 
    Solving Stokes system... 0+6 iterations.
-      Relative nonlinear residual (total Newton system) after nonlinear iteration 1: 9.8814e-05, norm of the rhs: 1.80069e+09
+      Newton system information: Norm of the rhs: 1.80069e+09
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 9.8814e-05
 
 
    Postprocessing:


### PR DESCRIPTION
I noticed that the (iterated advection and) defect correction and newton solver have diverged, both in output and code, which should not have happened. In this pull request I combine them and let the defect correction version call the newton one with a parameter to state that it is not using the newton solver. This should prevent these kind of issue in the future.