### PR TITLE
Newton method for plastic dilation

### DIFF
--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -46,6 +46,11 @@ namespace aspect
         double angle_internal_friction;
 
         /**
+         * Dilation angle (psi) for the current composition and phase
+         */
+        double angle_dilation;
+
+        /**
          * Cohesion for the current composition and phase
          */
         double cohesion;
@@ -138,9 +143,21 @@ namespace aspect
           compute_derivative (const double angle_internal_friction,
                               const double effective_strain_rate) const;
 
+          /**
+           * Compute the plastic dilation term, which is defined as the product of
+           * the plastic multiplier and the derivative of plastic potential with
+           * respect to minus pressure.
+           */
+          double
+          compute_plastic_dilation (const double angle_dilation,
+                                    const double non_yielding_viscosity,
+                                    const double effective_viscosity,
+                                    const double effective_strain_rate) const;
+
         private:
 
           std::vector<double> angles_internal_friction;
+          std::vector<double> angles_dilation;
           std::vector<double> cohesions;
           double max_yield_stress;
 

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -108,6 +108,13 @@ namespace aspect
        * The current cohesion.
        */
       std::vector<double> current_cohesions;
+
+      /**
+       * The plastic dilation terms, defined as the product of the
+       * plastic multiplier and the derivative of plastic potential
+       * with respect to negative pressure.
+       */
+      std::vector<double> plastic_dilation;
     };
 
     namespace Rheology
@@ -149,7 +156,7 @@ namespace aspect
            */
           void compute_viscosity_derivatives(const unsigned int point_index,
                                              const std::vector<double> &volume_fractions,
-                                             const std::vector<double> &composition_viscosities,
+                                             const IsostrainViscosities &isostrain_values,
                                              const MaterialModel::MaterialModelInputs<dim> &in,
                                              MaterialModel::MaterialModelOutputs<dim> &out,
                                              const std::vector<double> &phase_function_values = std::vector<double>(),

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -23,7 +23,7 @@
 
 #include <aspect/simulator_access.h>
 #include <aspect/material_model/interface.h>
-#include <aspect/material_model/equation_of_state/multicomponent_incompressible.h>
+#include <aspect/material_model/equation_of_state/multicomponent_compressible.h>
 #include <aspect/material_model/rheology/visco_plastic.h>
 
 #include<deal.II/fe/component_mask.h>
@@ -268,7 +268,7 @@ namespace aspect
         /**
          * Object for computing the equation of state.
          */
-        EquationOfState::MulticomponentIncompressible<dim> equation_of_state;
+        EquationOfState::MulticomponentCompressible<dim> equation_of_state;
 
         /**
          * Object that handles phase transitions.

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -63,6 +63,16 @@ namespace aspect
          * derivatives when material averaging is applied.
          */
         std::vector<double> viscosity_derivative_averaging_weights;
+
+        /**
+         * The derivatives of the prescribed dilation with respect to strain rate.
+         */
+        std::vector<SymmetricTensor<2,dim>> dilation_derivative_wrt_strain_rate;
+
+        /**
+         * The derivatives of the prescribed dilation term with respect to pressure.
+         */
+        std::vector<double> dilation_derivative_wrt_pressure;
     };
   }
 

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -126,6 +126,12 @@ namespace aspect
       bool apply_stabilization_free_surface_faces;
 
       /**
+       * If true, derivatives of the prescribed dilation are
+       * part of the operator.
+       */
+      bool enable_prescribed_dilation;
+
+      /**
        * Table which stores viscosity values for each cell.
        *
        * If the second dimension is of size 1, the viscosity is
@@ -144,7 +150,7 @@ namespace aspect
        * variables: viscosity derivative with respect to pressure,
        * the Newton derivative scaling factor, and the averaging weight.
        */
