### PR TITLE
allow variable grain size in diffusion creep

### DIFF
--- a/doc/modules/changes/20240704_myhill
+++ b/doc/modules/changes/20240704_myhill
@@ -1,0 +1,5 @@
+Added: The DiffusionCreep rheology module can now
+calculate viscosities and strain rates with grain size
+as an variable argument.
+<br>
+(Bob Myhill, 2024/07/04)

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -96,7 +96,7 @@ namespace aspect
                                     const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
-           * Compute the viscosity based on the diffusion creep law.
+           * Compute the viscosity based on the diffusion creep law with a fixed grain size.
            * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
@@ -110,8 +110,23 @@ namespace aspect
                              const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
+           * Compute the viscosity based on the diffusion creep law with a variable grain size.
+           * If @p n_phase_transitions_per_composition points to a vector of
+           * unsigned integers this is considered the number of phase transitions
+           * for each compositional field and viscosity will be first computed on
+           * each phase and then averaged for each compositional field.
+           */
+          double
+          compute_viscosity (const double pressure,
+                             const double temperature,
+                             const double grain_size,
+                             const unsigned int composition,
+                             const std::vector<double> &phase_function_values = std::vector<double>(),
+                             const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
+
+          /**
            * Compute the strain rate and first stress derivative as a function
-           * of stress based on the diffusion creep law.
+           * of stress based on the diffusion creep law with a fixed grain size.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,
@@ -120,13 +135,37 @@ namespace aspect
                                               const DiffusionCreepParameters creep_parameters) const;
 
           /**
+           * Compute the strain rate and first stress derivative as a function
+           * of stress based on the diffusion creep law with a variable grain size.
+           */
+          std::pair<double, double>
+          compute_strain_rate_and_derivative (const double stress,
+                                              const double pressure,
+                                              const double temperature,
+                                              const double grain_size,
+                                              const DiffusionCreepParameters creep_parameters) const;
+
+          /**
            * Compute the logarithm of strain rate and first derivative with respect to
-           * the logarithm of the stress based on the diffusion creep law.
+           * the logarithm of the stress based on the diffusion creep law
+           * with a fixed grain size.
            */
           std::pair<double, double>
           compute_log_strain_rate_and_derivative (const double log_stress,
                                                   const double pressure,
                                                   const double temperature,
+                                                  const DiffusionCreepParameters creep_parameters) const;
+
+          /**
+           * Compute the logarithm of strain rate and first derivative with respect to
+           * the logarithm of the stress based on the diffusion creep law
+           * with a variable grain size.
+           */
+          std::pair<double, double>
+          compute_log_strain_rate_and_derivative (const double log_stress,
+                                                  const double pressure,
+                                                  const double temperature,
+                                                  const double grain_size,
                                                   const DiffusionCreepParameters creep_parameters) const;
 
         private:
@@ -159,7 +198,7 @@ namespace aspect
           /**
            * Diffusion creep grain size d.
            */
-          double grain_size;
+          double fixed_grain_size;
       };
     }
   }

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -96,7 +96,8 @@ namespace aspect
                                     const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
-           * Compute the viscosity based on the diffusion creep law with a fixed grain size.
+           * Compute the viscosity based on the diffusion creep law with
+           * the fixed grain size given in the input file.
            * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
