### PR TITLE
Do not throw in destructor of ManagerBase during stack unwinding

### DIFF
--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -294,7 +294,16 @@ namespace aspect
     template <typename InterfaceType>
     ManagerBase<InterfaceType>::~ManagerBase()
     {
-      Assert (plugin_names.size() == plugin_objects.size(), ExcInternalError());
+      // only check and throw if we are not unwinding the stack due
+      // to an active exception
+#ifdef DEAL_II_HAVE_CXX17
+      if (std::uncaught_exceptions() == 0)
+#else
+      if (std::uncaught_exception() == false)
+#endif
+        {
+          Assert (plugin_names.size() == plugin_objects.size(), ExcInternalError());
+        }
     }
 
 


### PR DESCRIPTION
Noticed while working on #6097. If we throw an exception while parsing the parameters of the manager class the size of `plugin_names` and `plugin_objects` may not be the same. But if we throw an exception during the stack unwinding the program crashes without helpful error message. So only throw if during a regular destruction the size does not match.