### PR TITLE
Derive remaining managers from ManagerBase

### DIFF
--- a/doc/modules/changes/20250202_gassmoeller
+++ b/doc/modules/changes/20250202_gassmoeller
@@ -1,0 +1,9 @@
+Changed: ASPECT's boundary traction and boundary velocity manager classes are
+now also derived from the common classes Plugins::ManagerBase. In order to
+standardize the interface, the functions get_active_boundary_traction_conditions()
+and get_active_boundary_traction_names() (and their velocity counterparts)
+have been deprecated. They have been replaced by the new functions get_active_plugins(),
+get_active_plugin_boundary_indicators(), get_prescribed_boundary_traction_indicators(),
+and get_component_mask().
+<br>
+(Rene Gassmoeller, 2025/02/02)

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -638,14 +638,6 @@ namespace aspect
     bool                           enable_prescribed_dilation;
 
     /**
-     * Map from boundary id to a pair "components", "traction boundary type",
-     * where components is of the format "[x][y][z]" and the traction type is
-     * mapped to one of the plugins of traction boundary conditions (e.g.
-     * "function")
-     */
-    std::map<types::boundary_id, std::pair<std::string,std::string>> prescribed_traction_boundary_indicators;
-
-    /**
      * A set of boundary ids on which the boundary_heat_flux objects
      * will be applied.
      */

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -26,11 +26,12 @@
 
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/parameter_handler.h>
-#include <tuple>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/fe/component_mask.h>
 
 #include <boost/core/demangle.hpp>
 
+#include <tuple>
 #include <string>
 #include <list>
 #include <set>

--- a/source/boundary_traction/ascii_data.cc
+++ b/source/boundary_traction/ascii_data.cc
@@ -35,13 +35,16 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      for (const auto &bv : this->get_boundary_traction_manager().get_active_boundary_traction_conditions())
+      unsigned int i=0;
+      for (const auto &plugin : this->get_boundary_traction_manager().get_active_plugins())
         {
-          for (const auto &plugin : bv.second)
-            if (plugin.get() == this)
-              boundary_ids.insert(bv.first);
+          if (plugin.get() == this)
+            boundary_ids.insert(this->get_boundary_traction_manager().get_active_plugin_boundary_indicators()[i]);
+
+          ++i;
         }
-      AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
+
+      AssertThrow(boundary_ids.empty() == false,
                   ExcMessage("Did not find the boundary indicator for the traction ascii data plugin."));
 
       Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -49,13 +49,15 @@ namespace aspect
       // Ensure the initial lithostatic pressure traction boundary conditions are used,
       // and register for which boundary indicators these conditions are set.
       std::set<types::boundary_id> traction_bi;
-      for (const auto &p : this->get_boundary_traction_manager().get_active_boundary_traction_conditions())
+      unsigned int i=0;
+      for (const auto &plugin : this->get_boundary_traction_manager().get_active_plugins())
         {
-          for (const auto &plugin : p.second)
-            if (plugin.get() == this)
-              traction_bi.insert(p.first);
+          if (plugin.get() == this)
+            traction_bi.insert(this->get_boundary_traction_manager().get_active_plugin_boundary_indicators()[i]);
+
+          ++i;
         }
