### PR TITLE
jsontomarkdown.py: fix warning

### DIFF
--- a/contrib/utilities/jsontomarkdown.py
+++ b/contrib/utilities/jsontomarkdown.py
@@ -79,7 +79,7 @@ def escape_doc_string(text) :
     tmp = (text
            .replace("``", "&ldquo;")
            .replace("''", "&rdquo;")
-           .replace("\`", "[[[backtick]]]") # temporarily replace escaped backticks by a placeholder
+           .replace("\\`", "[[[backtick]]]") # temporarily replace escaped backticks by a placeholder
            .replace("`", "&lsquo;")
            .replace("'", "&rsquo;")
            .replace("[[[backtick]]]", "`") # and now change them to actual backticks


### PR DESCRIPTION
I am getting a SyntaxWarning about an invalid escape sequence.
