### PR TITLE
Rename (has|get)_matching_plugin_object to just (has|get)_matching_plugin.

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -160,8 +160,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename BoundaryCompositionType,
@@ -182,8 +182,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename BoundaryCompositionType,
@@ -264,7 +264,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_boundary_composition_model () const
     {
-      return this->template has_matching_plugin_object<BoundaryCompositionType>();
+      return this->template has_matching_plugin<BoundaryCompositionType>();
     }
 
 
@@ -275,7 +275,7 @@ namespace aspect
     const BoundaryCompositionType &
     Manager<dim>::get_matching_boundary_composition_model () const
     {
-      return this->template get_matching_plugin_object<BoundaryCompositionType>();
+      return this->template get_matching_plugin<BoundaryCompositionType>();
     }
 
 

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -194,8 +194,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename BoundaryTemperatureType,
@@ -216,8 +216,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename BoundaryTemperatureType,
@@ -298,7 +298,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_boundary_temperature_model () const
     {
-      return this->template has_matching_plugin_object<BoundaryTemperatureType>();
+      return this->template has_matching_plugin<BoundaryTemperatureType>();
     }
 
 
@@ -308,7 +308,7 @@ namespace aspect
     const BoundaryTemperatureType &
     Manager<dim>::get_matching_boundary_temperature_model () const
     {
-      return this->template get_matching_plugin_object<BoundaryTemperatureType>();
+      return this->template get_matching_plugin<BoundaryTemperatureType>();
     }
 
 

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -275,8 +275,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename HeatingModelType,
@@ -297,8 +297,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename HeatingModelType,
@@ -345,7 +345,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_heating_model () const
     {
-      return this->template has_matching_plugin_object<HeatingModelType>();
+      return this->template has_matching_plugin<HeatingModelType>();
     }
 
 
@@ -355,7 +355,7 @@ namespace aspect
     const HeatingModelType &
     Manager<dim>::get_matching_heating_model () const
     {
-      return this->template get_matching_plugin_object<HeatingModelType>();
+      return this->template get_matching_plugin<HeatingModelType>();
     }
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -149,8 +149,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename InitialCompositionType,
@@ -171,8 +171,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename InitialCompositionType,
@@ -226,7 +226,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_initial_composition_model () const
     {
-      return this->template has_matching_plugin_object<InitialCompositionType>();
+      return this->template has_matching_plugin<InitialCompositionType>();
     }
 
 
@@ -236,7 +236,7 @@ namespace aspect
     const InitialCompositionType &
     Manager<dim>::get_matching_initial_composition_model () const
     {
-      return this->template get_matching_plugin_object<InitialCompositionType>();
+      return this->template get_matching_plugin<InitialCompositionType>();
     }
 
 

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -146,8 +146,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename InitialTemperatureType,
@@ -168,8 +168,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename InitialTemperatureType,
@@ -224,7 +224,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_initial_temperature_model () const
     {
-      return this->template has_matching_plugin_object<InitialTemperatureType>();
+      return this->template has_matching_plugin<InitialTemperatureType>();
     }
 
 
@@ -234,7 +234,7 @@ namespace aspect
     const InitialTemperatureType &
     Manager<dim>::get_matching_initial_temperature_model () const
     {
-      return this->template get_matching_plugin_object<InitialTemperatureType>();
+      return this->template get_matching_plugin<InitialTemperatureType>();
     }
 
 

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -162,8 +162,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename MeshRefinementType,
@@ -184,8 +184,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename MeshRefinementType,
@@ -273,7 +273,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_mesh_refinement_strategy () const
     {
-      return this->template has_matching_plugin_object<MeshRefinementType>();
+      return this->template has_matching_plugin<MeshRefinementType>();
     }
 
 
@@ -284,7 +284,7 @@ namespace aspect
     const MeshRefinementType &
     Manager<dim>::get_matching_mesh_refinement_strategy () const
     {
-      return this->template get_matching_plugin_object<MeshRefinementType>();
+      return this->template get_matching_plugin<MeshRefinementType>();
     }
 
 

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -616,8 +616,8 @@ namespace aspect
            * argument) is a class derived from the Interface class in this namespace.
            *
            * @deprecated Instead of this function, use the
