### PR TITLE
Remove particle update ghost parameter

### DIFF
--- a/benchmarks/annulus/transient/transient_annulus.prm
+++ b/benchmarks/annulus/transient/transient_annulus.prm
@@ -76,7 +76,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = bilinear least squares
   set List of particle properties = particle density
-  set Update ghost particles = true
   set Particle generator name = random uniform
   set Load balancing strategy = add particles
   set Minimum particles per cell = 12

--- a/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
@@ -102,7 +102,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = cell average
   set Maximum particles per cell = 16384
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/benchmarks/rigid_shear/steady-state/rigid_shear.prm
+++ b/benchmarks/rigid_shear/steady-state/rigid_shear.prm
@@ -93,7 +93,6 @@ subsection Particles
   set List of particle properties = function
   set Integration scheme = rk2
   set Interpolation scheme = bilinear least squares
-  set Update ghost particles = true
   set Minimum particles per cell = 9
   set Maximum particles per cell = 16384
   set Particle generator name = reference cell

--- a/benchmarks/rigid_shear/transient/rigid_shear.prm
+++ b/benchmarks/rigid_shear/transient/rigid_shear.prm
@@ -110,7 +110,6 @@ subsection Particles
   set List of particle properties = function
   set Integration scheme = rk2
   set Interpolation scheme = bilinear least squares
-  set Update ghost particles = true
   set Minimum particles per cell = 12
   set Maximum particles per cell = 16384
   set Particle generator name = random uniform

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -110,7 +110,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = cell average
   set Maximum particles per cell = 16384
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -99,7 +99,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = cell average
   set Maximum particles per cell = 16384
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
+++ b/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
@@ -161,7 +161,6 @@ subsection Particles
   set Integration scheme = rk2 # or rk4
   set Interpolation scheme = bilinear least squares # or cell average
   set List of particle properties = function
-  set Update ghost particles = true
   set Particle generator name = reference cell
   set Load balancing strategy = none # not necessary for uniform mesh
 

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
@@ -30,7 +30,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = nearest neighbor
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator

--- a/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
+++ b/benchmarks/viscoelastic_plastic_shear_bands/kaus_2010/kaus_2010_extension.prm
@@ -227,7 +227,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, viscoplastic strain invariants, elastic stress
   set Interpolation scheme        = cell average
-  set Update ghost particles      = true
   set Particle generator name     = reference cell
 
   subsection Generator

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
@@ -32,7 +32,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = bilinear least squares
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
@@ -63,7 +63,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = bilinear least squares
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator

--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -113,7 +113,15 @@ def move_particle_postprocess_parameters_back(parameters):
 
     return parameters
 
+def remove_update_ghost_particles_parameter(parameters):
+    """ Remove the parameter 'Update ghost particles'. """
 
+    # Find the particle parameters and move
+    if "Particles" in parameters:
+        if "Update ghost particles" in parameters["Particles"]["value"]:
+            del parameters["Particles"]["value"]["Update ghost particles"]
+
+    return parameters
 
 def main(input_file, output_file):
     """Echo the input arguments to standard output"""
@@ -122,6 +130,7 @@ def main(input_file, output_file):
     parameters = move_particle_parameters_to_own_subsection(parameters)
     parameters = move_number_of_particles_to_correct_subsection(parameters)
     parameters = move_particle_postprocess_parameters_back(parameters)
+    parameters = remove_update_ghost_particles_parameter(parameters)
 
     aspect.write_parameter_file(parameters, output_file)
 

--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -116,7 +116,7 @@ def move_particle_postprocess_parameters_back(parameters):
 def remove_update_ghost_particles_parameter(parameters):
     """ Remove the parameter 'Update ghost particles'. """
 
-    # Find the particle parameters and move
+    # Find the "Update ghost particles" parameter and remove
     if "Particles" in parameters:
         if "Update ghost particles" in parameters["Particles"]["value"]:
             del parameters["Particles"]["value"]["Update ghost particles"]

