### PR TITLE
Rework particle update interface

### DIFF
--- a/doc/modules/changes/20240925_gassmoeller
+++ b/doc/modules/changes/20240925_gassmoeller
@@ -1,0 +1,8 @@
+New: The interface for particle property plugins has been updated.
+The new interface can update particles cell-wise and is more efficient. 
+In addition, the interface is more extensible for future improvements.
+All particle property plugins in ASPECT have been updated, user plugins
+will have to be updated accordingly before the support for the now deprecated
+old interface is dropped.
+<br>
+(Rene Gassmoeller, 2024/09/25)

--- a/include/aspect/particle/property/composition.h
+++ b/include/aspect/particle/property/composition.h
@@ -58,14 +58,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -99,36 +99,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           * It is obvious that
-           * this function is called a lot, so its code should be efficient.
-           * The interface provides a default implementation that does nothing,
-           * therefore derived plugins that do not require an update do not
-           * need to implement this function.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle The particle that is updated within
-           * the call of this function. The particle location can be accessed
-           * using particle->get_location() and its properties using
-           * particle->get_properties().
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -90,36 +90,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           * It is obvious that
-           * this function is called a lot, so its code should be efficient.
-           * The interface provides a default implementation that does nothing,
-           * therefore derived plugins that do not require an update do not
-           * need to implement this function.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle The particle that is updated within
-           * the call of this function. The particle location can be accessed
-           * using particle->get_location() and its properties using
-           * particle->get_properties().
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This function tells the particle manager that

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -158,36 +158,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           * It is obvious that
-           * this function is called a lot, so its code should be efficient.
-           * The interface provides a default implementation that does nothing,
-           * therefore derived plugins that do not require an update do not
-           * need to implement this function.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle The particle that is updated within
-           * the call of this function. The particle location can be accessed
-           * using particle->get_location() and its properties using
-           * particle->get_properties().
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/elastic_stress.h
+++ b/include/aspect/particle/property/elastic_stress.h
@@ -58,13 +58,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * @copydoc aspect::Particle::Property::Interface::need_update()

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -216,36 +216,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * Update function. This function is called every time an update is
-           * request by need_update() for every particle for every property.
-           * It is obvious that
-           * this function is called a lot, so its code should be efficient.
-           * The interface provides a default implementation that does nothing,
-           * therefore derived plugins that do not require an update do not
-           * need to implement this function.
-           *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of the particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the @p particle_properties vector.
-           *
-           * @param [in] solution The values of the solution variables at the
-           * current particle position.
-           *
-           * @param [in] gradients The gradients of the solution variables at
-           * the current particle position.
-           *
-           * @param [in,out] particle The particle that is updated within
-           * the call of this function. The particle location can be accessed
-           * using particle->get_location() and its properties using
-           * particle->get_properties().
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This function tells the particle manager that

--- a/include/aspect/particle/property/grain_size.h
+++ b/include/aspect/particle/property/grain_size.h
@@ -64,9 +64,7 @@ namespace aspect
            * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
           void
