### PR TITLE
Remove unnecessary includes from particle interpolators

### DIFF
--- a/include/aspect/particle/interpolator/bilinear_least_squares.h
+++ b/include/aspect/particle/interpolator/bilinear_least_squares.h
@@ -32,11 +32,6 @@ namespace aspect
   {
     namespace Interpolator
     {
-      namespace internal
-      {
-        bool string_to_bool(const std::string &s);
-      }
-
       /**
        * Evaluate the properties of all particles of the given cell
        * using a least squares projection onto the set of bilinear

--- a/include/aspect/particle/interpolator/quadratic_least_squares.h
+++ b/include/aspect/particle/interpolator/quadratic_least_squares.h
@@ -24,7 +24,6 @@
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/particle/interpolator/cell_average.h>
 #include <aspect/simulator_access.h>
-#include <deal.II/lac/lapack_full_matrix.h>
 
 namespace aspect
 {

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -20,13 +20,12 @@
 
 #include <aspect/particle/interpolator/bilinear_least_squares.h>
 #include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
+#include <aspect/particle/world.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/qr.h>
-
-#include <boost/lexical_cast.hpp>
 
 namespace aspect
 {

--- a/source/particle/interpolator/cell_average.cc
+++ b/source/particle/interpolator/cell_average.cc
@@ -19,8 +19,6 @@
  */
 
 #include <aspect/particle/interpolator/cell_average.h>
-#include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>

--- a/source/particle/interpolator/harmonic_average.cc
+++ b/source/particle/interpolator/harmonic_average.cc
@@ -19,9 +19,6 @@
  */
 
 #include <aspect/particle/interpolator/harmonic_average.h>
-#include <aspect/particle/property/interface.h>
-#include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>

--- a/source/particle/interpolator/nearest_neighbor.cc
+++ b/source/particle/interpolator/nearest_neighbor.cc
@@ -19,8 +19,6 @@
  */
 
 #include <aspect/particle/interpolator/nearest_neighbor.h>
-#include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
 
 #include <deal.II/grid/grid_tools.h>
 

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -19,16 +19,13 @@
  */
 
 #include <aspect/particle/interpolator/quadratic_least_squares.h>
-#include <aspect/particle/interpolator/bilinear_least_squares.h>
 #include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
+#include <aspect/particle/world.h>
+#include <aspect/utilities.h>
 
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/lac/qr.h>
-#include <deal.II/grid/tria_iterator_base.h>
-
-#include <boost/lexical_cast.hpp>
 
 namespace aspect
 {


### PR DESCRIPTION
While thinking about #5880 (which is most likely caused by another reason) I noticed that a lot of the particle interpolator plugins include unnecessary header files. Most of these header have been necessary in the past, but were forgotten when the code was deleted or reworked. I also found one function declaration that is no longer implemented or used (it was moved in #5702)