### PR TITLE
Only evaluate necessary solution components during particle property update

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -355,10 +355,34 @@ namespace aspect
       {
         ComponentMasks (const FEVariableCollection<dim> &fevs, const Introspection<dim>::ComponentIndices &indices);
 
+        /**
+         * The component mask for all velocity components.
+         */
         ComponentMask              velocities;
+
+        /**
+         * The component mask for the pressure component.
+         */
         ComponentMask              pressure;
+
+        /**
+         * The component mask for the temperature component.
+         */
         ComponentMask              temperature;
+
+        /**
+         * The component mask for each individual compositional field.
+         * The size of this vector is equal to the number of compositional fields.
+         * Each entry is a component mask that selects the component
+         * that corresponds to the respective compositional field.
+         */
         std::vector<ComponentMask> compositional_fields;
+
+        /**
+         * The component mask for all composition components.
+         * This mask selects all compositional fields.
+         */
+        ComponentMask              compositions;
       };
 
       /**

--- a/include/aspect/particle/property/composition.h
+++ b/include/aspect/particle/property/composition.h
@@ -72,11 +72,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The pressure and temperature need the values of their variables.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -113,11 +113,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The integrated strains needs the gradients of the velocity.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -104,11 +104,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * For example, the strains needs the gradients of the velocity.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -178,11 +178,10 @@ namespace aspect
           late_initialization_mode () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The integrated strains needs the gradients of the velocity.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/elastic_stress.h
+++ b/include/aspect/particle/property/elastic_stress.h
@@ -71,10 +71,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::get_needed_update_flags()
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * @copydoc aspect::Particle::Property::Interface::get_property_information()

--- a/include/aspect/particle/property/grain_size.h
+++ b/include/aspect/particle/property/grain_size.h
@@ -85,10 +85,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::get_needed_update_flags()
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * @copydoc aspect::Particle::Property::Interface::get_property_information()

--- a/include/aspect/particle/property/integrated_strain.h
+++ b/include/aspect/particle/property/integrated_strain.h
@@ -73,11 +73,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The integrated strains needs the gradients of the velocity.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/integrated_strain_invariant.h
+++ b/include/aspect/particle/property/integrated_strain_invariant.h
@@ -72,11 +72,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The integrated strains needs the gradients of the velocity.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -435,13 +435,41 @@ namespace aspect
           need_update () const;
 
           /**
+           * Return which data of the solution component @p component
+           * has to be provided to update the current particle property.
+           *
+           * Note that particle properties can only ask for update_default
+           * (no data), update_values (solution values), and update_gradients
+           * (solution gradients). All other update flags will have no effect.
+           *
+           * As an example consider a particle property that depends on the
+           * solution values and gradients of the velocity field. In this case
+           * the function should return update_values | update_gradients if the
+           * @p component is one of the velocity components, and update_default
+           * otherwise.
+           *
+           * @param component The component of the solution which is to be
+           * evaluated.
+           *
+           * @return The necessary update flags for the solution component
+           * @p component that is required for this particle property.
+           */
+          virtual
+          UpdateFlags
+          get_update_flags (const unsigned int component) const;
+
+          /**
            * Return which data has to be provided to update all properties.
            * Note that particle properties can only ask for update_default
            * (no data), update_values (solution values), and update_gradients
            * (solution gradients). All other update flags will have no effect.
            *
            * @return The necessary update flags for this particle property.
+           *
+           * @deprecated This function is deprecated. Use the above version of
+           * get_update_flags() instead.
            */
+          DEAL_II_DEPRECATED
           virtual
           UpdateFlags
           get_needed_update_flags () const;
@@ -624,9 +652,16 @@ namespace aspect
            * Note that particle properties can only ask for update_default
            * (no data), update_values (solution values), and update_gradients
            * (solution gradients). All other update flags will have no effect.
+           * The result of this function is a combination of the
+           * get_update_flags() functions of all individual properties
+           * that are selected.
+           *
+           * @return A vector that contains the update flags that are
+           * required to update all particle properties. The vector has as many entries
+           * as there solution components.
            */
