### PR TITLE
Remove deprecated functions

### DIFF
--- a/include/aspect/boundary_velocity/ascii_data.h
+++ b/include/aspect/boundary_velocity/ascii_data.h
@@ -76,10 +76,6 @@ namespace aspect
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const override;
 
-        // avoid -Woverloaded-virtual warning until the deprecated function
-        // is removed from the interface:
-        using Interface<dim>::boundary_velocity;
-
         /**
          * Declare the parameters this class takes through input files.
          */

--- a/include/aspect/boundary_velocity/function.h
+++ b/include/aspect/boundary_velocity/function.h
@@ -58,10 +58,6 @@ namespace aspect
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const override;
 
-        // avoid -Woverloaded-virtual warning until the deprecated function
-        // is removed from the interface:
-        using Interface<dim>::boundary_velocity;
-
         /**
          * A function that is called at the beginning of each time step to
          * indicate what the model time is for which the boundary values will

--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -182,10 +182,6 @@ namespace aspect
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const override;
 
-        // avoid -Woverloaded-virtual warning until the deprecated function
-        // is removed from the interface:
-        using Interface<dim>::boundary_velocity;
-
         /**
          * Initialization function. This function is called once at the
          * beginning of the program. Checks preconditions.

--- a/include/aspect/boundary_velocity/zero_velocity.h
+++ b/include/aspect/boundary_velocity/zero_velocity.h
@@ -47,10 +47,6 @@ namespace aspect
         Tensor<1,dim>
         boundary_velocity (const types::boundary_id boundary_indicator,
                            const Point<dim> &position) const override;
-
-        // avoid -Woverloaded-virtual warning until the deprecated function
-        // is removed from the interface:
-        using Interface<dim>::boundary_velocity;
     };
   }
 }

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -111,15 +111,6 @@ namespace aspect
   {
     public:
       /**
-       * @deprecated: This function is deprecated and only maintained for backward compatibility.
-       * Use the function compute_lateral_averages() with the same arguments instead.
-       */
-      DEAL_II_DEPRECATED
-      std::vector<std::vector<double>>
-      get_averages(const unsigned int n_slices,
-                   const std::vector<std::string> &property_names) const;
-
-      /**
        * Return a depth profile of lateral averages of the selected
        * @p property_names. This function is a convenience interface for
        * the other functions of the same name and is more efficient for

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -382,15 +382,6 @@ namespace aspect
                                     const ComponentMask &field_mask = ComponentMask());
 
       /**
-       * See compute_composition_fractions() for the documentation of this function.
-       * @deprecated: This function is deprecated. Please use compute_composition_fractions() instead.
-       */
-      DEAL_II_DEPRECATED
-      std::vector<double>
-      compute_volume_fractions(const std::vector<double> &compositional_fields,
-                               const ComponentMask &field_mask = ComponentMask());
-
-      /**
        * Given a vector of component masses,
        * and another of the corresponding densities, calculate the volumes
        * of each component. If return_as_fraction is true, the returned vector

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -210,20 +210,6 @@ namespace aspect
         double get_min_strain_rate() const;
 
         /**
-         * A function that returns whether the material is plastically yielding at
-         * the given pressure, temperature, composition, and strain rate.
-         *
-         * @deprecated: Use the other function with this name instead, which allows
-         * to pass in more general input variables.
-         */
-        DEAL_II_DEPRECATED
-        bool
-        is_yielding (const double pressure,
-                     const double temperature,
-                     const std::vector<double> &composition,
-                     const SymmetricTensor<2,dim> &strain_rate) const;
-
-        /**
          * A function that returns whether the material is plastically
          * yielding at the given input variables (pressure, temperature,
          * composition, strain rate, and so on).

--- a/include/aspect/particle/generator/ascii_file.h
+++ b/include/aspect/particle/generator/ascii_file.h
@@ -49,12 +49,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -77,25 +77,6 @@ namespace aspect
            * has to decide on the method and number of particles to generate,
            * for example using input parameters declared in their
            * declare_parameters and parse_parameters functions. This function
-           * should generate the particles and associate them to their according
-           * cells by inserting them into a multimap between cell and particle.
-           * This map becomes very large if the particle count per process
-           * is large, so we hand it over by reference instead of returning
-           * the multimap.
-           *
-           * @param [in,out] particles A multimap between cells and their
-           * particles. This map will be filled in this function.
-           */
-          DEAL_II_DEPRECATED
-          virtual
-          void
-          generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles);
-
-          /**
-           * Generate particles. Every derived class
-           * has to decide on the method and number of particles to generate,
-           * for example using input parameters declared in their
-           * declare_parameters and parse_parameters functions. This function
            * should generate the particles and insert them into @p particle_handler
            * by calling its respective functions.
            *
@@ -104,7 +85,7 @@ namespace aspect
            */
           virtual
           void
