### PR TITLE
Introspection: store discontinuous per composition

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -170,7 +170,7 @@ namespace aspect
        * A variable that holds whether the composition field(s) should use a
        * discontinuous discretization.
        */
-      const bool use_discontinuous_composition_discretization;
+      const std::vector<bool> use_discontinuous_composition_discretization;
 
       /**
        * A structure that enumerates the vector components of the finite

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -650,7 +650,8 @@ namespace aspect
     bool                           use_locally_conservative_discretization;
     bool                           use_equal_order_interpolation_for_stokes;
     bool                           use_discontinuous_temperature_discretization;
-    bool                           use_discontinuous_composition_discretization;
+    std::vector<bool>              use_discontinuous_composition_discretization;
+    bool                           have_discontinuous_composition_discretization;
     unsigned int                   temperature_degree;
     unsigned int                   composition_degree;
     std::string                    pressure_normalization;

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -169,7 +169,7 @@ namespace aspect
         if ((i==0 && parameters.use_discontinuous_temperature_discretization
              && parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::fem_field)
             ||
-            (i>0 && parameters.use_discontinuous_composition_discretization
+            (i>0 && parameters.use_discontinuous_composition_discretization[i-1]
              && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field))
           {
             assemblers->advection_system_on_boundary_face[i].push_back(
@@ -192,7 +192,7 @@ namespace aspect
             assemblers->advection_system_assembler_on_face_properties[0].need_face_finite_element_evaluation = true;
           }
 
-        if (i > 0 && parameters.use_discontinuous_composition_discretization
+        if (i > 0 && parameters.use_discontinuous_composition_discretization[i-1]
             && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_field)
           {
             assemblers->advection_system_assembler_on_face_properties[i].need_face_material_model_data = true;
@@ -201,20 +201,29 @@ namespace aspect
       }
 
     if (parameters.use_discontinuous_temperature_discretization ||
-        parameters.use_discontinuous_composition_discretization)
+        parameters.have_discontinuous_composition_discretization)
       {
         const bool dc_temperature = parameters.use_discontinuous_temperature_discretization && parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::fem_field;
-        const bool dc_composition = parameters.use_discontinuous_composition_discretization && std::find(parameters.compositional_field_methods.begin(),
-                                    parameters.compositional_field_methods.end(),
-                                    Parameters<dim>::AdvectionFieldMethod::fem_field) != parameters.compositional_field_methods.end();
-        const bool no_field_method = !(dc_temperature || dc_composition);
+        bool dc_composition = false;
+
+        for (unsigned int c=0; c<parameters.n_compositional_fields; ++c)
+          {
+            if (parameters.use_discontinuous_composition_discretization[c]
+                && parameters.compositional_field_methods[c] == Parameters<dim>::AdvectionFieldMethod::fem_field)
+              {
+                dc_composition = true;
+                break;
+              }
+          }
+
+        const bool no_dc_field_method = !dc_temperature && !dc_composition;
 
         // TODO: This currently does not work in parallel, because the sparsity
         // pattern of the matrix does not seem to know about flux terms
         // across periodic faces of different levels. Fix this.
         AssertThrow(geometry_model->get_periodic_boundary_pairs().size() == 0 ||
                     Utilities::MPI::n_mpi_processes(mpi_communicator) == 1 ||
-                    no_field_method ||
+                    no_dc_field_method ||
                     (parameters.initial_adaptive_refinement == 0 &&
                      parameters.adaptive_refinement_interval == 0),
                     ExcMessage("Combining discontinuous elements with periodic boundaries and "

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -178,7 +178,7 @@ namespace aspect
                                "These need to be the same during restarting "
                                "from a checkpoint."));
 
-      bool use_discontinuous_composition_discretization;
+      std::vector<bool> use_discontinuous_composition_discretization;
       ia >> use_discontinuous_composition_discretization;
       AssertThrow (use_discontinuous_composition_discretization == parameters.use_discontinuous_composition_discretization,
                    ExcMessage ("The value provided for `Use discontinuous composition discretization' that was stored "

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -108,7 +108,7 @@ namespace aspect
     if (field_type == temperature_field)
       return introspection.use_discontinuous_temperature_discretization;
     else if (field_type == compositional_field)
-      return introspection.use_discontinuous_composition_discretization;
+      return introspection.use_discontinuous_composition_discretization[compositional_variable];
 
     Assert (false, ExcInternalError());
     return false;

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -223,10 +223,11 @@ namespace aspect
         1,
         1));
 
+
     variables.push_back(
       VariableDeclaration<dim>(
         "compositions",
-        internal::new_FE_Q_or_DGQ<dim>(parameters.use_discontinuous_composition_discretization,
+        internal::new_FE_Q_or_DGQ<dim>(parameters.have_discontinuous_composition_discretization, // TODO: this is of course incorrect for now.
                                        parameters.composition_degree),
         parameters.n_compositional_fields,
         parameters.n_compositional_fields));
@@ -410,7 +411,7 @@ namespace aspect
   Introspection<dim>::name_for_compositional_index (const unsigned int index) const
   {
     // make sure that what we get here is really an index of one of the compositional fields
-    AssertIndexRange(index, composition_names.size());
+    AssertIndexRange(index,composition_names.size());
     return composition_names[index];
   }
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1798,7 +1798,7 @@ namespace aspect
     // The additional terms in the temperature systems have not been ported
     // to the DG formulation:
     AssertThrow(!this->get_parameters().use_discontinuous_temperature_discretization &&
-                !this->get_parameters().use_discontinuous_composition_discretization,
+                !this->get_parameters().have_discontinuous_composition_discretization,
                 ExcMessage("Using discontinuous elements for temperature "
                            "or composition in models with melt transport is currently not implemented.") );
     if (melt_parameters.use_discontinuous_p_c)

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1728,9 +1728,15 @@ namespace aspect
       use_discontinuous_temperature_discretization
         = prm.get_bool("Use discontinuous temperature discretization");
       use_discontinuous_composition_discretization
-        = prm.get_bool("Use discontinuous composition discretization");
+        = Utilities::possibly_extend_from_1_to_N (Utilities::string_to_bool(Utilities::split_string_list(prm.get("Use discontinuous composition discretization"))),
+                                                  n_compositional_fields,
+                                                  "Use discontinuous composition discretization");
+      have_discontinuous_composition_discretization =
+        (std::find(use_discontinuous_composition_discretization.begin(), use_discontinuous_composition_discretization.end(), true)
+         != use_discontinuous_composition_discretization.end());
 
-      AssertThrow(use_discontinuous_composition_discretization == true || composition_degree > 0,
+      // TODO: this needs to be modified once we lift the restriction that all compositions have the same degree.
+      AssertThrow(have_discontinuous_composition_discretization == true || composition_degree > 0,
                   ExcMessage("Using a composition polynomial degree of 0 (cell-wise constant composition) "
                              "is only supported if a discontinuous composition discretization is selected."));
 

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -736,13 +736,13 @@ namespace aspect
     pcout << solver_control.last_step()
           << " iterations." << std::endl;
 
-    if ((advection_field.is_temperature()
-         && parameters.use_discontinuous_temperature_discretization
-         && parameters.use_limiter_for_discontinuous_temperature_solution)
-        ||
-        (!advection_field.is_temperature()
-         && parameters.use_discontinuous_composition_discretization
-         && parameters.use_limiter_for_discontinuous_composition_solution[advection_field.compositional_variable]))
+    if ((advection_field.is_discontinuous(introspection)
+         &&
+         (
+           (advection_field.is_temperature() && parameters.use_limiter_for_discontinuous_temperature_solution)
+           ||
+           (!advection_field.is_temperature() && parameters.use_limiter_for_discontinuous_composition_solution[advection_field.compositional_variable])
+         )))
       {
         apply_limiter_to_dg_solutions(advection_field);
         // by applying the limiter we have modified the solution to no longer


### PR DESCRIPTION
This changes the type of ``use_discontinuous_composition_discretization`` to a std::vector<bool> and replaces all usages of this variable. No other new/different functionality.

part of #5748 