### PR TITLE
add missing include

### DIFF
--- a/source/particle/interface.cc
+++ b/source/particle/interface.cc
@@ -19,7 +19,7 @@
  */
 
 #include <aspect/particle/interface.h>
-
+#include <deal.II/base/numbers.h>
 
 namespace aspect
 {


### PR DESCRIPTION
clang complains:
```
/__w/aspect/aspect/source/particle/interface.cc:29:30: error: use of undeclared identifier 'numbers'; did you mean 'Plugins::numbers'? [clang-diagnostic-error]
```
see https://github.com/geodynamics/aspect/actions/runs/9691837223/job/26744048720#step:4:215