### PR TITLE
use correct type for particle counts

### DIFF
--- a/source/postprocess/load_balance_statistics.cc
+++ b/source/postprocess/load_balance_statistics.cc
@@ -45,18 +45,18 @@ namespace aspect
 
       if (this->n_particle_worlds() > 0)
         {
-          unsigned int locally_owned_particles = 0;
+          types::particle_index locally_owned_particles = 0;
           for (unsigned int particle_handler_index = 0; particle_handler_index < this->n_particle_worlds(); ++particle_handler_index)
             locally_owned_particles += this->get_particle_world(particle_handler_index).
                                        get_particle_handler().n_locally_owned_particles();
 
           const dealii::Utilities::MPI::MinMaxAvg particles_per_process =
-            dealii::Utilities::MPI::min_max_avg(locally_owned_particles,this->get_mpi_communicator());
+            dealii::Utilities::MPI::min_max_avg(locally_owned_particles, this->get_mpi_communicator());
 
           statistics.add_value ("Minimal particles per process",
-                                static_cast<unsigned int>(particles_per_process.min));
+                                static_cast<types::particle_index>(particles_per_process.min));
           statistics.add_value ("Maximal particles per process",
-                                static_cast<unsigned int>(particles_per_process.max));
+                                static_cast<types::particle_index>(particles_per_process.max));
           statistics.add_value ("Average particles per process",
                                 particles_per_process.avg);
 

--- a/source/postprocess/particles.cc
+++ b/source/postprocess/particles.cc
@@ -117,7 +117,7 @@ namespace aspect
         patches.resize(particle_handler.n_locally_owned_particles());
         typename dealii::Particles::ParticleHandler<dim>::particle_iterator particle = particle_handler.begin();
 
-        for (unsigned int i=0; particle != particle_handler.end(); ++particle, ++i)
+        for (types::particle_index i=0; particle != particle_handler.end(); ++particle, ++i)
           {
             patches[i].vertices[0] = particle->get_location();
             patches[i].patch_index = i;


### PR DESCRIPTION
We are unlikely to have more than 4B particles per cell, but I don't think it makes sense to use the wrong data type here.