-      Table<2, VectorizedArray<number>> newton_factor_wrt_pressure_table;
+      Table<2, VectorizedArray<number>> viscosity_derivative_wrt_pressure_table;
 
       /**
        * Table which stores the product of the following four
@@ -154,7 +160,20 @@ namespace aspect
        * is PD or SPD, otherwise, it is 1.
        */
       Table<2, SymmetricTensor<2, dim, VectorizedArray<number>>>
-      newton_factor_wrt_strain_rate_table;
+      viscosity_derivative_wrt_strain_rate_table;
+
+      /**
+       * Table which stores the product of the dilation derivative
+       * with respect to pressure and the Newton derivative scaling factor.
+       */
+      Table<2, VectorizedArray<number>> dilation_derivative_wrt_pressure_table;
+
+      /**
+       * Table which stores the product of the dilation derivative
+       * with respect to strain rate and the Newton derivative scaling factor.
+       */
+      Table<2, SymmetricTensor<2, dim, VectorizedArray<number>>>
+      dilation_derivative_wrt_strain_rate_table;
 
       /**
        * Table which stores the product of the pressure perturbation

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -34,6 +34,7 @@ namespace aspect
     {
       DruckerPragerParameters::DruckerPragerParameters()
         : angle_internal_friction (numbers::signaling_nan<double>()),
+          angle_dilation (numbers::signaling_nan<double>()),
           cohesion  (numbers::signaling_nan<double>()),
           max_yield_stress (numbers::signaling_nan<double>())
       {}
@@ -60,6 +61,7 @@ namespace aspect
           {
             // no phases
             drucker_prager_parameters.angle_internal_friction = angles_internal_friction[composition];
+            drucker_prager_parameters.angle_dilation = angles_dilation[composition];
             drucker_prager_parameters.cohesion = cohesions[composition];
           }
         else
@@ -67,6 +69,8 @@ namespace aspect
             // Average among phases
             drucker_prager_parameters.angle_internal_friction = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                                 angles_internal_friction, composition);
+            drucker_prager_parameters.angle_dilation = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
+                                                       angles_dilation, composition);
             drucker_prager_parameters.cohesion = MaterialModel::MaterialUtilities::phase_average_value(phase_function_values, n_phase_transitions_per_composition,
                                                  cohesions, composition);
           }
@@ -182,6 +186,26 @@ namespace aspect
 
 
       template <int dim>
+      double
+      DruckerPrager<dim>::compute_plastic_dilation(const double angle_dilation,
+                                                   const double non_yielding_viscosity,
+                                                   const double effective_viscosity,
+                                                   const double effective_strain_rate) const
+      {
+        const double sin_psi = std::sin(angle_dilation);
+        const double minus_dQ_dp = (dim == 3 ?
+                                    6.0 * sin_psi / (std::sqrt(3.0) * (3.0 + sin_psi)) :
+                                    sin_psi);
+
+        const double plastic_multiplier =
+          std::max(0.0, (1.0 - effective_viscosity / non_yielding_viscosity) * 2.0 * effective_strain_rate);
+
+        return minus_dQ_dp * plastic_multiplier;
+      }
+
+
+
+      template <int dim>
       void
       DruckerPrager<dim>::declare_parameters (ParameterHandler &prm)
       {
@@ -192,6 +216,13 @@ namespace aspect
                            "those corresponding to chemical compositions. "
                            "For a value of zero, in 2d the von Mises criterion is retrieved. "
                            "Angles higher than 30 degrees are harder to solve numerically. Units: degrees.");
+        prm.declare_entry ("Angles of dilation", "0.",
+                           Patterns::Anything(),
+                           "List of angles of plastic dilation, $\\psi$, for background material and compositional fields, "
+                           "for a total of N+1 values, where N is the number of all compositional fields or only "
+                           "those corresponding to chemical compositions. "
+                           "For a value of zero, the von Mises flow rule is retrieved. "
+                           "The dilation angle should never exceed the internal friction angle.");
         prm.declare_entry ("Cohesions", "1e20",
                            Patterns::Anything(),
                            "List of cohesions, $C$, for background material and compositional fields, "
@@ -248,10 +279,25 @@ namespace aspect
 
         angles_internal_friction = Utilities::MapParsing::parse_map_to_double_array(prm.get("Angles of internal friction"),
                                                                                     options);
+        angles_dilation = Utilities::MapParsing::parse_map_to_double_array(prm.get("Angles of dilation"),
+                                                                           options);
 
         // Convert angles from degrees to radians
-        for (double &angle : angles_internal_friction)
-          angle *= constants::degree_to_radians;
+        for (unsigned int i = 0; i < angles_internal_friction.size(); ++i)
+          {
+            angles_internal_friction[i] *= constants::degree_to_radians;
+            angles_dilation[i]          *= constants::degree_to_radians;
+
+            AssertThrow(angles_dilation[i] <= angles_internal_friction[i],
+                        ExcMessage("The dilation angle is greater than the internal friction angle for "
+                                   "composition " + Utilities::to_string(i) + "."));
+
+            if (angles_dilation[i] > 0.0)
+              AssertThrow(this->get_parameters().enable_prescribed_dilation == true,
+                          ExcMessage("ASPECT detected a nonzero dilation angle, but dilation is "
+                                     "not enabled. Please set parameter entry 'Enable prescribed "
+                                     "dilation' to 'true'."));
+          }
 
         options.property_name = "Cohesions";
         cohesions = Utilities::MapParsing::parse_map_to_double_array(prm.get("Cohesions"),

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1009,7 +1009,9 @@ namespace aspect
             // For equal-order interpolation, we need a stabilization term
             // in the bottom right of Stokes matrix. Make sure we have the
             // necessary entries.
-            if (parameters.use_equal_order_interpolation_for_stokes == true)
+            if (parameters.use_equal_order_interpolation_for_stokes == true ||
+                (assemble_newton_stokes_system == true &&
+                 parameters.enable_prescribed_dilation == true))
               coupling[x.pressure][x.pressure] = DoFTools::always;
           }
       }

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -37,6 +37,8 @@ namespace aspect
       : viscosity_derivative_wrt_pressure(n_points, numbers::signaling_nan<double>())
       , viscosity_derivative_wrt_strain_rate(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>())
       , viscosity_derivative_averaging_weights(n_points, numbers::signaling_nan<double>())
+      , dilation_derivative_wrt_strain_rate(n_points, numbers::signaling_nan<SymmetricTensor<2,dim>>())
+      , dilation_derivative_wrt_pressure(n_points, numbers::signaling_nan<double>())
     {}
   }
 


### PR DESCRIPTION
This PR adds dilation-relevant terms to the Newton solver for both AMG and GMG methods. It has also modified the Drucker-Prager model to allow the user to specify a dilation angle.

I have carried out experiments on the strip-footing problem with the following parameter file:
[strip_footing.prm.txt](https://github.com/user-attachments/files/16045190/strip_footing.prm.txt)
[strip_footing.cc.txt](https://github.com/user-attachments/files/16045191/strip_footing.cc.txt)
It turns out that when using Picard method (and also the Defect Correction method) the relative residual can only be reduced to ~0.01, while the Newton solver can reduce the residual to ~0.0001 within 30 iterations. The different convergence behavior is reflected in the effective viscosity, as shown below.
![strip_footing](https://github.com/geodynamics/aspect/assets/39404555/ce0ba89b-c035-4154-aaea-6987838d3745)

However, the plastic dilation model is far from the best shape, because (1) the Newton solver only converges when "Newton residual scaling method" is turned on; (2) it cannot produce shear bands as sharp as elASPECT. Currently I don't know why.

There is another problem about the plastic dilation model: _it works correctly only when the material is compressible_. This can be explained by the derivation in the following pdf (Remark 1):
[dilation.pdf](https://github.com/user-attachments/files/16045236/dilation.pdf)
However, I tried to modify the effective viscosity by Eq. (26), but the result is incorrect. Again, I don't know why.

Anyway, I think this PR has made some progress. Please let me know if it is worth being merged @naliboff @bobmyhill @cedrict .