-          UpdateFlags
-          get_needed_update_flags () const;
+          std::vector<UpdateFlags>
+          get_update_flags () const;
 
           /**
            * Checks if the particle plugin specified by @p name exists

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -73,11 +73,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The pressure and temperature need the values of their variables.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/pT_path.h
+++ b/include/aspect/particle/property/pT_path.h
@@ -84,11 +84,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The pressure and temperature need the values of their variables.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/strain_rate.h
+++ b/include/aspect/particle/property/strain_rate.h
@@ -70,12 +70,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The velocity particle property needs the values of the velocity
-           * solution.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/velocity.h
+++ b/include/aspect/particle/property/velocity.h
@@ -69,12 +69,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * Return which data has to be provided to update the property.
-           * The velocity particle property needs the values of the velocity
-           * solution.
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * Set up the information about the names and number of components

--- a/include/aspect/particle/property/viscoplastic_strain_invariants.h
+++ b/include/aspect/particle/property/viscoplastic_strain_invariants.h
@@ -74,10 +74,10 @@ namespace aspect
           need_update () const override;
 
           /**
-           * @copydoc aspect::Particle::Property::Interface::get_needed_update_flags()
+           * @copydoc aspect::Particle::Property::Interface::get_update_flags()
            */
           UpdateFlags
-          get_needed_update_flags () const override;
+          get_update_flags (const unsigned int component) const override;
 
           /**
            * @copydoc aspect::Particle::Property::Interface::get_property_information()

--- a/include/aspect/particle/world.h
+++ b/include/aspect/particle/world.h
@@ -418,11 +418,14 @@ namespace aspect
          * function will fill this structure with the necessary data.
          * @param positions The reference positions of the particles in the cell.
          * This function will update these positions for the current cell.
+         * @param update_flags The flags that indicate which properties need to
+         * be evaluated in order to update the particles in this cell.
          * @param evaluator The solution evaluator that is used to update the particles.
          */
         void
         local_update_particles(Property::ParticleUpdateInputs<dim> &inputs,
                                small_vector<Point<dim>> &positions,
+                               std::vector<EvaluationFlags::EvaluationFlags> &update_flags,
                                SolutionEvaluator<dim> &evaluator);
 
         /**

--- a/include/aspect/solution_evaluator.h
+++ b/include/aspect/solution_evaluator.h
@@ -162,7 +162,7 @@ namespace aspect
        * call to reinit().
        *
        * @p solution_values contains the values of the degrees of freedom.
-       * @p evaluation_flags controls if nothing, the solution values, or the gradients should be computed.
+       * @p evaluation_flags controls if nothing, the solution values, and/or the gradients should be computed.
        * The size of @p solution_flags has to be equal to the number of components as returned by
        * n_components().
        */

