### PR TITLE
Code cleanup

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -931,6 +931,12 @@ namespace aspect
       get_postprocess_manager () const;
 
       /**
+       * Returns whether there is at least one particle world.
+       */
+      unsigned int
+      n_particle_worlds() const;
+
+      /**
        * Returns a const reference to the particle world, in case anyone
        * wants to query something about particles.
        */

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -410,11 +410,9 @@ namespace aspect
           AssertThrow(false, ExcMessage("Not a valid Strain healing mechanism!"));
 
         // Currently this functionality only works in field composition
-        if (healing_mechanism != no_healing && this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::Particles<dim>>())
+        if (healing_mechanism != no_healing && this->n_particle_worlds() > 0)
           {
-            const Postprocess::Particles<dim> &particle_postprocessor = this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim>>();
-            const Particle::Property::Manager<dim> &particle_property_manager = particle_postprocessor.get_particle_world().get_property_manager();
-
+            const Particle::Property::Manager<dim> &particle_property_manager = this->get_particle_world().get_property_manager();
             AssertThrow(particle_property_manager.plugin_name_exists("viscoplastic strain invariants") == false, ExcMessage("This healing mechanism currently does not work if the strain is tracked on particles."));
           }
 

--- a/source/mesh_refinement/particle_density.cc
+++ b/source/mesh_refinement/particle_density.cc
@@ -21,8 +21,7 @@
 
 #include <aspect/mesh_refinement/particle_density.h>
 
