### PR TITLE
Change Weighted BFBT preconditioner pressure scaling factor

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -165,7 +165,6 @@ namespace aspect
                       if (scratch.dof_component_indices[i] == pressure_component_index && scratch.dof_component_indices[j] == pressure_component_index)
                         data.local_matrix(i, j) += (
                                                      1.0/sqrt_eta * pressure_scaling
-                                                     * pressure_scaling
                                                      * (scratch.grad_phi_p[i]
                                                         * scratch.grad_phi_p[j] + 1e-6*scratch.phi_p[i]*scratch.phi_p[j] ))
                                                    * JxW;


### PR DESCRIPTION
The Schur complement is S=BA^{-1}B^T, so if we are trying to approximate S^{-1} the pressure scaling factor should be 1/(pressure_scaling^2). The current implementation in Aspect has a factor of 1/(pressure_scaling^4). This pull request changes it to 1/(pressure_scaling^2).



