### PR TITLE
Fix particle update script

### DIFF
--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -23,11 +23,25 @@ import python.scripts.aspect_input as aspect
 def move_particle_parameters_to_own_subsection(parameters):
     """ Move the particle parameters to their own subsection. """
 
-    # Find the particle parameters and move
+    # Collect existing parameters and delete old entries
+    particle_params = dict({})
     if "Postprocess" in parameters:
         if "Particles" in parameters["Postprocess"]["value"]:
-            parameters["Particles"] = parameters["Postprocess"]["value"]["Particles"]
+            particle_params = parameters["Postprocess"]["value"]["Particles"]
             del parameters["Postprocess"]["value"]["Particles"]
+
+    # If there are any particle parameters
+    if "value" in particle_params:
+        # Make global section if necessary
+        if not "Particles" in parameters:
+            parameters["Particles"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+
+        # Move parameters one by one, throw an error if it already exists
+        for parameter in particle_params["value"]:
+            if not parameter in parameters["Particles"]["value"]:
+                parameters["Particles"]["value"][parameter] = particle_params["value"][parameter]
+            else:
+                assert False, "Error: Duplicated parameter found with name: " + str(parameter)
 
     return parameters
 


### PR DESCRIPTION
The current particle update script in #5394 had a bug that caused it to delete the parameters in the global "Particles" subsection if that subsection already existed (it did not exist in any file before #5394). This mostly means you cannot apply this script again to a file that was already updated without deleting parameters. This PR fixes the problem by detecting if the parameters have already been moved and then skipping the operation.