-          update_particle_properties (const unsigned int data_position,
-                                      const std::vector<Vector<double>> &solution,
-                                      const std::vector<std::vector<Tensor<1,dim>>> &gradients,
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
                                       typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -59,14 +59,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/integrated_strain_invariant.h
+++ b/include/aspect/particle/property/integrated_strain_invariant.h
@@ -58,14 +58,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -54,14 +54,14 @@ namespace aspect
            * The solution vector at each particle position. This vector is
            * only filled if the update function requires the solution values.
            */
-          small_vector<small_vector<double>> solution;
+          std::vector<small_vector<double,50>> solution;
 
           /**
            * The solution gradients at each particle position.
            * This vector is only filled if the update function requires the
            * gradients of the solution values.
            */
-          small_vector<small_vector<Tensor<1,dim>>> gradients;
+          std::vector<small_vector<Tensor<1,dim>,50>> gradients;
 
           /**
            * Cell iterator of the cell that is currently being updated.

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -43,6 +43,36 @@ namespace aspect
       using namespace dealii::Particles;
 
       /**
+       * A data structure with all inputs for the
+       * Particle::Property::update_particle_properties() method.
+       */
+      template <int dim>
+      struct ParticleUpdateInputs
+      {
+        public:
+          /**
+           * The solution vector at each particle position. This vector is
+           * only filled if the update function requires the solution values.
+           */
+          small_vector<small_vector<double>> solution;
+
+          /**
+           * The solution gradients at each particle position.
+           * This vector is only filled if the update function requires the
+           * gradients of the solution values.
+           */
+          small_vector<small_vector<Tensor<1,dim>>> gradients;
+
+          /**
+           * Cell iterator of the cell that is currently being updated.
+           * This allows for evaluating additional properties at the cell vertices,
+           * or to query the cell for material ids, neighbors, or other
+           * information that is not available solely from the particles.
+           */
+          typename DoFHandler<dim>::active_cell_iterator current_cell;
+      };
+
+      /**
        * This class is used to store all the necessary information to translate
        * between the data structure of the particle properties (a flat vector of
        * doubles) and the semantic meaning of these properties. It contains
@@ -335,26 +365,18 @@ namespace aspect
            * therefore derived plugins that do not require an update do not
            * need to implement this function.
            *
-           * @param [in] data_position An unsigned integer that denotes which
-           * component of each particle property vector is associated with the
-           * current property. For properties that own several components it
-           * denotes the first component of this property, all other components
-           * fill consecutive entries in the properties vector.
-           *
-           * @param [in] solution A vector of values of the solution variables
-           * at the given particle positions.
-           *
-           * @param [in] gradients A vector of gradients of the solution
-           * variables at the given particle positions.
+           * @param [in] inputs A struct of type ParticleUpdateInputs that contains
+           * all necessary inputs to compute the particle updates. See
+           * the documentation of this struct in
+           * include/aspect/particle/property/interface.h for a list of all
+           * available inputs.
            *
            * @param [in,out] particles The particles that are to be updated
            * within this function.
            */
           virtual
           void
-          update_particle_properties (const unsigned int data_position,
-                                      const std::vector<Vector<double>> &solution,
-                                      const std::vector<std::vector<Tensor<1,dim>>> &gradients,
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
                                       typename ParticleHandler<dim>::particle_iterator_range &particles) const;
 
           /**
@@ -383,7 +405,9 @@ namespace aspect
            * using particle->get_location() and its properties using
            * particle->get_properties().
            *
-           * @deprecated Use update_particle_properties() instead.
+           * @deprecated This version of the function is deprecated.
+           * Use update_particle_properties() instead, which allows to
+           * update all particles of a cell in one function call.
            */
           DEAL_II_DEPRECATED
           virtual
@@ -456,6 +480,28 @@ namespace aspect
           virtual
           std::vector<std::pair<std::string, unsigned int>>
           get_property_information() const = 0;
+
+          /**
+           * Set the position of this property in the particle property vector.
+           */
+          virtual
+          void
+          set_data_position (const unsigned int data_position);
+
+          /**
+           * Get the position of this property in the particle property vector.
+           */
+          virtual
+          unsigned int
+          get_data_position () const;
+
+        protected:
+          /**
+           * Store the position of the particle property in the particle property vector.
+           * If the property has multiple components, the first component is stored
+           * and all other components are stored consecutively after the first one.
+           */
+          unsigned int data_position;
       };
 
       /**
@@ -547,17 +593,17 @@ namespace aspect
            * Update function for particle properties. This function is
            * called once every time step for every cell.
            *
+           * @param inputs A struct of type ParticleUpdateInputs that contains
+           * all necessary inputs to compute the particle updates. See
+           * the documentation of this struct in
+           * include/aspect/particle/property/interface.h for a list of all
+           * available inputs.
            * @param particles The particles that are to be updated within
            * this function.
-           * @param solution The values of the solution variables at the
-           * given particle positions.
-           * @param gradients The gradients of the solution variables at
-           * the given particle positions.
            */
           void
-          update_particles (typename ParticleHandler<dim>::particle_iterator_range &particles,
-                            const std::vector<Vector<double>> &solution,
-                            const std::vector<std::vector<Tensor<1,dim>>> &gradients) const;
+          update_particles (ParticleUpdateInputs<dim> &inputs,
+                            typename ParticleHandler<dim>::particle_iterator_range &particles) const;
 
           /**
            * Returns an enum, which denotes at what time this class needs to

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -59,14 +59,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -70,14 +70,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/position.h
+++ b/include/aspect/particle/property/position.h
@@ -54,14 +54,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/reference_position.h
+++ b/include/aspect/particle/property/reference_position.h
@@ -54,14 +54,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/strain_rate.h
+++ b/include/aspect/particle/property/strain_rate.h
@@ -55,14 +55,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
 
           /**

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -55,14 +55,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * This implementation tells the particle manager that

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -61,14 +61,11 @@ namespace aspect
                                             std::vector<double> &particle_properties) const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::update_particle_property()
+           * @copydoc aspect::Particle::Property::Interface::update_particle_properties()
            */
-          virtual
           void