-      AssertThrow(*(traction_bi.begin()) != numbers::invalid_boundary_id,
+      AssertThrow(traction_bi.empty() == false,
                   ExcMessage("Did not find any boundary indicators for the initial lithostatic pressure plugin."));
 
       // Determine whether traction boundary conditions are only set on the bottom

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -33,23 +33,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    template <int dim>
-    Manager<dim>::~Manager()
-      = default;
-
-
-
-    template <int dim>
-    void
-    Manager<dim>::update ()
-    {
-      for (const auto &boundary : boundary_traction_objects)
-        for (const auto &p : boundary.second)
-          p->update();
-    }
-
-
-
     namespace
     {
       std::tuple
@@ -78,19 +61,31 @@ namespace aspect
                                      const Point<dim> &position,
                                      const Tensor<1,dim> &normal_vector) const
     {
-      typename std::map<types::boundary_id,std::vector<std::unique_ptr<BoundaryTraction::Interface<dim>>>>::const_iterator boundary_plugins =
-        boundary_traction_objects.find(boundary_indicator);
+      Tensor<1,dim> traction;
 
-      Assert(boundary_plugins != boundary_traction_objects.end(),
+      bool found_plugin = false;
+      unsigned int i=0;
+      for (const auto &plugin: this->plugin_objects)
+        {
+          if (boundary_indicators[i] == boundary_indicator)
+            {
+              found_plugin = true;
+              const Tensor<1,dim> plugin_traction = plugin->boundary_traction(boundary_indicator,
+                                                                              position,
+                                                                              normal_vector);
+              for (unsigned int d=0; d<dim; ++d)
+                if (component_masks[i][d] == true)
+                  traction[d] += plugin_traction[d];
+            }
+
+          ++i;
+        }
+
+      (void) found_plugin;
+      Assert(found_plugin == true,
              ExcMessage("The boundary traction manager class was asked for the "
                         "boundary traction at a boundary that contains no active "
                         "boundary traction plugin."));
-
-      Tensor<1,dim> traction = Tensor<1,dim>();
-
-      for (const auto &plugin : boundary_plugins->second)
-        traction += plugin->boundary_traction(boundary_indicator,
-                                              position,normal_vector);
 
       return traction;
     }
@@ -110,7 +105,57 @@ namespace aspect
     const std::map<types::boundary_id,std::vector<std::unique_ptr<BoundaryTraction::Interface<dim>>>> &
     Manager<dim>::get_active_boundary_traction_conditions () const
     {
+      AssertThrow(false, ExcMessage("This function has been removed. Use the function "
+                                    "get_active_plugins() of the base class ManagerBase "
+                                    "instead."));
       return boundary_traction_objects;
+    }
+
+
+
+    template <int dim>
+    const std::set<types::boundary_id> &
+    Manager<dim>::get_prescribed_boundary_traction_indicators () const
+    {
+      return prescribed_traction_boundary_indicators;
+    }
+
+
+
+    template <int dim>
+    const std::vector<types::boundary_id> &
+    Manager<dim>::get_active_plugin_boundary_indicators() const
+    {
+      return boundary_indicators;
+    }
+
+
+
+    template <int dim>
+    ComponentMask
+    Manager<dim>::get_component_mask(const types::boundary_id boundary_id) const
+    {
+      Assert(prescribed_traction_boundary_indicators.find(boundary_id) != prescribed_traction_boundary_indicators.end(),
+             ExcMessage("The boundary traction manager class was asked for the "
+                        "component mask of boundary indicator <"
+                        +
+                        Utilities::int_to_string(boundary_id)
+                        +
+                        "> with symbolic name <"
+                        +
+                        this->get_geometry_model().translate_id_to_symbol_name(boundary_id)
+                        +
+                        ">, but this boundary is not part of the active boundary traction plugins."));
+
+      // Since all component masks of plugins at the same boundary are identical, we can use
+      // the component mask of the first plugin we find that is responsible for this boundary.
+      for (unsigned int i=0; i<boundary_indicators.size(); ++i)
+        if (boundary_indicators[i] == boundary_id)
+          return component_masks[i];
+
+      // We should never get here if plugins and boundary indicators were set up correctly.
+      AssertThrow(false, ExcInternalError());
+      return ComponentMask();
     }
 
 
@@ -254,27 +299,40 @@ namespace aspect
               {
                 boundary_traction_indicators[boundary_id] = std::make_pair(comp,std::vector<std::string>(1,value));
               }
+
+            this->plugin_names.push_back(value);
+            boundary_indicators.push_back(boundary_id);
+            prescribed_traction_boundary_indicators.insert(boundary_id);
+
+            ComponentMask component_mask(this->introspection().n_components,
+                                         false);
+
+            if (comp.empty() || comp.find('x') != std::string::npos)
+              component_mask.set(this->introspection().component_indices.velocities[0],true);
+            if (comp.empty() || comp.find('y') != std::string::npos)
+              component_mask.set(this->introspection().component_indices.velocities[1],true);
+            if (dim == 3 && (comp.empty() || comp.find('z') != std::string::npos))
+              component_mask.set(this->introspection().component_indices.velocities[2],true);
+
+            component_masks.push_back(component_mask);
           }
       }
       prm.leave_subsection();
 
       // go through the list, create objects and let them parse
       // their own parameters