@@ -110,7 +111,7 @@ namespace aspect
                              const std::vector<unsigned int> &n_phase_transitions_per_composition = std::vector<unsigned int>()) const;
 
           /**
-           * Compute the viscosity based on the diffusion creep law with a variable grain size.
+           * Compute the viscosity based on the diffusion creep law for the given @p grain_size.
            * If @p n_phase_transitions_per_composition points to a vector of
            * unsigned integers this is considered the number of phase transitions
            * for each compositional field and viscosity will be first computed on
@@ -126,7 +127,8 @@ namespace aspect
 
           /**
            * Compute the strain rate and first stress derivative as a function
-           * of stress based on the diffusion creep law with a fixed grain size.
+           * of stress based on the diffusion creep law with
+           * the fixed grain size given in the input file.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,
@@ -136,7 +138,7 @@ namespace aspect
 
           /**
            * Compute the strain rate and first stress derivative as a function
-           * of stress based on the diffusion creep law with a variable grain size.
+           * of stress based on the diffusion creep law for the given @p grain_size.
            */
           std::pair<double, double>
           compute_strain_rate_and_derivative (const double stress,
@@ -148,7 +150,7 @@ namespace aspect
           /**
            * Compute the logarithm of strain rate and first derivative with respect to
            * the logarithm of the stress based on the diffusion creep law
-           * with a fixed grain size.
+           * with the fixed grain size given in the input file.
            */
           std::pair<double, double>
           compute_log_strain_rate_and_derivative (const double log_stress,
@@ -159,7 +161,7 @@ namespace aspect
           /**
            * Compute the logarithm of strain rate and first derivative with respect to
            * the logarithm of the stress based on the diffusion creep law
-           * with a variable grain size.
+           * for the given @p grain_size.
            */
           std::pair<double, double>
           compute_log_strain_rate_and_derivative (const double log_stress,
@@ -196,7 +198,9 @@ namespace aspect
           std::vector<double> activation_volumes_diffusion;
 
           /**
-           * Diffusion creep grain size d.
+           * Diffusion creep grain size d.  This is read from the
+           * input file, and is only used by the functions that do
+           * not take the grain size as additional argument.
            */
           double fixed_grain_size;
       };

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -92,6 +92,20 @@ namespace aspect
                                               const std::vector<double> &phase_function_values,
                                               const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
+        return compute_viscosity(pressure, temperature, fixed_grain_size, composition, phase_function_values, n_phase_transitions_per_composition);
+      }
+
+
+
+      template <int dim>
+      double
+      DiffusionCreep<dim>::compute_viscosity (const double pressure,
+                                              const double temperature,
+                                              const double grain_size,
+                                              const unsigned int composition,
+                                              const std::vector<double> &phase_function_values,
+                                              const std::vector<unsigned int> &n_phase_transitions_per_composition) const
+      {
         const DiffusionCreepParameters p = compute_creep_parameters(composition,
                                                                     phase_function_values,
                                                                     n_phase_transitions_per_composition);
@@ -124,12 +138,26 @@ namespace aspect
       }
 
 
+
       template <int dim>
       std::pair<double, double>
       DiffusionCreep<dim>::compute_strain_rate_and_derivative (const double stress,
                                                                const double pressure,
                                                                const double temperature,
                                                                const DiffusionCreepParameters creep_parameters) const
+      {
+        return compute_strain_rate_and_derivative(stress, pressure, temperature, fixed_grain_size, creep_parameters);
+      }
+
+
+
+      template <int dim>
+      std::pair<double, double>
+      DiffusionCreep<dim>::compute_strain_rate_and_derivative(const double stress,
+                                                              const double pressure,
+                                                              const double temperature,
+                                                              const double grain_size,
+                                                              const DiffusionCreepParameters creep_parameters) const
       {
         // Power law creep equation
         //   edot_ii_partial = A * stress^n * d^-m * exp(-(E + P*V)/(RT))
@@ -140,8 +168,8 @@ namespace aspect
         // For diffusion creep, n = 1 (strain rate is linearly dependent on stress).
         const double dstrain_rate_dstress_diffusion = creep_parameters.prefactor *
                                                       std::pow(grain_size, -creep_parameters.grain_size_exponent) *
-                                                      std::exp(-(creep_parameters.activation_energy + pressure*creep_parameters.activation_volume)/
-                                                               (constants::gas_constant*temperature));
+                                                      std::exp(-(creep_parameters.activation_energy + pressure * creep_parameters.activation_volume) /
+                                                               (constants::gas_constant * temperature));
 
         const double strain_rate_diffusion = stress * dstrain_rate_dstress_diffusion;
 
@@ -149,11 +177,25 @@ namespace aspect
       }
 
 
+
       template <int dim>
       std::pair<double, double>
       DiffusionCreep<dim>::compute_log_strain_rate_and_derivative (const double log_stress,
                                                                    const double pressure,
                                                                    const double temperature,
+                                                                   const DiffusionCreepParameters creep_parameters) const
+      {
+        return compute_log_strain_rate_and_derivative (log_stress, pressure, temperature, fixed_grain_size, creep_parameters);
+      }
+
+
+
+      template <int dim>
+      std::pair<double, double>
+      DiffusionCreep<dim>::compute_log_strain_rate_and_derivative (const double log_stress,
+                                                                   const double pressure,
+                                                                   const double temperature,
+                                                                   const double grain_size,
                                                                    const DiffusionCreepParameters creep_parameters) const
       {
         // Power law creep equation
@@ -173,7 +215,6 @@ namespace aspect
 
         return std::make_pair(log_strain_rate_diffusion, dlog_strain_rate_dlog_stress_diffusion);
       }
-
 
 
 
@@ -270,7 +311,7 @@ namespace aspect
         activation_volumes_diffusion = Utilities::MapParsing::parse_map_to_double_array(prm.get("Activation volumes for diffusion creep"),
                                                                                         options);
 
-        grain_size = prm.get_double("Grain size");
+        fixed_grain_size = prm.get_double("Grain size");
 
         // Check that there are no entries set to zero,
         // for example because the entry is for a field

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -257,6 +257,11 @@ namespace aspect
                            "If only one value is given, then all use the same value. "
                            "Units: \\si{\\meter\\cubed\\per\\mole}.");
         prm.declare_entry ("Grain size", "1e-3", Patterns::Double (0.),
+                           "The fixed grain size of the material. "
+                           "This grain size is only used if the parent "
+                           "material model does not provide its own "
+                           "(possibly variable) grain size when "
+                           "calling this rheology."
                            "Units: \\si{\\meter}.");
       }
 


### PR DESCRIPTION
This PR adds grain size as a variable argument to the functions in DiffusionCreep. Each function is overloaded so that old functionality is preserved. 

The old functions call the new functions, using the fixed grain size as input.

The changes in this PR will be useful for composite rheologies and material models where grain size is a variable.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
