### PR TITLE
Use pressure consistently for viscous creep in visco-plastic

### DIFF
--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -207,7 +207,7 @@ namespace aspect
                   case frank_kamenetskii:
                   {
                     non_yielding_viscosity = frank_kamenetskii_rheology->compute_viscosity(in.temperature[i], j,
-                                                                                           in.pressure[i],
+                                                                                           pressure_for_creep,
                                                                                            this->get_adiabatic_conditions().density(this->get_geometry_model().representative_point(0)),
                                                                                            this->get_gravity_model().gravity_vector(in.position[0]).norm());
                     break;
@@ -577,8 +577,8 @@ namespace aspect
         prm.declare_entry ("Use adiabatic pressure in creep viscosity", "false",
                            Patterns::Bool (),
                            "Whether to use the adiabatic pressure instead of the full "
-                           "pressure (default) when calculating creep (diffusion, dislocation, "
-                           "and peierls) viscosity. This may be helpful in models where the "
+                           "pressure (default) when calculating viscous creep. "
+                           "This may be helpful in models where the "
                            "full pressure has an unusually large negative value arising from "
                            "large negative dynamic pressure, resulting in solver convergence "
                            "issue and in some cases a viscosity of zero.");


### PR DESCRIPTION
#4247 introduced the option to use adiabatic pressure instead of full pressure to compute viscous creep viscosities in the visco_plastic rheology. However, this was not carried over to the Frank-Kamanetskii option introduced in #5655. This PR makes it consistent, i.e. the same pressure (either adiabatic or full) is used no matter if diffusion / dislocation / Peierls / Frank-Kamanetskii viscosity is computed.

I also removed the list of creep laws from the parameter description to avoid having to update the list whenever we introduce a new creep law.