### PR TITLE
Remove deprecated visualization options

### DIFF
--- a/benchmarks/annulus/instantaneous/annulus.prm
+++ b/benchmarks/annulus/instantaneous/annulus.prm
@@ -76,8 +76,12 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, dynamic topography, AnnulusVisualizationPostprocessor
+    set List of output variables = material properties, strain rate, dynamic topography, AnnulusVisualizationPostprocessor
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/benchmarks/annulus/transient/transient_annulus.prm
+++ b/benchmarks/annulus/transient/transient_annulus.prm
@@ -53,8 +53,12 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = density, gravity, AnnulusVisualizationPostprocessor
+    set List of output variables = material properties, gravity, AnnulusVisualizationPostprocessor
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Particles

--- a/benchmarks/blankenbach/base_case1a.prm
+++ b/benchmarks/blankenbach/base_case1a.prm
@@ -97,7 +97,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 0.05
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end
 

--- a/benchmarks/blankenbach/base_case2a.prm
+++ b/benchmarks/blankenbach/base_case2a.prm
@@ -97,7 +97,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 0.05
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end
 

--- a/benchmarks/blankenbach/base_case2b.prm
+++ b/benchmarks/blankenbach/base_case2b.prm
@@ -99,7 +99,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 0.002
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end
 

--- a/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
+++ b/benchmarks/buiter_et_al_2008_jgr/figure_6_1e20.prm
@@ -172,8 +172,12 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, basic statistics, temperature statistics, visualization
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, error indicator, partition
+    set List of output variables = material properties, strain rate, error indicator, partition
     set Time between graphical output = 1e5
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/buiter_et_al_2016_jsg/exp_1.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_1.prm
@@ -167,10 +167,14 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, basic statistics, visualization
 
   subsection Visualization
-    set List of output variables      = density, viscosity, strain rate, named additional outputs
+    set List of output variables      = material properties, strain rate, named additional outputs
     set Output format                 = vtu
     set Time between graphical output = 144
     set Interpolate output            = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
+++ b/benchmarks/buiter_et_al_2016_jsg/exp_2_high_resolution.prm
@@ -215,10 +215,14 @@ subsection Postprocess
   set List of postprocessors                         = velocity statistics, basic statistics, temperature statistics, visualization
 
   subsection Visualization
-    set List of output variables                     = density, viscosity, strain rate, error indicator
+    set List of output variables                     = material properties, strain rate, error indicator
     set Output format                                = vtu
     set Time between graphical output                = 144   # Equivalent to ~0.5 cm of shortening
     set Interpolate output                           = true
     set Number of grouped files                      = 1
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/burstedde/burstedde.prm
+++ b/benchmarks/burstedde/burstedde.prm
@@ -99,6 +99,10 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, BursteddePostprocessor
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.prm
+++ b/benchmarks/crameri_et_al/case_1/crameri_benchmark_1.prm
@@ -125,10 +125,14 @@ subsection Postprocess
   set List of postprocessors = visualization,topography
 
   subsection Visualization
-    set List of output variables = viscosity
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1.e4
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/benchmarks/crameri_et_al/case_2/crameri_benchmark_2.prm
+++ b/benchmarks/crameri_et_al/case_2/crameri_benchmark_2.prm
@@ -120,10 +120,14 @@ subsection Postprocess
   set List of postprocessors = visualization,topography
 
   subsection Visualization
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/benchmarks/doneahuerta/doneahuerta.prm
+++ b/benchmarks/doneahuerta/doneahuerta.prm
@@ -76,7 +76,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, DoneaHuertaPostprocessor
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, gravity
+    set List of output variables = material properties, strain rate, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/benchmarks/geoid-spectral-comparison/spectral-comparison.prm
+++ b/benchmarks/geoid-spectral-comparison/spectral-comparison.prm
@@ -113,9 +113,13 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = geoid, dynamic topography,  density, viscosity, gravity
+    set List of output variables      = geoid, dynamic topography, material properties, gravity
     set Time between graphical output = 0
     set Number of grouped files       = 1
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Geoid

--- a/benchmarks/grain_size_pinned_state/grain_size_plunge.prm
+++ b/benchmarks/grain_size_pinned_state/grain_size_plunge.prm
@@ -152,8 +152,12 @@ subsection Postprocess
   set List of postprocessors = composition statistics, temperature statistics, velocity statistics, visualization, material statistics, ODE statistics
 
   subsection Visualization
-    set List of output variables = viscosity, shear stress, stress, stress second invariant
+    set List of output variables = material properties, shear stress, stress, stress second invariant
     set Time between graphical output = 5e3
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/benchmarks/gravity_mantle/mantle_gravity.prm
+++ b/benchmarks/gravity_mantle/mantle_gravity.prm
@@ -57,9 +57,13 @@ subsection Postprocess
   set List of postprocessors = gravity calculation,visualization, material statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
     set Time between graphical output = 0
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Gravity calculation

--- a/benchmarks/gravity_thick_shell/thick_shell.prm
+++ b/benchmarks/gravity_thick_shell/thick_shell.prm
@@ -57,9 +57,13 @@ subsection Postprocess
   set List of postprocessors = gravity calculation,visualization
 
   subsection Visualization
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Gravity calculation

--- a/benchmarks/gravity_thin_shell/gravity_thin_shell.prm
+++ b/benchmarks/gravity_thin_shell/gravity_thin_shell.prm
@@ -69,9 +69,13 @@ subsection Postprocess
   set List of postprocessors = gravity calculation,visualization
 
   subsection Visualization
-    set List of output variables = density, viscosity, partition
+    set List of output variables = material properties, partition
     set Time between graphical output = 0
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Gravity calculation

--- a/benchmarks/hollow_sphere/hollow_sphere.prm
+++ b/benchmarks/hollow_sphere/hollow_sphere.prm
@@ -91,7 +91,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, HollowSpherePostprocessor, memory statistics, dynamic topography
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, dynamic topography, gravity
+    set List of output variables = material properties, strain rate, dynamic topography, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/benchmarks/inclusion/adaptive.prm.base
+++ b/benchmarks/inclusion/adaptive.prm.base
@@ -66,7 +66,11 @@ subsection Postprocess
   set List of postprocessors = InclusionPostprocessor, visualization
 
   subsection Visualization
-    set List of output variables = viscosity
+    set List of output variables = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.prm
@@ -86,6 +86,10 @@ subsection Postprocess
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
+++ b/benchmarks/inclusion/compositional_fields/inclusion_particles.prm
@@ -88,7 +88,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Particles

--- a/benchmarks/king2dcompressible/ala.prm
+++ b/benchmarks/king2dcompressible/ala.prm
@@ -171,7 +171,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 1e-2
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end
 

--- a/benchmarks/layeredflow/layeredflow.prm
+++ b/benchmarks/layeredflow/layeredflow.prm
@@ -82,7 +82,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, LayeredFlowPostprocessor
 
   subsection Visualization
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/benchmarks/nsinker/nsinker_gmg.prm
+++ b/benchmarks/nsinker/nsinker_gmg.prm
@@ -87,6 +87,10 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/benchmarks/nsinker_spherical_shell/gmg.prm
+++ b/benchmarks/nsinker_spherical_shell/gmg.prm
@@ -81,6 +81,10 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/benchmarks/polydiapirs/polydiapirs.prm
+++ b/benchmarks/polydiapirs/polydiapirs.prm
@@ -89,8 +89,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, composition statistics, material statistics, global statistics, Stokes residual
 
   subsection Visualization
-    set List of output variables = viscosity,density, strain rate
+    set List of output variables = material properties, strain rate
     set Output format                 = vtu
     set Time between graphical output = 5
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end

--- a/benchmarks/rayleigh_taylor_instability/blank.prm
+++ b/benchmarks/rayleigh_taylor_instability/blank.prm
@@ -47,6 +47,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.prm
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.prm
@@ -70,6 +70,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
+++ b/benchmarks/rayleigh_taylor_instability_free_surface/kaus_rayleigh_taylor_instability.prm
@@ -147,8 +147,12 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 1.0e5
-    set List of output variables      = viscosity, density
+    set List of output variables      = material properties
     set Output mesh velocity          = true
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 
   subsection Topography

