### PR TITLE
Reorder initialization of partial strain rates in composite visco plastic

### DIFF
--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -105,8 +105,8 @@ namespace aspect
         double viscosity = 0.;
 
         // Make sure partial_strain_rates is filled with zeros and is the right length
+        partial_strain_rates.resize(n_decomposed_strain_rates);
         std::fill(partial_strain_rates.begin(), partial_strain_rates.end(), 0);
-        partial_strain_rates.resize(n_decomposed_strain_rates, 0.);
 
         // Compute the viscosity and the partial strain rates
         // according to the isostress or isostrain viscosity averaging scheme.


### PR DESCRIPTION
I think this way the initialization is easier to understand (first resize, then initialize all values), the effect is the same.

Embarrassingly for the past two days I was hunting for a bug here that was already fixed in #5990 (my branch wasnt updated). The partial strain rates used to be not initialized and existing values would be included in the strain rates. After finding the bug I rebased and saw it was fixed already (in a PR I reviewed :man_facepalming:). Anyway, both the code before and after this PR is correct (before #5990 it was potentially broken depending on the prior values in `partial_strain_rates`).
