### PR TITLE
Introduce small vector type alias

### DIFF
--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -35,6 +35,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#include <boost/container/small_vector.hpp>
 
 #include <aspect/compat.h>
 
@@ -220,6 +221,27 @@ namespace aspect
    */
   class QuietException {};
 
+  /**
+   * A type that we use for small vectors, whose approximate size is known at
+   * compile time. Such a vector can be used just like std::vector.
+   * The benefit of using small_vector lies in the fact that it
+   * allocates a small number of elements on the stack. As long as the size
+   * of the vector does not exceed this number N, no dynamic memory allocation
+   * is necessary to create or resize this vector, making these operations
+   * around 100x faster than for std::vector. Our type definition uses a default
+   * size of 100, because most of the vectors in ASPECT are smaller than that,
+   * because they contain as many entries as the number of quadrature points,
+   * the number of compositional fields, the number of particles per cell, or
+   * the number of degrees of freedom per cell. If the size of
+   * the vector exceeds 100 elements, the computations performed on
+   * these 100 elements are significantly more expensive than the memory allocation
+   * anyway.
+   *
+   * See the documentation of boost::container::small_vector for implementation details,
+   * and the documentation of std::vector for available member functions.
+   */
+  template <class T, unsigned int N = 100>
+  using small_vector = boost::container::small_vector<T, N>;
 
   /**
    * A namespace that contains typedefs for classes used in the linear algebra

--- a/source/compat.cc
+++ b/source/compat.cc
@@ -565,11 +565,11 @@ namespace aspect
         return;
       }
 
-    boost::container::small_vector<std::pair<double, Tensor<1, spacedim>>, 100>
+    small_vector<std::pair<double, Tensor<1, spacedim>>>
     new_candidates(new_points.size());
-    boost::container::small_vector<Tensor<1, spacedim>, 100> directions(
+    small_vector<Tensor<1, spacedim>> directions(
       surrounding_points.size(), Point<spacedim>());
-    boost::container::small_vector<double, 100> distances(
+    small_vector<double> distances(
       surrounding_points.size(), 0.0);
     double max_distance = 0.;
     for (unsigned int i = 0; i < surrounding_points.size(); ++i)
@@ -597,7 +597,7 @@ namespace aspect
     // Step 1: Check for some special cases, create simple linear guesses
     // otherwise.
     const double                              tolerance = 1e-10;
-    boost::container::small_vector<bool, 100> accurate_point_was_found(
+    small_vector<bool> accurate_point_was_found(
       new_points.size(), false);
     const ArrayView<const Tensor<1, spacedim>> array_directions =
       make_array_view(directions.begin(), directions.end());
@@ -653,11 +653,11 @@ namespace aspect
 
         // Search for duplicate directions and merge them to minimize the cost of
         // the get_new_point function call below.
-        boost::container::small_vector<double, 1000> merged_weights(
+        small_vector<double, 1000> merged_weights(
           weights.size());
-        boost::container::small_vector<Tensor<1, spacedim>, 100>
+        small_vector<Tensor<1, spacedim>>
         merged_directions(surrounding_points.size(), Point<spacedim>());
-        boost::container::small_vector<double, 100> merged_distances(
+        small_vector<double> merged_distances(
           surrounding_points.size(), 0.0);
 
         unsigned int n_unique_directions = 0;
@@ -694,7 +694,7 @@ namespace aspect
 
         // Search for duplicate weight rows and merge them to minimize the cost of
         // the get_new_point function call below.
-        boost::container::small_vector<unsigned int, 100> merged_weights_index(
+        small_vector<unsigned int> merged_weights_index(
           new_points.size(), numbers::invalid_unsigned_int);
         for (unsigned int row = 0; row < weight_rows; ++row)
           {

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -663,10 +663,8 @@ namespace aspect
             // Prepare the field function and extract the old solution values at the current cell.
             std::vector<Point<dim>> quadrature_positions(1,this->get_mapping().transform_real_to_unit_cell(in.current_cell, in.position[i]));
 
-            // Use a boost::small_vector to avoid memory allocation if possible.
-            // Create 100 values by default, which should be enough for most cases.
-            // If there are more than 100 DoFs per cell, this will work like a normal vector.
-            boost::container::small_vector<double, 100> old_solution_values(this->get_fe().dofs_per_cell);
+            // Use a small_vector to avoid memory allocation if possible.
+            small_vector<double> old_solution_values(this->get_fe().dofs_per_cell);
             in.current_cell->get_dof_values(this->get_old_solution(),
                                             old_solution_values.begin(),
                                             old_solution_values.end());

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -460,7 +460,7 @@ namespace aspect
 
       const UpdateFlags update_flags = property_manager->get_needed_update_flags();
 
-      boost::container::small_vector<double, 100> solution_values(this->get_fe().dofs_per_cell);
+      small_vector<double> solution_values(this->get_fe().dofs_per_cell);
 
       cell->get_dof_values(this->get_solution(),
                            solution_values.begin(),
@@ -504,7 +504,7 @@ namespace aspect
     {
       const unsigned int n_particles_in_cell = particle_handler->n_particles_in_cell(cell);
 
-      boost::container::small_vector<Point<dim>, 100>   positions;
+      small_vector<Point<dim>> positions;
       positions.reserve(n_particles_in_cell);
       for (auto particle = begin_particle; particle!=end_particle; ++particle)
         positions.push_back(particle->get_reference_location());
@@ -527,7 +527,7 @@ namespace aspect
 
       if (required_solution_vectors[1] == true)
         {
-          boost::container::small_vector<double, 100> old_solution_values(this->get_fe().dofs_per_cell);
+          small_vector<double> old_solution_values(this->get_fe().dofs_per_cell);
           cell->get_dof_values(this->get_old_solution(),
                                old_solution_values.begin(),
                                old_solution_values.end());
@@ -542,7 +542,7 @@ namespace aspect
 
       if (required_solution_vectors[2] == true)
         {
-          boost::container::small_vector<double, 100> solution_values(this->get_fe().dofs_per_cell);
+          small_vector<double> solution_values(this->get_fe().dofs_per_cell);
           cell->get_dof_values(this->get_current_linearization_point(),
                                solution_values.begin(),
                                solution_values.end());


### PR DESCRIPTION
We are using `boost::container::small_vector` in a small number of places where we know the code path is used a lot  and might impact performance. However, it is a bit clunky to use (long name with namespaces, additional template parameter for the size on the stack), so whenever I review a PR with a `std::vector` in a code path that may or may not be important for performance I have to weigh the time to write the comment and explain how to use `small_vector` against the likelihood it actually affects performance. I suggest to create our own type alias `small_vector` to shorten the name and give it a default size. This way any `std::vector<T>` could theoretically be replaced with `small_vector<T>`, which makes it easier to use myself and to explain in PR reviews. For now I only replaced the existing occurences of `boost::container::small_vector` with the new type, but I think there are many places where it could make sense to replace existing `std::vector` with `small_vector`.

@bangerth or @tjhei I would be happy to get your input on this one.