-          update_particle_property (const unsigned int data_position,
-                                    const Vector<double> &solution,
-                                    const std::vector<Tensor<1,dim>> &gradients,
-                                    typename ParticleHandler<dim>::particle_iterator &particle) const override;
+          update_particle_properties (const ParticleUpdateInputs<dim> &inputs,
+                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
 
           /**
            * @copydoc aspect::Particle::Property::Interface::need_update()

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -413,10 +413,17 @@ namespace aspect
 
         /**
          * Update the particle properties of one cell.
+         *
+         * @param inputs The input data required for the particle update. This
+         * function will fill this structure with the necessary data.
+         * @param positions The reference positions of the particles in the cell.
+         * This function will update these positions for the current cell.
+         * @param evaluator The solution evaluator that is used to update the particles.
          */
         void
-        local_update_particles(const typename DoFHandler<dim>::active_cell_iterator &cell,
-                               SolutionEvaluator<dim> &evaluators);
+        local_update_particles(Property::ParticleUpdateInputs<dim> &inputs,
+                               small_vector<Point<dim>> &positions,
+                               SolutionEvaluator<dim> &evaluator);
 
         /**
          * Advect the particles of one cell. Performs only one step for

--- a/include/aspect/solution_evaluator.h
+++ b/include/aspect/solution_evaluator.h
@@ -166,18 +166,26 @@ namespace aspect
        * that this function only works after a successful call to reinit(),
        * because this function only returns the results of the computation that
        * happened in reinit().
+       *
+       * @param evaluation_point The index of the evaluation point in the positions array.
+       * @param solution The array to fill with the solution values. This array has to be
+       *                 of size n_components().
        */
       void get_solution(const unsigned int evaluation_point,
-                        const ArrayView<double> &solution);
+                        const ArrayView<double> &solution) const;
 
       /**
        * Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
        * that this function only works after a successful call to reinit(),
        * because this function only returns the results of the computation that
        * happened in reinit().
+       *
+       * @param evaluation_point The index of the evaluation point in the positions array.
+       * @param gradients The array to fill with the solution gradients. This array has to be
+       *                  of size n_components().
        */
       void get_gradients(const unsigned int evaluation_point,
-                         const ArrayView<Tensor<1, dim>> &gradients);
+                         const ArrayView<Tensor<1, dim>> &gradients) const;
 
       /**
        * Return the evaluator for velocity or fluid velocity. This is the only
@@ -191,6 +199,12 @@ namespace aspect
        */
       NonMatching::MappingInfo<dim> &
       get_mapping_info();
+
+      /**
+       * Return the number of components in the solution vector.
+       */
+      unsigned int
+      n_components() const;
 
     private:
       /**

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -37,19 +37,26 @@ namespace aspect
           data.push_back(this->get_initial_composition_manager().initial_composition(position,i));
       }
 
+
+
       template <int dim>
       void
-      Composition<dim>::update_particle_property(const unsigned int data_position,
-                                                 const Vector<double> &solution,
-                                                 const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
+      Composition<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                   typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        for (unsigned int i = 0; i < this->n_compositional_fields(); ++i)
+        unsigned int p = 0;
+        const auto &composition_components = this->introspection().component_indices.compositional_fields;
+        for (auto &particle: particles)
           {
-            const unsigned int solution_component = this->introspection().component_indices.compositional_fields[i];
-            particle->get_properties()[data_position+i] = solution[solution_component];
+            for (unsigned int j = 0; j < this->n_compositional_fields(); ++j)
+              {
+                particle.get_properties()[this->data_position+j] = inputs.solution[p][composition_components[j]];
+              }
+            ++p;
           }
       }
+
+
 
       template <int dim>
       UpdateTimeFlags
@@ -58,12 +65,16 @@ namespace aspect
         return update_time_step;
       }
 
+
+
       template <int dim>
       UpdateFlags
       Composition<dim>::get_needed_update_flags () const
       {
         return update_values;
       }
+
+
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
@@ -87,7 +98,6 @@ namespace aspect
           }
         return property_information;
       }
-
     }
   }
 }

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -140,25 +140,23 @@ namespace aspect
 
       template <int dim>
       void
-      CpoElasticTensor<dim>::update_particle_property(const unsigned int data_position,
-                                                      const Vector<double> &/*solution*/,
-                                                      const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                                      typename ParticleHandler<dim>::particle_iterator &particle) const
+      CpoElasticTensor<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &/*inputs*/,
+                                                        typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
         // Get a reference to the CPO particle property.
         const Particle::Property::CrystalPreferredOrientation<dim> &cpo_particle_property =
           this->get_particle_world(this->get_particle_world_index()).get_property_manager().template get_matching_active_plugin<Particle::Property::CrystalPreferredOrientation<dim>>();
 
