### PR TITLE
Fix plugin cmake for release only

### DIFF
--- a/cmake/AspectConfig.cmake.in
+++ b/cmake/AspectConfig.cmake.in
@@ -54,11 +54,23 @@ macro(ASPECT_SETUP_PLUGIN _target)
 
   if(${ASPECT_BUILD_RELEASE} MATCHES "ON")
     message(STATUS "  setting up RELEASE variant")
-    add_library(${_target}.release SHARED $<TARGET_PROPERTY:${_target},SOURCES>)
-    deal_ii_setup_target(${_target}.release RELEASE)
-    set_target_properties(${_target}.release PROPERTIES SUFFIX ".so")
 
-    list(APPEND _target_libs ${_target}.release)
+    # If we also build a debug build we need to set up a
+    # new target. If we do not also build in debug mode
+    # reuse the target name the user already set. In
+    # both cases make sure the library ends in .release.so
+    if(${ASPECT_BUILD_DEBUG} MATCHES "ON")
+      set(_release_target_name ${_target}.release)
+      add_library(${_release_target_name} SHARED $<TARGET_PROPERTY:${_target},SOURCES>)
+      deal_ii_setup_target(${_release_target_name} RELEASE)
+      set_target_properties(${_release_target_name} PROPERTIES SUFFIX ".so")
+    else()
+      set(_release_target_name ${_target})
+      deal_ii_setup_target(${_release_target_name} RELEASE)
+      set_target_properties(${_release_target_name} PROPERTIES SUFFIX ".release.so")
+    endif()
+
+    list(APPEND _target_libs ${_release_target_name})
   endif()
 
   foreach(_T ${_target_libs})
@@ -83,5 +95,17 @@ macro(ASPECT_SETUP_PLUGIN _target)
   add_custom_command(
     TARGET ${_target} POST_BUILD
     COMMAND ln -sf ${Aspect_DIR}/aspect .)
+
+  if(${ASPECT_BUILD_DEBUG} MATCHES "ON")
+    add_custom_command(
+      TARGET ${_target} POST_BUILD
+      COMMAND ln -sf ${Aspect_DIR}/aspect-debug .)
+  endif()
+
+  if(${ASPECT_BUILD_RELEASE} MATCHES "ON")
+  add_custom_command(
+    TARGET ${_target} POST_BUILD
+    COMMAND ln -sf ${Aspect_DIR}/aspect-release .)
+  endif()
 
 endmacro()


### PR DESCRIPTION
This PR is a fix for #6017. The problem was that if we build ASPECT in release only mode and then set up an external library, the user already sets up a target with the original library name (`${_target}`) in the CMakeLists.txt of the plugin. Then the macro in `AspectConfig.cmake.in` would set up another target with name `${_target}.release`, and only for this additional target would it configure the correct include files. But when running `make` the makefile would then try to compile both targets (with the same sources, but only one of them had correctly configured header files).

I changed the macro to now reuse the target name from the user CMakeLists for the release library. If no debug library is compiled, no new target name is necessary (this means the release target has a different name depending on whether a debug target exists). 

I also modified the creation of the symbolic links at the end, so that all existing ASPECT executables (`aspect-debug` and/or `aspect-release`) and the generic link `aspect` are available in the plugin directory.