### PR TITLE
move viscosity averaging function

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -754,8 +754,13 @@ namespace aspect
                              const FullMatrix<double>      &projection_matrix,
                              const FullMatrix<double>      &expansion_matrix,
                              std::vector<double>           &values_out);
-    }
 
+      /**
+       * Parse an AveragingOperation and alias to an AveragingOperation
+       * that is appropriate for viscosity averaging.
+       */
+      AveragingOperation get_averaging_operation_for_viscosity(const AveragingOperation operation);
+    }
 
     /**
      * Some material and heating models need more than just the basic material

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -757,7 +757,12 @@ namespace aspect
 
       /**
        * Parse an AveragingOperation and alias to an AveragingOperation
-       * that is appropriate for viscosity averaging.
+       * that only averages viscosity. If the input to this function is an
+       * AveragingOperation that averages all properties
+       * (e.g. 'harmonic_average'), the function returns the corresponding
+       * AveragingOperation that only operates on the viscosity
+       * (e.g. 'harmonic_average_only_viscosity'). This is useful in places
+       * where averaging is performed on only the viscosity property.
        */
       AveragingOperation get_averaging_operation_for_viscosity(const AveragingOperation operation);
     }

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -916,6 +916,33 @@ namespace aspect
         for (unsigned int i=0; i<values_out.additional_outputs.size(); ++i)
           values_out.additional_outputs[i]->average (operation, projection_matrix, expansion_matrix);
       }
+
+
+
+      AveragingOperation
+      get_averaging_operation_for_viscosity(const AveragingOperation operation)
+      {
+        AveragingOperation operation_for_viscosity = operation;
+        switch (operation)
+          {
+            case harmonic_average:
+              operation_for_viscosity = harmonic_average_only_viscosity;
+              break;
+
+            case geometric_average:
+              operation_for_viscosity = geometric_average_only_viscosity;
+              break;
+
+            case project_to_Q1:
+              operation_for_viscosity = project_to_Q1_only_viscosity;
+              break;
+
+            default:
+              operation_for_viscosity = operation;
+          }
+
+        return operation_for_viscosity;
+      }
     }
 
 

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -244,35 +244,6 @@ namespace aspect
       }
 
 
-      namespace
-      {
-        MaterialAveraging::AveragingOperation
-        get_averaging_operation_for_viscosity(const MaterialAveraging::AveragingOperation operation)
-        {
-          MaterialAveraging::AveragingOperation operation_for_viscosity = operation;
-          switch (operation)
-            {
-              case MaterialAveraging::harmonic_average:
-                operation_for_viscosity = MaterialAveraging::harmonic_average_only_viscosity;
-                break;
-
-              case MaterialAveraging::geometric_average:
-                operation_for_viscosity = MaterialAveraging::geometric_average_only_viscosity;
-                break;
-
-              case MaterialAveraging::project_to_Q1:
-                operation_for_viscosity = MaterialAveraging::project_to_Q1_only_viscosity;
-                break;
-
-              default:
-                operation_for_viscosity = operation;
-            }
-
-          return operation_for_viscosity;
-        }
-      }
-
-
 
       template <int dim>
       void


### PR DESCRIPTION
This PR moves the `get_averaging_operation_for_viscosity()` function from `material_model/rheology/elasticity.cc` into `material_model/interface.cc`.

This is a more logical place for the function, and makes it more easily accessible by rheology and material_model modules.

Addresses a single comment here: https://github.com/geodynamics/aspect/pull/5984#discussion_r1713714756