### PR TITLE
Avoid a C-style array

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -178,10 +178,10 @@ namespace aspect
        */
       struct ComponentIndices
       {
-        unsigned int       velocities[dim];
-        unsigned int       pressure;
-        unsigned int       temperature;
-        std::vector<unsigned int> compositional_fields;
+        std::array<unsigned int, dim> velocities;
+        unsigned int                  pressure;
+        unsigned int                  temperature;
+        std::vector<unsigned int>     compositional_fields;
       };
       /**
        * A variable that enumerates the vector components of the finite


### PR DESCRIPTION
C-Arrays can be replaced by `std::array` in most cases, which should also give the benefit of array-bounds checking in debug mode (#6007). Use cases should not be affected as far as I can see.