+        for (auto &particle: particles)
+          {
+            const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
+                                                                                cpo_data_position,
+                                                                                particle.get_properties());
 
-        const SymmetricTensor<2,6> C_average = voigt_average_elastic_tensor(cpo_particle_property,
-                                                                            cpo_data_position,
-                                                                            particle->get_properties());
-
-        Particle::Property::CpoElasticTensor<dim>::set_elastic_tensor(data_position,
-                                                                      particle->get_properties(),
-                                                                      C_average);
-
-
+            Particle::Property::CpoElasticTensor<dim>::set_elastic_tensor(this->data_position,
+                                                                          particle.get_properties(),
+                                                                          C_average);
+          }
       }
 
 

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -89,36 +89,39 @@ namespace aspect
 
       template <int dim>
       void
-      ElasticStress<dim>::update_particle_property(const unsigned int data_position,
-                                                   const Vector<double> &solution,
-                                                   const std::vector<Tensor<1,dim>> &gradients,
-                                                   typename ParticleHandler<dim>::particle_iterator &particle) const
+      ElasticStress<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                     typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        material_inputs.position[0] = particle->get_location();
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            material_inputs.position[0] = particle.get_location();
 
 
-        material_inputs.current_cell = typename DoFHandler<dim>::active_cell_iterator(*particle->get_surrounding_cell(),
-                                                                                      &(this->get_dof_handler()));
+            material_inputs.current_cell = inputs.current_cell;
 
-        material_inputs.temperature[0] = solution[this->introspection().component_indices.temperature];
+            material_inputs.temperature[0] = inputs.solution[p][this->introspection().component_indices.temperature];
 
-        material_inputs.pressure[0] = solution[this->introspection().component_indices.pressure];
+            material_inputs.pressure[0] = inputs.solution[p][this->introspection().component_indices.pressure];
 
-        for (unsigned int d = 0; d < dim; ++d)
-          material_inputs.velocity[0][d] = solution[this->introspection().component_indices.velocities[d]];
+            for (unsigned int d = 0; d < dim; ++d)
+              material_inputs.velocity[0][d] = inputs.solution[p][this->introspection().component_indices.velocities[d]];
 
-        for (unsigned int n = 0; n < this->n_compositional_fields(); ++n)
-          material_inputs.composition[0][n] = solution[this->introspection().component_indices.compositional_fields[n]];
+            for (unsigned int n = 0; n < this->n_compositional_fields(); ++n)
+              material_inputs.composition[0][n] = inputs.solution[p][this->introspection().component_indices.compositional_fields[n]];
 
-        Tensor<2,dim> grad_u;
-        for (unsigned int d=0; d<dim; ++d)
-          grad_u[d] = gradients[d];
-        material_inputs.strain_rate[0] = symmetrize (grad_u);
+            Tensor<2,dim> grad_u;
+            for (unsigned int d=0; d<dim; ++d)
+              grad_u[d] = inputs.gradients[p][d];
+            material_inputs.strain_rate[0] = symmetrize (grad_u);
 
-        this->get_material_model().evaluate (material_inputs,material_outputs);
+            this->get_material_model().evaluate (material_inputs,material_outputs);
 
-        for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
-          particle->get_properties()[data_position + i] += material_outputs.reaction_terms[0][i];
+            for (unsigned int i = 0; i < SymmetricTensor<2,dim>::n_independent_components ; ++i)
+              particle.get_properties()[this->data_position + i] += material_outputs.reaction_terms[0][i];
+
+            ++p;
+          }
       }
 
 

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -38,32 +38,36 @@ namespace aspect
 
       template <int dim>
       void
-      IntegratedStrainInvariant<dim>::update_particle_property(const unsigned int data_position,
-                                                               const Vector<double> &/*solution*/,
-                                                               const std::vector<Tensor<1,dim>> &gradients,
-                                                               typename ParticleHandler<dim>::particle_iterator &particle) const
+      IntegratedStrainInvariant<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                                 typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        // Integrated strain invariant from prior time step
-        const auto data = particle->get_properties();
-        double old_strain = data[data_position];
 
-        // Current timestep
-        const double dt = this->get_timestep();
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            // Integrated strain invariant from prior time step
+            const auto data = particle.get_properties();
+            const double old_strain = data[this->data_position];
 
-        // Velocity gradients
-        Tensor<2,dim> grad_u;
-        for (unsigned int d=0; d<dim; ++d)
-          grad_u[d] = gradients[d];
+            // Current timestep
+            const double dt = this->get_timestep();
 
