### PR TITLE
Mention VS code extension for input file editing

### DIFF
--- a/doc/modules/changes/20241009_guo
+++ b/doc/modules/changes/20241009_guo
@@ -1,0 +1,8 @@
+New: ASPECT now has a Visual Studio Code extension named
+ASPECT (https://marketplace.visualstudio.com/items?itemName=zhikui.vscode-aspect).
+This extension provides syntax highlighting and auto-completion for input parameter
+files, and can display the documentation of input parameters while writing parameter
+files in VS Code. It is now one of the recommended extensions for VS Code when using
+ASPECT.
+<br>
+(Zhikui Guo, Timo Heister, Rene Gassmoeller, 2024/10/09)

--- a/doc/sphinx/user/run-aspect/parameters-overview/index.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/index.md
@@ -16,9 +16,20 @@ What ASPECT computes is driven by two things:
     that is read at run time and whose name is specified on the command line.
     (See also {ref}`sec:run-aspect:overview`.)
 
-In this section, let us give an overview of what can be selected in the
-parameter file. Specific parameters, their default values, and allowed values
-for these parameters are documented in <https://aspect.geodynamics.org/doc/parameter_view/parameters.xml>.
+In this section, let us give an overview of the structure of these input
+parameter files. Specific parameters, their default values, and allowed values
+for these parameters are documented on our
+[parameter website](https://aspect.geodynamics.org/doc/parameter_view/parameters.xml),
+and the {ref}`parameters` chapter of this documentation.
+
+When writing or modifying parameter
+files we strongly recommend to use [Visual Studio Code](https://code.visualstudio.com/)
+with the [ASPECT extension](https://marketplace.visualstudio.com/items?itemName=zhikui.vscode-aspect).
+This extension enables syntax highlighting,
+auto-completion, and includes the documentation for all ASPECT parameters, thus greatly simplifying
+the process of writing ASPECT parameter files. Take note that by default the extension will make
+use of the input parameters of the latest ASPECT release. If you are using a different ASPECT
+version you can change the settings of the extension.
 
 :::{toctree}
 structure.md


### PR DESCRIPTION
We should advertise the VS code extension now that the old GUI is retired in #5735.

@zguoch are you ok with us crediting you in the changelog entry?