### PR TITLE
Update subsection for random uniform particle generator

### DIFF
--- a/benchmarks/annulus/transient/transient_annulus.prm
+++ b/benchmarks/annulus/transient/transient_annulus.prm
@@ -81,7 +81,7 @@ subsection Particles
   set Minimum particles per cell = 12
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 49152
     end
   end

--- a/benchmarks/rigid_shear/transient/rigid_shear.prm
+++ b/benchmarks/rigid_shear/transient/rigid_shear.prm
@@ -126,7 +126,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 8192
     end
   end

--- a/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
+++ b/benchmarks/viscoelastic_bending_beam/viscoelastic_bending_beam_particles.prm
@@ -33,7 +33,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 4e5
     end
   end

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_particles.prm
@@ -35,7 +35,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
+++ b/benchmarks/viscoelastic_stress_build-up/viscoelastic_stress_build-up_yield_particles.prm
@@ -66,7 +66,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/contrib/utilities/update_scripts/prm_files/move_particles.py
+++ b/contrib/utilities/update_scripts/prm_files/move_particles.py
@@ -75,7 +75,12 @@ def move_number_of_particles_to_correct_subsection(parameters):
                         parameters["Particles"]["value"]["Generator"]["value"]["Uniform radial"] = {"comment": "", "value" : dict({}), "type": "subsection"}
                     parameters["Particles"]["value"]["Generator"]["value"]["Uniform radial"]["value"]["Number of particles"] = parameter
 