-        // Calculate strain rate from velocity gradients
-        const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
+            // Velocity gradients
+            Tensor<2,dim> grad_u;
+            for (unsigned int d=0; d<dim; ++d)
+              grad_u[d] = inputs.gradients[p][d];
 
-        // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.));
+            // Calculate strain rate from velocity gradients
+            const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
 
-        // New strain is the old strain plus dt*edot_ii
-        const double new_strain = old_strain + dt*edot_ii;
-        data[data_position] = new_strain;
+            // Calculate strain rate second invariant
+            const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(strain_rate)), 0.));
+
+            // New strain is the old strain plus dt*edot_ii
+            const double new_strain = old_strain + dt*edot_ii;
+            data[this->data_position] = new_strain;
+            ++p;
+          }
       }
 
 

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -39,20 +39,23 @@ namespace aspect
 
       template <int dim>
       void
-      MeltParticle<dim>::update_particle_property(const unsigned int data_position,
-                                                  const Vector<double> &solution,
-                                                  const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                                  typename ParticleHandler<dim>::particle_iterator &particle) const
+      MeltParticle<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                    typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
         AssertThrow(this->introspection().compositional_name_exists("porosity"),
                     ExcMessage("Particle property melt particle only works if"
                                "there is a compositional field called porosity."));
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-        if (solution[this->introspection().component_indices.compositional_fields[porosity_idx]] > threshold_for_melt_presence)
-          particle->get_properties()[data_position] = 1.0;
-        else
-          particle->get_properties()[data_position] = 0.0;
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            if (inputs.solution[p][this->introspection().component_indices.compositional_fields[porosity_idx]] > threshold_for_melt_presence)
+              particle.get_properties()[this->data_position] = 1.0;
+            else
+              particle.get_properties()[this->data_position] = 0.0;
+            ++p;
+          }
       }
 
       template <int dim>

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -65,13 +65,16 @@ namespace aspect
 
       template <int dim>
       void
-      PTPath<dim>::update_particle_property(const unsigned int data_position,
-                                            const Vector<double> &solution,
-                                            const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                            typename ParticleHandler<dim>::particle_iterator &particle) const
+      PTPath<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                              typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        particle->get_properties()[data_position]   = solution[this->introspection().component_indices.pressure];
-        particle->get_properties()[data_position+1] = solution[this->introspection().component_indices.temperature];
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            particle.get_properties()[this->data_position]   = inputs.solution[p][this->introspection().component_indices.pressure];
+            particle.get_properties()[this->data_position+1] = inputs.solution[p][this->introspection().component_indices.temperature];
+            ++p;
+          }
       }
 
 

--- a/source/particle/property/position.cc
+++ b/source/particle/property/position.cc
@@ -37,13 +37,12 @@ namespace aspect
 
       template <int dim>
       void
-      Position<dim>::update_particle_property(const unsigned int data_position,
-                                              const Vector<double> &/*solution*/,
-                                              const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                              typename ParticleHandler<dim>::particle_iterator &particle) const
+      Position<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &/*inputs*/,
+                                                typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        for (unsigned int i = 0; i < dim; ++i)
-          particle->get_properties()[data_position+i] = particle->get_location()[i];
+        for (auto &particle: particles)
+          for (unsigned int i = 0; i < dim; ++i)
+            particle.get_properties()[this->data_position+i] = particle.get_location()[i];
       }
 
       template <int dim>

--- a/source/particle/property/reference_position.cc
+++ b/source/particle/property/reference_position.cc
@@ -37,13 +37,12 @@ namespace aspect
 
       template <int dim>
       void
-      ReferencePosition<dim>::update_particle_property(const unsigned int data_position,
-                                                       const Vector<double> &/*solution*/,
-                                                       const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                                       typename ParticleHandler<dim>::particle_iterator &particle) const
+      ReferencePosition<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &/*inputs*/,
+                                                         typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        for (unsigned int i = 0; i < dim; ++i)
-          particle->get_properties()[data_position+i] = particle->get_reference_location()[i];
+        for (auto &particle: particles)
+          for (unsigned int i = 0; i < dim; ++i)
+            particle.get_properties()[this->data_position+i] = particle.get_reference_location()[i];
       }
 
       template <int dim>

--- a/source/particle/property/strain_rate.cc
+++ b/source/particle/property/strain_rate.cc
@@ -41,22 +41,25 @@ namespace aspect
 
       template <int dim>
       void
