### PR TITLE
store particle worlds directly

### DIFF
--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -97,7 +97,7 @@ namespace aspect
          * Move constructor. This is required to be able to put instances
          * of this class into a std::vector.
          */
-        World(World &&) = default;
+        World(World &&);
 
         /**
          * Initialize the particle world.

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -94,6 +94,12 @@ namespace aspect
         ~World() override;
 
         /**
+         * Move constructor. This is required to be able to put instances
+         * of this class into a std::vector.
+         */
+        World(World &&) = default;
+
+        /**
          * Initialize the particle world.
          */
         void initialize();

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1986,9 +1986,9 @@ namespace aspect
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim>>                boundary_heat_flux;
 
       /**
-       * The world holding the particles
+       * The worlds holding different sets of particles
        */
-      std::vector<std::unique_ptr<Particle::World<dim>>> particle_worlds;
+      std::vector<Particle::World<dim>> particle_worlds;
 
       /**
        * @}

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -48,6 +48,22 @@ namespace aspect
       = default;
 
     template <int dim>
+    World<dim>::World(World &&other)
+      : generator(std::move(other.generator)),
+        integrator(std::move(other.integrator)),
+        interpolator(std::move(other.interpolator)),
+        particle_handler(std::move(other.particle_handler)),
+        particle_handler_backup(), // can not move
+        property_manager(std::move(other.property_manager)),
+        particle_load_balancing(other.particle_load_balancing),
+        min_particles_per_cell(other.min_particles_per_cell),
+        max_particles_per_cell(other.max_particles_per_cell),
+        particle_weight(other.particle_weight)
+    {}
+
+
+
+    template <int dim>
     void
     World<dim>::initialize()
     {

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -284,8 +284,8 @@ namespace aspect
     // need to write into it and we can not
     // write into vectors with ghost elements
 
-    const Particle::Interpolator::Interface<dim> &particle_interpolator = particle_worlds[0]->get_interpolator();
-    const Particle::Property::Manager<dim> &particle_property_manager = particle_worlds[0]->get_property_manager();
+    const Particle::Interpolator::Interface<dim> &particle_interpolator = particle_worlds[0].get_interpolator();
+    const Particle::Property::Manager<dim> &particle_property_manager = particle_worlds[0].get_property_manager();
 
     std::vector<unsigned int> particle_property_indices;
     ComponentMask property_mask  (particle_property_manager.get_data_info().n_components(),false);
@@ -357,7 +357,7 @@ namespace aspect
               try
                 {
                   particle_properties =
-                    particle_interpolator.properties_at_points(particle_worlds[world_index]->get_particle_handler(),
+                    particle_interpolator.properties_at_points(particle_worlds[world_index].get_particle_handler(),
                                                                quadrature_points,
                                                                property_mask,
                                                                cell);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -831,7 +831,7 @@ namespace aspect
   SimulatorAccess<dim>::get_particle_world(unsigned int particle_world_index) const
   {
     AssertThrow (particle_world_index < simulator->particle_worlds.size(), ExcInternalError());
-    return *simulator->particle_worlds[particle_world_index].get();
+    return simulator->particle_worlds[particle_world_index];
   }
 
 
@@ -841,7 +841,7 @@ namespace aspect
   SimulatorAccess<dim>::get_particle_world(unsigned int particle_world_index)
   {
     AssertThrow (particle_world_index < simulator->particle_worlds.size(), ExcInternalError());
-    return *simulator->particle_worlds[particle_world_index].get();
+    return const_cast<Particle::World<dim>&>(simulator->particle_worlds[particle_world_index]);
   }
 
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -233,10 +233,10 @@ namespace aspect
                                            && (pre_refinement_step < parameters.initial_adaptive_refinement);
         if (!in_initial_refinement)
           // Advance the particles in the world to the current time
-          particle_world->advance_timestep();
+          particle_world.advance_timestep();
 
-        if (particle_world->get_property_manager().need_update() == Particle::Property::update_output_step)
-          particle_world->update_particles();
+        if (particle_world.get_property_manager().need_update() == Particle::Property::update_output_step)
+          particle_world.update_particles();
       }
 
     std::vector<double> current_residual(introspection.n_compositional_fields,0.0);
@@ -964,7 +964,7 @@ namespace aspect
 
         if (nonlinear_iteration > 0)
           for (auto &particle_world : particle_worlds)
-            particle_world->restore_particles();
+            particle_world.restore_particles();
 
         const double relative_temperature_residual =
           assemble_and_solve_temperature(initial_temperature_residual,
@@ -1125,7 +1125,7 @@ namespace aspect
 
         if (nonlinear_iteration > 0)
           for (auto &particle_world : particle_worlds)
-            particle_world->restore_particles();
+            particle_world.restore_particles();
 
         const double relative_temperature_residual =
           assemble_and_solve_temperature(initial_temperature_residual,


### PR DESCRIPTION
We should be able to store Particle Worlds directly and not inside unique_ptr.