### PR TITLE
Use lighter green color in plugin graph

### DIFF
--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -822,7 +822,7 @@ namespace aspect
         output_stream << std::string(typeid(InterfaceClass).name())
                       << " [label=\""
                       << plugin_system_name
-                      << "\", height=.8,width=.8,shape=\"rect\",fillcolor=\"green\"]"
+                      << "\", height=.8,width=.8,shape=\"rect\",fillcolor=\"lightgreen\"]"
                       << std::endl;
 
         // then output the graph nodes for each plugin, with links to the


### PR DESCRIPTION
I made a poster for a conference and noticed that the current color of the interface classes in the plugin graph are hard to read. In dark light the text is barely readable. I suggest to change the color from green to light green (images below). No need to rebuild the graph right away, we can do that when we next update the parameters file.

Old:
![plugin_graph_old](https://github.com/user-attachments/assets/cda467a9-f403-4064-95e7-1731c6ae932e)

New:
![plugin_graph_new](https://github.com/user-attachments/assets/0dada559-5f0b-41a4-a19a-d3f220d4508c)