-      StrainRate<dim>::update_particle_property(const unsigned int data_position,
-                                                const Vector<double> &/*solution*/,
-                                                const std::vector<Tensor<1,dim>> &gradients,
-                                                typename ParticleHandler<dim>::particle_iterator &particle) const
+      StrainRate<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                  typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        const auto data = particle->get_properties();
-        // Velocity gradients
-        Tensor<2,dim> grad_u;
-        for (unsigned int d=0; d<dim; ++d)
-          grad_u[d] = gradients[d];
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            const auto data = particle.get_properties();
+            // Velocity gradients
+            Tensor<2,dim> grad_u;
+            for (unsigned int d=0; d<dim; ++d)
+              grad_u[d] = inputs.gradients[p][d];
 
-        // Calculate strain rate from velocity gradients
-        const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
+            // Calculate strain rate from velocity gradients
+            const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
 
-        for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
-          data[data_position + i] = strain_rate[Tensor<2,dim>::unrolled_to_component_indices(i)];
+            for (unsigned int i = 0; i < Tensor<2,dim>::n_independent_components ; ++i)
+              data[this->data_position + i] = strain_rate[Tensor<2,dim>::unrolled_to_component_indices(i)];
+            ++p;
+          }
 
       }
 

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -37,13 +37,16 @@ namespace aspect
 
       template <int dim>
       void
-      Velocity<dim>::update_particle_property(const unsigned int data_position,
-                                              const Vector<double> &solution,
-                                              const std::vector<Tensor<1,dim>> &/*gradients*/,
-                                              typename ParticleHandler<dim>::particle_iterator &particle) const
+      Velocity<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        for (unsigned int i = 0; i < dim; ++i)
-          particle->get_properties()[data_position+i] = solution[this->introspection().component_indices.velocities[i]];
+        unsigned int p = 0;
+        for (auto &particle: particles)
+          {
+            for (unsigned int i = 0; i < dim; ++i)
+              particle.get_properties()[this->data_position+i] = inputs.solution[p][this->introspection().component_indices.velocities[i]];
+            ++p;
+          }
       }
 
       template <int dim>

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -97,85 +97,92 @@ namespace aspect
 
       template <int dim>
       void