--- a/benchmarks/shear_bands/magmatic_shear_bands.prm
+++ b/benchmarks/shear_bands/magmatic_shear_bands.prm
@@ -125,13 +125,17 @@ subsection Postprocess
   set List of postprocessors = visualization,composition statistics,velocity statistics, shear bands growth rate
 
   subsection Visualization
-    set List of output variables      = density, viscosity, thermal expansivity, strain rate, melt material properties
+    set List of output variables      = material properties, strain rate, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/benchmarks/shear_bands/shear_bands.prm
+++ b/benchmarks/shear_bands/shear_bands.prm
@@ -114,7 +114,7 @@ subsection Postprocess
   set List of postprocessors = visualization,composition statistics,velocity statistics,shear bands statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity, thermal expansivity, strain rate, melt material properties, artificial viscosity composition
+    set List of output variables      = material properties, strain rate, melt material properties, artificial viscosity composition
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
@@ -125,6 +125,10 @@ subsection Postprocess
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/benchmarks/sinking_block/blank.prm
+++ b/benchmarks/sinking_block/blank.prm
@@ -53,6 +53,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/sinking_block/sinking_block.prm
+++ b/benchmarks/sinking_block/sinking_block.prm
@@ -66,6 +66,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/slab_detachment/slab_detachment.prm
+++ b/benchmarks/slab_detachment/slab_detachment.prm
@@ -122,7 +122,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 1e6
-    set List of output variables      = strain rate, viscosity, density
+    set List of output variables      = strain rate, material properties
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 
   subsection Particles

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.prm
@@ -90,6 +90,10 @@ subsection Postprocess
     set Output format = vtu
     set Number of grouped files = 1
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -96,7 +96,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Particles

--- a/benchmarks/solitary_wave/solitary_wave.prm
+++ b/benchmarks/solitary_wave/solitary_wave.prm
@@ -135,7 +135,7 @@ subsection Postprocess
   set List of postprocessors = visualization,composition statistics,velocity statistics,solitary wave statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -155,6 +155,10 @@ subsection Postprocess
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.prm
@@ -88,6 +88,10 @@ subsection Postprocess
     set Output format = vtu
     set Number of grouped files = 1
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/benchmarks/solkz/compositional_fields/solkz_particles.prm
+++ b/benchmarks/solkz/compositional_fields/solkz_particles.prm
@@ -85,7 +85,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Particles

--- a/benchmarks/solubility/solubility.prm
+++ b/benchmarks/solubility/solubility.prm
@@ -150,13 +150,17 @@ subsection Postprocess
   set List of postprocessors = visualization, composition statistics, velocity statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties, melt fraction
+    set List of output variables      = material properties, melt material properties, melt fraction
     set Output format                 = vtu
     set Time between graphical output = 0
     set Interpolate output            = false
 
     subsection Melt material properties
       set List of properties          = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/benchmarks/tangurnis/tala/tan.prm
+++ b/benchmarks/tangurnis/tala/tan.prm
@@ -132,9 +132,13 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables      = density, adiabat
+    set List of output variables      = material properties, adiabat
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/benchmarks/tangurnis/tala_c/tan.prm
+++ b/benchmarks/tangurnis/tala_c/tan.prm
@@ -131,9 +131,13 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables      = density, adiabat
+    set List of output variables      = material properties, adiabat
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
+++ b/benchmarks/time_dependent_annulus/time_dependent_annulus.prm
@@ -141,7 +141,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Number of grouped files       = 1
     set Time between graphical output = 0.0009817477042468104
-    set List of output variables      = density, gravity
+    set List of output variables      = material properties, gravity
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Particles

--- a/benchmarks/tosi_et_al_2015_gcubed/Tosi_base.prm
+++ b/benchmarks/tosi_et_al_2015_gcubed/Tosi_base.prm
@@ -169,7 +169,11 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = viscosity, strain rate, density, specific heat, thermal expansivity, gravity, heating
+    set List of output variables = material properties, strain rate, gravity, heating
     set Time between graphical output = 0.05
+
+    subsection Material properties
+      set List of material properties = viscosity, density, specific heat, thermal expansivity
+    end
   end
 end

--- a/benchmarks/viscosity_grooves/viscosity_grooves.prm
+++ b/benchmarks/viscosity_grooves/viscosity_grooves.prm
@@ -68,7 +68,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format = vtu
-    set List of output variables = density, viscosity, strain rate, gravity
+    set List of output variables = material properties, strain rate, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/contrib/opendap/prm_files/aspect_test.prm
+++ b/contrib/opendap/prm_files/aspect_test.prm
@@ -68,9 +68,13 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, basic statistics
 
   subsection Visualization
-    set List of output variables      = viscosity, density, strain rate
+    set List of output variables      = material properties, strain rate
     set Time between graphical output = 1.0
     set Output format = vtu
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/contrib/opendap/prm_files/aspect_url_test.prm
+++ b/contrib/opendap/prm_files/aspect_url_test.prm
@@ -64,9 +64,13 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, basic statistics
 
   subsection Visualization
-    set List of output variables      = viscosity, density, strain rate
+    set List of output variables      = material properties, strain rate
     set Time between graphical output = 1.0
     set Output format = vtu
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
+++ b/cookbooks/anisotropic_viscosity/AV_Rayleigh_Taylor.prm
@@ -88,13 +88,17 @@ subsection Postprocess
 
   subsection Visualization
     # add "named additional outputs" to the list to save the stress-strain director (AV tensor)
-    set List of output variables = compositional vector, density, viscosity, gravity, shear stress, stress, strain rate, strain rate tensor, named additional outputs
+    set List of output variables = compositional vector, material properties, gravity, shear stress, stress, strain rate, strain rate tensor, named additional outputs
     set Output format                 = vtu
     set Time between graphical output = 0.5
 
     subsection Compositional fields as vectors
       set Names of fields = ni,nj
       set Names of vectors = n
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity
     end
   end
 end

--- a/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
+++ b/cookbooks/bunge_et_al_mantle_convection/bunge_et_al.prm
@@ -91,10 +91,14 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, temperature statistics, heat flux statistics, depth average
 
   subsection Visualization
-    set List of output variables = viscosity, strain rate, density, specific heat, thermal expansivity, gravity, heating
+    set List of output variables = material properties, strain rate, gravity, heating
     set Output format                 = vtu
     set Time between graphical output = 1e6
     set Number of grouped files       = 0
+
+    subsection Material properties
+      set List of material properties = viscosity, density, specific heat, thermal expansivity
+    end
   end
 
   subsection Depth average

--- a/cookbooks/composition-reaction/composition-reaction.prm
+++ b/cookbooks/composition-reaction/composition-reaction.prm
@@ -108,6 +108,10 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 0.1
-    set List of output variables = density
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/composition_active/composition_active.prm
+++ b/cookbooks/composition_active/composition_active.prm
@@ -81,8 +81,12 @@ subsection Postprocess
   set List of postprocessors = visualization, temperature statistics, composition statistics
 
   subsection Visualization
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/cookbooks/composition_active/doc/postprocess.part.prm
+++ b/cookbooks/composition_active/doc/postprocess.part.prm
@@ -2,7 +2,11 @@ subsection Postprocess
   set List of postprocessors = visualization, temperature statistics, composition statistics
 
   subsection Visualization
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/composition_active_particles/composition_active_particles.prm
+++ b/cookbooks/composition_active_particles/composition_active_particles.prm
@@ -82,8 +82,12 @@ subsection Postprocess
   set List of postprocessors = visualization, temperature statistics, composition statistics,particles
 
   subsection Visualization
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Particles

--- a/cookbooks/continental_extension/continental_extension.prm
+++ b/cookbooks/continental_extension/continental_extension.prm
@@ -307,9 +307,13 @@ subsection Postprocess
   set List of postprocessors = basic statistics, composition statistics, heat flux densities, heat flux statistics, mass flux statistics, matrix statistics, pressure statistics, temperature statistics, topography, velocity statistics, visualization
 
   subsection Visualization