-      for (const auto &boundary_id : boundary_traction_indicators)
+      for (const auto &plugin_name: this->plugin_names)
         {
-          for (const auto &name : boundary_id.second.second)
-            {
-              boundary_traction_objects[boundary_id.first].push_back(
-                std::unique_ptr<Interface<dim>> (std::get<dim>(registered_plugins)
-                                                  .create_plugin (name,
-                                                                  "Boundary traction::Model names")));
+          // create boundary traction objects
+          this->plugin_objects.push_back(std::get<dim>(registered_plugins)
+                                         .create_plugin (plugin_name,
+                                                         "Boundary traction::Model names"));
 
-              if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(boundary_traction_objects[boundary_id.first].back().get()))
-                sim->initialize_simulator (this->get_simulator());
+          if (SimulatorAccess<dim> *sim = dynamic_cast<SimulatorAccess<dim>*>(this->plugin_objects.back().get()))
+            sim->initialize_simulator (this->get_simulator());
 
-              boundary_traction_objects[boundary_id.first].back()->parse_parameters (prm);
-              boundary_traction_objects[boundary_id.first].back()->initialize ();
-            }
+          this->plugin_objects.back()->parse_parameters (prm);
+          this->plugin_objects.back()->initialize ();
         }
     }
 

--- a/source/boundary_velocity/ascii_data.cc
+++ b/source/boundary_velocity/ascii_data.cc
@@ -38,14 +38,17 @@ namespace aspect
     void
     AsciiData<dim>::initialize ()
     {
-      for (const auto &p : this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions())
+      unsigned int i=0;
+      for (const auto &plugin : this->get_boundary_velocity_manager().get_active_plugins())
         {
-          for (const auto &plugin : p.second)
-            if (plugin.get() == this)
-              boundary_ids.insert(p.first);
+          if (plugin.get() == this)
+            boundary_ids.insert(this->get_boundary_velocity_manager().get_active_plugin_boundary_indicators()[i]);
+
+          ++i;
         }
-      AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
-                  ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));
+
+      AssertThrow(boundary_ids.empty() == false,
+                  ExcMessage("Did not find the boundary indicator for the velocity ascii data plugin."));
 
       Utilities::AsciiDataBoundary<dim>::initialize(boundary_ids,
                                                     dim);

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -50,20 +50,17 @@ namespace aspect
       std::set<types::boundary_id> velocity_boundary_indicators = this->get_boundary_velocity_manager().get_zero_boundary_velocity_indicators();
 
       // Get the tangential velocity boundary indicators
-      const std::set<types::boundary_id> tmp_tangential_vel_boundary_indicators = this->get_boundary_velocity_manager().get_tangential_boundary_velocity_indicators();
-      velocity_boundary_indicators.insert(tmp_tangential_vel_boundary_indicators.begin(),
-                                          tmp_tangential_vel_boundary_indicators.end());
+      const auto &tangential_boundary_indicators = this->get_boundary_velocity_manager().get_tangential_boundary_velocity_indicators();
+      velocity_boundary_indicators.insert(tangential_boundary_indicators.begin(),
+                                          tangential_boundary_indicators.end());
 
       // Get the active velocity boundary indicators
-      const std::map<types::boundary_id, std::pair<std::string,std::vector<std::string>>>
-      tmp_active_vel_boundary_indicators = this->get_boundary_velocity_manager().get_active_boundary_velocity_names();
-
-      for (const auto &p : tmp_active_vel_boundary_indicators)
-        velocity_boundary_indicators.insert(p.first);
+      const auto &prescribed_boundary_indicators = this->get_boundary_velocity_manager().get_prescribed_boundary_velocity_indicators();
+      velocity_boundary_indicators.insert(prescribed_boundary_indicators.begin(),
+                                          prescribed_boundary_indicators.end());
 
       // Get the mesh deformation boundary indicators
-      const std::set<types::boundary_id> tmp_mesh_deformation_boundary_indicators = this->get_mesh_deformation_boundary_indicators();
-      for (const auto &p : tmp_mesh_deformation_boundary_indicators)
+      for (const auto &p : this->get_mesh_deformation_boundary_indicators())
         AssertThrow(velocity_boundary_indicators.find(p) == velocity_boundary_indicators.end(),
                     ExcMessage("The free surface mesh deformation plugin cannot be used with the current velocity boundary conditions"));
     }

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -942,9 +942,9 @@ namespace aspect
 
       const typename DoFHandler<dim>::face_iterator face = scratch.cell->face(scratch.face_number);
 