-      ViscoPlasticStrainInvariant<dim>::update_particle_property(const unsigned int data_position,
-                                                                 const Vector<double> &solution,
-                                                                 const std::vector<Tensor<1,dim>> &gradients,
-                                                                 typename ParticleHandler<dim>::particle_iterator &particle) const
+      ViscoPlasticStrainInvariant<dim>::update_particle_properties(const ParticleUpdateInputs<dim> &inputs,
+                                                                   typename ParticleHandler<dim>::particle_iterator_range &particles) const
       {
-        // Current timestep
-        const double dt = this->get_timestep();
-
-        // Velocity gradients
-        Tensor<2,dim> grad_u;
-        for (unsigned int d=0; d<dim; ++d)
-          grad_u[d] = gradients[d];
-
-        material_inputs.pressure[0] = solution[this->introspection().component_indices.pressure];
-        material_inputs.temperature[0] = solution[this->introspection().component_indices.temperature];
-        material_inputs.position[0] = particle->get_location();
-
-        // Calculate strain rate from velocity gradients
-        material_inputs.strain_rate[0] = symmetrize (grad_u);
-
-        // Put compositional fields into single variable
-        for (unsigned int i = 0; i < this->n_compositional_fields(); ++i)
-          {
-            material_inputs.composition[0][i] = solution[this->introspection().component_indices.compositional_fields[i]];
-          }
-
         // Find out plastic yielding by calling function in material model.
         const MaterialModel::ViscoPlastic<dim> &viscoplastic
           = Plugins::get_plugin_as_type<const MaterialModel::ViscoPlastic<dim>>(this->get_material_model());
 
-        const bool plastic_yielding = viscoplastic.is_yielding(material_inputs);
+        // Current timestep
+        const double dt = this->get_timestep();
+        const unsigned int data_position = this->data_position;
 
-        // Next take the integrated strain invariant from the prior time step.
-        const auto data = particle->get_properties();
-
-        // Calculate strain rate second invariant
-        const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(material_inputs.strain_rate[0])), 0.));
-
-        // Calculate strain invariant magnitude over the last time step
-        const double strain_update = dt*edot_ii;
-
-        /* Update the strain values that are used in the simulation, which use the following assumptions
-         * to identify the correct position in the data vector for each value:
-         * (1) Total strain cannot be used in combination with any other strain field
-         * (2) If plastic strain is tracked, it will always be in the first data position
-         * (3) If noninitial plastic strain is tracked, it will always be in the last data position
-         * (4) If noninitial plastic strain is tracked, plastic strain is also being tracked
-         * (5) If only viscous strain is tracked, it will be in the first data position.
-         * (6) If both viscous and plastic strain are tracked, viscous strain will be in the second data position
-         * If these assumptions change in the future, they will need to be updated.
-         * */
-
-        if (this->introspection().compositional_name_exists("plastic_strain") && plastic_yielding == true)
-          data[data_position] += strain_update;
-
-        if (this->introspection().compositional_name_exists("viscous_strain") && plastic_yielding == false)
+        unsigned int p = 0;
+        for (auto &particle: particles)
           {
-            // Not yielding and only one field, which tracks the viscous strain.
-            if (n_components == 1)
+
+            // Velocity gradients
+            Tensor<2,dim> grad_u;
+            for (unsigned int d=0; d<dim; ++d)
+              grad_u[d] = inputs.gradients[p][d];
+
+            material_inputs.pressure[0] = inputs.solution[p][this->introspection().component_indices.pressure];
+            material_inputs.temperature[0] = inputs.solution[p][this->introspection().component_indices.temperature];
+            material_inputs.position[0] = particle.get_location();
+
+            // Calculate strain rate from velocity gradients
+            material_inputs.strain_rate[0] = symmetrize (grad_u);
+
+            // Put compositional fields into single variable
+            for (unsigned int i = 0; i < this->n_compositional_fields(); ++i)
+              {
+                material_inputs.composition[0][i] = inputs.solution[p][this->introspection().component_indices.compositional_fields[i]];
+              }
+
+
+            const bool plastic_yielding = viscoplastic.is_yielding(material_inputs);
+
+            // Next take the integrated strain invariant from the prior time step.
+            const auto data = particle.get_properties();
+
+            // Calculate strain rate second invariant
+            const double edot_ii = std::sqrt(std::max(-second_invariant(deviator(material_inputs.strain_rate[0])), 0.));
+
+            // Calculate strain invariant magnitude over the last time step
+            const double strain_update = dt*edot_ii;
+
+            /* Update the strain values that are used in the simulation, which use the following assumptions
+             * to identify the correct position in the data vector for each value:
+             * (1) Total strain cannot be used in combination with any other strain field
+             * (2) If plastic strain is tracked, it will always be in the first data position
+             * (3) If noninitial plastic strain is tracked, it will always be in the last data position
+             * (4) If noninitial plastic strain is tracked, plastic strain is also being tracked
+             * (5) If only viscous strain is tracked, it will be in the first data position.
+             * (6) If both viscous and plastic strain are tracked, viscous strain will be in the second data position
+             * If these assumptions change in the future, they will need to be updated.
+             * */
+
+            if (this->introspection().compositional_name_exists("plastic_strain") && plastic_yielding == true)
               data[data_position] += strain_update;
 
-            // Not yielding and either two or three fields are tracked. If two fields are tracked,
-            // they represent plastic strain (first data position) and viscous strain (second data
-            // data position, updated below). If three fields are tracked, they represent plastic
-            // strain (first data position), viscous strain (second data position, updated below),
-            // and noninitial plastic strain (third data position). In either case, the viscous
-            // strain is in the second data position, allowing us to use a single expression.
-            if (n_components > 1)
-              data[data_position+1] += strain_update;
+            if (this->introspection().compositional_name_exists("viscous_strain") && plastic_yielding == false)
+              {
+                // Not yielding and only one field, which tracks the viscous strain.
+                if (n_components == 1)
+                  data[data_position] += strain_update;
+
+                // Not yielding and either two or three fields are tracked. If two fields are tracked,
+                // they represent plastic strain (first data position) and viscous strain (second data
+                // data position, updated below). If three fields are tracked, they represent plastic
+                // strain (first data position), viscous strain (second data position, updated below),
+                // and noninitial plastic strain (third data position). In either case, the viscous
+                // strain is in the second data position, allowing us to use a single expression.
+                if (n_components > 1)
+                  data[data_position+1] += strain_update;
+              }
+
+            // Only one field, which tracks total strain and is updated regardless of whether the
+            // material is yielding or not.
+            if (this->introspection().compositional_name_exists("total_strain"))
+              data[data_position] += strain_update;
+
+            // Yielding, and noninitial plastic strain (last data position, updated below) is tracked.
+            if (this->introspection().compositional_name_exists("noninitial_plastic_strain") && plastic_yielding == true)
+              data[data_position+(n_components-1)] += strain_update;
+
+            ++p;
           }
