### PR TITLE
Use a variable in the base class instead of local ones.

### DIFF
--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -96,7 +96,6 @@ namespace aspect
                                                   this->plugin_names.size(),
                                                   "List of model operators");
         model_operators = Utilities::create_model_operator_list(model_operator_names);
-
       }
       prm.leave_subsection ();
 

--- a/source/mesh_refinement/interface.cc
+++ b/source/mesh_refinement/interface.cc
@@ -343,13 +343,12 @@ namespace aspect
 
       // find out which plugins are requested and the various other
       // parameters we declare here
-      std::vector<std::string> plugin_names;
       prm.enter_subsection("Mesh refinement");
       {
-        plugin_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("Strategy"));
 
-        AssertThrow(Utilities::has_unique_entries(plugin_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Mesh refinement/Strategy' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
@@ -359,13 +358,13 @@ namespace aspect
         scaling_factors
           = Utilities::string_to_double(
               Utilities::split_string_list(prm.get("Refinement criteria scaling factors")));
-        AssertThrow (scaling_factors.size() == plugin_names.size()
+        AssertThrow (scaling_factors.size() == this->plugin_names.size()
                      ||
                      scaling_factors.size() == 0,
                      ExcMessage ("The number of scaling factors given here must either be "
                                  "zero or equal to the number of chosen refinement criteria."));
         if (scaling_factors.size() == 0)
-          scaling_factors = std::vector<double> (plugin_names.size(), 1.0);
+          scaling_factors = std::vector<double> (this->plugin_names.size(), 1.0);
 
         if (prm.get("Refinement criteria merge operation") == "plus")
           merge_operation = plus;
@@ -378,9 +377,9 @@ namespace aspect
 
       // go through the list, create objects and let them parse
       // their own parameters
-      AssertThrow (plugin_names.size() >= 1,
+      AssertThrow (this->plugin_names.size() >= 1,
                    ExcMessage ("You need to provide at least one mesh refinement criterion in the input file!"));
-      for (auto &plugin_name : plugin_names)
+      for (auto &plugin_name : this->plugin_names)
         {
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
                                           (std::get<dim>(registered_plugins)

--- a/source/termination_criteria/interface.cc
+++ b/source/termination_criteria/interface.cc
@@ -194,25 +194,24 @@ namespace aspect
               ExcMessage ("No termination criteria plugins registered!?"));
 
       // first find out which plugins are requested
-      std::vector<std::string> plugin_names;
       prm.enter_subsection("Termination criteria");
       {
-        plugin_names = Utilities::split_string_list(prm.get("Termination criteria"));
-        AssertThrow(Utilities::has_unique_entries(plugin_names),
+        this->plugin_names = Utilities::split_string_list(prm.get("Termination criteria"));
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Termination criteria/Termination criteria' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
         // as described, the end time plugin is always active
-        if (std::find (plugin_names.begin(), plugin_names.end(), "end time")
-            == plugin_names.end())
-          plugin_names.emplace_back("end time");
+        if (std::find (this->plugin_names.begin(), this->plugin_names.end(), "end time")
+            == this->plugin_names.end())
+          this->plugin_names.emplace_back("end time");
       }
       prm.leave_subsection();
 
       // go through the list, create objects, initialize them, and let them parse
       // their own parameters
-      for (const auto &plugin_name : plugin_names)
+      for (const auto &plugin_name : this->plugin_names)
         {
           this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
                                           (std::get<dim>(registered_plugins)
@@ -222,8 +221,6 @@ namespace aspect
             sim->initialize_simulator (this->get_simulator());
           this->plugin_objects.back()->parse_parameters (prm);
           this->plugin_objects.back()->initialize ();
-
-          this->plugin_names.push_back(plugin_name);
         }
     }
 

--- a/source/time_stepping/interface.cc
+++ b/source/time_stepping/interface.cc
@@ -278,23 +278,22 @@ namespace aspect
         minimum_time_step_size = prm.get_double("Minimum time step size")
                                  * (this->convert_output_to_years() ? year_in_seconds : 1.0);
 
-        std::vector<std::string>
-        model_names
+        this->plugin_names
           = Utilities::split_string_list(prm.get("List of model names"));
 
-        AssertThrow(Utilities::has_unique_entries(model_names),
+        AssertThrow(Utilities::has_unique_entries(this->plugin_names),
                     ExcMessage("The list of strings for the parameter "
                                "'Time stepping/List of model names' contains entries more than once. "
                                "This is not allowed. Please check your parameter file."));
 
-        if (model_names.size()==0)
+        if (this->plugin_names.size()==0)
           {
             // handle the default case, where the user has not chosen any time stepping scheme explicitly:
 
-            model_names.emplace_back("convection time step");
+            this->plugin_names.emplace_back("convection time step");
 
             if (this->get_parameters().use_conduction_timestep)
-              model_names.emplace_back("conduction time step");
+              this->plugin_names.emplace_back("conduction time step");
           }
         else
           {
@@ -306,7 +305,7 @@ namespace aspect
 
         prm.leave_subsection();
 
-        for (const auto &model_name : model_names)
+        for (const auto &model_name : this->plugin_names)
           {
             this->plugin_objects.push_back (std::unique_ptr<Interface<dim>>
                                             (std::get<dim>(registered_plugins)


### PR DESCRIPTION
The `ManagerBase` class has a `plugin_names` member variable that we should fill (see the bullet point in #1775 for this). Not all current manager classes do that -- some just use a local variable and leave `plugin_names` untouched. This patch makes them use `this->plugin_names` instead.