--- a/cookbooks/composition_active_particles/composition_active_particles.prm
+++ b/cookbooks/composition_active_particles/composition_active_particles.prm
@@ -116,7 +116,6 @@ end
 subsection Particles
   set List of particle properties = velocity, initial composition
   set Interpolation scheme = cell average
-  set Update ghost particles = true
   set Particle generator name = random uniform
 
   subsection Generator

--- a/cookbooks/grain_size_ridge/doc/particles.part.prm
+++ b/cookbooks/grain_size_ridge/doc/particles.part.prm
@@ -14,7 +14,6 @@ subsection Particles
   set Minimum particles per cell = 40
   set Maximum particles per cell = 640
   set Integration scheme = rk2
-  set Update ghost particles = true
 
   subsection Interpolator
     subsection Bilinear least squares

--- a/cookbooks/grain_size_ridge/grain_size_ridge.prm
+++ b/cookbooks/grain_size_ridge/grain_size_ridge.prm
@@ -294,7 +294,6 @@ subsection Particles
   set Minimum particles per cell = 40
   set Maximum particles per cell = 640
   set Integration scheme = rk2
-  set Update ghost particles = true
 
   subsection Interpolator
     subsection Bilinear least squares

--- a/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
+++ b/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
@@ -197,7 +197,6 @@ end
 
 subsection Particles
   set List of particle properties   = position, velocity, initial composition, pT path, initial position
-  set Update ghost particles        = true
   set Particle generator name       = reference cell
   set Load balancing strategy       = remove and add particles
   set Minimum particles per cell    = 80

