### PR TITLE
Fix particle benchmark scripts

### DIFF
--- a/benchmarks/annulus/transient/run_all_models.sh
+++ b/benchmarks/annulus/transient/run_all_models.sh
@@ -70,13 +70,14 @@ for refinement in 2 3 4; do
 
         echo "subsection Postprocess" >> particles.prm
         echo "  set List of postprocessors = visualization, velocity statistics, AnnulusPostprocessor, rotation statistics, particles, particle count statistics" >> particles.prm
-        echo "  subsection Particles" >> particles.prm
-        echo "    set Number of particles = $number_of_particles" >> particles.prm
-        echo "    set Integration scheme = rk2" >> particles.prm
-        echo "    subsection Integrator" >> particles.prm
-        echo "      subsection RK2" >> particles.prm
-        echo "        set Higher order accurate in time = $higher_order_time" >> particles.prm
-        echo "      end" >> particles.prm
+        echo "end" >> particles.prm
+
+        echo "subsection Particles" >> particles.prm
+        echo "  set Number of particles = $number_of_particles" >> particles.prm
+        echo "  set Integration scheme = rk2" >> particles.prm
+        echo "  subsection Integrator" >> particles.prm
+        echo "    subsection RK2" >> particles.prm
+        echo "      set Higher order accurate in time = $higher_order_time" >> particles.prm
         echo "    end" >> particles.prm
         echo "  end" >> particles.prm
         echo "end" >> particles.prm

--- a/benchmarks/annulus/transient/run_all_models.sh
+++ b/benchmarks/annulus/transient/run_all_models.sh
@@ -73,7 +73,11 @@ for refinement in 2 3 4; do
         echo "end" >> particles.prm
 
         echo "subsection Particles" >> particles.prm
-        echo "  set Number of particles = $number_of_particles" >> particles.prm
+        echo "  subsection Generator" >> particles.prm
+        echo "    subsection Probability density function" >> particles.prm
+        echo "      set Number of particles = $number_of_particles" >> particles.prm
+        echo "    end" >> particles.prm
+        echo "  end" >> particles.prm
         echo "  set Integration scheme = rk2" >> particles.prm
         echo "  subsection Integrator" >> particles.prm
         echo "    subsection RK2" >> particles.prm

--- a/benchmarks/rigid_shear/steady-state/run_all_models.sh
+++ b/benchmarks/rigid_shear/steady-state/run_all_models.sh
@@ -19,10 +19,7 @@ for stokes_degree in 2 3; do
         echo "  set Use locally conservative discretization = $discontinuous_pressure" >> current.prm
         echo "end" >> current.prm
 
-        number_of_particles=`echo "$particles_per_direction * $particles_per_direction * 2 ^ (2 * $refinement)" | bc -l`
-        echo "subsection Postprocess" >> current.prm
-        echo "  subsection Particles" >> current.prm
-        echo "  set Number of particles = $number_of_particles" >> current.prm
+        echo "subsection Particles" >> current.prm
         echo "  set Particle generator name = $generator" >> current.prm
 
         # If using longer runtimes it is necessary to add particles to
@@ -34,10 +31,9 @@ for stokes_degree in 2 3; do
 
         echo "  set Interpolation scheme = $interpolator" >> current.prm
         echo "  set Integration scheme = $integrator" >> current.prm
-        echo "    subsection Generator" >> current.prm
-        echo "      subsection Reference cell" >> current.prm
-        echo "        set Number of particles per cell per direction = $particles_per_direction" >> current.prm
-        echo "      end" >> current.prm
+        echo "  subsection Generator" >> current.prm
+        echo "    subsection Reference cell" >> current.prm
+        echo "      set Number of particles per cell per direction = $particles_per_direction" >> current.prm
         echo "    end" >> current.prm
         echo "  end" >> current.prm
         echo "end" >> current.prm

--- a/benchmarks/rigid_shear/transient/run_all_models.sh
+++ b/benchmarks/rigid_shear/transient/run_all_models.sh
@@ -71,7 +71,11 @@ for refinement in 2 3 4 5 6 7; do
         echo "end" >> particles.prm
 
         echo "subsection Particles" >> particles.prm
-        echo "  set Number of particles = $number_of_particles" >> particles.prm
+        echo "  subsection Generator" >> particles.prm
+        echo "    subsection Probability density function" >> particles.prm
+        echo "      set Number of particles = $number_of_particles" >> particles.prm
+        echo "    end" >> particles.prm
+        echo "  end" >> particles.prm
         echo "  set Integration scheme = rk2" >> particles.prm
         echo "  set Interpolation scheme = $interpolation_scheme" >> particles.prm
         echo "  set Particle generator name = random uniform" >> particles.prm

--- a/benchmarks/rigid_shear/transient/run_all_models.sh
+++ b/benchmarks/rigid_shear/transient/run_all_models.sh
@@ -68,15 +68,16 @@ for refinement in 2 3 4 5 6 7; do
 
         echo "subsection Postprocess" >> particles.prm
         echo "  set List of postprocessors = visualization, particles, rigid shear, velocity statistics, particle count statistics" >> particles.prm
-        echo "  subsection Particles" >> particles.prm
-        echo "    set Number of particles = $number_of_particles" >> particles.prm
-        echo "    set Integration scheme = rk2" >> particles.prm
-        echo "    set Interpolation scheme = $interpolation_scheme" >> particles.prm
-        echo "    set Particle generator name = random uniform" >> particles.prm
-        echo "    subsection Integrator" >> particles.prm
-        echo "      subsection RK2" >> particles.prm
-        echo "        set Higher order accurate in time = $higher_order_time" >> particles.prm
-        echo "      end" >> particles.prm
+        echo "end" >> particles.prm
+
+        echo "subsection Particles" >> particles.prm
+        echo "  set Number of particles = $number_of_particles" >> particles.prm
+        echo "  set Integration scheme = rk2" >> particles.prm
+        echo "  set Interpolation scheme = $interpolation_scheme" >> particles.prm
+        echo "  set Particle generator name = random uniform" >> particles.prm
+        echo "  subsection Integrator" >> particles.prm
+        echo "    subsection RK2" >> particles.prm
+        echo "      set Higher order accurate in time = $higher_order_time" >> particles.prm
         echo "    end" >> particles.prm
         echo "  end" >> particles.prm
         echo "end" >> particles.prm

--- a/benchmarks/time_dependent_annulus/transient/run_all_models.sh
+++ b/benchmarks/time_dependent_annulus/transient/run_all_models.sh
@@ -11,12 +11,10 @@ for stokes_degree in 2; do #3
         echo "  set Stokes velocity polynomial degree = $stokes_degree" >> current.prm
         echo "end" >> current.prm
 
-        echo "subsection Postprocess" >> current.prm
-        echo "  subsection Particles" >> current.prm
-        echo "    subsection Generator" >> current.prm
-        echo "      subsection Reference cell" >> current.prm
-        echo "        set Number of particles per cell per direction = $particles_per_direction" >> current.prm
-        echo "      end" >> current.prm
+        echo "subsection Particles" >> current.prm
+        echo "  subsection Generator" >> current.prm
+        echo "    subsection Reference cell" >> current.prm
+        echo "      set Number of particles per cell per direction = $particles_per_direction" >> current.prm
         echo "    end" >> current.prm
         echo "  end" >> current.prm
         echo "end" >> current.prm


### PR DESCRIPTION
Follow up to #5394. These benchmarks scripts were not updated, because I didnt see that they used the subsection in the bash script.