### PR TITLE
Fix a unit typo in continental_extension_cookbook

### DIFF
--- a/cookbooks/continental_extension/continental_extension.prm
+++ b/cookbooks/continental_extension/continental_extension.prm
@@ -173,7 +173,7 @@ end
 #   Geological Society of London Special Publications, v.24, p.63-70.
 # The initial constraints are:
 #   Surface Temperature  - upper crust (ts1) = 273 K
-#   Surface Heat Flow    - upper crust (qs1) = 0.055 mW/m^2
+#   Surface Heat Flow    - upper crust (qs1) = 0.055 W/m^2
 #   Heat Production      - upper crust (A1)  = 1.00e-6 W/m^3;
 #   Heat Production      - lower crust (A2)  = 0.25e-6 W/m^3;
 #   Heat Production      - mantle (A3)       = 0.00e-6 W/m^3;


### PR DESCRIPTION
I fixed the units described for a parameter in the continental extension cookbook.

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