-    set List of output variables = density, heat flux map, named additional outputs, strain rate, viscosity
+    set List of output variables = material properties, heat flux map, named additional outputs, strain rate
     set Output format                 = vtu
     set Time between graphical output = 100.e3
     set Interpolate output            = true
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/crustal_deformation/crustal_model_2D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_2D.prm
@@ -118,8 +118,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, basic statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, error indicator, heating, partition
+    set List of output variables = material properties, strain rate, error indicator, heating, partition
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/cookbooks/crustal_deformation/crustal_model_3D.prm
+++ b/cookbooks/crustal_deformation/crustal_model_3D.prm
@@ -116,8 +116,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography, pressure statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, error indicator, partition
+    set List of output variables = material properties, strain rate, error indicator, partition
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/cookbooks/future/radiogenic_heating.prm
+++ b/cookbooks/future/radiogenic_heating.prm
@@ -99,6 +99,10 @@ subsection Postprocess
     # if the solution already reached steady state, this parameter can be set
     # to a smaller value.
     set Time between graphical output = 1e4
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/future/radiogenic_heating_function.prm
+++ b/cookbooks/future/radiogenic_heating_function.prm
@@ -103,6 +103,10 @@ subsection Postprocess
     # if the solution already reached steady state, this parameter can be set
     # to a smaller value.
     set Time between graphical output = 1e4
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/heat_flow/heat-flow-terms.prm
+++ b/cookbooks/heat_flow/heat-flow-terms.prm
@@ -35,6 +35,10 @@ end
 
 subsection Postprocess
   subsection Visualization
-    set List of output variables = density, heat flux map, vertical heat flux, heating, viscosity
+    set List of output variables = material properties, heat flux map, vertical heat flux, heating
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/inclusions/ellipse_pure_shear_nonlinear.prm
+++ b/cookbooks/inclusions/ellipse_pure_shear_nonlinear.prm
@@ -79,7 +79,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/cookbooks/inclusions/ellipse_ref.prm
+++ b/cookbooks/inclusions/ellipse_ref.prm
@@ -89,6 +89,10 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/inclusions/rectangle_ref.prm
+++ b/cookbooks/inclusions/rectangle_ref.prm
@@ -89,6 +89,10 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/initial-condition-S20RTS/S20RTS.prm
+++ b/cookbooks/initial-condition-S20RTS/S20RTS.prm
@@ -130,7 +130,7 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = geoid, dynamic topography, heat flux map, density,viscosity, gravity
+    set List of output variables      = geoid, dynamic topography, heat flux map, material properties, gravity
     set Time between graphical output = 0
     set Number of grouped files       = 1
 
@@ -139,6 +139,10 @@ subsection Postprocess
     # flux map' postprocessor.
     subsection Heat flux map
       set Output point wise heat flux = true
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity
     end
   end
 

--- a/cookbooks/inner_core_convection/inner_core_traction.prm
+++ b/cookbooks/inner_core_convection/inner_core_traction.prm
@@ -125,7 +125,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Time between graphical output = 0
     set Number of grouped files       = 0
-    set List of output variables      = strain rate, gravity, density, specific heat, heating
+    set List of output variables      = strain rate, gravity, material properties, heating
+
+    subsection Material properties
+      set List of material properties = density, specific heat
+    end
   end
 end
 

--- a/cookbooks/kinematically_driven_subduction_2d/doc/Case1_postprocessing.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/Case1_postprocessing.prm
@@ -2,8 +2,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, heating statistics, maximum depth of field, composition velocity statistics, viscous dissipation statistics, trench location
 
   subsection Visualization
-    set List of output variables      = density, viscosity, strain rate, error indicator
+    set List of output variables      = material properties, strain rate, error indicator
     set Time between graphical output = 5e5
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Trench location

--- a/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
+++ b/cookbooks/kinematically_driven_subduction_2d/kinematically_driven_subduction_2d_case1.prm
@@ -177,8 +177,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, heating statistics, maximum depth of field, composition velocity statistics, viscous dissipation statistics, trench location
 
   subsection Visualization
-    set List of output variables      = density, viscosity, strain rate, error indicator
+    set List of output variables      = material properties, strain rate, error indicator
     set Time between graphical output = 5e5
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Trench location

--- a/cookbooks/latent-heat/latent-heat.prm
+++ b/cookbooks/latent-heat/latent-heat.prm
@@ -140,6 +140,10 @@ subsection Postprocess
     # if the solution already reached steady state, this parameter can be set
     # to a smaller value.
     set Time between graphical output = 5e17
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/lower_crustal_flow/lower_crustal_flow_obstacle.prm
+++ b/cookbooks/lower_crustal_flow/lower_crustal_flow_obstacle.prm
@@ -110,7 +110,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format = vtu
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/magnetic_stripes/magnetic_stripes.prm
+++ b/cookbooks/magnetic_stripes/magnetic_stripes.prm
@@ -236,6 +236,10 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 1e5
-    set List of output variables = density, heat flux map, vertical heat flux
+    set List of output variables = material properties, heat flux map, vertical heat flux
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
+++ b/cookbooks/mantle_convection_with_continents_in_annulus/modelR.prm
@@ -184,7 +184,11 @@ subsection Postprocess
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
-    set List of output variables = density, viscosity, strain rate, stress, temperature anomaly, spherical velocity components, adiabat, heat flux map, heating, vertical heat flux
+    set List of output variables = material properties, strain rate, stress, temperature anomaly, spherical velocity components, adiabat, heat flux map, heating, vertical heat flux
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Particles

--- a/cookbooks/plume_2D_chunk/plume2D.prm
+++ b/cookbooks/plume_2D_chunk/plume2D.prm
@@ -96,9 +96,13 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, temperature statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, vertical heat flux
+    set List of output variables = material properties, vertical heat flux
     set Output format                 = vtu
     set Time between graphical output = 10e7
     set Number of grouped files       = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.part.prm
+++ b/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.part.prm
@@ -3,7 +3,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = geoid, dynamic topography, density, viscosity, gravity
+    set List of output variables      = geoid, dynamic topography, material properties, gravity
     set Number of grouped files       = 1
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/shell_3d_postprocess/shell_3d_postprocess.prm
+++ b/cookbooks/shell_3d_postprocess/shell_3d_postprocess.prm
@@ -102,7 +102,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = geoid, dynamic topography, density, viscosity, gravity
+    set List of output variables      = geoid, dynamic topography, material properties, gravity
     set Number of grouped files       = 1
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/sinker-with-averaging/doc/full.prm
+++ b/cookbooks/sinker-with-averaging/doc/full.prm
@@ -81,6 +81,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
+++ b/cookbooks/sinker-with-averaging/sinker-with-averaging.prm
@@ -81,6 +81,10 @@ subsection Postprocess
   subsection Visualization
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/stokes/doc/stokeslaw.prm
+++ b/cookbooks/stokes/doc/stokeslaw.prm
@@ -113,6 +113,10 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/stokes/stokes.prm
+++ b/cookbooks/stokes/stokes.prm
@@ -116,6 +116,10 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/subduction_initiation/subduction_initiation_compositional_fields.prm
+++ b/cookbooks/subduction_initiation/subduction_initiation_compositional_fields.prm
@@ -43,8 +43,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, composition statistics, pressure statistics, material statistics, global statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Time between graphical output = 0
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
+++ b/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
@@ -41,9 +41,13 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, composition statistics, pressure statistics, material statistics, global statistics, particles
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Time between graphical output = 0
     set Interpolate output = false
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Particles

--- a/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
+++ b/cookbooks/tian_parameterization_kinematic_slab/coupled-two-phase-tian-parameterization-kinematic-slab.prm
@@ -290,7 +290,7 @@ subsection Postprocess
   set List of postprocessors = visualization, composition statistics, velocity statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties, melt fraction
+    set List of output variables      = material properties, melt material properties, melt fraction
     set Output format                 = vtu
     set Time between graphical output = 5e4
     set Interpolate output            = true
@@ -298,6 +298,10 @@ subsection Postprocess
 
     subsection Melt material properties
       set List of properties          = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/cookbooks/tian_parameterization_kinematic_slab/uncoupled-two-phase-tian-parameterization-kinematic-slab.prm
+++ b/cookbooks/tian_parameterization_kinematic_slab/uncoupled-two-phase-tian-parameterization-kinematic-slab.prm
@@ -31,6 +31,10 @@ subsection Postprocess
   set List of postprocessors     = visualization, composition statistics, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, thermal expansivity, melt fraction
+    set List of output variables = material properties, melt fraction
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
+    end
   end
 end

