### PR TITLE
Unify AUTHORS.md text

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,33 +1,41 @@
+(sec:authors)=
+# Authors
+
 ASPECT is being developed by a large, collaborative, and inclusive
 community. The code and its community are currently maintained by the
 following *Maintainers*:
 
 * Wolfgang Bangerth (Colorado State University, USA)
-* Juliane Dannberg (University of Florida, USA)
+* Juliane Dannberg (GEOMAR Helmholtz Centre for Ocean Research, Germany)
 * Menno Fraters (University of California, Davis, USA)
-* Rene Gassmoeller (University of Florida, USA)
+* Rene Gassmoeller (GEOMAR Helmholtz Centre for Ocean Research, Germany)
 * Anne Glerum (Geoforschungszentrum Potsdam, Germany)
 * Timo Heister (Clemson University, USA)
 * Bob Myhill (University of Bristol, UK)
 * John Naliboff (New Mexico Tech, USA)
+
+## Principal developers
 
 The following people currently serve as *Principal Developers* -- people
 who have and are providing substantial technical contributions to ASPECT:
 
 * Jacky Austermann (Columbia University and Lamont-Doherty Earth Observatory, USA)
 * Wolfgang Bangerth (Colorado State University, USA)
-* Juliane Dannberg (University of Florida, USA)
+* Juliane Dannberg (GEOMAR Helmholtz Centre for Ocean Research, Germany)
 * Menno Fraters (University of California, Davis, USA)
-* Rene Gassmoeller (University of Florida, USA)
+* Rene Gassmoeller (GEOMAR Helmholtz Centre for Ocean Research, Germany)
 * Anne Glerum (Geoforschungszentrum Potsdam, Germany)
 * Timo Heister (Clemson University, USA)
 * Bob Myhill (University of Bristol, UK)
 * John Naliboff (New Mexico Tech, USA)
 * Cedric Thieulot (Utrecht University, Netherlands)
 
+## Community
 
-A complete and growing list of the many authors that have contributed
-over the years can be found at [here](https://github.com/geodynamics/aspect/graphs/contributors).
+A complete and growing list of the many authors that have contributed to ASPECT
+can be found [in our Github repository](https://github.com/geodynamics/aspect/graphs/contributors).
 
-We are grateful for the contributions of all of these people, and
-their participation in our community!
+**With special contributions to the manual by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang.
+
+We are grateful for all contributions to ASPECT and its documentation, and
+your participation in our community!

--- a/doc/sphinx/user/authors.md
+++ b/doc/sphinx/user/authors.md
@@ -1,16 +1,1 @@
-(sec:authors)=
-# Authors of the ASPECT manual
-ASPECT is primarily maintained and developed by a group of principal developers. Several people have contributed significantly to the software and manual, and the list of authors in the documentation is compiled below.
-
-## Principal developers
-
-* Wolfgang Bangerth
-* Juliane Dannberg
-* Menno Fraters
-* Rene Gassmöller
-* Anne Glerum
-* Timo Heister
-* Bob Myhill
-* John Naliboff
-
-**With contributions by:** Jacqueline Austermann, Magali Billen, Markus B&uuml;rg, Thomas Clevenger, Samuel Cox, William Durkin, Grant Euen, Thomas Geenen, Ryan Grove, Eric Heien, Ludovic Jeanniot, Louise Kellogg, Scott King, Martin Kronbichler, Marine Lasbleis, Haoyuan Li, Shangxin Liu, Hannah Mark, Elvira Mulyukova, Bart Niday, Jonathan Perry-Houts, Elbridge Gerry Puckett, Tahiry Rajaonarison, Fred Richards, Jonathan Robey, Ian Rose, Max Rudolph, Stephanie Sparks, D. Sarah Stamps, Cedric Thieulot, Wanying Wang, Iris van Zelst, Siqi Zhang
+../../../AUTHORS.md


### PR DESCRIPTION
We had two separate author lists for source code and manual, which is a problem, because I kept forgetting we need to keep the manual authors up to date as well (and they are probably way outdated already). It also lead to us forgetting to mention @cedrict as principal developer in the manual (sorry! you were mentiond in the main AUTHORS.md). To avoid this it would be easier to unify the files and make sure we only have one authors file to keep up to date. I deleted the one in the manual, and replaced it with a symbolic link to the file in the main directory. Let's see if readthedocs picks this up correctly, if not I can keep a separate file in the sphinx directory that just contains an `include` directive.