### PR TITLE
Add ParticleInterfaceBase to set the particle world index for the particle plugins.

### DIFF
--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -21,7 +21,7 @@
 #ifndef _aspect_particle_generator_interface_h
 #define _aspect_particle_generator_interface_h
 
-#include <aspect/plugins.h>
+#include <aspect/particle/interface.h>
 #include <aspect/simulator_access.h>
 
 #include <deal.II/particles/particle.h>
@@ -65,7 +65,7 @@ namespace aspect
        * @ingroup ParticleGenerators
        */
       template <int dim>
-      class Interface : public SimulatorAccess<dim>, public Plugins::InterfaceBase
+      class Interface : public SimulatorAccess<dim>, public ParticleInterfaceBase
       {
         public:
           virtual

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -21,7 +21,7 @@
 #ifndef _aspect_particle_integrator_interface_h
 #define _aspect_particle_integrator_interface_h
 
-#include <aspect/plugins.h>
+#include <aspect/particle/interface.h>
 #include <aspect/global.h>
 
 #include <deal.II/particles/particle.h>
@@ -44,7 +44,7 @@ namespace aspect
        * @ingroup ParticleIntegrators
        */
       template <int dim>
-      class Interface : public Plugins::InterfaceBase
+      class Interface : public ParticleInterfaceBase
       {
         public:
           /**

--- a/include/aspect/particle/interface.h
+++ b/include/aspect/particle/interface.h
@@ -21,14 +21,14 @@
 #ifndef _aspect_particle_interface_h
 #define _aspect_particle_interface_h
 
-#include "aspect/plugins.h"
+#include <aspect/plugins.h>
 
 namespace aspect
 {
   namespace Particle
   {
     /**
-     * An abstract base class defining methods and member variables
+     * A base class defining methods and member variables
      * shared along all the particle plugins. This includes the generator,
      * integrator, interpolator and the property classes.
      *
@@ -38,7 +38,7 @@ namespace aspect
     {
       public:
         /**
-         * @brief Set which particle world the plugin belong to.
+         * @brief Set which particle world the plugin belongs to.
          *
          * @param particle_world_index The index of the particle world this plugin belongs to.
          */
@@ -51,8 +51,7 @@ namespace aspect
 
       private:
         /**
-         * Stores the index to the particle world in the
-         * particle worlds vector, to which the plugin belongs.
+         * Stores the index to the particle world, to which the plugin belongs.
          */
         unsigned int particle_world_index;
     };

--- a/include/aspect/particle/interface.h
+++ b/include/aspect/particle/interface.h
@@ -1,0 +1,64 @@
+/*
+ Copyright (C) 2015 - 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _aspect_particle_interface_h
+#define _aspect_particle_interface_h
+
+#include "aspect/plugins.h"
+
+namespace aspect
+{
+  namespace Particle
+  {
+    /**
+     * An abstract base class defining methods and member variables
+     * shared along all the particle plugins. This includes the generator,
+     * integrator, interpolator and the property classes.
+     *
+     * @ingroup Particle
+     */
+    class ParticleInterfaceBase : public Plugins::InterfaceBase
+    {
+      public:
+        /**
+         * @brief Set which particle world the plugin belong to.
+         *
+         * @param particle_world_index The index of the particle world this plugin belongs to.
+         */
+        void set_particle_world_index(unsigned int particle_world_index);
+
+        /**
+         * @brief Gets which particle world the plugin belong to.
+         */
+        unsigned int get_particle_world_index() const;
+
+      private:
+        /**
+         * Stores the index to the particle world in the
+         * particle worlds vector, to which the plugin belongs.
+         */
+        unsigned int particle_world_index;
+    };
+
+  }
+}
+
+
+#endif

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -21,7 +21,7 @@
 #ifndef _aspect_particle_interpolator_interface_h
 #define _aspect_particle_interpolator_interface_h
 
-#include <aspect/plugins.h>
+#include <aspect/particle/interface.h>
 #include <aspect/global.h>
 
 #include <deal.II/particles/particle.h>
@@ -47,7 +47,7 @@ namespace aspect
        * @ingroup ParticleInterpolators
        */
       template <int dim>
-      class Interface : public Plugins::InterfaceBase
+      class Interface : public ParticleInterfaceBase
       {
         public:
           /**

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -21,8 +21,8 @@
 #ifndef _aspect_particle_property_interface_h
 #define _aspect_particle_property_interface_h
 
+#include <aspect/particle/interface.h>
 #include <aspect/global.h>
-#include <aspect/plugins.h>
 
 #include <aspect/particle/interpolator/interface.h>
 #include <aspect/simulator_access.h>
@@ -305,7 +305,7 @@ namespace aspect
        * @ingroup ParticleProperties
        */
       template <int dim>
-      class Interface : public Plugins::InterfaceBase
+      class Interface : public ParticleInterfaceBase
       {
         public:
           /**
@@ -733,6 +733,12 @@ namespace aspect
           void
           parse_parameters (ParameterHandler &prm);
 
+          /**
+           * @brief Set the particle world for all particle properties
+           *
+           * @param particle_world_index The index of the particle world.
+           */
+          void set_particle_world_index(unsigned int particle_world_index);
 
           /**
            * For the current plugin subsystem, write a connection graph of all of the

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -734,7 +734,7 @@ namespace aspect
           parse_parameters (ParameterHandler &prm);
 
           /**
-           * @brief Set the particle world for all particle properties
+           * @brief Set the particle world index for all particle properties
            *
            * @param particle_world_index The index of the particle world.
            */

--- a/source/particle/interface.cc
+++ b/source/particle/interface.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2015 - 2022 by the authors of the ASPECT code.
+  Copyright (C) 2024 by the authors of the ASPECT code.
 
  This file is part of ASPECT.
 
@@ -31,11 +31,12 @@ namespace aspect
       this->particle_world_index = particle_world_index;
     }
 
+
+
     unsigned int
     ParticleInterfaceBase::get_particle_world_index() const
     {
-      return this->particle_world_index;
+      return particle_world_index;
     }
-
   }
 }

