### PR TITLE
Use constexpr where possible

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -419,7 +419,7 @@ namespace aspect
         /**
          * Give a symbolic name to the manifold id to be used by this class.
          */
-        static const types::manifold_id my_manifold_id = 15;
+        static constexpr types::manifold_id my_manifold_id = 15;
     };
   }
 }

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -445,7 +445,7 @@ namespace aspect
         /**
          * Give a symbolic name to the manifold id to be used by this class.
          */
-        static const types::manifold_id my_manifold_id = 99;
+        static constexpr types::manifold_id my_manifold_id = 99;
     };
   }
 }

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -311,7 +311,7 @@ namespace aspect
         /**
          * Give a symbolic name to the manifold id to be used by this class.
          */
-        static const types::manifold_id my_manifold_id = 15;
+        static constexpr types::manifold_id my_manifold_id = 15;
 
         /**
          * Bind boundary indicators to child cells after each mesh refinement round.

--- a/include/aspect/particle/integrator/euler.h
+++ b/include/aspect/particle/integrator/euler.h
@@ -91,7 +91,7 @@ namespace aspect
            *
            * The forward Euler integrator does not need any intermediate storage space.
            */
-          static const unsigned int n_integrator_properties = 0;
+          static constexpr unsigned int n_integrator_properties = 0;
       };
 
     }

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -127,7 +127,7 @@ namespace aspect
            *
            * The Runge-Kutta 2 integrator requires a single point with dim components.
            */
-          static const unsigned int n_integrator_properties = dim;
+          static constexpr unsigned int n_integrator_properties = dim;
 
         private:
           /**

--- a/include/aspect/particle/integrator/rk_4.h
+++ b/include/aspect/particle/integrator/rk_4.h
@@ -114,7 +114,7 @@ namespace aspect
            *
            * The Runge-Kutta 4 integrator requires 4 tensors with dim components each.
            */
-          static const unsigned int n_integrator_properties = 4*dim;
+          static constexpr unsigned int n_integrator_properties = 4*dim;
 
         private:
           /**


### PR DESCRIPTION
`static const` members that have the same value independent of run-time parameters may just as well be `constexpr`. In fact the current implementation may be wrong if these header files are included in multiple places (at least @mfraters got a linker error when including the rk_2 header in a user plugin, which was fixed by the change in this PR). As far as I understand without `constexpr` we would actually have to put the definition of the static const members into the source file, or use a `inline static const ...` which is only supported since c++17.