-          generate_particles(Particles::ParticleHandler<dim> &particle_handler);
+          generate_particles(Particles::ParticleHandler<dim> &particle_handler) = 0;
 
           /**
            * Generate one particle in the given cell. This function's main purpose

--- a/include/aspect/particle/generator/probability_density_function.h
+++ b/include/aspect/particle/generator/probability_density_function.h
@@ -73,12 +73,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/generator/quadrature_points.h
+++ b/include/aspect/particle/generator/quadrature_points.h
@@ -49,12 +49,6 @@ namespace aspect
            */
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
-
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
       };
     }
   }

--- a/include/aspect/particle/generator/random_uniform.h
+++ b/include/aspect/particle/generator/random_uniform.h
@@ -49,12 +49,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/generator/reference_cell.h
+++ b/include/aspect/particle/generator/reference_cell.h
@@ -53,12 +53,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/generator/uniform_box.h
+++ b/include/aspect/particle/generator/uniform_box.h
@@ -53,12 +53,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/generator/uniform_radial.h
+++ b/include/aspect/particle/generator/uniform_radial.h
@@ -61,12 +61,6 @@ namespace aspect
           void
           generate_particles(Particles::ParticleHandler<dim> &particle_handler) override;
 
-          // avoid -Woverloaded-virtual
-          // TODO: remove this using directive once the following deprecated
-          // function in the interface class has been removed:
-          // generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &particles)
-          using Generator::Interface<dim>::generate_particles;
-
           /**
            * Declare the parameters this class takes through input files.
            */

--- a/include/aspect/particle/property/interface.h
+++ b/include/aspect/particle/property/interface.h
@@ -760,17 +760,6 @@ namespace aspect
           get_data_info() const;
 
           /**
-           * Get the position of the property specified by name in the property
-           * vector of the particles.
-           *
-           * @deprecated This function will be replaced by
-           * ParticlePropertyInformation::get_position_by_field_name(name)
-           */
-          DEAL_II_DEPRECATED
-          unsigned int
-          get_property_component_by_name(const std::string &name) const;
-
-          /**
            * A function that is used to register particle property
            * objects in such a way that the Manager can deal with all of them
            * without having to know them by name. This allows the files in which

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -869,14 +869,6 @@ namespace aspect
       double solve_advection (const AdvectionField &advection_field);
 
       /**
-       * Interpolate a particular particle property to the solution field.
-       *
-       * @deprecated: Use interpolate_particle_property_vector() instead.
-       */
-      DEAL_II_DEPRECATED
-      void interpolate_particle_properties (const AdvectionField &advection_field);
-
-      /**
        * Interpolate the corresponding particle properties into the given
        * @p advection_fields solution fields.
        */

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -767,11 +767,6 @@ namespace aspect
          */
         std::unique_ptr<aspect::Utilities::StructuredDataLookup<1>> lookup;
     };
-
-
-
-    template <int dim>
-    using AsciiDataLookup DEAL_II_DEPRECATED = StructuredDataLookup<dim>;
   }
 }
 

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -288,6 +288,7 @@ namespace aspect
      *   Utilities::MapParsing::parse_map_to_double_array() function. Please
      *   use the other function instead.
      */
+    DEAL_II_DEPRECATED
     std::vector<double>
     parse_map_to_double_array (const std::string &key_value_map,
                                const std::vector<std::string> &list_of_keys,

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -952,15 +952,6 @@ namespace aspect
 
 
       std::vector<double>
-      compute_volume_fractions(const std::vector<double> &compositional_fields,
-                               const ComponentMask &field_mask)
-      {
-        return compute_composition_fractions(compositional_fields, field_mask);
-      }
-
-
-
-      std::vector<double>
       compute_volumes_from_masses(const std::vector<double> &masses,
                                   const std::vector<double> &densities,
                                   const bool return_as_fraction)

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -30,46 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-
-    template <int dim>
-    bool
-    ViscoPlastic<dim>::
-    is_yielding (const double pressure,
-                 const double temperature,
-                 const std::vector<double> &composition,
-                 const SymmetricTensor<2,dim> &strain_rate) const
-    {
-      /* The following returns whether or not the material is plastically yielding
-       * as documented in evaluate.
-       */
-      bool plastic_yielding = false;
-
-      MaterialModel::MaterialModelInputs <dim> in (/*n_evaluation_points=*/1,
-                                                                           this->n_compositional_fields());
-      unsigned int i = 0;
-
-      in.pressure[i] = pressure;
-      in.temperature[i] = temperature;
-      in.composition[i] = composition;
-      in.strain_rate[i] = strain_rate;
-
-      const std::vector<double> volume_fractions = MaterialUtilities::compute_only_composition_fractions(composition,
-                                                   this->introspection().chemical_composition_field_indices());
-
-      const IsostrainViscosities isostrain_viscosities
-        = rheology->calculate_isostrain_viscosities(in, i, volume_fractions);
-
-      std::vector<double>::const_iterator max_composition
-        = std::max_element(volume_fractions.begin(),volume_fractions.end());
-
-      plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(),
-                                                                                  max_composition)];
-
-      return plastic_yielding;
-    }
-
-
-
     template <int dim>
     bool
     ViscoPlastic<dim>::

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -42,43 +42,6 @@ namespace aspect
 
 
       template <int dim>