--- a/cookbooks/vankeken_subduction/vankeken_corner_flow.prm
+++ b/cookbooks/vankeken_subduction/vankeken_corner_flow.prm
@@ -149,9 +149,13 @@ subsection Postprocess
   set List of postprocessors = visualization, temperature statistics, velocity statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, stress second invariant, heat flux map, depth
+    set List of output variables = material properties, strain rate, stress second invariant, heat flux map, depth
     set Output format = vtu
     set Interpolate output = true
     set Time between graphical output = 1e7
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/cookbooks/visualizing_phase_diagram/visualizing_phase_diagram.prm
+++ b/cookbooks/visualizing_phase_diagram/visualizing_phase_diagram.prm
@@ -125,7 +125,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = density, thermal expansivity, specific heat
+    set List of output variables      = material properties
     set Time between graphical output = 0e6
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat
+    end
   end
 end

--- a/doc/modules/changes/20241016_gassmoeller
+++ b/doc/modules/changes/20241016_gassmoeller
@@ -1,0 +1,8 @@
+Removed: A number of deprecated source code functions and input parameters
+have been removed. In particular the deprecated option to specify
+individual material properties in the parameter 
+'Postprocess/Visualization/List of output variables' has been removed.
+Input files will be automatically fixed and updated
+by the update scripts in the directory contrib/utilities.
+<br>
+(Rene Gassmoeller, 2024/10/16)

--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -1420,53 +1420,22 @@ namespace aspect
                 viz_names.push_back (std::get<0>(*p));
             }
 
-          // Unify material property visualization plugins into the 'material properties'
-          // plugin to avoid duplicated code and multiple calls to the material model
-          prm.enter_subsection("Material properties");
-          {
-            bool material_properties_enabled = std::find(viz_names.begin(),
-                                                         viz_names.end(),
-                                                         "material properties") != viz_names.end() ;
+          // TODO: Remove deprecated options
+          const std::set<std::string> deprecated_postprocessors = {"density",
+                                                                   "specific heat",
+                                                                   "thermal conductivity",
+                                                                   "thermal diffusivity",
+                                                                   "thermal expansivity",
+                                                                   "viscosity"
+                                                                  };
 
-            std::set<std::string> deprecated_postprocessors = {"density",
-                                                               "specific heat",
-                                                               "thermal conductivity",
-                                                               "thermal diffusivity",
-                                                               "thermal expansivity",
-                                                               "viscosity"
-                                                              };
-
-            // For all selected visualization plugins
-            auto plugin_name = viz_names.begin();
-            while (plugin_name != viz_names.end())
-              {
-                // Check if the current name is in the set of the deprecated names
-                if (deprecated_postprocessors.count(*plugin_name) != 0)
-                  {
-                    // If there is no 'material properties' yet
-                    if (material_properties_enabled == false)
-                      {
-                        // Set the current property name as the parameter for 'material properties'
-                        prm.set("List of material properties",*plugin_name);
-                        // Then replace the currently selected plugin with 'material properties'
-                        *plugin_name = "material properties";
-                        material_properties_enabled = true;
-                        ++plugin_name;
-                      }
-                    else
-                      {
-                        // Add the current property name to the parameter of 'material properties'
-                        std::string new_property_names = prm.get("List of material properties") + ", " + *plugin_name;
-                        prm.set("List of material properties",new_property_names);
-                        // Then delete the current plugin
-                        plugin_name = viz_names.erase(plugin_name);
-                      }
-                  }
-                else
-                  ++plugin_name;
-              }
-          }
-          prm.leave_subsection();
+          for (const auto &viz_name: viz_names)
+            {
+              // Check if the current name is in the set of the deprecated names
+              AssertThrow(deprecated_postprocessors.count(viz_name) == 0,
+                          ExcMessage("The visualization postprocessor '" + viz_name + "' has been removed. "
+                                     "Please use the 'material properties' postprocessor instead."));
+            }
         }
         prm.leave_subsection();
       }

--- a/tests/additional_outputs_02.prm
+++ b/tests/additional_outputs_02.prm
@@ -71,7 +71,11 @@ subsection Postprocess
     set Interpolate output = false
     set Number of grouped files       = 0
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/additional_outputs_03.prm
+++ b/tests/additional_outputs_03.prm
@@ -72,7 +72,11 @@ subsection Postprocess
     set Interpolate output = false
     set Number of grouped files       = 0
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/adiabatic_heating.prm
+++ b/tests/adiabatic_heating.prm
@@ -119,6 +119,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end

--- a/tests/adiabatic_heating_simplified.prm
+++ b/tests/adiabatic_heating_simplified.prm
@@ -125,6 +125,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end

--- a/tests/adiabatic_heating_with_melt.prm
+++ b/tests/adiabatic_heating_with_melt.prm
@@ -135,7 +135,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/adiabatic_plate_cooling.prm
+++ b/tests/adiabatic_plate_cooling.prm
@@ -76,6 +76,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end

--- a/tests/adiabatic_plate_function.prm
+++ b/tests/adiabatic_plate_function.prm
@@ -81,6 +81,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end

--- a/tests/advect_field_with_melt_velocity.prm
+++ b/tests/advect_field_with_melt_velocity.prm
@@ -124,13 +124,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/always_refine.prm
+++ b/tests/always_refine.prm
@@ -82,8 +82,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/analytic_artificial_viscosity_0.prm
+++ b/tests/analytic_artificial_viscosity_0.prm
@@ -88,6 +88,10 @@ subsection Postprocess
   subsection Visualization
     set Time between graphical output = 0
     set Interpolate output = true
-    set List of output variables = material properties, thermal conductivity, artificial viscosity
+    set List of output variables = material properties, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end

--- a/tests/annulus_transient.prm
+++ b/tests/annulus_transient.prm
@@ -60,8 +60,12 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = density, gravity, AnnulusVisualizationPostprocessor
+    set List of output variables = material properties, gravity, AnnulusVisualizationPostprocessor
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Particles

--- a/tests/average_arithmetic.prm
+++ b/tests/average_arithmetic.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_geometric.prm
+++ b/tests/average_geometric.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_harmonic.prm
+++ b/tests/average_harmonic.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_log.prm
+++ b/tests/average_log.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_none.prm
+++ b/tests/average_none.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_nwd_arithmetic.prm
+++ b/tests/average_nwd_arithmetic.prm
@@ -89,7 +89,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_nwd_geometric.prm
+++ b/tests/average_nwd_geometric.prm
@@ -89,7 +89,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_nwd_harmonic.prm
+++ b/tests/average_nwd_harmonic.prm
@@ -89,7 +89,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_pick_largest.prm
+++ b/tests/average_pick_largest.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/average_project_to_q1.prm
+++ b/tests/average_project_to_q1.prm
@@ -84,7 +84,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/blankenbach_approximation.prm
+++ b/tests/blankenbach_approximation.prm
@@ -88,6 +88,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 1e-10
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end

--- a/tests/boundary_temperature_function.prm
+++ b/tests/boundary_temperature_function.prm
@@ -65,6 +65,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/cell_reference.prm
+++ b/tests/cell_reference.prm
@@ -63,6 +63,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/compositing_named_outputs.prm
+++ b/tests/compositing_named_outputs.prm
@@ -81,8 +81,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density, named additional outputs
+    set List of output variables      = material properties, named additional outputs
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/composition_active.prm
+++ b/tests/composition_active.prm
@@ -82,8 +82,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/composition_active_nans.prm
+++ b/tests/composition_active_nans.prm
@@ -12,10 +12,14 @@ set End time                               = 0.1
 
 subsection Postprocess
   subsection Visualization
-    set List of output variables = density, artificial viscosity, artificial viscosity composition
+    set List of output variables = material properties, artificial viscosity, artificial viscosity composition
 
     subsection Artificial viscosity composition
       set Name of compositional field = C_1
+    end
+
+    subsection Material properties
+      set List of material properties = density
     end
   end
 end

