### PR TITLE
Use effective strain rate in viscoplastic stress limiter case as well

### DIFF
--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -335,7 +335,7 @@ namespace aspect
                 {
                   //Step 5b-1: always rescale the viscosity back to the yield surface
                   const double viscosity_limiter = yield_stress / (2.0 * ref_strain_rate)
-                                                   * std::pow((edot_ii/ref_strain_rate),
+                                                   * std::pow((effective_edot_ii/ref_strain_rate),
                                                               1./exponents_stress_limiter[j] - 1.0);
                   effective_viscosity = 1. / ( 1./viscosity_limiter + 1./non_yielding_viscosity);
                   break;


### PR DESCRIPTION
In the viscoplastic material model, the strain rate can adapted for elastic stresses and is then called `effective_edot_ii` instead of `edot_ii`. `effective_edot_ii` is then used to compute the current cohesion and friction angle and the resulting yield stress. This yield stress is used in the stress limiter case, which however uses `edot_ii` in further calculations. This PR changes `edot_ii` to `effective_edot_ii` in the stress limiter case to be consistent.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
