### PR TITLE
fix units spacing in initial temperature plugins

### DIFF
--- a/source/initial_temperature/S40RTS_perturbation.cc
+++ b/source/initial_temperature/S40RTS_perturbation.cc
@@ -405,9 +405,9 @@ namespace aspect
                              "This will set the heterogeneity prescribed by S20RTS or S40RTS to zero "
                              "down to the specified depth (in meters). Note that your resolution has "
                              "to be adequate to capture this cutoff. For example if you specify a depth "
-                             "of 660km, but your closest spherical depth layers are only at 500km and "
-                             "750km (due to a coarse resolution) it will only zero out heterogeneities "
-                             "down to 500km. Similar caution has to be taken when using adaptive meshing.");
+                             "of 660 km, but your closest spherical depth layers are only at 500 km and "
+                             "750 km (due to a coarse resolution) it will only zero out heterogeneities "
+                             "down to 500 km. Similar caution has to be taken when using adaptive meshing.");
           prm.declare_entry ("Specify a lower maximum degree","false",
                              Patterns::Bool (),
                              "Option to use a lower maximum degree when reading the data file of spherical "

--- a/source/initial_temperature/SAVANI_perturbation.cc
+++ b/source/initial_temperature/SAVANI_perturbation.cc
@@ -413,9 +413,9 @@ namespace aspect
                              "This will set the heterogeneity prescribed by SAVANI to zero "
                              "down to the specified depth (in meters). Note that your resolution has "
                              "to be adequate to capture this cutoff. For example if you specify a depth "
-                             "of 660km, but your closest spherical depth layers are only at 500km and "
-                             "750km (due to a coarse resolution) it will only zero out heterogeneities "
-                             "down to 500km. Similar caution has to be taken when using adaptive meshing.");
+                             "of 660 km, but your closest spherical depth layers are only at 500 km and "
+                             "750 km (due to a coarse resolution) it will only zero out heterogeneities "
+                             "down to 500 km. Similar caution has to be taken when using adaptive meshing.");
           prm.declare_entry ("Specify a lower maximum degree","false",
                              Patterns::Bool (),
                              "Option to use a lower maximum degree when reading the data file of spherical "

--- a/source/initial_temperature/patch_on_S40RTS.cc
+++ b/source/initial_temperature/patch_on_S40RTS.cc
@@ -130,9 +130,9 @@ namespace aspect
                              "This will set the heterogeneity prescribed by the Vs ascii grid and S40RTS to zero "
                              "down to the specified depth (in meters). Note that your resolution has "
                              "to be adequate to capture this cutoff. For example if you specify a depth "
-                             "of 660km, but your closest spherical depth layers are only at 500km and "
-                             "750km (due to a coarse resolution) it will only zero out heterogeneities "
-                             "down to 500km. Similar caution has to be taken when using adaptive meshing.");
+                             "of 660 km, but your closest spherical depth layers are only at 500 km and "
+                             "750 km (due to a coarse resolution) it will only zero out heterogeneities "
+                             "down to 500 km. Similar caution has to be taken when using adaptive meshing.");
 
           Utilities::AsciiDataBase<dim>::declare_parameters(prm,
                                                             "$ASPECT_SOURCE_DIR/data/initial-temperature/patch-on-S40RTS/test/",


### PR DESCRIPTION
This PR adds a space between the numeric value and units (km) in the documentation or comments for multiple initial temperature plugins.
* [ X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.
* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