-      void
-      Interface<dim>::generate_particles(std::multimap<Particles::internal::LevelInd, Particle<dim>> &/*particles*/)
-      {
-        AssertThrow(false,ExcInternalError());
-      }
-
-
-
-      template <int dim>
-      void
-      Interface<dim>::generate_particles(Particles::ParticleHandler<dim> &particle_handler)
-      {
-        // This function is implemented to ensure backwards compatibility to an old interface.
-        // Once the old interface function has been removed this implementation can be removed
-        // as well and the function can be made pure.
-
-        std::multimap<Particles::internal::LevelInd, Particles::Particle<dim>> particles;
-
-        // avoid deprecation warnings about calling the old interface
-        DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-        generate_particles(particles);
-        DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
-        std::multimap<typename Triangulation<dim>::active_cell_iterator, Particles::Particle<dim>> new_particles;
-
-        for (const auto &particle : particles)
-          new_particles.insert(new_particles.end(),
-                               std::make_pair(typename Triangulation<dim>::active_cell_iterator(&this->get_triangulation(),
-                                              particle.first.first, particle.first.second),
-                                              particle.second));
-
-        particle_handler.insert_particles(new_particles);
-      }
-
-
-
-      template <int dim>
       std::pair<Particles::internal::LevelInd,Particle<dim>>
       Interface<dim>::generate_particle(const Point<dim> &position,
                                         const types::particle_index id) const

--- a/source/particle/property/interface.cc
+++ b/source/particle/property/interface.cc
@@ -726,15 +726,6 @@ namespace aspect
 
 
 