-
-        // Only one field, which tracks total strain and is updated regardless of whether the
-        // material is yielding or not.
-        if (this->introspection().compositional_name_exists("total_strain"))
-          data[data_position] += strain_update;
-
-        // Yielding, and noninitial plastic strain (last data position, updated below) is tracked.
-        if (this->introspection().compositional_name_exists("noninitial_plastic_strain") && plastic_yielding == true)
-          data[data_position+(n_components-1)] += strain_update;
       }
 
 

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -476,10 +476,10 @@ namespace aspect
         }
 
       if (update_flags & update_values)
-        inputs.solution.resize(n_particles,small_vector<double>(evaluator.n_components()));
+        inputs.solution.resize(n_particles,small_vector<double,50>(evaluator.n_components()));
 
       if (update_flags & update_gradients)
-        inputs.gradients.resize(n_particles,small_vector<Tensor<1,dim>>(evaluator.n_components()));
+        inputs.gradients.resize(n_particles,small_vector<Tensor<1,dim>,50>(evaluator.n_components()));
 
       for (unsigned int i = 0; i<n_particles; ++i)
         {

--- a/source/solution_evaluator.cc
+++ b/source/solution_evaluator.cc
@@ -383,7 +383,7 @@ namespace aspect
   template <int dim>
   void
   SolutionEvaluator<dim>::get_solution(const unsigned int evaluation_point,
-                                       const ArrayView<double> &solution)
+                                       const ArrayView<double> &solution) const
   {
     Assert(solution.size() == simulator_access.introspection().n_components,
            ExcDimensionMismatch(solution.size(), simulator_access.introspection().n_components));
@@ -421,7 +421,7 @@ namespace aspect
   template <int dim>
   void
   SolutionEvaluator<dim>::get_gradients(const unsigned int evaluation_point,
-                                        const ArrayView<Tensor<1,dim>> &gradients)
+                                        const ArrayView<Tensor<1,dim>> &gradients) const
   {
     Assert(gradients.size() == simulator_access.introspection().n_components,
            ExcDimensionMismatch(gradients.size(), simulator_access.introspection().n_components));
@@ -456,6 +456,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   FEPointEvaluation<dim, dim> &
   SolutionEvaluator<dim>::get_velocity_or_fluid_velocity_evaluator(const bool use_fluid_velocity)
@@ -467,6 +468,9 @@ namespace aspect
 
     return velocity;
   }
+
+
+
   template <int dim>
   NonMatching::MappingInfo<dim> &
   SolutionEvaluator<dim>::get_mapping_info()
@@ -475,7 +479,16 @@ namespace aspect
   }
 
 
-  // A function to create a pointer to a SolutionEvaluator object.
+
+  template <int dim>
+  unsigned int
+  SolutionEvaluator<dim>::n_components() const
+  {
+    return simulator_access.introspection().n_components;
+  }
+
+
+
   template <int dim>
   std::unique_ptr<SolutionEvaluator<dim>>
   construct_solution_evaluator (const SimulatorAccess<dim> &simulator_access,


### PR DESCRIPTION
This is a suggestion for a change to the particle update plugin interface that removes a lot of dynamic memory allocation and also reduces the number of unnecessary copies of the solution values. It is build on top of #6018 and can automatically incorporate the new features of #5963 when they are merged (because they would just exist within `SolutionEvaluator`).  The total particle property update of the test introduced in #5963 is about 15% faster than in the best case discussed there (the branch https://github.com/tjhei/aspect/tree/composition-particles-experimental). I should mention that the majority of the gains could be achieved by switching the interface from:
```
         update_particle_properties (const unsigned int data_position,
                                      const std::vector<Vector<double>> &solution,
                                      const std::vector<std::vector<Tensor<1,dim>>> &gradients,
                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
```
to:
```
         update_particle_properties (const unsigned int data_position,
                                      const small_vector<small_vector<double>> &solution,
                                      const small_vector<small_vector<Tensor<1,dim>>> &gradients,
                                      typename ParticleHandler<dim>::particle_iterator_range &particles) const override;
```

instead of what I propose here. That would be a smaller change to the interface, but I think the version of this PR is interesting, because it would allow for further optimizations in the future. E.g. we could introduce a `get_solution_component` function into `SolutionEvaluator` that allows to access individual components instead of all components. This would allow to further reduce computational cost, by only evaluating and accessing necessary components.

The change is backward compatible for now (until we remove the transition function in the property interface), but I think eventually we would want to migrate all property plugins to this new interface.

I think it would be good to merge this PR (or whatever we agree on) before the next release, because we already introduced a new interface function in #5874, and if we update it before the next release we do not need to worry about changing the interface twice in two subsequent releases.

Opinions welcome, I also need to clean this PR a bit.