-           *   Plugins::ManagerBase::has_matching_plugin_object() and
-           *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+           *   Plugins::ManagerBase::has_matching_plugin() and
+           *   Plugins::ManagerBase::get_matching_plugin() functions of the base
            *   class of the current class.
            */
           template <typename ParticlePropertyType,
@@ -638,8 +638,8 @@ namespace aspect
            * argument) is a class derived from the Interface class in this namespace.
            *
            * @deprecated Instead of this function, use the
-           *   Plugins::ManagerBase::has_matching_plugin_object() and
-           *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+           *   Plugins::ManagerBase::has_matching_plugin() and
+           *   Plugins::ManagerBase::get_matching_plugin() functions of the base
            *   class of the current class.
            */
           template <typename ParticlePropertyType,
@@ -771,7 +771,7 @@ namespace aspect
       bool
       Manager<dim>::has_matching_property () const
       {
-        return this->template has_matching_plugin_object<ParticlePropertyType>();
+        return this->template has_matching_plugin<ParticlePropertyType>();
       }
 
 
@@ -781,7 +781,7 @@ namespace aspect
       const ParticlePropertyType &
       Manager<dim>::get_matching_property () const
       {
-        return this->template get_matching_plugin_object<ParticlePropertyType>();
+        return this->template get_matching_plugin<ParticlePropertyType>();
       }
 
 

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -232,7 +232,7 @@ namespace aspect
         template <typename PluginType,
                   typename = typename std::enable_if_t<std::is_base_of<InterfaceType,PluginType>::value>>
         bool
-        has_matching_plugin_object () const;
+        has_matching_plugin () const;
 
         /**
          * Go through the list of all plugins that have been selected
@@ -248,7 +248,7 @@ namespace aspect
         template <typename PluginType,
                   typename = typename std::enable_if_t<std::is_base_of<InterfaceType,PluginType>::value>>
         const PluginType &
-        get_matching_plugin_object () const;
+        get_matching_plugin () const;
 
       protected:
         /**
@@ -320,7 +320,7 @@ namespace aspect
     template <typename PluginType, typename>
     inline
     bool
-    ManagerBase<InterfaceType>::has_matching_plugin_object () const
+    ManagerBase<InterfaceType>::has_matching_plugin () const
     {
       for (const auto &p : plugin_objects)
         if (Plugins::plugin_type_matches<PluginType>(*p))
@@ -333,9 +333,9 @@ namespace aspect
     template <typename PluginType, typename>
     inline
     const PluginType &
-    ManagerBase<InterfaceType>::get_matching_plugin_object () const
+    ManagerBase<InterfaceType>::get_matching_plugin () const
     {
-      AssertThrow(has_matching_plugin_object<PluginType> (),
+      AssertThrow(has_matching_plugin<PluginType> (),
                   ExcMessage("You asked the object managing a collection of plugins for a "
                              "plugin object of type <" + boost::core::demangle(typeid(PluginType).name()) + "> "
                              "that could not be found in the current model. You need to "

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -111,7 +111,7 @@ namespace aspect
          * This can be done by deriving your postprocessor from
          * SimulatorAccess, and then using the
          * SimulatorAccess::get_postprocess_manager() function, followed
-         * by asking the resulting object via get_matching_plugin_object()
+         * by asking the resulting object via get_matching_plugin()
          * for a specific postprocessor object.
          */
         virtual
@@ -196,8 +196,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename PostprocessorType,
@@ -218,8 +218,8 @@ namespace aspect
          * argument) is a class derived from the Interface class in this namespace.
          *
          * @deprecated Instead of this function, use the
-         *   Plugins::ManagerBase::has_matching_plugin_object() and
-         *   Plugins::ManagerBase::get_matching_plugin_object() functions of the base
+         *   Plugins::ManagerBase::has_matching_plugin() and
+         *   Plugins::ManagerBase::get_matching_plugin() functions of the base
          *   class of the current class.
          */
         template <typename PostprocessorType,