--- a/tests/composition_stabilization.prm
+++ b/tests/composition_stabilization.prm
@@ -88,8 +88,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/compressibility.prm
+++ b/tests/compressibility.prm
@@ -102,9 +102,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/compressibility_iterated_stokes.prm
+++ b/tests/compressibility_iterated_stokes.prm
@@ -91,9 +91,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, volumetric strain rate
+    set List of output variables      = material properties, volumetric strain rate
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/compressibility_iterated_stokes_direct_solver.prm
+++ b/tests/compressibility_iterated_stokes_direct_solver.prm
@@ -72,10 +72,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/compressibility_volumetric_strain_rate.prm
+++ b/tests/compressibility_volumetric_strain_rate.prm
@@ -79,9 +79,13 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Point-wise stress and strain = true
-    set List of output variables      = density, volumetric strain rate
+    set List of output variables      = material properties, volumetric strain rate
     set Number of grouped files       = 0
     set Output format                 = gnuplot
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/compression_heating.prm
+++ b/tests/compression_heating.prm
@@ -130,7 +130,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature, heating
+    set List of output variables = material properties, nonadiabatic temperature, heating
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/compute-no-normal-flux-constraints.prm
+++ b/tests/compute-no-normal-flux-constraints.prm
@@ -130,9 +130,13 @@ subsection Postprocess
   end
 
   subsection Visualization
-    set List of output variables = density, viscosity, error indicator
+    set List of output variables = material properties, error indicator
     set Output format = vtu
     set Time between graphical output = 0.1e6
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/cpo_simple_shearbox.prm
+++ b/tests/cpo_simple_shearbox.prm
@@ -94,7 +94,11 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 1e6
-    set List of output variables = viscosity, strain rate, stress, density
+    set List of output variables = material properties, strain rate, stress
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 
   subsection Crystal Preferred Orientation

--- a/tests/density_boundary.prm
+++ b/tests/density_boundary.prm
@@ -80,8 +80,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/diffusion.prm
+++ b/tests/diffusion.prm
@@ -293,12 +293,16 @@ subsection Postprocess
 
     # The file format to be used for graphical output.
     set Output format                 = vtu
-    set List of output variables      = density,viscosity
+    set List of output variables      = material properties
 
     # The time interval between each generation of graphical output files. A
     # value of zero indicates that output should be generated in each time
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/diffusion_velocity.prm
+++ b/tests/diffusion_velocity.prm
@@ -292,12 +292,16 @@ subsection Postprocess
 
     # The file format to be used for graphical output.
     set Output format                 = vtu
-    set List of output variables      = density,viscosity
+    set List of output variables      = material properties
 
     # The time interval between each generation of graphical output files. A
     # value of zero indicates that output should be generated in each time
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/direct_solver_1.prm
+++ b/tests/direct_solver_1.prm
@@ -137,7 +137,11 @@ subsection Postprocess
     # if the solution already reached steady state, this parameter can be set
     # to a smaller value.
     set Time between graphical output = 0
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/direct_solver_2.prm
+++ b/tests/direct_solver_2.prm
@@ -135,7 +135,11 @@ subsection Postprocess
     # if the solution already reached steady state, this parameter can be set
     # to a smaller value.
     set Time between graphical output = 0
-    set List of output variables      = density
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/doneahuerta_3.prm
+++ b/tests/doneahuerta_3.prm
@@ -76,7 +76,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity, strain rate, gravity
+    set List of output variables = material properties, strain rate, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/drucker_prager_derivatives_2d.prm
+++ b/tests/drucker_prager_derivatives_2d.prm
@@ -96,8 +96,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/drucker_prager_derivatives_3d.prm
+++ b/tests/drucker_prager_derivatives_3d.prm
@@ -96,8 +96,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/ellipsoidal_chunk_coordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_coordinate_parallel.prm
@@ -80,7 +80,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables          = density
+    set List of output variables          = material properties
     set Output format                     = gnuplot
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/ellipsoidal_chunk_geometry.prm
+++ b/tests/ellipsoidal_chunk_geometry.prm
@@ -72,7 +72,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables          = density
+    set List of output variables          = material properties
     set Output format                     = gnuplot
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
+++ b/tests/ellipsoidal_chunk_noncoordinate_parallel.prm
@@ -81,7 +81,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables          = density
+    set List of output variables          = material properties
     set Output format                     = gnuplot
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/ellipsoidal_chunk_topography.prm
+++ b/tests/ellipsoidal_chunk_topography.prm
@@ -87,7 +87,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables          = density
+    set List of output variables          = material properties
     set Output format                     = gnuplot
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/gmg_mesh_deform_adaptive_bug2.prm
+++ b/tests/gmg_mesh_deform_adaptive_bug2.prm
@@ -120,9 +120,13 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, basic statistics, material statistics, topography
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, error indicator, heating, partition
+    set List of output variables = material properties, strain rate, error indicator, heating, partition
     set Time between graphical output = 0
     set Output mesh velocity = true
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Topography

--- a/tests/graphical_output.prm
+++ b/tests/graphical_output.prm
@@ -69,6 +69,10 @@ subsection Postprocess
     set Number of grouped files       = 0
     set Output format                 = gnuplot
     set Time between graphical output = 0
-    set List of output variables = viscosity, nonadiabatic pressure
+    set List of output variables = material properties, nonadiabatic pressure
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/graphical_output_hdf5.prm
+++ b/tests/graphical_output_hdf5.prm
@@ -73,6 +73,10 @@ subsection Postprocess
     set Number of grouped files       = 0
     set Output format                 = hdf5
     set Time between graphical output = 0
-    set List of output variables = viscosity, nonadiabatic pressure
+    set List of output variables = material properties, nonadiabatic pressure
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/gravity_function.prm
+++ b/tests/gravity_function.prm
@@ -66,6 +66,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = gnuplot
-    set List of output variables      = density, viscosity, gravity
+    set List of output variables      = material properties, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/gravity_function_time.prm
+++ b/tests/gravity_function_time.prm
@@ -66,7 +66,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = gnuplot
-    set List of output variables      = density, gravity
+    set List of output variables      = material properties, gravity
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/heat_advection_by_melt.prm
+++ b/tests/heat_advection_by_melt.prm
@@ -132,7 +132,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature, heating
+    set List of output variables = material properties, nonadiabatic temperature, heating
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/heat_advection_by_melt_operator_splitting.prm
+++ b/tests/heat_advection_by_melt_operator_splitting.prm
@@ -123,7 +123,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature, heating
+    set List of output variables = material properties, nonadiabatic temperature, heating
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/heat_flux_densities.prm
+++ b/tests/heat_flux_densities.prm
@@ -105,6 +105,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.002
-    set List of output variables      = material properties, adiabat, thermal conductivity, heating, artificial viscosity
+    set List of output variables      = material properties, adiabat, heating, artificial viscosity
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
+    end
   end
 end

--- a/tests/hollow_sphere.prm
+++ b/tests/hollow_sphere.prm
@@ -87,7 +87,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/hollow_sphere_gmg.prm
+++ b/tests/hollow_sphere_gmg.prm
@@ -83,7 +83,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/hollow_sphere_gmg_q3.prm
+++ b/tests/hollow_sphere_gmg_q3.prm
@@ -83,7 +83,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/inner_core.prm
+++ b/tests/inner_core.prm
@@ -129,7 +129,11 @@ subsection Postprocess
     set Output format                 = vtu
     set Time between graphical output = 0
     set Number of grouped files       = 0
-    set List of output variables      = strain rate, gravity, density, specific heat, heating
+    set List of output variables      = strain rate, gravity, material properties, heating
+
+    subsection Material properties
+      set List of material properties = density, specific heat
+    end
   end
 
   subsection Depth average

--- a/tests/kaus_rayleigh_taylor_instability.prm
+++ b/tests/kaus_rayleigh_taylor_instability.prm
@@ -29,9 +29,13 @@ subsection Postprocess
 
   subsection Visualization
     set Time between graphical output = 0
-    set List of output variables      = viscosity, density
+    set List of output variables      = material properties
     set Output mesh velocity          = true
     set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 
   subsection Topography

--- a/tests/kinematically_driven_subduction_2d_case1.prm
+++ b/tests/kinematically_driven_subduction_2d_case1.prm
@@ -157,8 +157,12 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, heating statistics, maximum depth of field, composition velocity statistics, viscous dissipation statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity, strain rate, error indicator
+    set List of output variables      = material properties, strain rate, error indicator
     set Time between graphical output = 5e5
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 
   subsection Composition velocity statistics

