### PR TITLE
Consistently format 'deal.II' in the manual.

### DIFF
--- a/doc/sphinx/user/extending/index.md
+++ b/doc/sphinx/user/extending/index.md
@@ -125,8 +125,7 @@ which there is an extensive amount of documentation:
     <https://github.com/dealii/dealii/wiki/Frequently-Asked-Questions> that
     also have extensive sections on developing code with
     deal.II as well as on debugging. It also answers
-    a number of questions we frequently get about the use of C++ in <span
-    deal.II.
+    a number of questions we frequently get about the use of C++ in deal.II.
 
 -   Several other parts of the deal.II website
     at <https://www.dealii.org/> also have information that may be relevant if

--- a/doc/sphinx/user/install/docker-container/developing-in-container.md
+++ b/doc/sphinx/user/install/docker-container/developing-in-container.md
@@ -5,8 +5,8 @@ The workflow described previously does not include advice on how to modify
 ASPECT inside the container. We recommend a slightly
 different workflow for advanced users that want to modify parts of
 ASPECT. The ASPECT
-docker container itself is built on top of a <span
-class="smallcaps">deal.II</span> container that contains all dependencies for
+docker container itself is built on top of a deal.II
+container that contains all dependencies for
 compiling ASPECT. Therefore it is possible to
 run the deal.II container, mount an ASPECT
 source directory from your host system and compile it inside of the container.

--- a/doc/sphinx/user/install/local-installation/using-candi.md
+++ b/doc/sphinx/user/install/local-installation/using-candi.md
@@ -1,8 +1,8 @@
 
 # Using candi to compile dependencies
 
-In its default configuration `candi` downloads and compiles a <span
-class="smallcaps">deal.II</span> configuration that is able to run
+In its default configuration `candi` downloads and compiles a
+deal.II configuration that is able to run
 ASPECT, but it also contains a number of packages
 that are not required. We strive to keep
 the development version of ASPECT compatible

--- a/doc/sphinx/user/run-aspect/debug-mode.md
+++ b/doc/sphinx/user/run-aspect/debug-mode.md
@@ -1,8 +1,7 @@
 (sec:run-aspect:debug-mode)=
 # Debug or optimized mode
 
-ASPECT utilizes a <span
-class="smallcaps">deal.II</span> feature called *debug mode*. By default,
+ASPECT utilizes a deal.II feature called *debug mode*. By default,
 ASPECT is configured in debug mode, i.e., it calls a
 version of the deal.II library that contains
 lots of checks for the correctness of function arguments, the consistency of
@@ -11,8 +10,7 @@ many similar consistency checks enabled only in debug mode. Finally,
 you can only expect a good debugging experience (for example using *gdb*)
 because we only enable debug symbols in *debug mode* (at least by default).
 
-If you program with <span
-class="smallcaps">deal.II</span>, for example to extend
+If you program deal.II, for example to extend
 ASPECT, it has been our experience over the years
 that, by number, most programming errors are of the kind where one forgets to
 initialize a vector, one accesses data that has not been updated, one tries to


### PR DESCRIPTION
I found a missing `</span>` when reading about plugins - it looks like `ASPECT` is usually in small-caps but `deal.II` is plain text so I also went through and made `deal.II` plain text everywhere else I found it.