### PR TITLE
Push the variable that stores the active plugin names down to the base class.

### DIFF
--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -230,12 +230,6 @@ namespace aspect
                         << "> among the names of registered boundary composition objects.");
       private:
         /**
-         * A list of names of boundary composition objects that have been requested
-         * in the parameter file.
-         */
-        std::vector<std::string> model_names;
-
-        /**
          * A list of enums of boundary composition operators that have been
          * requested in the parameter file. Each name is associated
          * with a model_name, and is used to modify the composition

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -264,12 +264,6 @@ namespace aspect
                         << "> among the names of registered boundary temperature objects.");
       private:
         /**
-         * A list of names of boundary temperature objects that have been requested
-         * in the parameter file.
-         */
-        std::vector<std::string> model_names;
-
-        /**
          * A list of enums of boundary temperature operators that have been
          * requested in the parameter file. Each name is associated
          * with a model_name, and is used to modify the temperature

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -329,12 +329,6 @@ namespace aspect
                         << "Could not find entry <"
                         << arg1
                         << "> among the names of registered heating model objects.");
-      private:
-        /**
-         * A list of names of heating model objects that have been requested
-         * in the parameter file.
-         */
-        std::vector<std::string> model_names;
     };
 
 

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -204,12 +204,6 @@ namespace aspect
                         << "> among the names of registered initial composition objects.");
       private:
         /**
-         * A list of names of initial composition objects that have been requested
-         * in the parameter file.
-         */
-        std::vector<std::string> model_names;
-
-        /**
          * A list of enums of initial composition operators that have been
          * requested in the parameter file. Each entry is used to modify the
          * initial compositional field with the values from the associated plugin

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -202,12 +202,6 @@ namespace aspect
                         << "> among the names of registered initial temperature objects.");
       private:
         /**
-         * A list of names of initial temperature objects that have been requested
-         * in the parameter file.
-         */
-        std::vector<std::string> model_names;
-
-        /**
          * A list of enums of initial temperature operators that have been
          * requested in the parameter file. Each entry is used to modify the
          * initial temperature field with the values from the associated plugin

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -755,12 +755,6 @@ namespace aspect
           unsigned int particle_world_index;
 
           /**
-           * Stores the names of the plugins which are present
-           * in the order they are executed.
-           */
-          std::vector<std::string> plugin_names;
-
-          /**
            * A class that stores all information about the particle properties,
            * their association with property plugins and their storage pattern.
            */

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -214,6 +214,11 @@ namespace aspect
     {
       public:
         /**
+         * Destructor.
+         */
+        ~ManagerBase () override;
+
+        /**
          * A function that is called at the beginning of each time step,
          * calling the update function of the individual heating models.
          */
@@ -256,7 +261,25 @@ namespace aspect
          * parameter file.
          */
         std::list<std::unique_ptr<InterfaceType>> plugin_objects;
+
+        /**
+         * A list of names used in the input file to identify plugins,
+         * corresponding to the plugin objects stored in the previous variable.
+         */
+        std::vector<std::string> plugin_names;
     };
+
+
+
+    template <typename InterfaceType>
+    ManagerBase<InterfaceType>::~ManagerBase()
+    {
+      // Not all derived manager classes currently set the 'plugin_names'
+      // variable, but for those that do, they better have as many names
+      // as there are plugins.
+      if (plugin_names.size() > 0)
+        Assert (plugin_names.size() == plugin_objects.size(), ExcInternalError());
+    }
 
 
     template <typename InterfaceType>

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -208,12 +208,6 @@ namespace aspect
                         << "Could not find entry <"
                         << arg1
                         << "> among the names of registered termination criteria objects.");