--- a/tests/maximum_horizontal_compressive_stress_case_one.prm
+++ b/tests/maximum_horizontal_compressive_stress_case_one.prm
@@ -93,10 +93,14 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography, pressure statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, maximum horizontal compressive stress
+    set List of output variables = material properties, maximum horizontal compressive stress
     set Time between graphical output = 0
     set Interpolate output = true
     set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/maximum_horizontal_compressive_stress_case_two.prm
+++ b/tests/maximum_horizontal_compressive_stress_case_two.prm
@@ -95,10 +95,14 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography, pressure statistics
 
   subsection Visualization
-    set List of output variables = density, viscosity, maximum horizontal compressive stress
+    set List of output variables = material properties, maximum horizontal compressive stress
     set Time between graphical output = 0
     set Interpolate output = true
     set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/melt_boundary_heat_flux.prm
+++ b/tests/melt_boundary_heat_flux.prm
@@ -109,13 +109,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/melt_introspection.prm
+++ b/tests/melt_introspection.prm
@@ -89,7 +89,11 @@ subsection Postprocess
     set Interpolate output = false
     set Number of grouped files       = 0
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/melt_track.prm
+++ b/tests/melt_track.prm
@@ -137,7 +137,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -157,6 +157,10 @@ subsection Postprocess
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 

--- a/tests/melt_transport.prm
+++ b/tests/melt_transport.prm
@@ -130,7 +130,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity
+    set List of output variables      = material properties
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -147,5 +147,9 @@ subsection Postprocess
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
+    end
   end
 end

--- a/tests/melting_rate.prm
+++ b/tests/melting_rate.prm
@@ -120,13 +120,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/melting_rate_operator_splitting.prm
+++ b/tests/melting_rate_operator_splitting.prm
@@ -142,13 +142,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties, melt fraction
+    set List of output variables      = material properties, melt material properties, melt fraction
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/melting_rate_operator_splitting2.prm
+++ b/tests/melting_rate_operator_splitting2.prm
@@ -132,13 +132,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties, melt fraction
+    set List of output variables      = material properties, melt material properties, melt fraction
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/multicomponent_arithmetic.prm
+++ b/tests/multicomponent_arithmetic.prm
@@ -113,10 +113,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/multicomponent_compressible_averaging.prm
+++ b/tests/multicomponent_compressible_averaging.prm
@@ -106,7 +106,7 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = gnuplot
-    set List of output variables      = material properties, thermal conductivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
 
     subsection Vp anomaly
@@ -115,6 +115,10 @@ subsection Postprocess
 
     subsection Vs anomaly
       set Number of depth slices = 12
+    end
+
+    subsection Material properties
+      set List of material properties = density, thermal expansivity, specific heat, viscosity, thermal conductivity
     end
   end
 

--- a/tests/multicomponent_geometric.prm
+++ b/tests/multicomponent_geometric.prm
@@ -113,10 +113,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/multicomponent_harmonic.prm
+++ b/tests/multicomponent_harmonic.prm
@@ -113,10 +113,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/multicomponent_max_composition.prm
+++ b/tests/multicomponent_max_composition.prm
@@ -113,10 +113,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Number of grouped files       = 1
     set Output format                 = vtu
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/multicomponent_steinberger.prm
+++ b/tests/multicomponent_steinberger.prm
@@ -108,8 +108,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity,density
+    set List of output variables = material properties
     set Output format                 = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/nonlinear_solver_history.prm
+++ b/tests/nonlinear_solver_history.prm
@@ -58,7 +58,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/nsinker_bfbt.prm
+++ b/tests/nsinker_bfbt.prm
@@ -2,6 +2,7 @@ set Dimension = 3
 
 include $ASPECT_SOURCE_DIR/benchmarks/nsinker/nsinker.prm
 
+
 # Follow as closely as possible the parameters from Rudi et al. (2017)
 subsection Solver parameters
   subsection Stokes solver parameters
@@ -18,6 +19,7 @@ subsection Solver parameters
     set AMG aggregation threshold = 0.02
   end
 end
+
 subsection Mesh refinement
   set Initial adaptive refinement              = 0
   set Initial global refinement                = 1

--- a/tests/output_averaging_arithmetic.prm
+++ b/tests/output_averaging_arithmetic.prm
@@ -76,7 +76,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Interpolate output            = false
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/output_averaging_harmonic.prm
+++ b/tests/output_averaging_harmonic.prm
@@ -76,7 +76,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Interpolate output            = false
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/particle_load_balancing_repartition_multiple_systems.prm
+++ b/tests/particle_load_balancing_repartition_multiple_systems.prm
@@ -90,9 +90,11 @@ subsection Mesh refinement
   set Time steps between mesh refinement = 1
   set Coarsening fraction                = 0.05
   set Refinement fraction                = 0.3
+
   subsection Maximum refinement function
     set Function expression = 3
   end
+
   subsection Minimum refinement function
     set Function expression = 3
   end

--- a/tests/particle_property_composition.prm
+++ b/tests/particle_property_composition.prm
@@ -137,7 +137,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -157,6 +157,10 @@ subsection Postprocess
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 

--- a/tests/periodic_compressible.prm
+++ b/tests/periodic_compressible.prm
@@ -78,7 +78,11 @@ subsection Postprocess
 
   subsection Visualization
     set Output format                 = vtu
-    set List of output variables      = viscosity, density, thermal expansivity, specific heat, nonadiabatic temperature #, named additional outputs
+    set List of output variables      = material properties, nonadiabatic temperature #, named additional outputs
     set Time between graphical output = 1e6
+
+    subsection Material properties
+      set List of material properties = viscosity, density, thermal expansivity, specific heat
+    end
   end
 end

--- a/tests/point_value_01.prm
+++ b/tests/point_value_01.prm
@@ -91,7 +91,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/point_value_02.prm
+++ b/tests/point_value_02.prm
@@ -94,10 +94,14 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity, artificial viscosity composition
+    set List of output variables = material properties, artificial viscosity composition
 
     subsection Artificial viscosity composition
       set Name of compositional field = C_1
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity
     end
   end
 end

--- a/tests/point_value_02_mpi.prm
+++ b/tests/point_value_02_mpi.prm
@@ -96,7 +96,11 @@ subsection Postprocess
     set Interpolate output = false
     set Output format                 = vtu
     set Time between graphical output = 0
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/postprocess_initial.prm
+++ b/tests/postprocess_initial.prm
@@ -80,8 +80,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/postprocess_iterations_Stokes_only.prm
+++ b/tests/postprocess_iterations_Stokes_only.prm
@@ -74,10 +74,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/pre_data_out_build_patches.prm
+++ b/tests/pre_data_out_build_patches.prm
@@ -61,7 +61,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics
 
   subsection Visualization
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/prescribed_field.prm
+++ b/tests/prescribed_field.prm
@@ -82,9 +82,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/prescribed_field_temperature.prm
+++ b/tests/prescribed_field_temperature.prm
@@ -70,9 +70,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/prescribed_viscosity_additional_outputs.prm
+++ b/tests/prescribed_viscosity_additional_outputs.prm
@@ -35,7 +35,11 @@ subsection Postprocess
   set List of postprocessors = composition statistics,temperature statistics, velocity statistics, visualization
 
   subsection Visualization
-    set List of output variables = viscosity, named additional outputs
+    set List of output variables = material properties, named additional outputs
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/pressure_compatibility_4.prm
+++ b/tests/pressure_compatibility_4.prm
@@ -85,8 +85,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/q1_q1.prm
+++ b/tests/q1_q1.prm
@@ -84,7 +84,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, DoneaHuertaPostprocessor
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, gravity
+    set List of output variables = material properties, strain rate, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/q1_q1_6.prm
+++ b/tests/q1_q1_6.prm
@@ -81,7 +81,11 @@ subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, DoneaHuertaPostprocessor
 
   subsection Visualization