@@ -352,7 +352,7 @@ namespace aspect
     bool
     Manager<dim>::has_matching_postprocessor () const
     {
-      return this->template has_matching_plugin_object<PostprocessorType>();
+      return this->template has_matching_plugin<PostprocessorType>();
     }
 
 
@@ -363,7 +363,7 @@ namespace aspect
     const PostprocessorType &
     Manager<dim>::get_matching_postprocessor () const
     {
-      return this->template get_matching_plugin_object<PostprocessorType>();
+      return this->template get_matching_plugin<PostprocessorType>();
     }
 
 

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -594,11 +594,11 @@ namespace aspect
       // It is not available at the time initialize() function of boundary temperature is called.
       if (is_first_call==true)
         {
-          AssertThrow(this->get_postprocess_manager().template has_matching_plugin_object<const Postprocess::CoreStatistics<dim>>(),
+          AssertThrow(this->get_postprocess_manager().template has_matching_plugin<const Postprocess::CoreStatistics<dim>>(),
                       ExcMessage ("Dynamic core boundary condition has to work with dynamic core statistics postprocessor."));
 
           const Postprocess::CoreStatistics<dim> &core_statistics
-            = this->get_postprocess_manager().template get_matching_plugin_object<const Postprocess::CoreStatistics<dim>>();
+            = this->get_postprocess_manager().template get_matching_plugin<const Postprocess::CoreStatistics<dim>>();
           // The restart data is stored in 'core statistics' postprocessor.
           // If restart from checkpoint, extract data from there.
           core_data = core_statistics.get_core_data();

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -59,7 +59,7 @@ namespace aspect
     bool
     Manager<dim>::adiabatic_heating_enabled() const
     {
-      return this->template has_matching_plugin_object<HeatingModel::AdiabaticHeating<dim>>() ;
+      return this->template has_matching_plugin<HeatingModel::AdiabaticHeating<dim>>() ;
     }
 
 
@@ -68,7 +68,7 @@ namespace aspect
     bool
     Manager<dim>::shear_heating_enabled() const
     {
-      return this->template has_matching_plugin_object<HeatingModel::ShearHeating<dim>>() ;
+      return this->template has_matching_plugin<HeatingModel::ShearHeating<dim>>() ;
     }
 
 

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -252,7 +252,7 @@ namespace aspect
         {
           // Get a pointer to the CPO particle property.
           cpo_particle_property = std::make_unique<const Particle::Property::CrystalPreferredOrientation<dim>> (
-                                    this->get_particle_world(this->get_particle_world_index()).get_property_manager().template get_matching_plugin_object<Particle::Property::CrystalPreferredOrientation<dim>>());
+                                    this->get_particle_world(this->get_particle_world_index()).get_property_manager().template get_matching_plugin<Particle::Property::CrystalPreferredOrientation<dim>>());
 
           random_number_seed = prm.get_integer ("Random number seed");
           n_grains = cpo_particle_property->get_number_of_grains();

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -147,7 +147,7 @@ namespace aspect
       {
         // Get a reference to the CPO particle property.
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
-          this->get_particle_world(this->get_particle_world_index()).get_property_manager().template get_matching_plugin_object<Particle::Property::CrystalPreferredOrientation<dim>>();
+          this->get_particle_world(this->get_particle_world_index()).get_property_manager().template get_matching_plugin<Particle::Property::CrystalPreferredOrientation<dim>>();
 
 
         const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,

--- a/source/postprocess/core_statistics.cc
+++ b/source/postprocess/core_statistics.cc
@@ -47,7 +47,7 @@ namespace aspect
       std::ostringstream screen_text;
 
       const BoundaryTemperature::DynamicCore<dim> &dynamic_core =
-        this->get_boundary_temperature_manager().template get_matching_plugin_object<BoundaryTemperature::DynamicCore<dim>>();
+        this->get_boundary_temperature_manager().template get_matching_plugin<BoundaryTemperature::DynamicCore<dim>>();
 
       core_data = dynamic_core.get_core_data();
 

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -180,7 +180,7 @@ namespace aspect
 
       // Get a reference to the CPO particle property.
       const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
-        manager.template get_matching_plugin_object<Particle::Property::CrystalPreferredOrientation<dim>>();
+        manager.template get_matching_plugin<Particle::Property::CrystalPreferredOrientation<dim>>();
 
       const unsigned int n_grains = cpo_particle_property.get_number_of_grains();
       const unsigned int n_minerals = cpo_particle_property.get_number_of_minerals();

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -35,7 +35,7 @@ namespace aspect
     DynamicTopography<dim>::execute (TableHandler &)
     {
       const Postprocess::BoundaryPressures<dim> &boundary_pressures =
-        this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::BoundaryPressures<dim>>();
+        this->get_postprocess_manager().template get_matching_plugin<Postprocess::BoundaryPressures<dim>>();
 
       // Get the average pressure at the top and bottom boundaries.
       // This will be used to compute the dynamic pressure at the boundaries.

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -182,7 +182,7 @@ namespace aspect
     {
       // Get a pointer to the boundary densities postprocessor.
       const Postprocess::BoundaryDensities<3> &boundary_densities =
-        this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::BoundaryDensities<3>>();
+        this->get_postprocess_manager().template get_matching_plugin<Postprocess::BoundaryDensities<3>>();
 
       const double top_layer_average_density = boundary_densities.density_at_top();
       const double bottom_layer_average_density = boundary_densities.density_at_bottom();
@@ -270,7 +270,7 @@ namespace aspect
                       {
                         // Get a reference to the dynamic topography postprocessor.
                         const Postprocess::DynamicTopography<3> &dynamic_topography =
-                          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::DynamicTopography<3>>();
+                          this->get_postprocess_manager().template get_matching_plugin<Postprocess::DynamicTopography<3>>();
 
                         // Get the already-computed dynamic topography solution.
                         const LinearAlgebra::BlockVector &topo_vector = dynamic_topography.topography_vector();
@@ -317,7 +317,7 @@ namespace aspect
                       {
                         // Get a reference to the dynamic topography postprocessor.
                         const Postprocess::DynamicTopography<3> &dynamic_topography =
-                          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::DynamicTopography<3>>();
+                          this->get_postprocess_manager().template get_matching_plugin<Postprocess::DynamicTopography<3>>();
 
                         // Get the already-computed dynamic topography solution.
                         const LinearAlgebra::BlockVector &topo_vector = dynamic_topography.topography_vector();

--- a/source/postprocess/sea_level.cc
+++ b/source/postprocess/sea_level.cc
@@ -84,7 +84,7 @@ namespace aspect
       const int dim = 3;
 
       const Postprocess::Geoid<dim> &geoid =
-        this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Geoid<dim>>();
+        this->get_postprocess_manager().template get_matching_plugin<Postprocess::Geoid<dim>>();
 
       const double geoid_displacement = geoid.evaluate(position); // TODO: check sign of geoid_displacement
       const double topography = this->get_geometry_model().height_above_reference_surface(position);
@@ -125,7 +125,7 @@ namespace aspect
       const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
 
       const Postprocess::Geoid<dim> &geoid =
-        this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Geoid<dim>>();
+        this->get_postprocess_manager().template get_matching_plugin<Postprocess::Geoid<dim>>();
 
       const unsigned int quadrature_degree = this->introspection().polynomial_degree.temperature;
       const QGauss<dim-1> quadrature_formula_face(quadrature_degree);
@@ -266,7 +266,7 @@ namespace aspect
       const types::boundary_id top_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("top");
 
       const Postprocess::Geoid<dim> &geoid =
-        this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Geoid<dim>>();
+        this->get_postprocess_manager().template get_matching_plugin<Postprocess::Geoid<dim>>();
 
       // Get the sea level offset (constant for every location).
       sea_level_offset = compute_sea_level_offset();

--- a/source/postprocess/visualization/boundary_strain_rate_residual.cc
+++ b/source/postprocess/visualization/boundary_strain_rate_residual.cc
@@ -73,7 +73,7 @@ namespace aspect
         const double unit_scaling_factor = this->convert_output_to_years() ? year_in_seconds : 1.0;
 
         const Postprocess::BoundaryStrainRateResidualStatistics<dim> &boundary_strain_rate_residual_statistics =
-          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::BoundaryStrainRateResidualStatistics<dim>>();
+          this->get_postprocess_manager().template get_matching_plugin<Postprocess::BoundaryStrainRateResidualStatistics<dim>>();
 
         // We only want the output at the top boundary, so only compute it if the current cell
         // has a face at the top boundary.
@@ -106,7 +106,7 @@ namespace aspect
 
             }
 
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
 

--- a/source/postprocess/visualization/boundary_velocity_residual.cc
+++ b/source/postprocess/visualization/boundary_velocity_residual.cc
@@ -68,7 +68,7 @@ namespace aspect
           this->convert_output_to_years() ? year_in_seconds : 1.0;
 
         const Postprocess::BoundaryVelocityResidualStatistics<dim> &boundary_velocity_residual_statistics =
-          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::BoundaryVelocityResidualStatistics<dim>>();
+          this->get_postprocess_manager().template get_matching_plugin<Postprocess::BoundaryVelocityResidualStatistics<dim>>();
 
         // We only want the output at the top boundary, so only compute it if the current cell
         // has a face at the top boundary.

--- a/source/postprocess/visualization/dynamic_topography.cc
+++ b/source/postprocess/visualization/dynamic_topography.cc
@@ -50,7 +50,7 @@ namespace aspect
           quantity(0) = 0;
 
         const Postprocess::DynamicTopography<dim> &dynamic_topography =
-          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::DynamicTopography<dim>>();
+          this->get_postprocess_manager().template get_matching_plugin<Postprocess::DynamicTopography<dim>>();
 
         auto cell = input_data.template get_cell<dim>();
 

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -68,7 +68,7 @@ namespace aspect
           quantity(0) = 0;
 
         const Postprocess::Geoid<dim> &geoid =
-          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Geoid<dim>>();
+          this->get_postprocess_manager().template get_matching_plugin<Postprocess::Geoid<dim>>();
 
         auto cell = input_data.template get_cell<dim>();
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -111,7 +111,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/postprocess/visualization/strain_rate.cc
+++ b/source/postprocess/visualization/strain_rate.cc
@@ -65,7 +65,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -71,7 +71,7 @@ namespace aspect
                   = deviatoric_strain_rate[d][e];
           }
 
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
 

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -111,7 +111,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/postprocess/visualization/stress_second_invariant.cc
+++ b/source/postprocess/visualization/stress_second_invariant.cc
@@ -109,7 +109,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/postprocess/visualization/surface_dynamic_topography.cc
+++ b/source/postprocess/visualization/surface_dynamic_topography.cc
@@ -50,7 +50,7 @@ namespace aspect
           quantity(0) = 0;
 
         const Postprocess::DynamicTopography<dim> &dynamic_topography =
-          this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::DynamicTopography<dim>>();
+          this->get_postprocess_manager().template get_matching_plugin<Postprocess::DynamicTopography<dim>>();
 
         auto cell = input_data.template get_cell<dim>();
 

--- a/source/postprocess/visualization/surface_strain_rate_tensor.cc
+++ b/source/postprocess/visualization/surface_strain_rate_tensor.cc
@@ -72,7 +72,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
 

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -103,7 +103,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/postprocess/visualization/volumetric_strain_rate.cc
+++ b/source/postprocess/visualization/volumetric_strain_rate.cc
@@ -62,7 +62,7 @@ namespace aspect
           }
 
         // average the values if requested
-        const auto &viz = this->get_postprocess_manager().template get_matching_plugin_object<Postprocess::Visualization<dim>>();
+        const auto &viz = this->get_postprocess_manager().template get_matching_plugin<Postprocess::Visualization<dim>>();
         if (!viz.output_pointwise_stress_and_strain())
           average_quantities(computed_quantities);
       }

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -446,7 +446,7 @@ namespace aspect
     postprocess_manager.initialize_simulator (*this);
     postprocess_manager.parse_parameters (prm);
 
-    if (postprocess_manager.template has_matching_plugin_object<Postprocess::Particles<dim>>())
+    if (postprocess_manager.template has_matching_plugin<Postprocess::Particles<dim>>())
       {
         particle_worlds.emplace_back(std::move(std::make_unique<Particle::World<dim>>()));
         for (unsigned int particle_world_index = 0 ; particle_world_index < particle_worlds.size(); ++particle_world_index)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2242,7 +2242,7 @@ namespace aspect
                                "Please check the consistency of your input file."));
 
         const bool use_simplified_adiabatic_heating =
-          heating_model_manager.template get_matching_plugin_object<HeatingModel::AdiabaticHeating<dim>>()
+          heating_model_manager.template get_matching_plugin<HeatingModel::AdiabaticHeating<dim>>()
           .use_simplified_adiabatic_heating();
 
         AssertThrow(use_simplified_adiabatic_heating == true,

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -427,7 +427,7 @@ namespace aspect
     if ( this->get_parameters().initial_adaptive_refinement > 0 ||
          this->get_parameters().adaptive_refinement_interval > 0 )
       {
-        AssertThrow(this->get_mesh_refinement_manager().template has_matching_plugin_object<MeshRefinement::VolumeOfFluidInterface<dim>>(),
+        AssertThrow(this->get_mesh_refinement_manager().template has_matching_plugin<MeshRefinement::VolumeOfFluidInterface<dim>>(),
                     ExcMessage("Volume of Fluid Interface Tracking requires that the 'volume of fluid interface' strategy be used for AMR"));
 
         AssertThrow(this->get_parameters().adaptive_refinement_interval <(1/this->get_parameters().CFL_number),

--- a/tests/find_boundary_composition_model_fail_1/screen-output
+++ b/tests/find_boundary_composition_model_fail_1/screen-output
@@ -18,7 +18,7 @@ Exception on MPI process <0> while running plugin <N6aspect19BoundaryTemperature
 An error occurred in line <338> of file </home/bangerth/p/deal.II/1/projects/aspect/include/aspect/plugins.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    has_matching_plugin_object<PluginType> ()
+    has_matching_plugin<PluginType> ()
 Additional information: 
     You asked the object managing a collection of plugins for a plugin
     object of type <aspect::BoundaryComposition::Box<2>> that could not be

--- a/tests/find_mesh_refinement_fail_1/screen-output
+++ b/tests/find_mesh_refinement_fail_1/screen-output
@@ -18,7 +18,7 @@ Exception on MPI process <0> while running plugin <N6aspect19BoundaryTemperature
 An error occurred in line <338> of file </home/bangerth/p/deal.II/1/projects/aspect/include/aspect/plugins.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    has_matching_plugin_object<PluginType> ()
+    has_matching_plugin<PluginType> ()
 Additional information: 
     You asked the object managing a collection of plugins for a plugin
     object of type <aspect::MeshRefinement::Boundary<2>> that could not be

--- a/tests/find_postprocess_fail_1/screen-output
+++ b/tests/find_postprocess_fail_1/screen-output
@@ -18,7 +18,7 @@ Exception on MPI process <0> while running plugin <N6aspect19BoundaryTemperature
 An error occurred in line <338> of file </home/bangerth/p/deal.II/1/projects/aspect/include/aspect/plugins.h> in function
 (line in output replaced by default.sh script)
 The violated condition was: 
-    has_matching_plugin_object<PluginType> ()
+    has_matching_plugin<PluginType> ()
 Additional information: 
     You asked the object managing a collection of plugins for a plugin
     object of type <aspect::Postprocess::PressureStatistics<2>> that could


### PR DESCRIPTION
This is the promised follow-up to #5934. In pursuance of #1775.