### PR TITLE
Avoid generator expression in custom target COMMENT text.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,7 +771,7 @@ add_custom_target(aspect ALL
                            $<TARGET_PROPERTY:${TARGET_EXE},OUTPUT_NAME>  # executable file name
                            ${CMAKE_BINARY_DIR}/aspect                    # link name
                   DEPENDS ${TARGET_EXE}
-                  COMMENT "Creating symlink $<TARGET_PROPERTY:${TARGET_EXE},OUTPUT_NAME> -> aspect")
+                  COMMENT "Creating symlink from ${TARGET_EXE} to './aspect'")
 install(PROGRAMS ${CMAKE_BINARY_DIR}/aspect
 	TYPE BIN)
 


### PR DESCRIPTION
The COMMENT part of `add_custom_target` is shown as the message by `make`/`ninja` when a target is being built. Apparently, the string to be shown is evaluated at the time when `add_custom_target` is parsed, not when the target is actually built, and as a consequence cmake generator expressions are not evaluated but shown verbatim.

This leads to awkward screen messages in a case I introduced in one of my previous patches. Instead, show a message like this, which while not perfect is better than the awkward `$<...>` text:
```
[1/1] Creating symlink from aspect.exe.debug to './aspect'
```