--- a/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
+++ b/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
@@ -56,7 +56,6 @@ subsection Particles
   set List of particle properties = initial composition, velocity
   set Particle generator name = random uniform
   set Interpolation scheme = cell average
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/doc/modules/changes/20240625_gassmoeller
+++ b/doc/modules/changes/20240625_gassmoeller
@@ -1,0 +1,5 @@
+Removed: The input parameter 'Update ghost particles' has been deprecated.
+Ghost particles are now always updated. Existing parameter files can
+be updated by the script in 'contrib/utilities/update_prm_files.sh'.
+<br>
+(Rene Gassmoeller, 2024/06/25)

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -443,15 +443,6 @@ namespace aspect
         unsigned int particle_weight;
 
         /**
-         * Some particle interpolation algorithms require knowledge
-         * about particles in neighboring cells. To allow this,
-         * particles in ghost cells need to be exchanged between the
-         * processes neighboring this cell. This parameter determines
-         * whether this transport is happening.
-         */
-        bool update_ghost_particles;
-
-        /**
          * Get a map between subdomain id and the neighbor index. In other words
          * the returned map answers the question: Given a subdomain id, which
          * neighbor of the current processor's domain (in terms of a contiguous

--- a/source/particle/interpolator/bilinear_least_squares.cc
+++ b/source/particle/interpolator/bilinear_least_squares.cc
@@ -333,9 +333,6 @@ namespace aspect
           prm.leave_subsection();
         }
         prm.leave_subsection();
-        const bool limiter_enabled_for_at_least_one_property = (use_linear_least_squares_limiter.n_selected_components() != 0);
-        AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
-                    ExcMessage("If 'Use linear least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
       }
     }
   }

--- a/source/particle/interpolator/quadratic_least_squares.cc
+++ b/source/particle/interpolator/quadratic_least_squares.cc
@@ -610,13 +610,6 @@ namespace aspect
           prm.leave_subsection();
         }
         prm.leave_subsection();
-
-        // In general n_selected_components() requests an argument of the ComponentMask's size since it could be initialized to be entirely true without a size.
-        // Here it is given a size equal to n_property_components, so that argument is not necessary.
-        const bool limiter_enabled_for_at_least_one_property = (use_quadratic_least_squares_limiter.n_selected_components() != 0);
-        AssertThrow(limiter_enabled_for_at_least_one_property == false || prm.get_bool("Update ghost particles") == true,
-                    ExcMessage("If 'Use quadratic least squares limiter' is enabled for any particle property, then 'Update ghost particles' must be set to true"));
-
       }
     }
   }

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -238,8 +238,7 @@ namespace aspect
           });
         }
 
-      if (update_ghost_particles &&
-          dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
+      if (dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
         {
           auto do_ghost_exchange = [&] (typename parallel::distributed::Triangulation<dim> &)
           {
@@ -604,8 +603,7 @@ namespace aspect
             local_initialize_particles(particle_handler->begin(),
                                        particle_handler->end());
 
-          if (update_ghost_particles &&
-              dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
+          if (dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
             {
               TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Exchange ghosts");
               particle_handler->exchange_ghost_particles();
@@ -1145,8 +1143,7 @@ namespace aspect
 
       // Now that all particle information was updated, exchange the new
       // ghost particles.
-      if (update_ghost_particles &&
-          dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
+      if (dealii::Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()) > 1)
         {
           TimerOutput::Scope timer_section(this->get_computing_timer(), "Particles: Exchange ghosts");
           particle_handler->exchange_ghost_particles();
@@ -1234,13 +1231,6 @@ namespace aspect
                                "particle weight is recommended. Before adding the weights "
                                "of particles, each cell already carries a weight of 1000 to "
                                "account for the cost of field-based computations.");
-            prm.declare_entry ("Update ghost particles", "false",
-                               Patterns::Bool (),
-                               "Some particle interpolation algorithms require knowledge "
-                               "about particles in neighboring cells. To allow this, "
-                               "particles in ghost cells need to be exchanged between the "
-                               "processes neighboring this cell. This parameter determines "
-                               "whether this transport is happening.");
 
             Generator::declare_parameters<dim>(prm);
             Integrator::declare_parameters<dim>(prm);
@@ -1291,8 +1281,6 @@ namespace aspect
                                "that is smaller than or equal to the 'Maximum particles per cell' parameter."));
 
         particle_weight = prm.get_integer("Particle weight");
-
-        update_ghost_particles = prm.get_bool("Update ghost particles");
 
         const std::vector<std::string> strategies = Utilities::split_string_list(prm.get ("Load balancing strategy"));
         AssertThrow(Utilities::has_unique_entries(strategies),

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -1231,6 +1231,15 @@ namespace aspect
                                "particle weight is recommended. Before adding the weights "
                                "of particles, each cell already carries a weight of 1000 to "
                                "account for the cost of field-based computations.");
+            prm.declare_entry ("Update ghost particles", "true",
+                               Patterns::Bool (),
+                               "Some particle interpolation algorithms require knowledge "
+                               "about particles in neighboring cells. To allow this, "
+                               "particles in ghost cells need to be exchanged between the "
+                               "processes neighboring this cell. This parameter determines "
+                               "whether this transport is happening. This parameter is "
+                               "deprecated and will be removed in the future. Ghost particle "
+                               "updates are always performed. Please set the parameter to `true'.");
 
             Generator::declare_parameters<dim>(prm);
             Integrator::declare_parameters<dim>(prm);
@@ -1281,6 +1290,11 @@ namespace aspect
                                "that is smaller than or equal to the 'Maximum particles per cell' parameter."));
 
         particle_weight = prm.get_integer("Particle weight");
+
+        const bool update_ghost_particles = prm.get_bool("Update ghost particles");
+        AssertThrow(update_ghost_particles == true,
+                    ExcMessage("The 'Update ghost particles' parameter is deprecated and will be removed in the future. "
+                               "Ghost particle updates are always performed. Please set the parameter to `true'."));
 
         const std::vector<std::string> strategies = Utilities::split_string_list(prm.get ("Load balancing strategy"));
         AssertThrow(Utilities::has_unique_entries(strategies),

--- a/tests/annulus_transient.prm
+++ b/tests/annulus_transient.prm
@@ -83,7 +83,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = bilinear least squares
   set List of particle properties = particle density
-  set Update ghost particles = true
   set Particle generator name = random uniform
   set Load balancing strategy = add particles
   set Minimum particles per cell = 12

--- a/tests/grain_size_growth_one_cell_particles.prm
+++ b/tests/grain_size_growth_one_cell_particles.prm
@@ -33,7 +33,6 @@ subsection Particles
   set List of particle properties = grain size
   set Load balancing strategy = none
   set Integration scheme = rk2
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/matrix_nonzeros_2.prm
+++ b/tests/matrix_nonzeros_2.prm
@@ -90,7 +90,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = cell average
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/matrix_nonzeros_3.prm
+++ b/tests/matrix_nonzeros_3.prm
@@ -96,7 +96,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = cell average
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/particle_interpolator_bilinear_3d.prm
+++ b/tests/particle_interpolator_bilinear_3d.prm
@@ -101,7 +101,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = bilinear least squares
-  set Update ghost particles   = true
   set Particle generator name = reference cell
 
   subsection Interpolator

--- a/tests/particle_interpolator_bilinear_3d_add_particles.prm
+++ b/tests/particle_interpolator_bilinear_3d_add_particles.prm
@@ -100,7 +100,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = bilinear least squares
-  set Update ghost particles   = true
   set Load balancing strategy = add particles, repartition
   set Minimum particles per cell = 4
   set Particle generator name = reference cell

--- a/tests/particle_interpolator_bilinear_add_particles.prm
+++ b/tests/particle_interpolator_bilinear_add_particles.prm
@@ -93,7 +93,6 @@ subsection Particles
   set Minimum particles per cell = 50
   set Maximum particles per cell = 16384
   set Load balancing strategy = remove and add particles
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/tests/particle_interpolator_bilinear_least_squares_solkz.prm
+++ b/tests/particle_interpolator_bilinear_least_squares_solkz.prm
@@ -91,7 +91,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = bilinear least squares
   set Maximum particles per cell = 16384
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/tests/particle_interpolator_bilinear_limiter.prm
+++ b/tests/particle_interpolator_bilinear_limiter.prm
@@ -103,7 +103,6 @@ end
 subsection Particles
   set List of particle properties = velocity, initial composition, initial position #, integrated strain
   set Interpolation scheme = bilinear least squares
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Generator

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -107,7 +107,6 @@ end
 subsection Particles
   set List of particle properties = velocity, function, initial composition
   set Interpolation scheme = cell average
-  set Update ghost particles = true
   set Particle generator name = random uniform
 
   subsection Function

--- a/tests/particle_interpolator_cell_average_2.prm
+++ b/tests/particle_interpolator_cell_average_2.prm
@@ -109,7 +109,6 @@ end
 
 subsection Particles
   set List of particle properties = initial composition
-  set Update ghost particles   = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/particle_interpolator_distance_weighted_average.prm
+++ b/tests/particle_interpolator_distance_weighted_average.prm
@@ -107,7 +107,6 @@ end
 subsection Particles
   set List of particle properties = velocity, function, initial composition
   set Interpolation scheme = distance weighted average
-  set Update ghost particles = true
   set Particle generator name = random uniform
 
   subsection Function

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -86,7 +86,6 @@ end
 subsection Particles
   set List of particle properties = initial composition, initial position
   set Interpolation scheme = cell average
-  set Update ghost particles = true
   set Particle generator name = random uniform
   set Minimum particles per cell = 2
   set Maximum particles per cell = 100

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -92,7 +92,6 @@ subsection Particles
   set Minimum particles per cell = 2
   set Maximum particles per cell = 100
   set Load balancing strategy = none
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/particle_interpolator_harmonic_average_solkz.prm
+++ b/tests/particle_interpolator_harmonic_average_solkz.prm
@@ -99,7 +99,6 @@ subsection Particles
   set Integration scheme = rk2
   set Interpolation scheme = harmonic average
   set Maximum particles per cell = 4096
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   # The initial condition is adapted from the original solkz benchmark by adding a constant

--- a/tests/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particle_interpolator_nearest_neighbor.prm
@@ -108,7 +108,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = nearest neighbor
-  set Update ghost particles = true
   set Maximum particles per cell = 10
   set Minimum particles per cell = 10
   set Particle generator name = uniform box

--- a/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_add_particles.prm
@@ -96,7 +96,6 @@ subsection Particles
   set Minimum particles per cell = 10
   set Maximum particles per cell = 16384
   set Load balancing strategy = remove and add particles
-  set Update ghost particles = false
   set Particle generator name = reference cell
 
   subsection Function

--- a/tests/particle_interpolator_quadratic_least_squares_2d_limiter.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_limiter.prm
@@ -15,7 +15,6 @@ subsection Postprocess
 end
 
 subsection Particles
-  set Update ghost particles = true
   set Load balancing strategy = none
   set Minimum particles per cell = 7
 

--- a/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
@@ -25,7 +25,6 @@ end
 
 subsection Particles
   set Interpolation scheme = quadratic least squares
-  set Update ghost particles = true
 
   subsection Interpolator
     subsection Quadratic least squares

--- a/tests/particle_interpolator_quadratic_least_squares_3d.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_3d.prm
@@ -101,7 +101,6 @@ end
 subsection Particles
   set List of particle properties = initial composition
   set Interpolation scheme = quadratic least squares
-  set Update ghost particles   = true
   set Particle generator name = reference cell
 
   subsection Generator

--- a/tests/particle_interpolator_time_dependence.prm
+++ b/tests/particle_interpolator_time_dependence.prm
@@ -99,7 +99,6 @@ end
 
 subsection Particles
   set List of particle properties = initial composition
-  set Update ghost particles   = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -97,7 +97,6 @@ subsection Particles
   set Maximum particles per cell = 10
   set Minimum particles per cell = 5
   set Integration scheme = euler
-  set Update ghost particles = true
 
   subsection Generator
     subsection Probability density function

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -99,7 +99,6 @@ end
 
 subsection Particles
   set List of particle properties = velocity, function, initial composition
-  set Update ghost particles = true
   set Particle generator name = random uniform
 
   subsection Function

--- a/tests/particles_with_AMR_on.prm
+++ b/tests/particles_with_AMR_on.prm
@@ -108,7 +108,6 @@ subsection Particles
   set List of particle properties = function
   set Integration scheme = rk2
   set Interpolation scheme = cell average
-  set Update ghost particles = true
   set Particle generator name = reference cell
 
   subsection Function

--- a/tests/time_stepping_repeat_particles.prm
+++ b/tests/time_stepping_repeat_particles.prm
@@ -111,7 +111,6 @@ subsection Particles
   set Maximum particles per cell  = 100
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, composition
-  set Update ghost particles      = true
   set Allow cells without particles = true
   set Particle generator name = uniform box
 

--- a/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
+++ b/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
@@ -81,7 +81,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = bilinear least squares
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator

--- a/tests/viscoelastic_bending_beam_particles.prm
+++ b/tests/viscoelastic_bending_beam_particles.prm
@@ -42,7 +42,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = bilinear least squares
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator

--- a/tests/viscoelastic_numerical_elastic_time_step_particles.prm
+++ b/tests/viscoelastic_numerical_elastic_time_step_particles.prm
@@ -64,7 +64,6 @@ subsection Particles
   set Load balancing strategy     = remove and add particles
   set List of particle properties = initial composition, elastic stress
   set Interpolation scheme        = bilinear least squares
-  set Update ghost particles      = true
   set Particle generator name     = random uniform
 
   subsection Generator


### PR DESCRIPTION
I think it was a bad choice to only update ghost particles if this parameter was set. It is inconsistent with the handling of FE degrees of freedom (where entries on ghost cells are always available), and by now both the linear and quadratic least squares interpolators require the ghost particles if their limiters are active. The new interpolator in #5815 also requires ghost particles in all models. Therefore and as part of #5568 I would suggest to remove the input parameter and update ghost particles unconditionally.

Note that I could keep the parameter and only change the default, and/or assert that the parameter is set to true if we want to stay more compatible with old parameter files. I would be open for discussion about that, I just thought I would start with the most radical solution and see what opinions are out there.