### PR TITLE
Poison the default constructed values of MeltOutputs

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -45,7 +45,7 @@ namespace aspect
       public:
         /**
          * Constructor. When the MeltInputs are created,
-         * all properties are initialized with signalingNaNs.
+         * all properties are initialized with signaling NaNs.
          * This means that individual heating or material models
          * can all attach the plugins they need, and in a later
          * step they will all be filled together (using the fill
@@ -76,15 +76,16 @@ namespace aspect
     class MeltOutputs : public AdditionalMaterialOutputs<dim>
     {
       public:
+        /**
+        * Constructor. When the MeltOutputs are created,
+        * all properties are initialized with signaling NaNs.
+        * This means that after the call to the material model
+        * it can be checked if the material model actually
+        * computed the values, by checking if the individual
+        * values are finite (using std::isfinite).
+        */
         MeltOutputs (const unsigned int n_points,
-                     const unsigned int /*n_comp*/)
-        {
-          compaction_viscosities.resize(n_points);
-          fluid_viscosities.resize(n_points);
-          permeabilities.resize(n_points);
-          fluid_densities.resize(n_points);
-          fluid_density_gradients.resize(n_points, Tensor<1,dim>());
-        }
+                     const unsigned int n_comp);
 
         /**
          * Compaction viscosity values $\xi$ at the given positions.

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -72,6 +72,19 @@ namespace aspect
 
 
     template <int dim>
+    MeltOutputs<dim>::MeltOutputs  (const unsigned int n_points,
+                                    const unsigned int /*n_comp*/)
+      :
+      compaction_viscosities(n_points, numbers::signaling_nan<double>()),
+      fluid_viscosities(n_points, numbers::signaling_nan<double>()),
+      permeabilities(n_points, numbers::signaling_nan<double>()),
+      fluid_densities(n_points, numbers::signaling_nan<double>()),
+      fluid_density_gradients(n_points, numbers::signaling_nan<Tensor<1,dim>>())
+    {}
+
+
+
+    template <int dim>
     void MeltOutputs<dim>::average (const MaterialAveraging::AveragingOperation operation,
                                     const FullMatrix<double>  &projection_matrix,
                                     const FullMatrix<double>  &expansion_matrix)


### PR DESCRIPTION
Similar to #5247. I saw this during the review of #5902. We currently have no good way to check if a material model fills the `MeltOutputs`, because they are default constructed (different from other AdditionalMaterialOutputs like `ElasticOutputs`). We should initialize them with signaling NaNs like other optional outputs, which then allows us to check after the call to the material model whether they have been properly filled.