### PR TITLE
Use 4 processes for github actions

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -48,7 +48,7 @@ jobs:
       run: |
         cd build
         cmake -D CMAKE_CXX_FLAGS='-Werror' .
-        make -j 2
+        make -j 4
     - name: test
       run: |
         cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ jobs:
         mkdir build-no-unity
         cd build-no-unity
         cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
-        make -j 2
+        make -j 4
         ./aspect --test
 
   linux:
@@ -89,7 +89,7 @@ jobs:
         cd build
         /usr/bin/cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=ON -D ASPECT_UNITY_BUILD=ON \
                        -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_INSTALL_EXAMPLES=ON ..
-        make -j 2
+        make -j 4
         ./aspect --test
     - name: doc
       run: |
@@ -138,7 +138,7 @@ jobs:
         -D ASPECT_COMPARE_TEST_RESULTS='${{ matrix.compare-tests }}' \
         -D CMAKE_UNITY_BUILD_BATCH_SIZE=8 \
         ..
-        ninja -j 2
+        ninja -j 4
         ./aspect --test
     - name: prebuild tests
       run: |

--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/geodynamics/aspect.git $Aspect_DIR && \
     cd ${Aspect_DIR}/build && \
     cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
     -DASPECT_INSTALL_EXAMPLES=ON .. && \
-    make -j2 && make install && make clean && \
+    make -j 4 && make install && make clean && \
     ln -s $Aspect_DIR/bin/aspect $Aspect_DIR/aspect && \
     ln -s $Aspect_DIR/bin/aspect-release $Aspect_DIR/aspect-release
 

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /opt && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
     echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
     echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \
-    ./candi.sh -j 2 --packages="once:cmake once:p4est once:trilinos once:hdf5 once:netcdf once:sundials dealii" -p /opt && \
+    ./candi.sh -j 4 --packages="once:cmake once:p4est once:trilinos once:hdf5 once:netcdf once:sundials dealii" -p /opt && \
     rm -rf /opt/tmp
 
 # Build aspect, replace git checkout command to create image for release
@@ -32,6 +32,6 @@ RUN source /opt/configuration/enable.sh && \
     cd ${Aspect_DIR}/build && \
     cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
     -DASPECT_INSTALL_EXAMPLES=ON .. && \
-    make -j2 && make install && make clean
+    make -j 4 && make install && make clean
 
 ENV PATH ${Aspect_DIR}/bin:${PATH}

--- a/contrib/docker/tester-clang/Dockerfile
+++ b/contrib/docker/tester-clang/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /opt && \
     git clone https://github.com/dealii/candi && \
     cd candi && \
     mv /opt/local.cfg . && \
-    CXX=clang++ CC=clang ./candi.sh -p /opt -j2 && \
+    CXX=clang++ CC=clang ./candi.sh -p /opt -j4 && \
     rm -rf /opt/tmp
 
 # Set environment variables for this image to be used

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /opt && \
     git clone https://github.com/dealii/candi && \
     cd candi && \
     mv /opt/local.cfg . && \
-    ./candi.sh -p /opt -j2 && \
+    ./candi.sh -p /opt -j4 && \
     rm -rf /opt/tmp
 
 # Set environment variables for this image to be used


### PR DESCRIPTION
It turns out github actions upgraded the resources for the default runners to 4 cpus and 16 GB RAM (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). We should make use of this for compiling aspect and for building docker images (precomputing the test results likely already did this, because it doesnt limit the processes ninja uses).