--- a/include/aspect/solution_evaluator.h
+++ b/include/aspect/solution_evaluator.h
@@ -150,42 +150,57 @@ namespace aspect
                         const UpdateFlags update_flags);
 
       /**
-       * Reinitialize all variables to evaluate the given solution for the given cell
-       * and the given positions. The update flags control if only the solution or
-       * also the gradients should be evaluated.
-       * If other flags are set an assertion is triggered.
+       * Reinitialize all variables to prepare for evaluation for the given @p cell
+       * and at the given @p positions in the reference coordinate system of that cell.
        */
       void
       reinit(const typename DoFHandler<dim>::active_cell_iterator &cell,
-             const ArrayView<Point<dim>> &positions,
-             const ArrayView<double> &solution_values,
-             const UpdateFlags update_flags);
+             const ArrayView<Point<dim>> &positions);
+
+      /**
+       * Evaluate all variables in the cell and at the positions controlled by a previous
+       * call to reinit().
+       *
+       * @p solution_values contains the values of the degrees of freedom.
+       * @p evaluation_flags controls if nothing, the solution values, or the gradients should be computed.
+       * The size of @p solution_flags has to be equal to the number of components as returned by
+       * n_components().
+       */
+      void
+      evaluate(const ArrayView<double> &solution_values,
+               const std::vector<EvaluationFlags::EvaluationFlags> &evaluation_flags);
 
       /**
        * Fill @p solution with all solution components at the given @p evaluation_point. Note
-       * that this function only works after a successful call to reinit(),
+       * that this function only works after a successful call to reinit() and evaluate()
        * because this function only returns the results of the computation that
-       * happened in reinit().
+       * happened in those functions.
        *
        * @param evaluation_point The index of the evaluation point in the positions array.
        * @param solution The array to fill with the solution values. This array has to be
        *                 of size n_components().
+       * @param evaluation_flags The flags that indicate which values should be copied into the
+       *                        solution array. This vector has to be of size n_components().
        */
       void get_solution(const unsigned int evaluation_point,
-                        const ArrayView<double> &solution) const;
+                        const ArrayView<double> &solution,
+                        const std::vector<EvaluationFlags::EvaluationFlags> &evaluation_flags) const;
 
       /**
        * Fill @p gradients with all solution gradients at the given @p evaluation_point. Note
-       * that this function only works after a successful call to reinit(),
+       * that this function only works after a successful call to reinit() and evaluate()
        * because this function only returns the results of the computation that
-       * happened in reinit().
+       * happened in those functions.
        *
        * @param evaluation_point The index of the evaluation point in the positions array.
        * @param gradients The array to fill with the solution gradients. This array has to be
        *                  of size n_components().
+       * @param evaluation_flags The flags that indicate which gradients should be copied into the
+       *                        solution array. This vector has to be of size n_components().
        */
       void get_gradients(const unsigned int evaluation_point,
-                         const ArrayView<Tensor<1, dim>> &gradients) const;
+                         const ArrayView<Tensor<1, dim>> &gradients,
+                         const std::vector<EvaluationFlags::EvaluationFlags> &evaluation_flags) const;
 
       /**
        * Return the evaluator for velocity or fluid velocity. This is the only

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -71,10 +71,7 @@ namespace aspect
       UpdateFlags
       Composition<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.compositional_fields.front() &&
-            component <= component_indices.compositional_fields.back())
+        if (this->introspection().component_masks.compositions[component] == true)
           return update_values;
 
         return update_default;

--- a/source/particle/property/composition.cc
+++ b/source/particle/property/composition.cc
@@ -69,9 +69,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      Composition<dim>::get_needed_update_flags () const
+      Composition<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.compositional_fields.front() &&
+            component <= component_indices.compositional_fields.back())
+          return update_values;
+
+        return update_default;
       }
 
 

--- a/source/particle/property/cpo_bingham_average.cc
+++ b/source/particle/property/cpo_bingham_average.cc
@@ -196,7 +196,7 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      CpoBinghamAverage<dim>::get_needed_update_flags () const
+      CpoBinghamAverage<dim>::get_update_flags (const unsigned int /*component*/) const
       {
         return update_default;
       }

--- a/source/particle/property/cpo_elastic_tensor.cc
+++ b/source/particle/property/cpo_elastic_tensor.cc
@@ -196,7 +196,7 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      CpoElasticTensor<dim>::get_needed_update_flags () const
+      CpoElasticTensor<dim>::get_update_flags (const unsigned int /*component*/) const
       {
         return update_default;
       }

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -429,10 +429,7 @@ namespace aspect
       UpdateFlags
       CrystalPreferredOrientation<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_values | update_gradients;
 
         return update_values;

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -427,9 +427,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      CrystalPreferredOrientation<dim>::get_needed_update_flags () const
+      CrystalPreferredOrientation<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values | update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_values | update_gradients;
+
+        return update_values;
       }
 
 

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -137,9 +137,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      ElasticStress<dim>::get_needed_update_flags () const
+      ElasticStress<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values | update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_values | update_gradients;
+
+        return update_values;
       }
 
 

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -139,10 +139,7 @@ namespace aspect
       UpdateFlags
       ElasticStress<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_values | update_gradients;
 
         return update_values;

--- a/source/particle/property/grain_size.cc
+++ b/source/particle/property/grain_size.cc
@@ -135,9 +135,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      GrainSize<dim>::get_needed_update_flags () const
+      GrainSize<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values | update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_values | update_gradients;
+
+        return update_values;
       }
 
 

--- a/source/particle/property/grain_size.cc
+++ b/source/particle/property/grain_size.cc
@@ -137,10 +137,7 @@ namespace aspect
       UpdateFlags
       GrainSize<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_values | update_gradients;
 
         return update_values;

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -88,9 +88,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      IntegratedStrain<dim>::get_needed_update_flags () const
+      IntegratedStrain<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_gradients;
+
+        return update_default;
       }
 
       template <int dim>

