### PR TITLE
fix particle world index in properties

### DIFF
--- a/include/aspect/particle/interface.h
+++ b/include/aspect/particle/interface.h
@@ -38,6 +38,11 @@ namespace aspect
     {
       public:
         /**
+         * Constructor.
+         */
+        ParticleInterfaceBase();
+
+        /**
          * @brief Set which particle world the plugin belongs to.
          *
          * @param particle_world_index The index of the particle world this plugin belongs to.

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -750,6 +750,11 @@ namespace aspect
 
         private:
           /**
+           * Stores the index to the particle world, to which this manager belongs.
+           */
+          unsigned int particle_world_index;
+
+          /**
            * Stores the names of the plugins which are present
            * in the order they are executed.
            */

--- a/source/particle/interface.cc
+++ b/source/particle/interface.cc
@@ -25,6 +25,12 @@ namespace aspect
 {
   namespace Particle
   {
+    ParticleInterfaceBase::ParticleInterfaceBase()
+      : particle_world_index(numbers::invalid_unsigned_int)
+    {}
+
+
+
     void
     ParticleInterfaceBase::set_particle_world_index(const unsigned int particle_world_index)
     {

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -714,11 +714,13 @@ namespace aspect
             if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(this->plugin_objects.back().get()))
               sim->initialize_simulator (this->get_simulator());
 
+            this->plugin_objects.back()->set_particle_world_index(particle_world_index);
             this->plugin_objects.back()->parse_parameters (prm);
           }
 
-        // lastly store internal integrator properties
+        // lastly store internal integrator properties:
         this->plugin_objects.emplace_back (std::make_unique<IntegratorProperties<dim>>());
+        this->plugin_objects.back()->set_particle_world_index(particle_world_index);
         this->plugin_objects.back()->parse_parameters (prm);
       }
 
@@ -728,10 +730,9 @@ namespace aspect
       void
       Manager<dim>::set_particle_world_index(unsigned int particle_world_index)
       {
-        for (auto &property : this->plugin_objects)
-          {
-            property->set_particle_world_index(particle_world_index);
-          }
+        // Save this value. We will tell our plugins about this, once they
+        // have been created in parse_parameters().
+        this->particle_world_index = particle_world_index;
       }
 
 


### PR DESCRIPTION
We need to create all plugins inside parse_parameters() before we can set their particle world. Also make sure we initialize this value to be invalid so errors will trigger more reliably.

fixes #5947

FYI @MFraters 