### PR TITLE
Convert year to second in the adiabatic profile function

### DIFF
--- a/doc/modules/changes/20241021_ranpengli
+++ b/doc/modules/changes/20241021_ranpengli
@@ -1,0 +1,3 @@
+Changed: The time dimension of the surface condition function of the 'compute profile' adiabatic conditions plugin now respects the value of the parameter 'Use years in output instead of seconds'.
+<br>
+(Ranpeng Li, 2024/10/21)

--- a/source/adiabatic_conditions/compute_profile.cc
+++ b/source/adiabatic_conditions/compute_profile.cc
@@ -47,7 +47,11 @@ namespace aspect
       if (use_surface_condition_function)
         {
           initialized = false;
-          surface_condition_function.set_time(this->get_time());
+          if (this->convert_output_to_years())
+            surface_condition_function.set_time(this->get_time() / year_in_seconds);
+
+          else
+            surface_condition_function.set_time(this->get_time());
           initialize();
         }
     }

--- a/tests/update_script.prm
+++ b/tests/update_script.prm
@@ -17,7 +17,7 @@ subsection Adiabatic conditions model
   subsection Compute profile
     set Use surface condition function = true
     subsection Surface condition function
-      set Function expression = 1e-2*t; 1613.0+1e-13*t
+      set Function expression = 1e-2*(365.2425*24*60*60)*t; 1613.0+1e-13*(365.2425*24*60*60)*t
     end
   end
 end

--- a/tests/update_script_2.prm
+++ b/tests/update_script_2.prm
@@ -21,7 +21,7 @@ subsection Adiabatic conditions model
   subsection Compute profile
     set Use surface condition function = true
     subsection Surface condition function
-      set Function expression = 1e-2*t; 1613.0+1e-13*t
+      set Function expression = 1e-2*(365.2425*24*60*60)*t; 1613.0+1e-13*(365.2425*24*60*60)*t
     end
   end
 end

--- a/tests/update_script_2/updated2.prm
+++ b/tests/update_script_2/updated2.prm
@@ -23,7 +23,7 @@ subsection Adiabatic conditions model
     set Use surface condition function = true
 
     subsection Surface condition function
-      set Function expression = 1e-2*t; 1613.0+1e-13*t
+      set Function expression = 1e-2*(365.2425*24*60*60)*t; 1613.0+1e-13*(365.2425*24*60*60)*t
     end
   end
 end


### PR DESCRIPTION
Convert year to second in the adiabatic profile function when 'Use years in output instead of seconds = true'

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