--- a/source/particle/property/integrated_strain.cc
+++ b/source/particle/property/integrated_strain.cc
@@ -90,10 +90,7 @@ namespace aspect
       UpdateFlags
       IntegratedStrain<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_gradients;
 
         return update_default;

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -55,7 +55,7 @@ namespace aspect
             // Velocity gradients
             Tensor<2,dim> grad_u;
             for (unsigned int d=0; d<dim; ++d)
-              grad_u[d] = inputs.gradients[p][d];
+              grad_u[d] = inputs.gradients[p][this->introspection().component_indices.velocities[d]];
 
             // Calculate strain rate from velocity gradients
             const SymmetricTensor<2,dim> strain_rate = symmetrize (grad_u);
@@ -83,9 +83,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      IntegratedStrainInvariant<dim>::get_needed_update_flags () const
+      IntegratedStrainInvariant<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_gradients;
+
+        return update_default;
       }
 
 

--- a/source/particle/property/integrated_strain_invariant.cc
+++ b/source/particle/property/integrated_strain_invariant.cc
@@ -85,10 +85,7 @@ namespace aspect
       UpdateFlags
       IntegratedStrainInvariant<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_gradients;
 
         return update_default;

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -250,8 +250,12 @@ namespace aspect
               {
                 solution.reinit(inputs.solution[i].size());
                 for (unsigned int j=0; j<solution.size(); ++j)
-                  if (get_update_flags(j) & update_values)
-                    solution[j] = inputs.solution[i][j];
+                  {
+                    if (get_update_flags(j) & update_values)
+                      solution[j] = inputs.solution[i][j];
+                    else
+                      solution[j] = numbers::signaling_nan<double>();
+                  }
               }
 
             if (need_gradient)
@@ -259,8 +263,12 @@ namespace aspect
                 gradient.resize(inputs.gradients[i].size());
 
                 for (unsigned int j=0; j<gradient.size(); ++j)
-                  if (get_update_flags(j) & update_gradients)
-                    gradient[j] = inputs.gradients[i][j];
+                  {
+                    if (get_update_flags(j) & update_gradients)
+                      gradient[j] = inputs.gradients[i][j];
+                    else
+                      gradient[j] = numbers::signaling_nan<Tensor<1,dim>>();
+                  }
               }
 
             // call the deprecated version of this function

--- a/source/particle/property/melt_particle.cc
+++ b/source/particle/property/melt_particle.cc
@@ -66,10 +66,7 @@ namespace aspect
       UpdateFlags
       MeltParticle<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.compositional_fields.front() &&
-            component <= component_indices.compositional_fields.back())
+        if (this->introspection().component_masks.compositions[component] == true)
           return update_values;
 
         return update_default;

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -90,9 +90,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      PTPath<dim>::get_needed_update_flags () const
+      PTPath<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component == component_indices.pressure ||
+            component == component_indices.temperature)
+          return update_values;
+
+        return update_default;
       }
 
 

--- a/source/particle/property/pT_path.cc
+++ b/source/particle/property/pT_path.cc
@@ -92,10 +92,8 @@ namespace aspect
       UpdateFlags
       PTPath<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component == component_indices.pressure ||
-            component == component_indices.temperature)
+        if (this->introspection().component_masks.pressure[component] == true ||
+            this->introspection().component_masks.temperature[component] == true)
           return update_values;
 
         return update_default;

--- a/source/particle/property/strain_rate.cc
+++ b/source/particle/property/strain_rate.cc
@@ -74,10 +74,7 @@ namespace aspect
       UpdateFlags
       StrainRate<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_gradients;
 
         return update_default;

--- a/source/particle/property/strain_rate.cc
+++ b/source/particle/property/strain_rate.cc
@@ -72,9 +72,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      StrainRate<dim>::get_needed_update_flags () const
+      StrainRate<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_gradients;
+
+        return update_default;
       }
 
       template <int dim>

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -60,10 +60,7 @@ namespace aspect
       UpdateFlags
       Velocity<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_values;
 
         return update_default;