-      private:
-        /**
-         * A list of names corresponding to the termination criteria in the
-         * termination_objects.
-         */
-        std::list<std::string>                       termination_obj_names;
     };
 
 

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -72,29 +72,29 @@ namespace aspect
       // parameters we declare here
       prm.enter_subsection ("Boundary composition model");
       {
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Boundary composition model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         const std::string model_name = prm.get ("Model name");
 
-        AssertThrow (model_name == "unspecified" || model_names.size() == 0,
+        AssertThrow (model_name == "unspecified" || this->plugin_names.size() == 0,
                      ExcMessage ("The parameter 'Model name' is only used for reasons"
                                  "of backwards compatibility and can not be used together with "
                                  "the new functionality 'List of model names'. Please add your "
                                  "boundary composition model to the list instead."));
 
         if (!(model_name == "unspecified"))
-          model_names.push_back(model_name);
+          this->plugin_names.push_back(model_name);
 
         // create operator list
         std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                  model_names.size(),
+                                                  this->plugin_names.size(),
                                                   "List of model operators");
         model_operators = Utilities::create_model_operator_list(model_operator_names);
 
@@ -111,7 +111,7 @@ namespace aspect
             // ignore the set values, do not create objects that are never used.
             if (fixed_composition_boundary_indicators.size() == 0)
               {
-                model_names.clear();
+                this->plugin_names.clear();
                 model_operators.clear();
               }
           }