-    set List of output variables = density, viscosity, strain rate, gravity
+    set List of output variables = material properties, strain rate, gravity
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/random_perturbation_box.prm
+++ b/tests/random_perturbation_box.prm
@@ -64,7 +64,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/random_perturbation_chunk.prm
+++ b/tests/random_perturbation_chunk.prm
@@ -66,7 +66,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/random_perturbation_merged_boxes.prm
+++ b/tests/random_perturbation_merged_boxes.prm
@@ -67,7 +67,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/random_perturbation_sphere.prm
+++ b/tests/random_perturbation_sphere.prm
@@ -61,7 +61,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/random_perturbation_spherical_shell.prm
+++ b/tests/random_perturbation_spherical_shell.prm
@@ -60,7 +60,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0.1
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/refinement_strainrate.prm
+++ b/tests/refinement_strainrate.prm
@@ -115,7 +115,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format = gnuplot
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/rising_melt_blob.prm
+++ b/tests/rising_melt_blob.prm
@@ -117,13 +117,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/rising_melt_blob_freezing.prm
+++ b/tests/rising_melt_blob_freezing.prm
@@ -111,13 +111,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/segregation_heating.prm
+++ b/tests/segregation_heating.prm
@@ -131,7 +131,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature, heating
+    set List of output variables = material properties, nonadiabatic temperature, heating
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/shear_bands.prm
+++ b/tests/shear_bands.prm
@@ -107,13 +107,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, strain rate, melt material properties
+    set List of output variables      = material properties, strain rate, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/shear_heating.prm
+++ b/tests/shear_heating.prm
@@ -79,7 +79,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = heating, viscosity, strain rate
+    set List of output variables = heating, material properties, strain rate
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/shear_heating_compressible.prm
+++ b/tests/shear_heating_compressible.prm
@@ -102,8 +102,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = heating, viscosity, strain rate
+    set List of output variables = heating, material properties, strain rate
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/shear_heating_compressible_melt.prm
+++ b/tests/shear_heating_compressible_melt.prm
@@ -135,8 +135,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = heating, viscosity, strain rate, density
+    set List of output variables = heating, material properties, strain rate
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 end
 

--- a/tests/shear_heating_limited.prm
+++ b/tests/shear_heating_limited.prm
@@ -25,6 +25,10 @@ subsection Postprocess
   set List of postprocessors = heating statistics, visualization
 
   subsection Visualization
-    set List of output variables = heating, viscosity, strain rate, stress second invariant
+    set List of output variables = heating, material properties, strain rate, stress second invariant
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/signal_fem.prm
+++ b/tests/signal_fem.prm
@@ -85,7 +85,11 @@ subsection Postprocess
     set Interpolate output = false
     set Number of grouped files       = 0
     set Output format                 = gnuplot
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/simple_composite.prm
+++ b/tests/simple_composite.prm
@@ -85,8 +85,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/simple_compressibility_iterated_stokes.prm
+++ b/tests/simple_compressibility_iterated_stokes.prm
@@ -73,9 +73,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/simple_compressible.prm
+++ b/tests/simple_compressible.prm
@@ -80,8 +80,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/simple_incompressible.prm
+++ b/tests/simple_incompressible.prm
@@ -77,8 +77,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/simpler_box.prm
+++ b/tests/simpler_box.prm
@@ -58,6 +58,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/solitary_wave.prm
+++ b/tests/solitary_wave.prm
@@ -136,13 +136,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = vtu
     set Time between graphical output = 5e5
 
     subsection Melt material properties
       set List of properties = fluid density, permeability, fluid viscosity, compaction viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/solver_history.prm
+++ b/tests/solver_history.prm
@@ -58,7 +58,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/static_temperature.prm
+++ b/tests/static_temperature.prm
@@ -86,10 +86,14 @@ subsection Postprocess
   set List of postprocessors = velocity statistics, temperature statistics, visualization
 
   subsection Visualization
-    set List of output variables      = density, viscosity, strain rate
+    set List of output variables      = material properties, strain rate
     set Output format                 = gnuplot
     set Time between graphical output = 20e3
     set Number of grouped files       = 0
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end
 

--- a/tests/statistics_output.prm
+++ b/tests/statistics_output.prm
@@ -127,7 +127,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = viscosity, density, nonadiabatic temperature
+    set List of output variables = material properties, nonadiabatic temperature
+
+    subsection Material properties
+      set List of material properties = viscosity, density
+    end
   end
 
   subsection Global statistics

--- a/tests/steinberger_background.prm
+++ b/tests/steinberger_background.prm
@@ -91,8 +91,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density, thermal conductivity, thermal expansivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, thermal conductivity, thermal expansivity
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_compressible.prm
+++ b/tests/steinberger_compressible.prm
@@ -80,8 +80,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_conductivity.prm
+++ b/tests/steinberger_conductivity.prm
@@ -74,7 +74,11 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output            = true
     set Output format                 = gnuplot
-    set List of output variables      = thermal conductivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = thermal conductivity
+    end
   end
 end

--- a/tests/steinberger_conductivity_tosi.prm
+++ b/tests/steinberger_conductivity_tosi.prm
@@ -76,8 +76,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output            = true
     set Output format                 = gnuplot
-    set List of output variables      = thermal conductivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = thermal conductivity
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_lateral_fail.prm
+++ b/tests/steinberger_lateral_fail.prm
@@ -86,8 +86,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_projected_density.prm
+++ b/tests/steinberger_projected_density.prm
@@ -94,8 +94,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density, thermal conductivity, thermal expansivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, thermal conductivity, thermal expansivity
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_projected_density_dcPicard.prm
+++ b/tests/steinberger_projected_density_dcPicard.prm
@@ -98,8 +98,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density, thermal conductivity, thermal expansivity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density, thermal conductivity, thermal expansivity
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_viscosity.prm
+++ b/tests/steinberger_viscosity.prm
@@ -80,8 +80,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output            = false
     set Output format                 = vtu
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 
   subsection Depth average

--- a/tests/steinberger_viscosity_adiabatic.prm
+++ b/tests/steinberger_viscosity_adiabatic.prm
@@ -90,8 +90,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output            = false
     set Output format                 = vtu
-    set List of output variables      = viscosity
+    set List of output variables      = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 
   subsection Depth average

--- a/tests/stokes.prm
+++ b/tests/stokes.prm
@@ -118,7 +118,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
     set Output format                 = gnuplot
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/stokes_residual.prm
+++ b/tests/stokes_residual.prm
@@ -61,6 +61,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_box.prm
+++ b/tests/symbolic_boundary_names_box.prm
@@ -61,6 +61,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_box_constant_bc.prm
+++ b/tests/symbolic_boundary_names_box_constant_bc.prm
@@ -65,6 +65,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_spherical_shell_2d_180_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_180_degrees.prm
@@ -59,6 +59,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_spherical_shell_2d_90_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_90_degrees.prm
@@ -59,6 +59,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_spherical_shell_2d_full.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_2d_full.prm
@@ -55,6 +55,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_spherical_shell_3d_90_degrees.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_3d_90_degrees.prm
@@ -59,6 +59,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/symbolic_boundary_names_spherical_shell_3d_full.prm
+++ b/tests/symbolic_boundary_names_spherical_shell_3d_full.prm
@@ -55,6 +55,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity
+    set List of output variables      = material properties
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/tangurnis_tala.prm
+++ b/tests/tangurnis_tala.prm
@@ -235,7 +235,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, adiabat
+    set List of output variables      = material properties, adiabat
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -252,6 +252,10 @@ subsection Postprocess
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/tangurnis_tala_c.prm
+++ b/tests/tangurnis_tala_c.prm
@@ -235,7 +235,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, adiabat
+    set List of output variables      = material properties, adiabat
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -252,6 +252,10 @@ subsection Postprocess
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/tangurnis_tala_implicit.prm
+++ b/tests/tangurnis_tala_implicit.prm
@@ -237,7 +237,7 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, adiabat
+    set List of output variables      = material properties, adiabat
 
     # VTU file output supports grouping files from several CPUs into one file
     # using MPI I/O when writing on a parallel filesystem. Select 0 for no
@@ -254,6 +254,10 @@ subsection Postprocess
     # step. Units: years if the 'Use years in output instead of seconds'
     # parameter is set; seconds otherwise.
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end
 

--- a/tests/temperature_dependent_stokes_matrix.prm
+++ b/tests/temperature_dependent_stokes_matrix.prm
@@ -71,6 +71,10 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -112,8 +112,12 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format                 = vtu
-    set List of output variables      = density, heating
+    set List of output variables      = material properties, heating
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 
   subsection Depth average

--- a/tests/upwelling_melting_peridotite.prm
+++ b/tests/upwelling_melting_peridotite.prm
@@ -122,10 +122,14 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = melt fraction, viscosity, density, nonadiabatic temperature
+    set List of output variables = melt fraction, material properties, nonadiabatic temperature
 
     subsection Melt fraction
       set Mass fraction cpx = 0.10