-#include <aspect/postprocess/particles.h>
-#include <aspect/simulator.h>
+#include <aspect/particle/world.h>
 
 namespace aspect
 {
@@ -32,15 +31,12 @@ namespace aspect
     void
     ParticleDensity<dim>::execute(Vector<float> &indicators) const
     {
-      AssertThrow(this->get_postprocess_manager().template has_matching_postprocessor<Postprocess::Particles<dim>>(),
+      AssertThrow(this->n_particle_worlds() > 0,
                   ExcMessage("The mesh refinement plugin `particle density' requires the "
                              "postprocessor plugin `particles' to be selected. Please activate the "
                              "particles or deactivate this mesh refinement plugin."));
 
-      const Postprocess::Particles<dim> &particle_postprocessor =
-        this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim>>();
-
-      const Particle::ParticleHandler<dim> &particle_handler = particle_postprocessor.get_particle_world().get_particle_handler();
+      const Particle::ParticleHandler<dim> &particle_handler = this->get_particle_world().get_particle_handler();
 
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())
         if (cell->is_locally_owned())

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -19,7 +19,6 @@
  */
 
 #include <aspect/particle/interpolator/bilinear_least_squares.h>
-#include <aspect/postprocess/particles.h>
 #include <aspect/particle/world.h>
 #include <aspect/utilities.h>
 
@@ -282,9 +281,7 @@ namespace aspect
         {
           prm.enter_subsection("Bilinear least squares");
           {
-            const Postprocess::Particles<dim> &particle_postprocessor =
-              this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
-            const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+            const auto &particle_property_information = this->get_particle_world().get_property_manager().get_data_info();
             const unsigned int n_property_components = particle_property_information.n_components();
             const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -19,7 +19,6 @@
  */
 
 #include <aspect/particle/interpolator/quadratic_least_squares.h>
-#include <aspect/postprocess/particles.h>
 #include <aspect/particle/world.h>
 #include <aspect/utilities.h>
 
@@ -559,9 +558,7 @@ namespace aspect
         {
           prm.enter_subsection("Quadratic least squares");
           {
-            const Postprocess::Particles<dim> &particle_postprocessor =
-              this->get_postprocess_manager().template get_matching_postprocessor<const Postprocess::Particles<dim>>();
-            const auto &particle_property_information = particle_postprocessor.get_particle_world().get_property_manager().get_data_info();
+            const auto &particle_property_information = this->get_particle_world().get_property_manager().get_data_info();
             const unsigned int n_property_components = particle_property_information.n_components();
             const unsigned int n_internal_components = particle_property_information.get_components_by_field_name("internal: integrator properties");
 

--- a/source/postprocess/load_balance_statistics.cc
+++ b/source/postprocess/load_balance_statistics.cc
@@ -21,9 +21,7 @@
 
 #include <aspect/postprocess/load_balance_statistics.h>
 
-#include <aspect/postprocess/particles.h>
 #include <aspect/particle/world.h>
-#include <aspect/simulator.h>
 
 namespace aspect
 {
@@ -45,12 +43,9 @@ namespace aspect
       statistics.add_value ("Average cells per process",
                             cell_distribution.avg);
 
-      if (this->get_postprocess_manager().template
-          has_matching_postprocessor<const Postprocess::Particles<dim>>())
+      if (this->n_particle_worlds() > 0)
         {
-          const auto &particle_postprocessor = this->get_postprocess_manager().template
-                                               get_matching_postprocessor<const Postprocess::Particles<dim>>();
-          const unsigned int locally_owned_particles = particle_postprocessor.get_particle_world().
+          const unsigned int locally_owned_particles = this->get_particle_world().
                                                        get_particle_handler().n_locally_owned_particles();
           const dealii::Utilities::MPI::MinMaxAvg particles_per_process =
             dealii::Utilities::MPI::min_max_avg(locally_owned_particles,this->get_mpi_communicator());

--- a/source/postprocess/particle_count_statistics.cc
+++ b/source/postprocess/particle_count_statistics.cc
@@ -20,14 +20,10 @@
 
 
 #include <aspect/postprocess/particle_count_statistics.h>
+#include <aspect/particle/world.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
-
-#include <aspect/postprocess/particles.h>
-#include <aspect/particle/world.h>
-#include <aspect/simulator.h>
-
 
 
 namespace aspect
@@ -38,15 +34,12 @@ namespace aspect
     std::pair<std::string,std::string>
     ParticleCountStatistics<dim>::execute (TableHandler &statistics)
     {
-      const Postprocess::Particles<dim> &particle_postprocessor =
-        this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim>>();
-
       const Particle::ParticleHandler<dim> &particle_handler =
-        particle_postprocessor.get_particle_world().get_particle_handler();
+        this->get_particle_world().get_particle_handler();
 
       unsigned int local_min_particles = std::numeric_limits<unsigned int>::max();
       unsigned int local_max_particles = 0;
-      const Particle::types::particle_index global_particles = particle_postprocessor.get_particle_world().n_global_particles();
+      const Particle::types::particle_index global_particles = this->get_particle_world().n_global_particles();
 
       // compute local min/max
       for (const auto &cell : this->get_dof_handler().active_cell_iterators())

--- a/source/postprocess/visualization/particle_count.cc
+++ b/source/postprocess/visualization/particle_count.cc
@@ -20,10 +20,7 @@
 
 
 #include <aspect/postprocess/visualization/particle_count.h>
-
-#include <aspect/postprocess/particles.h>
 #include <aspect/particle/world.h>
-#include <aspect/simulator.h>
 
 
 namespace aspect
@@ -45,11 +42,8 @@ namespace aspect
       std::pair<std::string, std::unique_ptr<Vector<float>>>
       ParticleCount<dim>::execute() const
       {
-        const Postprocess::Particles<dim> &particle_postprocessor =
-          this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::Particles<dim>>();
-
         const Particle::ParticleHandler<dim> &particle_handler =
-          particle_postprocessor.get_particle_world().get_particle_handler();
+          this->get_particle_world().get_particle_handler();
 
         std::pair<std::string, std::unique_ptr<Vector<float>>>
         return_value ("particles_per_cell",

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -284,14 +284,11 @@ namespace aspect
     // need to write into it and we can not
     // write into vectors with ghost elements
 
-    const Postprocess::Particles<dim> &particle_postprocessor =
-      postprocess_manager.template get_matching_postprocessor<Postprocess::Particles<dim>>();
-
-    const Particle::Interpolator::Interface<dim> *particle_interpolator = &particle_postprocessor.get_particle_world().get_interpolator();
-    const Particle::Property::Manager<dim> *particle_property_manager = &particle_postprocessor.get_particle_world().get_property_manager();
+    const Particle::Interpolator::Interface<dim> &particle_interpolator = particle_world->get_interpolator();
+    const Particle::Property::Manager<dim> &particle_property_manager = particle_world->get_property_manager();
 
     std::vector<unsigned int> particle_property_indices;
-    ComponentMask property_mask  (particle_property_manager->get_data_info().n_components(),false);
+    ComponentMask property_mask  (particle_property_manager.get_data_info().n_components(),false);
 
     for (const auto &advection_field: advection_fields)
       {
@@ -299,7 +296,7 @@ namespace aspect
           {
             const std::pair<std::string,unsigned int> particle_property_and_component = parameters.mapped_particle_properties.find(advection_field.compositional_variable)->second;
 
-            const unsigned int particle_property_index = particle_property_manager->get_data_info().get_position_by_field_name(particle_property_and_component.first)
+            const unsigned int particle_property_index = particle_property_manager.get_data_info().get_position_by_field_name(particle_property_and_component.first)
                                                          + particle_property_and_component.second;
 
             particle_property_indices.push_back(particle_property_index);
@@ -311,7 +308,7 @@ namespace aspect
             const unsigned int particle_property_index = std::count(introspection.compositional_field_methods.begin(),
                                                                     introspection.compositional_field_methods.begin() + advection_field.compositional_variable,
                                                                     Parameters<dim>::AdvectionFieldMethod::particles);
-            AssertThrow(particle_property_index <= particle_property_manager->get_data_info().n_components(),
+            AssertThrow(particle_property_index <= particle_property_manager.get_data_info().n_components(),
                         ExcMessage("Can not automatically match particle properties to fields, because there are"
                                    "more fields that are marked as particle advected than particle properties"));
 
@@ -359,10 +356,10 @@ namespace aspect
           try
             {
               particle_properties =
-                particle_interpolator->properties_at_points(particle_postprocessor.get_particle_world().get_particle_handler(),
-                                                            quadrature_points,
-                                                            property_mask,
-                                                            cell);
+                particle_interpolator.properties_at_points(particle_world->get_particle_handler(),
+                                                           quadrature_points,
+                                                           property_mask,
+                                                           cell);
             }
           // interpolators that throw exceptions usually do not result in
           // anything good, because they result in an unwinding of the stack

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -816,6 +816,17 @@ namespace aspect
   }
 
 
+
+  template <int dim>
+  unsigned int
+  SimulatorAccess<dim>::n_particle_worlds() const
+  {
+    // operator () returns whether an object is managed by a unique ptr
+    return (simulator->particle_world ? 1 : 0);
+  }
+
+
+
   template <int dim>
   const Particle::World<dim> &
   SimulatorAccess<dim>::get_particle_world() const
@@ -824,6 +835,8 @@ namespace aspect
             ExcMessage("You can not call this function if there is no particle world."));
     return *simulator->particle_world.get();
   }
+
+
 
   template <int dim>
   Particle::World<dim> &


### PR DESCRIPTION
There are still a lot of places that get the particle world through a convoluted process through the particles postprocessor. This is not longer necessary, as it is owned by Simulator and available through SimulatorAccess. Clean up the code, which also makes includes unnecessary.