### PR TITLE
make SchurComplementOperator destructor virtual

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -372,6 +372,8 @@ namespace aspect
     class SchurComplementOperator
     {
       public:
+        virtual ~SchurComplementOperator() = default;
+
         virtual void vmult(TrilinosWrappers::MPI::Vector &dst,
                            const TrilinosWrappers::MPI::Vector &src) const=0;
         virtual unsigned int n_iterations() const=0;


### PR DESCRIPTION
clang rightfully complains that we can not delete these objects with a pointer to base otherwise.