### PR TITLE
Remove old and broken link on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,8 +95,7 @@
                 <td style="vertical-align:top">
                   <i>
                     The online manual explains most of what you may want to know
-                    about <abbr>ASPECT</abbr>. <br>
-		    <a href="manual.pdf">The old pdf manual is available by clicking here.</a>
+                    about <abbr>ASPECT</abbr>.
                   </i>
                 </td>
               </tr>


### PR DESCRIPTION
This link seems to be broken, but maybe we dont need it anymore anyway since the pdf manual is out of date by now.