### PR TITLE
Update table of content of documentation

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -77,7 +77,7 @@ html_theme_options = {
             "icon": "fab fa-github-square",
         },
     ],
-    "show_navbar_depth": 2,
+    "show_navbar_depth": 1,
     "use_repository_button": True,
     "use_edit_page_button": True,
     "use_issues_button": True,

--- a/doc/sphinx/index.md
+++ b/doc/sphinx/index.md
@@ -27,9 +27,11 @@ ASPECT is published under the GNU GPL v2 or newer license.
 ## Table of Contents
 ```{toctree}
 ---
-maxdepth: 2
+maxdepth: 1
 ---
 user/index.md
 parameters/index.md
+user/developer_documentation.md
+user/authors.md
 references.md
 ```

--- a/doc/sphinx/user/answers.md
+++ b/doc/sphinx/user/answers.md
@@ -1,5 +1,5 @@
 (cha:answers)=
-# Finding answers to more questions
+# Finding answers to questions
 
 If you have questions that go beyond this manual, there are a number of
 resources:

--- a/doc/sphinx/user/developer_documentation.md
+++ b/doc/sphinx/user/developer_documentation.md
@@ -1,0 +1,4 @@
+(cha:developer-documentation)=
+# Developer Documentation
+
+ASPECT's developer documentation is available [here](https://aspect.geodynamics.org/doc/doxygen/index.html).

--- a/doc/sphinx/user/extending/future-plans.md
+++ b/doc/sphinx/user/extending/future-plans.md
@@ -1,6 +1,6 @@
 # Future plans for ASPECT
 
 The ASPECT community is working on various
-future features. If you are curious or want to contribute, please see the
-"future plans" project page on GitHub:
-<https://github.com/geodynamics/aspect/projects/2>.
+future features. If you are curious or want to contribute, please check
+the list of [open issues](https://github.com/geodynamics/aspect/issues) and see the
+[project page](https://github.com/geodynamics/aspect/projects?query=is%3Aopen) on GitHub.

--- a/doc/sphinx/user/extending/index.md
+++ b/doc/sphinx/user/extending/index.md
@@ -1,5 +1,5 @@
 (cha:extending)=
-# Extending and contributing to ASPECT
+# Extending and contributing
 
 After you have familiarized yourself with
 ASPECT using the examples of

--- a/doc/sphinx/user/index.md
+++ b/doc/sphinx/user/index.md
@@ -12,5 +12,4 @@ cookbooks/index.md
 benchmarks/index.md
 extending/index.md
 answers.md
-authors.md
 :::

--- a/doc/sphinx/user/methods/index.md
+++ b/doc/sphinx/user/methods/index.md
@@ -1,5 +1,5 @@
 (cha:methods)=
-# Modeling assumptions and numerical methods
+# Assumptions and methods
 
 :::{toctree}
 ---


### PR DESCRIPTION
This PR contains small modifications to the structure of the online documentation to make it easier to use, and improve its design a bit. I reduced the visual clutter on the start page and shortened some headings, so that they do not break over two lines in the table of contents. Opinions welcome.

To illustrate the old documentation start page:

![Screenshot from 2024-10-09 14-33-58](https://github.com/user-attachments/assets/fcfcb64f-a6a4-41a5-9f1f-66aefff5640c)

And the new start page:

![Screenshot from 2024-10-09 14-34-42](https://github.com/user-attachments/assets/93578a24-5751-4689-8145-6224e1423b47)