@@ -137,7 +137,7 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (auto &model_name : model_names)
+      for (auto &model_name : this->plugin_names)
         {
           // create boundary composition objects
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
@@ -179,7 +179,7 @@ namespace aspect
     const std::vector<std::string> &
     Manager<dim>::get_active_boundary_composition_names () const
     {
-      return model_names;
+      return this->plugin_names;
     }
 
 

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -72,29 +72,29 @@ namespace aspect
       // parameters we declare here
       prm.enter_subsection ("Boundary temperature model");
       {
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Boundary temperature model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         const std::string model_name = prm.get ("Model name");
 
-        AssertThrow (model_name == "unspecified" || model_names.size() == 0,
+        AssertThrow (model_name == "unspecified" || this->plugin_names.size() == 0,
                      ExcMessage ("The parameter 'Model name' is only used for reasons"
                                  "of backwards compatibility and can not be used together with "
                                  "the new functionality 'List of model names'. Please add your "
                                  "boundary temperature model to the list instead."));
 
         if (!(model_name == "unspecified"))
-          model_names.push_back(model_name);
+          this->plugin_names.push_back(model_name);
 
         // create operator list
         std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                  model_names.size(),
+                                                  this->plugin_names.size(),
                                                   "List of model operators");
         model_operators = Utilities::create_model_operator_list(model_operator_names);
 
@@ -111,7 +111,7 @@ namespace aspect
             // If that is indeed the case, clear the model_operators vector. Otherwise, raise an exception.
             if (fixed_temperature_boundary_indicators.size() == 0)
               {
-                AssertThrow(model_names.size() == 0,
+                AssertThrow(this->plugin_names.size() == 0,
                             ExcMessage ("You have indicated that you wish to apply a boundary temperature "
                                         "model, but the <Fixed temperature boundary indicators> parameter "
                                         "is empty. Please use this parameter to specify the boundaries "
@@ -134,7 +134,7 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (auto &model_name : model_names)
+      for (auto &model_name : this->plugin_names)
         {
           // create boundary temperature objects
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
@@ -204,7 +204,7 @@ namespace aspect
     const std::vector<std::string> &
     Manager<dim>::get_active_boundary_temperature_names () const
     {
-      return model_names;
+      return this->plugin_names;
     }
 
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -105,10 +105,10 @@ namespace aspect
       // parameters we declare here
       prm.enter_subsection ("Heating model");
       {
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Heating model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
@@ -117,7 +117,7 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (auto &model_name : model_names)
+      for (auto &model_name : this->plugin_names)
         {
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
                                           (std::get<dim>(registered_plugins)
@@ -204,7 +204,7 @@ namespace aspect
     const std::vector<std::string> &
     Manager<dim>::get_active_heating_model_names () const
     {
-      return model_names;
+      return this->plugin_names;
     }
 
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -71,36 +71,36 @@ namespace aspect
       // parameters we declare here
       prm.enter_subsection ("Initial composition model");
       {
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Initial composition model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         const std::string model_name = prm.get ("Model name");
 
-        AssertThrow (model_name == "unspecified" || model_names.size() == 0,
+        AssertThrow (model_name == "unspecified" || this->plugin_names.size() == 0,
                      ExcMessage ("The parameter 'Model name' is only used for reasons"
                                  "of backwards compatibility and can not be used together with "
                                  "the new functionality 'List of model names'. Please add your "
                                  "initial composition model to the list instead."));
 
         if (!(model_name == "unspecified"))
-          model_names.push_back(model_name);
+          this->plugin_names.push_back(model_name);
 
         // create operator list
         const std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                  model_names.size(),
+                                                  this->plugin_names.size(),
                                                   "List of model operators");
         model_operators = Utilities::create_model_operator_list(model_operator_names);
 
       }
       prm.leave_subsection ();
 
-      if (model_names.size() > 0)
+      if (this->plugin_names.size() > 0)
         AssertThrow(this->n_compositional_fields() > 0,
                     ExcMessage("A plugin for the initial composition condition was specified, but there "
                                "is no compositional field. This can lead to errors within the initialization of "
@@ -109,7 +109,7 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (const auto &model_name : model_names)
+      for (const auto &model_name : this->plugin_names)
         {
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
                                           (std::get<dim>(registered_plugins)
@@ -149,7 +149,7 @@ namespace aspect
     const std::vector<std::string> &
     Manager<dim>::get_active_initial_composition_names () const
     {
-      return model_names;
+      return this->plugin_names;
     }
 
 

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -68,29 +68,29 @@ namespace aspect
       // parameters we declare here
       prm.enter_subsection ("Initial temperature model");
       {
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Initial temperature model/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         const std::string model_name = prm.get ("Model name");
 
-        AssertThrow (model_name == "unspecified" || model_names.size() == 0,
+        AssertThrow (model_name == "unspecified" || this->plugin_names.size() == 0,
                      ExcMessage ("The parameter 'Model name' is only used for reasons"
                                  "of backwards compatibility and can not be used together with "
                                  "the new functionality 'List of model names'. Please add your "
                                  "initial temperature model to the list instead."));
 
         if (!(model_name == "unspecified"))
-          model_names.push_back(model_name);
+          this->plugin_names.push_back(model_name);
 
         // create operator list
         const std::vector<std::string> model_operator_names =
           Utilities::possibly_extend_from_1_to_N (Utilities::split_string_list(prm.get("List of model operators")),
-                                                  model_names.size(),
+                                                  this->plugin_names.size(),
                                                   "List of model operators");
         model_operators = Utilities::create_model_operator_list(model_operator_names);
       }
@@ -98,7 +98,7 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (auto &model_name : model_names)
+      for (auto &model_name : this->plugin_names)
         {
           // create initial temperature objects
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
@@ -137,7 +137,7 @@ namespace aspect
     const std::vector<std::string> &
     Manager<dim>::get_active_initial_temperature_names () const
     {
-      return model_names;
+      return this->plugin_names;
     }
 
 

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -563,7 +563,7 @@ namespace aspect
       bool
       Manager<dim>::plugin_name_exists(const std::string &name) const
       {
-        return (std::find(plugin_names.begin(),plugin_names.end(),name) != plugin_names.end());
+        return (std::find(this->plugin_names.begin(),this->plugin_names.end(),name) != this->plugin_names.end());
       }
 
 
@@ -580,8 +580,8 @@ namespace aspect
         AssertThrow(plugin_name_exists(second),
                     ExcMessage("Could not find a plugin with the name <" + second + ">."));
 
-        return (std::find(plugin_names.begin(),plugin_names.end(),first)
-                < std::find(plugin_names.begin(),plugin_names.end(),second));
+        return (std::find(this->plugin_names.begin(),this->plugin_names.end(),first)
+                < std::find(this->plugin_names.begin(),this->plugin_names.end(),second));
       }
 
 
@@ -590,15 +590,15 @@ namespace aspect
       unsigned int
       Manager<dim>::get_plugin_index_by_name(const std::string &name) const
       {
-        const std::vector<std::string>::const_iterator plugin = std::find(plugin_names.begin(),
-                                                                          plugin_names.end(),
+        const std::vector<std::string>::const_iterator plugin = std::find(this->plugin_names.begin(),
+                                                                          this->plugin_names.end(),
                                                                           name);
 
-        AssertThrow(plugin != plugin_names.end(),
+        AssertThrow(plugin != this->plugin_names.end(),
                     ExcMessage("The particle property manager was asked for a plugin "
                                "with the name <" + name + ">, but no such plugin could "
                                "be found."));
-        return std::distance(plugin_names.begin(),plugin);
+        return std::distance(this->plugin_names.begin(),plugin);
       }
 
 
@@ -684,28 +684,28 @@ namespace aspect
                 ExcMessage ("No postprocessors registered!?"));
 
         // now also see which derived quantities we are to compute
-        plugin_names = Utilities::split_string_list(prm.get("List of particle properties"));
-        AssertThrow(Utilities::has_unique_entries(plugin_names),
+        this->plugin_names = Utilities::split_string_list(prm.get("List of particle properties"));
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Particles/List of particle properties' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         // see if 'all' was selected (or is part of the list). if so
         // simply replace the list with one that contains all names
-        if (std::find (plugin_names.begin(),
-                       plugin_names.end(),
-                       "all") != plugin_names.end())
+        if (std::find (this->plugin_names.begin(),
+                       this->plugin_names.end(),
+                       "all") != this->plugin_names.end())
           {
-            plugin_names.clear();
+            this->plugin_names.clear();
             for (typename std::list<typename aspect::internal::Plugins::PluginList<aspect::Particle::Property::Interface<dim>>::PluginInfo>::const_iterator
                  p = std::get<dim>(registered_plugins).plugins->begin();
                  p != std::get<dim>(registered_plugins).plugins->end(); ++p)
-              plugin_names.push_back (std::get<0>(*p));
+              this->plugin_names.push_back (std::get<0>(*p));
           }
 
         // then go through the list, create objects and let them parse
         // their own parameters
-        for (auto &plugin_name : plugin_names)
+        for (auto &plugin_name : this->plugin_names)
           {
             this->plugin_objects.emplace_back (std::get<dim>(registered_plugins)
                                                .create_plugin (plugin_name,

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -722,6 +722,7 @@ namespace aspect
         this->plugin_objects.emplace_back (std::make_unique<IntegratorProperties<dim>>());
         this->plugin_objects.back()->set_particle_world_index(particle_world_index);
         this->plugin_objects.back()->parse_parameters (prm);
+        this->plugin_names.emplace_back("internal: integrator properties");
       }
 
 

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -68,7 +68,7 @@ namespace aspect
 
       // call the execute() functions of all plugins we have
       // here in turns.
-      std::list<std::string>::const_iterator  itn = termination_obj_names.begin();
+      std::vector<std::string>::const_iterator  itn = this->plugin_names.begin();
       for (typename std::list<std::unique_ptr<Interface<dim>>>::const_iterator
            p = this->plugin_objects.begin();
            p != this->plugin_objects.end(); ++p,++itn)
@@ -223,7 +223,7 @@ namespace aspect
           this->plugin_objects.back()->parse_parameters (prm);
           this->plugin_objects.back()->initialize ();
 
-          termination_obj_names.push_back(plugin_name);
+          this->plugin_names.push_back(plugin_name);
         }
     }
 


### PR DESCRIPTION
In pursuance of #1775.

This is not particularly pretty. Some of the manager classes store a list of names of the plugins that are active in this manager, but some do not. Some used `std::list<std::string>`, some `std::vector<std::string>`. Some had accessor functions that returned a reference to the object (preserving the type :-( ). 

This patch pushes the member variable down into the base class, but not yet the accessor functions. It is another incremental step, with the remaining steps listed in #1775 and left for the coming days or weeks.