### PR TITLE
add clang/clang-tidy Github-Actions workflow

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,60 @@
+name: clang
+
+on:
+  push:
+   branches:
+     - 'main'
+     - 'aspect-*'
+  # pull_request: disable testing of PRs because it is too slow
+
+concurrency:
+  group: ${{ github.actor }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  OMPI_MCA_btl_base_warn_component_unused: 0
+  OMPI_MCA_mpi_yield_when_idle: 1
+  OMPI_MCA_rmaps_base_oversubscribe: 1
+  OMPI_ALLOW_RUN_AS_ROOT: 1
+  OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+  OMPI_MCA_btl_vader_single_copy_mechanism: none
+
+jobs:
+  tidy:
+    # run clang-tidy
+    name: tidy
+    runs-on: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: "geodynamics/aspect-tester:noble-dealii-master-clang"
+            result-file: "clang-tidy-results.txt"
+            container-options: '--user 0 --name container'
+
+    container:
+      image: ${{ matrix.image }}
+      options: ${{ matrix.container-options }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: clang-tidy
+      run: |
+        mkdir build
+        cd build
+        ../contrib/utilities/run_clang_tidy.sh $PWD/..
+        mv output.txt ${{ matrix.result-file }}
+    - name: compile
+      run: |
+        cd build
+        cmake -D CMAKE_CXX_FLAGS='-Werror' .
+        make -j 2
+    - name: test
+      run: |
+        cd build
+        ./aspect --test
+    - name: archive test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.result-file }}
+        path: build/${{ matrix.result-file }}

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -54,7 +54,7 @@ if test ! -d "$SRC/source" -o ! -d "$SRC/include" -o ! -f "$SRC/CMakeLists.txt" 
     exit 1
 fi
 
-if ! [ -x "$(command -v run-clang-tidy.py)" ] || ! [ -x "$(command -v clang++)" ]; then
+if ! [ -x "$(command -v run-clang-tidy)" ] || ! [ -x "$(command -v clang++)" ]; then
     echo "Error: Either the 'run-clang-tidy.py' or the 'clang++' program could not be found."
     echo "       Make sure 'clang', 'clang++', and 'run-clang-tidy.py' (part of clang) are in the path."
     exit 2
@@ -81,7 +81,7 @@ CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) 
 # finally run it:
 # pipe away stderr (just contains nonsensical "x warnings generated")
 # pipe output to output.txt
-run-clang-tidy.py -p . -quiet -header-filter="$SRC/include/*" 2>error.txt >output.txt
+run-clang-tidy -p . -quiet -header-filter="$SRC/include/*" 2>error.txt >output.txt
 
 if grep -E -q '(warning|error): ' output.txt; then
     grep -E '(warning|error): ' output.txt
@@ -90,4 +90,3 @@ fi
 
 echo "OK"
 exit 0
-


### PR DESCRIPTION
- add action to compile with Clang and run clang-tidy
- This action takes close to 2hr to complete, so disable for PRs for now