-      if (this->get_boundary_traction_manager().get_active_boundary_traction_names().find (face->boundary_id())
-          !=
-          this->get_boundary_traction_manager().get_active_boundary_traction_names().end())
+      const auto &traction_bis = this->get_boundary_traction_manager().get_prescribed_boundary_traction_indicators();
+
+      if (traction_bis.find(face->boundary_id()) != traction_bis.end())
         {
           for (unsigned int q=0; q<scratch.face_finite_element_values.n_quadrature_points; ++q)
             {

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -126,7 +126,7 @@ namespace aspect
                              " defined that handles this formulation."));
 
     // add the terms for traction boundary conditions
-    if (!boundary_traction_manager.get_active_boundary_traction_names().empty())
+    if (!boundary_traction_manager.get_prescribed_boundary_traction_indicators().empty())
       {
         assemblers->stokes_system_on_boundary_face.push_back(
           std::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());
@@ -739,7 +739,7 @@ namespace aspect
     // we will update the right-hand side with boundary information in
     // StokesMatrixFreeHandler::correct_stokes_rhs().
     if (!stokes_matrix_free)
-      Assert(rebuild_stokes_matrix || boundary_velocity_manager.get_active_boundary_velocity_conditions().size()==0,
+      Assert(rebuild_stokes_matrix || boundary_velocity_manager.get_prescribed_boundary_velocity_indicators().empty(),
              ExcInternalError("If we have inhomogeneous constraints, we must re-assemble the system matrix."));
 
     system_rhs = 0;
@@ -763,7 +763,7 @@ namespace aspect
       = (
           // see if we need to assemble traction boundary conditions.
           // only if so do we actually need to have an FEFaceValues object
-          boundary_traction_manager.get_active_boundary_traction_names ().size() > 0
+          !boundary_traction_manager.get_prescribed_boundary_traction_indicators().empty()
           ?
           update_values |
           update_quadrature_points |

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1039,11 +1039,9 @@ namespace aspect
       Assert(face_no != numbers::invalid_unsigned_int,ExcInternalError());
 
       const typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
+      const auto &traction_bis = this->get_boundary_traction_manager().get_prescribed_boundary_traction_indicators();
 
-      if (this->get_boundary_traction_manager().get_active_boundary_traction_names()
-          .find (face->boundary_id())
-          !=
-          this->get_boundary_traction_manager().get_active_boundary_traction_names().end())
+      if (traction_bis.find(face->boundary_id()) != traction_bis.end())
         {
           scratch.face_finite_element_values.reinit (cell, face_no);
 
@@ -1697,7 +1695,7 @@ namespace aspect
       std::make_unique<aspect::Assemblers::MeltStokesSystemBoundary<dim>>());
 
     // add the terms for traction boundary conditions
-    if (!this->get_boundary_traction_manager().get_active_boundary_traction_names().empty())
+    if (!this->get_boundary_traction_manager().get_prescribed_boundary_traction_indicators().empty())
       {
         assemblers.stokes_system_on_boundary_face.push_back(
           std::make_unique<Assemblers::MeltBoundaryTraction<dim>> ());

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -96,7 +96,7 @@ namespace aspect
                              " defined that handles this formulation."));
 
     // add the terms for traction boundary conditions
-    if (!this->get_boundary_traction_manager().get_active_boundary_traction_names().empty())
+    if (!this->get_boundary_traction_manager().get_prescribed_boundary_traction_indicators().empty())
       {
         assemblers.stokes_system_on_boundary_face.push_back(
           std::make_unique<aspect::Assemblers::StokesBoundaryTraction<dim>>());

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -370,7 +370,7 @@ namespace aspect
     // don't need to force assembly of the matrix.
     if (stokes_matrix_depends_on_solution()
         ||
-        (boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0)
+        (boundary_velocity_manager.get_prescribed_boundary_velocity_indicators().size() > 0)
         || parameters.mesh_deformation_enabled
        )
       rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
@@ -570,7 +570,7 @@ namespace aspect
         // don't need to force assembly of the matrix.
         if (stokes_matrix_depends_on_solution()
             ||
-            (nonlinear_iteration == 0 && boundary_velocity_manager.get_active_boundary_velocity_conditions().size() > 0))
+            (nonlinear_iteration == 0 && boundary_velocity_manager.get_prescribed_boundary_velocity_indicators().size() > 0))
           rebuild_stokes_matrix = rebuild_stokes_preconditioner = assemble_newton_stokes_matrix = true;
         else if (parameters.enable_prescribed_dilation)
           // The dilation requires the Stokes matrix (which is on the rhs
@@ -664,8 +664,7 @@ namespace aspect
 
             // Rebuild the rhs to determine the new residual.
             assemble_newton_stokes_matrix = rebuild_stokes_preconditioner = false;
-            rebuild_stokes_matrix = (boundary_velocity_manager.get_active_boundary_velocity_conditions().empty()
-                                     == false);
+            rebuild_stokes_matrix = !boundary_velocity_manager.get_prescribed_boundary_velocity_indicators().empty();
 
             assemble_stokes_system();
 

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -2509,40 +2509,23 @@ namespace aspect
       mg_constrained_dofs_A_block.initialize(dof_handler_v);
 
       std::set<types::boundary_id> dirichlet_boundary = sim.boundary_velocity_manager.get_zero_boundary_velocity_indicators();
-      for (const auto &it: sim.boundary_velocity_manager.get_active_boundary_velocity_names())
+      for (const auto boundary_id: sim.boundary_velocity_manager.get_prescribed_boundary_velocity_indicators())
         {
-          const types::boundary_id bdryid = it.first;
-          const std::string component=it.second.first;
+          const ComponentMask component_mask = sim.boundary_velocity_manager.get_component_mask(boundary_id);
 
-          if (component.length()>0)
+          if (component_mask != ComponentMask(sim.introspection.n_components, false))
             {
-              std::vector<bool> mask(fe_v.n_components(), false);
-              for (const auto &direction : component)
-                {
-                  switch (direction)
-                    {
-                      case 'x':
-                        mask[0] = true;
-                        break;
-                      case 'y':
-                        mask[1] = true;
-                        break;
-                      case 'z':
-                        // we must be in 3d, or 'z' should never have gotten through
-                        Assert (dim==3, ExcInternalError());
-                        if (dim==3)
-                          mask[2] = true;
-                        break;
-                      default:
-                        Assert (false, ExcInternalError());
-                    }
-                }
-              mg_constrained_dofs_A_block.make_zero_boundary_constraints(dof_handler_v, {bdryid}, ComponentMask(mask));
+              ComponentMask velocity_mask(fe_v.n_components(), false);
+
+              for (unsigned int i=0; i<dim; ++i)
+                velocity_mask.set(i, component_mask[sim.introspection.component_indices.velocities[i]]);
+
+              mg_constrained_dofs_A_block.make_zero_boundary_constraints(dof_handler_v, {boundary_id}, velocity_mask);
             }
           else
             {
               // no mask given: add at the end
-              dirichlet_boundary.insert(bdryid);
+              dirichlet_boundary.insert(boundary_id);
             }
         }
 

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -98,16 +98,17 @@ namespace aspect
   void
   AsciiBoundaryMember<dim>::initialize ()
   {
-    const std::map<types::boundary_id,std::vector<std::unique_ptr<BoundaryVelocity::Interface<dim>>>> &
-    bvs = this->get_boundary_velocity_manager().get_active_boundary_velocity_conditions();
-    for (const auto &boundary : bvs)
-      for (const auto &p : boundary.second)
-        {
-          if (p.get() == this)
-            boundary_ids.insert(boundary.first);
-        }
-    AssertThrow(*(boundary_ids.begin()) != numbers::invalid_boundary_id,
-                ExcMessage("Did not find the boundary indicator for the prescribed data plugin."));
+    unsigned int i=0;
+    for (const auto &plugin : this->get_boundary_velocity_manager().get_active_plugins())
+      {
+        if (plugin.get() == this)
+          boundary_ids.insert(this->get_boundary_velocity_manager().get_active_plugin_boundary_indicators()[i]);
+
+        ++i;
+      }
+
+    AssertThrow(boundary_ids.empty() == false,
+                ExcMessage("Did not find the boundary indicator for the velocity ascii data plugin."));
 
     member->initialize(boundary_ids,
                        dim);

--- a/tests/ascii_boundary_member/screen-output
+++ b/tests/ascii_boundary_member/screen-output
@@ -2,13 +2,13 @@
 Loading shared library <./libascii_boundary_member.debug.so>
 
 
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
+
+
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.

--- a/tests/ascii_data_boundary_velocity_2d_box/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box/screen-output
@@ -1,12 +1,12 @@
 
 
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
+
+
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_right.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_bottom.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.

--- a/tests/ascii_data_boundary_velocity_2d_box_time/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_box_time/screen-output
@@ -1,5 +1,11 @@
 
 
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.
+
+
+   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
+
+
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_left.0.txt.
 
 
@@ -20,12 +26,6 @@
    If the Ascii data represented a time-dependent boundary condition,
    that time-dependence ends at this timestep  (i.e. the boundary condition
    will continue unchanged from the last known state into the future).
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.0.txt.
-
-
-   Also loading next Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_2d_top.1.txt.
 
 Number of active cells: 80 (on 3 levels)
 Number of degrees of freedom: 1,212 (738+105+369)

--- a/tests/ascii_data_boundary_velocity_2d_chunk/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_chunk/screen-output
@@ -1,15 +1,15 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_bottom.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_top.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_west.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_east.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_bottom.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/chunk_2d_top.0.txt.
 
 Number of active cells: 64 (on 4 levels)
 Number of degrees of freedom: 948 (578+81+289)

--- a/tests/ascii_data_boundary_velocity_2d_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_shell/screen-output
@@ -1,15 +1,15 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_left.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_right.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top.0.txt.
 
 Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 2,724 (1,666+225+833)

--- a/tests/ascii_data_boundary_velocity_2d_shell_spherical/screen-output
+++ b/tests/ascii_data_boundary_velocity_2d_shell_spherical/screen-output
@@ -1,15 +1,15 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom_spherical.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top_spherical.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_left_spherical.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_right_spherical.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_bottom_spherical.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_2d_top_spherical.0.txt.
 
 Number of active cells: 192 (on 4 levels)
 Number of degrees of freedom: 2,724 (1,666+225+833)

--- a/tests/ascii_data_boundary_velocity_3d_box/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_box/screen-output
@@ -1,21 +1,21 @@
 
 
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_bottom.0.txt.
+
+
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_left.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_right.0.txt.
 
 
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_top.0.txt.
+
+
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_front.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_back.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_bottom.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/box_3d_top.0.txt.
 
 Number of active cells: 200 (on 2 levels)
 Number of degrees of freedom: 9,183 (6,615+363+2,205)

--- a/tests/ascii_data_boundary_velocity_3d_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_shell/screen-output
@@ -1,18 +1,18 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)

--- a/tests/ascii_data_boundary_velocity_3d_shell_spherical/screen-output
+++ b/tests/ascii_data_boundary_velocity_3d_shell_spherical/screen-output
@@ -1,18 +1,18 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom_spherical.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top_spherical.0.txt.
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west_spherical.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east_spherical.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west_spherical.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south_spherical.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom_spherical.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top_spherical.0.txt.
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)

--- a/tests/ascii_data_boundary_velocity_residual_shell/screen-output
+++ b/tests/ascii_data_boundary_velocity_residual_shell/screen-output
@@ -1,18 +1,18 @@
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
-
-
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
 
 
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_east.0.txt.
 
 
-   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_west.0.txt.
-
-
    Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_south.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_bottom.0.txt.
+
+
+   Loading Ascii data boundary file ASPECT_DIR/data/boundary-velocity/ascii-data/test/shell_3d_top.0.txt.
 
 Number of active cells: 24 (on 2 levels)
 Number of degrees of freedom: 1,277 (915+57+305)


### PR DESCRIPTION
A suggestion for how to finish #1775. This is still work in progress and unfortunately not completely backwards compatible, but at least the incompatibility is only limited to two rarely used functions in the code, not the input file. The traction manager (and the velocity manager once I get to it) need additional information compared to `ManagerBase`, namely which boundary each plugin is responsible for, and which components (of the tensor components xyz). The main change is the type of internal storage container, and the access functions `get_active_boundary_traction_conditions` and `get_active_boundary_traction_names`. Opinions? If we we agree this is a good idea I can continue with the velocity manager.