--- a/source/particle/interface.cc
+++ b/source/particle/interface.cc
@@ -1,0 +1,41 @@
+/*
+  Copyright (C) 2015 - 2022 by the authors of the ASPECT code.
+
+ This file is part of ASPECT.
+
+ ASPECT is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2, or (at your option)
+ any later version.
+
+ ASPECT is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with ASPECT; see the file LICENSE.  If not see
+ <http://www.gnu.org/licenses/>.
+ */
+
+#include <aspect/particle/interface.h>
+
+
+namespace aspect
+{
+  namespace Particle
+  {
+    void
+    ParticleInterfaceBase::set_particle_world_index(const unsigned int particle_world_index)
+    {
+      this->particle_world_index = particle_world_index;
+    }
+
+    unsigned int
+    ParticleInterfaceBase::get_particle_world_index() const
+    {
+      return this->particle_world_index;
+    }
+
+  }
+}

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -750,6 +750,18 @@ namespace aspect
 
       template <int dim>
       void
+      Manager<dim>::set_particle_world_index(unsigned int particle_world_index)
+      {
+        for (auto &property : property_list)
+          {
+            property->set_particle_world_index(particle_world_index);
+          }
+      }
+
+
+
+      template <int dim>
+      void
       Manager<dim>::
       register_particle_property (const std::string &name,
                                   const std::string &description,

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1333,6 +1333,7 @@ namespace aspect
           sim->initialize_simulator (this->get_simulator());
         generator->parse_parameters(prm);
         generator->initialize();
+        generator->set_particle_world_index(world_index);
 
         // Create a property_manager object and initialize its properties
         property_manager = std::make_unique<Property::Manager<dim>> ();
@@ -1340,6 +1341,7 @@ namespace aspect
         sim->initialize_simulator (this->get_simulator());
         property_manager->parse_parameters(prm);
         property_manager->initialize();
+        property_manager->set_particle_world_index(world_index);
 
         // Create an integrator object depending on the specified parameter
         integrator = Integrator::create_particle_integrator<dim> (prm);
@@ -1347,6 +1349,7 @@ namespace aspect
           sim->initialize_simulator (this->get_simulator());
         integrator->parse_parameters(prm);
         integrator->initialize();
+        integrator->set_particle_world_index(world_index);
 
         // Create an interpolator object depending on the specified parameter
         interpolator = Interpolator::create_particle_interpolator<dim> (prm);
@@ -1354,6 +1357,7 @@ namespace aspect
           sim->initialize_simulator (this->get_simulator());
         interpolator->parse_parameters(prm);
         interpolator->initialize();
+        interpolator->set_particle_world_index(world_index);
 
       }
       prm.leave_subsection ();

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1331,33 +1331,33 @@ namespace aspect
         generator = Generator::create_particle_generator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(generator.get()))
           sim->initialize_simulator (this->get_simulator());
+        generator->set_particle_world_index(world_index);
         generator->parse_parameters(prm);
         generator->initialize();
-        generator->set_particle_world_index(world_index);
 
         // Create a property_manager object and initialize its properties
         property_manager = std::make_unique<Property::Manager<dim>> ();
         SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(property_manager.get());
         sim->initialize_simulator (this->get_simulator());
+        property_manager->set_particle_world_index(world_index);
         property_manager->parse_parameters(prm);
         property_manager->initialize();
-        property_manager->set_particle_world_index(world_index);
 
         // Create an integrator object depending on the specified parameter
         integrator = Integrator::create_particle_integrator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(integrator.get()))
           sim->initialize_simulator (this->get_simulator());
+        integrator->set_particle_world_index(world_index);
         integrator->parse_parameters(prm);
         integrator->initialize();
-        integrator->set_particle_world_index(world_index);
 
         // Create an interpolator object depending on the specified parameter
         interpolator = Interpolator::create_particle_interpolator<dim> (prm);
         if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(interpolator.get()))
           sim->initialize_simulator (this->get_simulator());
+        interpolator->set_particle_world_index(world_index);
         interpolator->parse_parameters(prm);
         interpolator->initialize();
-        interpolator->set_particle_world_index(world_index);
 
       }
       prm.leave_subsection ();


### PR DESCRIPTION
This pull request adds a ParticleInterfaceBase to set the particle world index in the particle plugins as suggested by @gassmoeller. Let me know if this was what you had in mind.

This pull request is parallel to #5920 and should be able to be review and merged independently. 