+    end
+
+    subsection Material properties
+      set List of material properties = viscosity, density
     end
   end
 end

--- a/tests/upwelling_melting_peridotite_compressible.prm
+++ b/tests/upwelling_melting_peridotite_compressible.prm
@@ -115,10 +115,14 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Time between graphical output = 0.01
-    set List of output variables = melt fraction, viscosity, density, nonadiabatic temperature
+    set List of output variables = melt fraction, material properties, nonadiabatic temperature
 
     subsection Melt fraction
       set Mass fraction cpx = 0.10
+    end
+
+    subsection Material properties
+      set List of material properties = viscosity, density
     end
   end
 end

--- a/tests/velocity_in_years.prm
+++ b/tests/velocity_in_years.prm
@@ -83,7 +83,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density
+    set List of output variables = material properties
     set Time between graphical output = 0
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/vep_chemical_compositions.prm
+++ b/tests/vep_chemical_compositions.prm
@@ -78,7 +78,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Time between graphical output = 1000
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_additional_plastic_outputs.prm
+++ b/tests/visco_plastic_additional_plastic_outputs.prm
@@ -126,7 +126,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_adiabat_temperature.prm
+++ b/tests/visco_plastic_adiabat_temperature.prm
@@ -106,8 +106,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_adiabatic_heating_density.prm
+++ b/tests/visco_plastic_adiabatic_heating_density.prm
@@ -109,7 +109,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = adiabat, density
+    set List of output variables = adiabat, material properties
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = density
+    end
   end
 end

--- a/tests/visco_plastic_adiabatic_pressure_in_plasticity.prm
+++ b/tests/visco_plastic_adiabatic_pressure_in_plasticity.prm
@@ -101,7 +101,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, named additional outputs, adiabat
+    set List of output variables = material properties, named additional outputs, adiabat
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_adiabatic_pressure_in_viscous_creep.prm
+++ b/tests/visco_plastic_adiabatic_pressure_in_viscous_creep.prm
@@ -137,8 +137,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_composite.prm
+++ b/tests/visco_plastic_composite.prm
@@ -96,8 +96,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity
+    set List of output variables = material properties
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_derivatives_2d.prm
+++ b/tests/visco_plastic_derivatives_2d.prm
@@ -106,8 +106,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_derivatives_3d.prm
+++ b/tests/visco_plastic_derivatives_3d.prm
@@ -106,8 +106,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_diffusion.prm
+++ b/tests/visco_plastic_diffusion.prm
@@ -98,8 +98,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_diffusion_dislocation_composite.prm
+++ b/tests/visco_plastic_diffusion_dislocation_composite.prm
@@ -104,8 +104,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_dislocation.prm
+++ b/tests/visco_plastic_dislocation.prm
@@ -97,8 +97,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_frank_kamenetskii.prm
+++ b/tests/visco_plastic_frank_kamenetskii.prm
@@ -95,8 +95,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_frank_kamenetskii_pressure.prm
+++ b/tests/visco_plastic_frank_kamenetskii_pressure.prm
@@ -96,8 +96,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_frank_kamenetskii_pressure_user_refs.prm
+++ b/tests/visco_plastic_frank_kamenetskii_pressure_user_refs.prm
@@ -98,8 +98,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate
+    set List of output variables = material properties, strain rate
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_total_strain_healing_temperature_dependent.prm
+++ b/tests/visco_plastic_total_strain_healing_temperature_dependent.prm
@@ -159,8 +159,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
     set Time between graphical output = 2e6
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_track_noninitial_plastic_strain.prm
+++ b/tests/visco_plastic_track_noninitial_plastic_strain.prm
@@ -126,8 +126,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
     set Time between graphical output       = 1e3
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_viscous_strain_weakening.prm
+++ b/tests/visco_plastic_viscous_strain_weakening.prm
@@ -124,7 +124,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_yield_max.prm
+++ b/tests/visco_plastic_yield_max.prm
@@ -104,10 +104,14 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = strain rate, viscosity
+    set List of output variables      = strain rate, material properties
     set Output format                 = gnuplot
     set Time between graphical output = 0.25e6
     set Number of grouped files       = 0
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
+++ b/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
@@ -35,9 +35,13 @@ subsection Postprocess
   set List of postprocessors = composition statistics, mass flux statistics, particles, particle count statistics, velocity statistics, visualization
 
   subsection Visualization
-    set List of output variables       = named additional outputs, strain rate, viscosity
+    set List of output variables       = named additional outputs, strain rate, material properties
     set Time between graphical output  = 0
     set Output format                  = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 
   subsection Particles

--- a/tests/visco_plastic_yield_plastic_strain_weakening.prm
+++ b/tests/visco_plastic_yield_plastic_strain_weakening.prm
@@ -126,7 +126,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/visco_plastic_yield_plastic_viscous_strain_healing.prm
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_healing.prm
@@ -135,9 +135,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
     set Time between graphical output = 5e7
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_plastic_viscous_strain_weakening.prm
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_weakening.prm
@@ -123,8 +123,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_strain_weakening.prm
+++ b/tests/visco_plastic_yield_strain_weakening.prm
@@ -120,8 +120,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor.prm
@@ -122,8 +122,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor_3d.prm
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor_3d.prm
@@ -118,8 +118,12 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_total_strain_healing.prm
+++ b/tests/visco_plastic_yield_total_strain_healing.prm
@@ -134,9 +134,13 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
     set Time between graphical output = 5e7
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end
 

--- a/tests/visco_plastic_yield_viscous_strain_weakening.prm
+++ b/tests/visco_plastic_yield_viscous_strain_weakening.prm
@@ -125,7 +125,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Output format            = gnuplot
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/viscoelastoplastic_yield_plastic_viscous_strain_weakening.prm
+++ b/tests/viscoelastoplastic_yield_plastic_viscous_strain_weakening.prm
@@ -71,7 +71,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = viscosity, strain rate, named additional outputs
+    set List of output variables = material properties, strain rate, named additional outputs
     set Time between graphical output = 1000
+
+    subsection Material properties
+      set List of material properties = viscosity
+    end
   end
 end

--- a/tests/viscoplastic_melt_blob_freezing.prm
+++ b/tests/viscoplastic_melt_blob_freezing.prm
@@ -52,13 +52,17 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables      = density, viscosity, thermal expansivity, melt material properties
+    set List of output variables      = material properties, melt material properties
     set Number of grouped files       = 0
     set Output format                 = gnuplot
     set Time between graphical output = 0
 
     subsection Melt material properties
       set List of properties = permeability, fluid density, compaction viscosity, fluid viscosity
+    end
+
+    subsection Material properties
+      set List of material properties = density, viscosity, thermal expansivity
     end
   end
 end

--- a/tests/viscous_dissipation_statistics.prm
+++ b/tests/viscous_dissipation_statistics.prm
@@ -118,7 +118,11 @@ subsection Postprocess
 
   subsection Visualization
     set Interpolate output = false
-    set List of output variables = density, viscosity
+    set List of output variables = material properties
     set Output format                 = gnuplot
+
+    subsection Material properties
+      set List of material properties = density, viscosity
+    end
   end
 end

--- a/tests/visualization_conductivity_diffusivity.prm
+++ b/tests/visualization_conductivity_diffusivity.prm
@@ -75,6 +75,10 @@ subsection Postprocess
   subsection Visualization
     set Interpolate output = false
     set Output format = gnuplot
-    set List of output variables = density, thermal conductivity, thermal diffusivity, specific heat
+    set List of output variables = material properties
+
+    subsection Material properties
+      set List of material properties = density, thermal conductivity, thermal diffusivity, specific heat
+    end
   end
 end


### PR DESCRIPTION
This is a continuation of #6083, which only deals with the long deprecated option to specify individual material properties in the parameter 'Postprocess/Visualization/List of output variables'. This has long been replaced by the visualization postprocessor 'material properties', but we never consistently updated all parameter files in the repository. I changed the update script to automatically replace the deprecated options with the 'new' postprocessor, applied the update script to all prm files in the repo, and removed the legacy functionality in the code to automatically replace those options with the new postprocessor. Now an assert is thrown if users still use the old option, the assert also explains how to fix this. In a few years we can then remove the assert.