-                elif generator == "random uniform" or generator == "probability density function":
+                elif generator == "random uniform":
+                    if not "Random uniform" in parameters["Particles"]["value"]["Generator"]["value"]:
+                        parameters["Particles"]["value"]["Generator"]["value"]["Random uniform"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+                    parameters["Particles"]["value"]["Generator"]["value"]["Random uniform"]["value"]["Number of particles"] = parameter
+
+                elif generator == "probability density function":
                     if not "Probability density function" in parameters["Particles"]["value"]["Generator"]["value"]:
                         parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"] = {"comment": "", "value" : dict({}), "type": "subsection"}
                     parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"]["value"]["Number of particles"] = parameter
@@ -83,11 +88,25 @@ def move_number_of_particles_to_correct_subsection(parameters):
                 # the parameter was not used by other generators. silently delete it
             else:
                 # No generator was manually selected, move the parameter into the default generator subsection
-                if not "Probability density function" in parameters["Particles"]["value"]["Generator"]["value"]:
-                    parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"] = {"comment": "", "value" : dict({}), "type": "subsection"}
+                if not "Random uniform" in parameters["Particles"]["value"]["Generator"]["value"]:
+                    parameters["Particles"]["value"]["Generator"]["value"]["Random uniform"] = {"comment": "", "value" : dict({}), "type": "subsection"}
 
-                parameters["Particles"]["value"]["Generator"]["value"]["Probability density function"]["value"]["Number of particles"] = parameter
-            
+                parameters["Particles"]["value"]["Generator"]["value"]["Random uniform"]["value"]["Number of particles"] = parameter
+
+    # If 'random uniform' is selected or defaulted, but there is no 'random uniform' subsection, move the 'probability density function' subsection
+    # this is necessary, because for a while the 'probability density function' section was used for the 'random uniform' generator as well
+    for particle_section in ["Particles","Particles 2"]:
+        if particle_section in parameters:
+            if ("Particle generator name" in parameters[particle_section]["value"] and parameters[particle_section]["value"]["Particle generator name"]["value"] == "random uniform") \
+                or not "Particle generator name" in parameters[particle_section]["value"]:
+                if "Generator" in parameters["Particles"]["value"]:
+                    # if the parameter does not already exist in random uniform
+                    if not "Random uniform" in parameters[particle_section]["value"]["Generator"]["value"] \
+                    and "Probability density function" in parameters[particle_section]["value"]["Generator"]["value"]:
+                        subsection = parameters[particle_section]["value"]["Generator"]["value"]["Probability density function"]
+                        parameters[particle_section]["value"]["Generator"]["value"]["Random uniform"] = subsection
+                        del parameters[particle_section]["value"]["Generator"]["value"]["Probability density function"]
+        
     return parameters
 
 def move_particle_postprocess_parameters_back(parameters):

--- a/cookbooks/composition_active_particles/composition_active_particles.prm
+++ b/cookbooks/composition_active_particles/composition_active_particles.prm
@@ -119,7 +119,7 @@ subsection Particles
   set Particle generator name = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100000
     end
   end

--- a/cookbooks/composition_active_particles/doc/particles.part.prm
+++ b/cookbooks/composition_active_particles/doc/particles.part.prm
@@ -11,7 +11,7 @@ subsection Particles
   set Particle generator name   = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles         = 100000
     end
   end

--- a/cookbooks/composition_passive_particles/composition_passive_particles.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles.prm
@@ -107,7 +107,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 1000
     end
   end

--- a/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
+++ b/cookbooks/composition_passive_particles/composition_passive_particles_properties.prm
@@ -114,7 +114,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 50000
     end
   end

--- a/cookbooks/composition_passive_particles/doc/particle-properties.part.prm
+++ b/cookbooks/composition_passive_particles/doc/particle-properties.part.prm
@@ -10,7 +10,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 50000
     end
   end

--- a/cookbooks/composition_passive_particles/doc/particles.part.prm
+++ b/cookbooks/composition_passive_particles/doc/particles.part.prm
@@ -13,7 +13,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 1000
     end
   end

--- a/cookbooks/convection-box-particles/convection-box-particles.prm
+++ b/cookbooks/convection-box-particles/convection-box-particles.prm
@@ -163,7 +163,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/model_input/tutorial.prm
@@ -138,7 +138,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/cookbooks/grain_size_ridge/doc/particles.part.prm
+++ b/cookbooks/grain_size_ridge/doc/particles.part.prm
@@ -22,7 +22,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 500000
     end
   end

--- a/cookbooks/grain_size_ridge/grain_size_ridge.prm
+++ b/cookbooks/grain_size_ridge/grain_size_ridge.prm
@@ -302,7 +302,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 500000
     end
   end

--- a/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
+++ b/cookbooks/subduction_initiation/subduction_initiation_particle_in_cell.prm
@@ -58,7 +58,7 @@ subsection Particles
   set Interpolation scheme = cell average
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles      = 350000
     end
   end

--- a/include/aspect/particle/generator/random_uniform.h
+++ b/include/aspect/particle/generator/random_uniform.h
@@ -21,7 +21,7 @@
 #ifndef _aspect_particle_generator_random_uniform_h
 #define _aspect_particle_generator_random_uniform_h
 
-#include <aspect/particle/generator/probability_density_function.h>
+#include <aspect/particle/generator/interface.h>
 
 namespace aspect
 {

--- a/source/particle/generator/random_uniform.cc
+++ b/source/particle/generator/random_uniform.cc
@@ -49,7 +49,7 @@ namespace aspect
       {
         prm.enter_subsection("Generator");
         {
-          prm.enter_subsection("Probability density function");
+          prm.enter_subsection("Random uniform");
           {
             prm.declare_entry ("Number of particles", "1000",
                                Patterns::Double (0.),
@@ -92,7 +92,7 @@ namespace aspect
       {
         prm.enter_subsection("Generator");
         {
-          prm.enter_subsection("Probability density function");
+          prm.enter_subsection("Random uniform");
           {
             n_particles = static_cast<types::particle_index>(prm.get_double ("Number of particles"));
             random_cell_selection = prm.get_bool("Random cell selection");

--- a/tests/annulus_transient.prm
+++ b/tests/annulus_transient.prm
@@ -88,7 +88,7 @@ subsection Particles
   set Minimum particles per cell = 12
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 49152
     end
   end

--- a/tests/checkpoint_03_particles.prm
+++ b/tests/checkpoint_03_particles.prm
@@ -90,7 +90,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/tests/checkpoint_04_particles_no_output.prm
+++ b/tests/checkpoint_04_particles_no_output.prm
@@ -90,7 +90,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/tests/checkpoint_08_particles_multiple_systems.prm
+++ b/tests/checkpoint_08_particles_multiple_systems.prm
@@ -91,7 +91,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end
@@ -106,7 +106,7 @@ subsection Particles 2
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/composition_passive_particles.prm
+++ b/tests/composition_passive_particles.prm
@@ -104,7 +104,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/cookbook_mantle_convection_annulus.prm
+++ b/tests/cookbook_mantle_convection_annulus.prm
@@ -29,7 +29,7 @@ subsection Particles
       set Radial layers  = 50
     end
 
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles           = 123
     end
   end

--- a/tests/grain_size_growth_one_cell_particles.prm
+++ b/tests/grain_size_growth_one_cell_particles.prm
@@ -35,7 +35,7 @@ subsection Particles
   set Integration scheme = rk2
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 50000
     end
   end

--- a/tests/grain_size_growth_particles.prm
+++ b/tests/grain_size_growth_particles.prm
@@ -42,7 +42,7 @@ subsection Particles
   set Integration scheme = rk2
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/grain_size_phase_function.prm
+++ b/tests/grain_size_phase_function.prm
@@ -136,7 +136,7 @@ subsection Particles
   set List of particle properties = grain size
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10000
     end
   end

--- a/tests/gs_drucker_prager_extension.prm
+++ b/tests/gs_drucker_prager_extension.prm
@@ -86,7 +86,7 @@ subsection Particles
   set List of particle properties = grain size
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10000
     end
   end

--- a/tests/gs_drucker_prager_extension_adiabatic.prm
+++ b/tests/gs_drucker_prager_extension_adiabatic.prm
@@ -85,7 +85,7 @@ subsection Particles
   set List of particle properties = grain size
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10000
     end
   end

--- a/tests/matrix_nonzeros_2.prm
+++ b/tests/matrix_nonzeros_2.prm
@@ -92,7 +92,7 @@ subsection Particles
   set Interpolation scheme = cell average
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/matrix_nonzeros_3.prm
+++ b/tests/matrix_nonzeros_3.prm
@@ -98,7 +98,7 @@ subsection Particles
   set Interpolation scheme = cell average
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles.prm
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_particles.prm
@@ -31,7 +31,7 @@ subsection Particles
   set Load balancing strategy = remove and add particles
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 512
     end
   end

--- a/tests/nsinker_bfbt.prm
+++ b/tests/nsinker_bfbt.prm
@@ -2,6 +2,7 @@ set Dimension = 3
 
 include $ASPECT_SOURCE_DIR/benchmarks/nsinker/nsinker.prm
 
+
 # Follow as closely as possible the parameters from Rudi et al. (2017)
 subsection Solver parameters
   subsection Stokes solver parameters
@@ -18,6 +19,7 @@ subsection Solver parameters
     set AMG aggregation threshold = 0.02
   end
 end
+
 subsection Mesh refinement
   set Initial adaptive refinement              = 0
   set Initial global refinement                = 1

--- a/tests/particle_count_statistics.prm
+++ b/tests/particle_count_statistics.prm
@@ -84,7 +84,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/tests/particle_exclude_all_properties.prm
+++ b/tests/particle_exclude_all_properties.prm
@@ -110,7 +110,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/particle_exclude_one_property.prm
+++ b/tests/particle_exclude_one_property.prm
@@ -110,7 +110,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/particle_exclude_one_property_vtu.prm
+++ b/tests/particle_exclude_one_property_vtu.prm
@@ -110,7 +110,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/particle_exclude_three_properties_vtu.prm
+++ b/tests/particle_exclude_three_properties_vtu.prm
@@ -110,7 +110,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/particle_exclude_two_properties_vtu.prm
+++ b/tests/particle_exclude_two_properties_vtu.prm
@@ -110,7 +110,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, velocity # lpo, integrated strain invariant #function, initial composition, initial position, pT path
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/particle_fast_evaluate_many_compositions.prm
+++ b/tests/particle_fast_evaluate_many_compositions.prm
@@ -109,7 +109,7 @@ subsection Particles
   set List of particle properties   = composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles           = 10
     end
   end

--- a/tests/particle_fast_evaluate_multiple_compositions.prm
+++ b/tests/particle_fast_evaluate_multiple_compositions.prm
@@ -109,7 +109,7 @@ subsection Particles
   set List of particle properties   = composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles           = 10
     end
   end

--- a/tests/particle_generator_random_uniform.prm
+++ b/tests/particle_generator_random_uniform.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = true
       set Number of particles = 256
     end

--- a/tests/particle_generator_random_uniform_3mpi_1particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_1particle.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = true
       set Number of particles = 1
     end

--- a/tests/particle_generator_random_uniform_3mpi_2particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_2particle.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = true
       set Number of particles = 2
     end

--- a/tests/particle_generator_random_uniform_3mpi_3particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_3particle.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = true
       set Number of particles = 3
     end

--- a/tests/particle_generator_random_uniform_3mpi_4particle.prm
+++ b/tests/particle_generator_random_uniform_3mpi_4particle.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = true
       set Number of particles = 4
     end

--- a/tests/particle_generator_random_uniform_deterministic_cell.prm
+++ b/tests/particle_generator_random_uniform_deterministic_cell.prm
@@ -102,7 +102,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = false
       set Number of particles = 256
     end

--- a/tests/particle_generator_random_uniform_empty_rank.prm
+++ b/tests/particle_generator_random_uniform_empty_rank.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Random cell selection = false
       set Number of particles = 1
     end

--- a/tests/particle_integrator_euler.prm
+++ b/tests/particle_integrator_euler.prm
@@ -102,7 +102,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_integrator_rk4.prm
+++ b/tests/particle_integrator_rk4.prm
@@ -102,7 +102,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_interpolator_cell_average.prm
+++ b/tests/particle_interpolator_cell_average.prm
@@ -115,7 +115,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Variable names      = x,z
       set Function expression = x*x*z
       set Number of particles = 100000

--- a/tests/particle_interpolator_cell_average_2.prm
+++ b/tests/particle_interpolator_cell_average_2.prm
@@ -111,7 +111,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 20000
     end
   end

--- a/tests/particle_interpolator_distance_weighted_average.prm
+++ b/tests/particle_interpolator_distance_weighted_average.prm
@@ -115,7 +115,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Variable names      = x,z
       set Function expression = x*x*z
       set Number of particles = 100000

--- a/tests/particle_interpolator_empty_cells.prm
+++ b/tests/particle_interpolator_empty_cells.prm
@@ -92,7 +92,7 @@ subsection Particles
   set Load balancing strategy = remove and add particles
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 2500
     end
   end

--- a/tests/particle_interpolator_from_ghost_cells.prm
+++ b/tests/particle_interpolator_from_ghost_cells.prm
@@ -94,7 +94,7 @@ subsection Particles
   set Load balancing strategy = none
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 400
     end
   end

--- a/tests/particle_interpolator_nearest_neighbor.prm
+++ b/tests/particle_interpolator_nearest_neighbor.prm
@@ -114,11 +114,6 @@ subsection Particles
   set Load balancing strategy = add particles
 
   subsection Generator
-    subsection Probability density function
-      set Variable names      = x,z
-      set Function expression = 1 #x*x*z
-    end
-
     subsection Uniform box
       set Number of particles = 1000
     end

--- a/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
+++ b/tests/particle_interpolator_quadratic_least_squares_2d_periodic.prm
@@ -33,7 +33,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10000
     end
   end

--- a/tests/particle_interpolator_time_dependence.prm
+++ b/tests/particle_interpolator_time_dependence.prm
@@ -101,7 +101,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 20000
     end
   end

--- a/tests/particle_load_balancing_none.prm
+++ b/tests/particle_load_balancing_none.prm
@@ -99,7 +99,7 @@ subsection Particles
   set Integration scheme = euler
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1000
     end
   end

--- a/tests/particle_load_balancing_removal.prm
+++ b/tests/particle_load_balancing_removal.prm
@@ -96,7 +96,7 @@ subsection Particles
   set Integration scheme = euler
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/particle_load_balancing_removal_addition.prm
+++ b/tests/particle_load_balancing_removal_addition.prm
@@ -99,7 +99,7 @@ subsection Particles
   set Integration scheme = euler
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/particle_load_balancing_removal_addition_properties.prm
+++ b/tests/particle_load_balancing_removal_addition_properties.prm
@@ -99,7 +99,7 @@ subsection Particles
   set Integration scheme = euler
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/particle_load_balancing_repartition_multiple_systems.prm
+++ b/tests/particle_load_balancing_repartition_multiple_systems.prm
@@ -90,9 +90,11 @@ subsection Mesh refinement
   set Time steps between mesh refinement = 1
   set Coarsening fraction                = 0.05
   set Refinement fraction                = 0.3
+
   subsection Maximum refinement function
     set Function expression = 3
   end
+
   subsection Minimum refinement function
     set Function expression = 3
   end

--- a/tests/particle_multiple_systems.prm
+++ b/tests/particle_multiple_systems.prm
@@ -84,7 +84,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end
@@ -100,7 +100,7 @@ subsection Particles 2
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_multiple_systems_hdf5.prm
+++ b/tests/particle_multiple_systems_hdf5.prm
@@ -85,7 +85,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end
@@ -101,7 +101,7 @@ subsection Particles 2
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_multiple_systems_vtu.prm
+++ b/tests/particle_multiple_systems_vtu.prm
@@ -85,7 +85,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end
@@ -101,7 +101,7 @@ subsection Particles 2
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_gnuplot.prm
+++ b/tests/particle_output_gnuplot.prm
@@ -100,7 +100,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_hdf5.prm
+++ b/tests/particle_output_hdf5.prm
@@ -100,7 +100,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_multiple_formats.prm
+++ b/tests/particle_output_multiple_formats.prm
@@ -99,7 +99,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_none.prm
+++ b/tests/particle_output_none.prm
@@ -102,7 +102,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 30
     end
   end

--- a/tests/particle_output_vtu.prm
+++ b/tests/particle_output_vtu.prm
@@ -100,7 +100,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_vtu_group.prm
+++ b/tests/particle_output_vtu_group.prm
@@ -103,7 +103,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_output_vtu_temp.prm
+++ b/tests/particle_output_vtu_temp.prm
@@ -102,7 +102,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_periodic_boundaries.prm
+++ b/tests/particle_periodic_boundaries.prm
@@ -107,7 +107,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_periodic_boundaries_dc.prm
+++ b/tests/particle_periodic_boundaries_dc.prm
@@ -28,7 +28,7 @@ subsection Particles
   set Interpolation scheme = bilinear least squares
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10000
     end
   end

--- a/tests/particle_periodic_boundaries_rk4.prm
+++ b/tests/particle_periodic_boundaries_rk4.prm
@@ -106,7 +106,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_property_initial_composition.prm
+++ b/tests/particle_property_initial_composition.prm
@@ -99,7 +99,7 @@ subsection Particles
   set List of particle properties = initial composition
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_property_integrated_strain_invariant.prm
+++ b/tests/particle_property_integrated_strain_invariant.prm
@@ -105,7 +105,7 @@ subsection Particles
   set Particle generator name = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 100
     end
   end

--- a/tests/particle_property_integrated_strain_pure_shear.prm
+++ b/tests/particle_property_integrated_strain_pure_shear.prm
@@ -85,7 +85,7 @@ subsection Particles
   set Particle generator name = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_property_integrated_strain_simple_shear.prm
+++ b/tests/particle_property_integrated_strain_simple_shear.prm
@@ -84,7 +84,7 @@ subsection Particles
   set Particle generator name = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/particle_property_multiple_functions_with_interpolation.prm
+++ b/tests/particle_property_multiple_functions_with_interpolation.prm
@@ -108,7 +108,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Variable names      = x,z
       set Function expression = x*x*z
       set Number of particles = 1024

--- a/tests/particle_property_post_initialize_function.prm
+++ b/tests/particle_property_post_initialize_function.prm
@@ -98,7 +98,7 @@ subsection Particles
   set List of particle properties = initial position, initial composition, PostInitializeParticleProperty, velocity
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles        = 100
     end
   end

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -128,7 +128,7 @@ end
 
 subsection Particles
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 50
     end
   end

--- a/tests/van_keken_smooth_particle.prm
+++ b/tests/van_keken_smooth_particle.prm
@@ -101,7 +101,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 10
     end
   end

--- a/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
+++ b/tests/visco_plastic_vep_stress_build-up_yield_particles.prm
@@ -84,7 +84,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 12e3
     end
   end

--- a/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
+++ b/tests/visco_plastic_yield_noninitial-plastic-strain_particles.prm
@@ -52,7 +52,7 @@ subsection Particles
   set Interpolation scheme = nearest neighbor
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/tests/visco_plastic_yield_plastic_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_plastic_strain_weakening_particles.prm
@@ -24,7 +24,7 @@ subsection Particles
   set Interpolation scheme = nearest neighbor
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles.prm
@@ -24,7 +24,7 @@ subsection Particles
   set Interpolation scheme = nearest neighbor
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/tests/visco_plastic_yield_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_strain_weakening_particles.prm
@@ -24,7 +24,7 @@ subsection Particles
   set Interpolation scheme = nearest neighbor
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/tests/visco_plastic_yield_viscous_strain_weakening_particles.prm
+++ b/tests/visco_plastic_yield_viscous_strain_weakening_particles.prm
@@ -24,7 +24,7 @@ subsection Particles
   set Interpolation scheme = nearest neighbor
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 1e5
     end
   end

--- a/tests/viscoelastic_bending_beam_particles.prm
+++ b/tests/viscoelastic_bending_beam_particles.prm
@@ -45,7 +45,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 4.5e3
     end
   end

--- a/tests/viscoelastic_numerical_elastic_time_step_particles.prm
+++ b/tests/viscoelastic_numerical_elastic_time_step_particles.prm
@@ -67,7 +67,7 @@ subsection Particles
   set Particle generator name     = random uniform
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 12e3
     end
   end

--- a/tests/world_builder_select_grains.prm
+++ b/tests/world_builder_select_grains.prm
@@ -88,7 +88,7 @@ subsection Particles
   end
 
   subsection Generator
-    subsection Probability density function
+    subsection Random uniform
       set Number of particles = 50
     end
   end


### PR DESCRIPTION
This is in response to https://community.geodynamics.org/t/cannot-specify-the-number-of-particles-with-random-uniform-particle-generator/3709/2. It was a mistake to let the 'random uniform' particle generator use the same subsection as the 'probability density function'. I think this was a leftover, because 'random uniform' used to be a child class of 'probability density function'. The change is straightforward, except the update script implementation is a bit complicated, because it needs to handle two cases:
1. .prm files older than the update of the particle parameters need to move 'Number of particles' into the new 'Random uniform' subsection.
2. .prm files younger than the update (or which have already been updated) need to move the whole subsection of 'Probability density function' to the new 'Random uniform' subsection.