--- a/source/particle/property/velocity.cc
+++ b/source/particle/property/velocity.cc
@@ -58,9 +58,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      Velocity<dim>::get_needed_update_flags () const
+      Velocity<dim>::get_update_flags (const unsigned int component) const
       {
-        return update_values;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_values;
+
+        return update_default;
       }
 
       template <int dim>

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -200,10 +200,7 @@ namespace aspect
       UpdateFlags
       ViscoPlasticStrainInvariant<dim>::get_update_flags (const unsigned int component) const
       {
-        const auto &component_indices = this->introspection().component_indices;
-
-        if (component >= component_indices.velocities[0] &&
-            component <= component_indices.velocities[dim-1])
+        if (this->introspection().component_masks.velocities[component] == true)
           return update_values | update_gradients;
 
         return update_values;

--- a/source/particle/property/viscoplastic_strain_invariants.cc
+++ b/source/particle/property/viscoplastic_strain_invariants.cc
@@ -198,10 +198,15 @@ namespace aspect
 
       template <int dim>
       UpdateFlags
-      ViscoPlasticStrainInvariant<dim>::get_needed_update_flags () const
+      ViscoPlasticStrainInvariant<dim>::get_update_flags (const unsigned int component) const
       {
-        // Need to update both of these to send into material model.
-        return update_values | update_gradients;
+        const auto &component_indices = this->introspection().component_indices;
+
+        if (component >= component_indices.velocities[0] &&
+            component <= component_indices.velocities[dim-1])
+          return update_values | update_gradients;
+
+        return update_values;
       }
 
       template <int dim>

--- a/source/particle/world.cc
+++ b/source/particle/world.cc
@@ -481,10 +481,10 @@ namespace aspect
         }
 
       if (evaluation_flags_union & update_values)
-        inputs.solution.resize(n_particles,small_vector<double,50>(evaluator.n_components()));
+        inputs.solution.resize(n_particles,small_vector<double,50>(evaluator.n_components(), numbers::signaling_nan<double>()));
 
       if (evaluation_flags_union & update_gradients)
-        inputs.gradients.resize(n_particles,small_vector<Tensor<1,dim>,50>(evaluator.n_components()));
+        inputs.gradients.resize(n_particles,small_vector<Tensor<1,dim>,50>(evaluator.n_components(), numbers::signaling_nan<Tensor<1,dim>>()));
 
       for (unsigned int i = 0; i<n_particles; ++i)
         {

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -398,6 +398,16 @@ namespace aspect
         }
       return result;
     }
+
+    template <int dim>
+    ComponentMask
+    make_composition_component_mask (const FEVariableCollection<dim> &fevs, const std::vector<ComponentMask> &compositional_fields)
+    {
+      ComponentMask result(fevs.n_components(), false);
+      for (const auto &mask : compositional_fields)
+        result = result | mask;
+      return result;
+    }
   }
 
 
@@ -408,7 +418,8 @@ namespace aspect
     velocities (fevs.variable("velocity").component_mask),
     pressure (fevs.variable("pressure").component_mask),
     temperature (fevs.variable("temperature").component_mask),
-    compositional_fields (make_composition_component_mask_sequence (fevs, indices))
+    compositional_fields (make_composition_component_mask_sequence (fevs, indices)),
+    compositions(make_composition_component_mask(fevs, compositional_fields))
   {}
 
 


### PR DESCRIPTION
This is one further performance improvement on top of #6020 and something I wanted to implement for a long time. The particle property interface now allows to:
- specify which evaluation flags are required for which solution component
- this information is transported into the solution evaluator class to only evaluate the required components
- and into the function `World::local_update_particles` to only copy the requested components into the `ParticlePropertyInputs` object

If a model uses particle properties that  only need certain solution components (like `IntegratedStrain`) this marks another significant speedup of the particle update cost of up to 40% (in my test model).

One aspect of the code that is not optimal yet is the number of if-conditions necessary inside `SolutionEvaluator<dim>::evaluate`. One would expect that if `FEPointEvaluation::evaluate` is called with the evaluation flags `nothing` that the function returns immediately without expensive work. That is however not what happens at the moment, the function call with `nothing` is only slightly cheaper than a call to evaluate `values`. I will open a separate PR against deal.II to see if we can fix that, but for now the current solution works well for ASPECT.