-      template <int dim>
-      unsigned int
-      Manager<dim>::get_property_component_by_name(const std::string &name) const
-      {
-        return property_information.get_position_by_field_name(name);
-      }
-
-
-
       namespace
       {
         std::tuple

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -251,15 +251,6 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::interpolate_particle_properties (const AdvectionField &advection_field)
-  {
-    std::vector<AdvectionField> advection_fields(1,advection_field);
-    interpolate_particle_properties(advection_fields);
-  }
-
-
-
-  template <int dim>
   void Simulator<dim>::interpolate_particle_properties (const std::vector<AdvectionField> &advection_fields)
   {
     TimerOutput::Scope timer (computing_timer, "Particles: Interpolate");
@@ -568,8 +559,7 @@ namespace aspect
 #define INSTANTIATE(dim) \
   template void Simulator<dim>::set_initial_temperature_and_compositional_fields(); \
   template void Simulator<dim>::compute_initial_pressure_field(); \
-  template void Simulator<dim>::interpolate_particle_properties(const AdvectionField &);
-
+  template void Simulator<dim>::interpolate_particle_properties(const std::vector<AdvectionField> &advection_fields);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -811,16 +811,6 @@ namespace aspect
 
   template <int dim>
   std::vector<std::vector<double>>
-  LateralAveraging<dim>::get_averages(const unsigned int n_slices,
-                                      const std::vector<std::string> &property_names) const
-  {
-    return compute_lateral_averages(n_slices, property_names);
-  }
-
-
-
-  template <int dim>
-  std::vector<std::vector<double>>
   LateralAveraging<dim>::compute_lateral_averages(const unsigned int n_slices,
                                                   const std::vector<std::string> &property_names) const
   {

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -210,8 +210,7 @@ namespace aspect
                                                "single Advection, iterated defect correction Stokes|"
                                                "iterated Advection and defect correction Stokes|"
                                                "iterated Advection and Newton Stokes|single Advection, iterated Newton Stokes|"
-                                               "single Advection, no Stokes|IMPES|iterated IMPES|"
-                                               "iterated Stokes|Newton Stokes|Stokes only|Advection only|"
+                                               "single Advection, no Stokes|"
                                                "first timestep only, single Stokes|no Advection, no Stokes";
 
     prm.declare_entry ("Nonlinear solver scheme", "single Advection, single Stokes",
@@ -254,20 +253,7 @@ namespace aspect
                        "iterations for the Stokes system. "
                        "The `first timestep only, single Stokes' scheme solves the Stokes equations exactly "
                        "once, at the first time step. No nonlinear iterations are done, and the temperature and "
-                       "composition systems are not solved. "
-                       "\n\n"
-                       "The `IMPES' scheme is deprecated and only allowed for reasons of backwards "
-                       "compatibility. It is the same as `single Advection, single Stokes' ."
-                       "The `iterated IMPES' scheme is deprecated and only allowed for reasons of "
-                       "backwards compatibility. It is the same as `iterated Advection and Stokes'. "
-                       "The `iterated Stokes' scheme is deprecated and only allowed for reasons of "
-                       "backwards compatibility. It is the same as `single Advection, iterated Stokes'. "
-                       "The `Stokes only' scheme is deprecated and only allowed for reasons of "
-                       "backwards compatibility. It is the same as `no Advection, iterated Stokes'. "
-                       "The `Advection only' scheme is deprecated and only allowed for reasons of "
-                       "backwards compatibility. It is the same as `single Advection, no Stokes'. "
-                       "The `Newton Stokes' scheme is deprecated and only allowed for reasons of "
-                       "backwards compatibility. It is the same as `iterated Advection and Newton Stokes'.");
+                       "composition systems are not solved.");
 
     prm.declare_entry ("Nonlinear solver failure strategy", "continue with next timestep",
                        Patterns::Selection("continue with next timestep|cut timestep size|abort program"),
@@ -1462,13 +1448,13 @@ namespace aspect
 
     {
       const std::string solver_scheme = prm.get ("Nonlinear solver scheme");
-      if (solver_scheme == "single Advection, single Stokes" || solver_scheme == "IMPES")
+      if (solver_scheme == "single Advection, single Stokes")
         nonlinear_solver = NonlinearSolver::single_Advection_single_Stokes;
-      else if (solver_scheme == "iterated Advection and Stokes" || solver_scheme == "iterated IMPES")
+      else if (solver_scheme == "iterated Advection and Stokes")
         nonlinear_solver = NonlinearSolver::iterated_Advection_and_Stokes;
-      else if (solver_scheme == "single Advection, iterated Stokes" || solver_scheme == "iterated Stokes")
+      else if (solver_scheme == "single Advection, iterated Stokes")
         nonlinear_solver = NonlinearSolver::single_Advection_iterated_Stokes;
-      else if (solver_scheme == "no Advection, iterated Stokes" || solver_scheme == "Stokes only")
+      else if (solver_scheme == "no Advection, iterated Stokes")
         nonlinear_solver = NonlinearSolver::no_Advection_iterated_Stokes;
       else if (solver_scheme == "no Advection, single Stokes")
         nonlinear_solver = NonlinearSolver::no_Advection_single_Stokes;
@@ -1478,11 +1464,11 @@ namespace aspect
         nonlinear_solver = NonlinearSolver::single_Advection_iterated_defect_correction_Stokes;
       else if (solver_scheme == "iterated Advection and defect correction Stokes")
         nonlinear_solver = NonlinearSolver::iterated_Advection_and_defect_correction_Stokes;
-      else if (solver_scheme == "iterated Advection and Newton Stokes" || solver_scheme == "Newton Stokes")
+      else if (solver_scheme == "iterated Advection and Newton Stokes")
         nonlinear_solver = NonlinearSolver::iterated_Advection_and_Newton_Stokes;
       else if (solver_scheme == "single Advection, iterated Newton Stokes")
         nonlinear_solver = NonlinearSolver::single_Advection_iterated_Newton_Stokes;
-      else if (solver_scheme == "single Advection, no Stokes" || solver_scheme == "Advection only")
+      else if (solver_scheme == "single Advection, no Stokes")
         nonlinear_solver = NonlinearSolver::single_Advection_no_Stokes;
       else if (solver_scheme == "first timestep only, single Stokes")
         nonlinear_solver = NonlinearSolver::first_timestep_only_single_Stokes;


### PR DESCRIPTION
Not quite finished, do not review yet, but I need to stop for today and want to see the test results.

I thought 3.0 is a good opportunity to remove deprecated functions and parameters. I made sure to only remove items that were deprecated at least 2 releases (2-3 years) ago or before. There are still some items I cannot remove yet, because we didnt finish the deprecation properly (e.g. forgot to mark the function as deprecated, or left a lot of input files that still use the deprecated options).