### PR TITLE
add grain size to composite viscoplastic

### DIFF
--- a/doc/modules/changes/20240717_myhill
+++ b/doc/modules/changes/20240717_myhill
@@ -1,0 +1,4 @@
+Added: The functions in the CompositeViscoPlastic
+rheology model now have grain_size as an argument.
+<br>
+(Bob Myhill, 2024/07/17)

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -76,6 +76,7 @@ namespace aspect
           double
           compute_viscosity (const double pressure,
                              const double temperature,
+                             const double grain_size,
                              const std::vector<double> &volume_fractions,
                              const SymmetricTensor<2,dim> &strain_rate,
                              std::vector<double> &partial_strain_rates,
@@ -93,6 +94,7 @@ namespace aspect
           double
           compute_composition_viscosity (const double pressure,
                                          const double temperature,
+                                         const double grain_size,
                                          const unsigned int composition,
                                          const SymmetricTensor<2,dim> &strain_rate,
                                          std::vector<double> &partial_strain_rates,
@@ -107,6 +109,7 @@ namespace aspect
           compute_strain_rate_and_derivative (const double creep_stress,
                                               const double pressure,
                                               const double temperature,
+                                              const double grain_size,
                                               const DiffusionCreepParameters diffusion_creep_parameters,
                                               const DislocationCreepParameters dislocation_creep_parameters,
                                               const PeierlsCreepParameters peierls_creep_parameters,

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -72,6 +72,7 @@ namespace aspect
       double
       CompositeViscoPlastic<dim>::compute_viscosity (const double pressure,
                                                      const double temperature,
+                                                     const double grain_size,
                                                      const std::vector<double> &volume_fractions,
                                                      const SymmetricTensor<2,dim> &strain_rate,
                                                      std::vector<double> &partial_strain_rates,
@@ -94,6 +95,7 @@ namespace aspect
                 viscosity += (volume_fractions[composition]
                               * compute_composition_viscosity (pressure,
                                                                temperature,
+                                                               grain_size,
                                                                composition,
                                                                strain_rate,
                                                                partial_strain_rates_composition,
@@ -120,6 +122,7 @@ namespace aspect
       double
       CompositeViscoPlastic<dim>::compute_composition_viscosity (const double pressure,
                                                                  const double temperature,
+                                                                 const double grain_size,
                                                                  const unsigned int composition,
                                                                  const SymmetricTensor<2,dim> &strain_rate,
                                                                  std::vector<double> &partial_strain_rates,
@@ -145,7 +148,7 @@ namespace aspect
         if (use_diffusion_creep)
           {
             diffusion_creep_parameters = diffusion_creep->compute_creep_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
-            eta_diff = diffusion_creep->compute_viscosity(pressure, temperature, composition, phase_function_values, n_phase_transitions_per_composition);
+            eta_diff = diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition, phase_function_values, n_phase_transitions_per_composition);
           }
 
         if (use_dislocation_creep)
@@ -194,6 +197,7 @@ namespace aspect
             const std::pair<double, double> creep_edot_and_deriv = compute_strain_rate_and_derivative (creep_stress,
                                                                    pressure,
                                                                    temperature,
+                                                                   grain_size,
                                                                    diffusion_creep_parameters,
                                                                    dislocation_creep_parameters,
                                                                    peierls_creep_parameters,
@@ -242,7 +246,7 @@ namespace aspect
         // dictated by make_strain_rate_additional_outputs_names
         if (use_diffusion_creep)
           {
-            const std::pair<double, double> diff_edot_and_deriv = diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, diffusion_creep_parameters);
+            const std::pair<double, double> diff_edot_and_deriv = diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, grain_size, diffusion_creep_parameters);
             partial_strain_rates[0] = diff_edot_and_deriv.first;
           }
 
@@ -285,6 +289,7 @@ namespace aspect
       CompositeViscoPlastic<dim>::compute_strain_rate_and_derivative (const double creep_stress,
                                                                       const double pressure,
                                                                       const double temperature,
+                                                                      const double grain_size,
                                                                       const DiffusionCreepParameters diffusion_creep_parameters,
                                                                       const DislocationCreepParameters dislocation_creep_parameters,
                                                                       const PeierlsCreepParameters peierls_creep_parameters,
@@ -293,7 +298,7 @@ namespace aspect
         std::pair<double, double> creep_edot_and_deriv = std::make_pair(0., 0.);
 
         if (use_diffusion_creep)
-          creep_edot_and_deriv = creep_edot_and_deriv + diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, diffusion_creep_parameters);
+          creep_edot_and_deriv = creep_edot_and_deriv + diffusion_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, grain_size, diffusion_creep_parameters);
 
         if (use_dislocation_creep)
           creep_edot_and_deriv = creep_edot_and_deriv + dislocation_creep->compute_strain_rate_and_derivative(creep_stress, pressure, temperature, dislocation_creep_parameters);

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -94,6 +94,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   // The test involves pure shear calculations at 1 GPa and variable temperature
   double temperature;
   const double pressure = 1.e9;
+  const double grain_size = 1.e-3;
   SymmetricTensor<2,dim> strain_rate;
   strain_rate[0][0] = -1e-11;
   strain_rate[0][1] = 0.;
@@ -122,7 +123,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
       temperature = 1000. + i*100.;
 
       // Compute the viscosity
-      viscosity = composite_creep->compute_composition_viscosity(pressure, temperature, composition, strain_rate, partial_strain_rates);
+      viscosity = composite_creep->compute_composition_viscosity(pressure, temperature, grain_size, composition, strain_rate, partial_strain_rates);
       total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
 
       // The creep strain rate is calculated by subtracting the strain rate
@@ -144,7 +145,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
       // experiences the same creep stress
 
       // Each creep mechanism should experience the same stress
-      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, composition);
+      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
       disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
       prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
       if (partial_strain_rates[3] > 0.)


### PR DESCRIPTION
This PR adds grain size as an argument to the functions in CompositeViscoplastic. This will facilitate incorporation into material models with grain size evolution.

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have modified a testcase for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
