### PR TITLE
Enable deprecation warnings in tester

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build-no-unity
         cd build-no-unity
-        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' ..
+        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Wdeprecated-declarations -Werror' ..
         make -j 4
         ./aspect --test
 
@@ -129,7 +129,7 @@ jobs:
         cmake \
         -D CMAKE_BUILD_TYPE=Debug \
         -G 'Ninja' \
-        -D CMAKE_CXX_FLAGS='-Werror' \
+        -D CMAKE_CXX_FLAGS='-Wdeprecated-declarations -Werror' \
         -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \
         -D ASPECT_TEST_GENERATOR='Ninja' \
         -D ASPECT_PRECOMPILE_HEADERS=ON \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir build-no-unity
         cd build-no-unity
-        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Wdeprecated-declarations -Werror' ..
+        cmake -D CMAKE_BUILD_TYPE=Debug -D ASPECT_PRECOMPILE_HEADERS=OFF -D ASPECT_UNITY_BUILD=OFF -D CMAKE_CXX_FLAGS='-Werror' -D ASPECT_ADDITIONAL_CXX_FLAGS='-Wdeprecated-declarations' ..
         make -j 4
         ./aspect --test
 
@@ -129,8 +129,8 @@ jobs:
         cmake \
         -D CMAKE_BUILD_TYPE=Debug \
         -G 'Ninja' \
-        -D CMAKE_CXX_FLAGS='-Wdeprecated-declarations -Werror' \
-        -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3' \
+        -D CMAKE_CXX_FLAGS='-Werror' \
+        -D ASPECT_ADDITIONAL_CXX_FLAGS='-O3 -Wdeprecated-declarations' \
         -D ASPECT_TEST_GENERATOR='Ninja' \
         -D ASPECT_PRECOMPILE_HEADERS=ON \
         -D ASPECT_UNITY_BUILD=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,8 @@ if(ASPECT_WITH_WORLD_BUILDER)
 
       set(WB_TARGET "WorldBuilderDebug")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
-      target_compile_options(WorldBuilderDebug PRIVATE "-g" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
+      separate_arguments(SEPARATED_FLAGS NATIVE_COMMAND ${ASPECT_ADDITIONAL_CXX_FLAGS})
+      target_compile_options(WorldBuilderDebug PRIVATE "-g" "${SEPARATED_FLAGS}")
 
       set(CMAKE_BUILD_TYPE ${_build_type})
     endif()
@@ -308,7 +309,9 @@ if(ASPECT_WITH_WORLD_BUILDER)
       set(WB_TARGET "WorldBuilderRelease")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder_release/)
       target_compile_definitions(WorldBuilderRelease PUBLIC "NDEBUG")
-      target_compile_options(WorldBuilderRelease PRIVATE "-O3" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
+
+      separate_arguments(SEPARATED_FLAGS NATIVE_COMMAND ${ASPECT_ADDITIONAL_CXX_FLAGS})
+      target_compile_options(WorldBuilderRelease PRIVATE "-O3" "${SEPARATED_FLAGS}")
 
       set(CMAKE_BUILD_TYPE ${_build_type})
     endif()

--- a/source/material_model/diffusion_dislocation.cc
+++ b/source/material_model/diffusion_dislocation.cc
@@ -142,15 +142,13 @@ namespace aspect
           // Establish that a background field is required here
           chemical_field_names.insert(chemical_field_names.begin(),"background");
 
-          Utilities::MapParsing::Options options(chemical_field_names, "Densities");
+          Utilities::MapParsing::Options options(chemical_field_names, "");
           options.list_of_allowed_keys = compositional_field_names;
-
-          densities = Utilities::MapParsing::parse_map_to_double_array (prm.get("Densities"),
-                                                                        options);
+          options.property_name = "Densities";
+          densities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
           options.property_name = "Thermal expansivities";
-          thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array (prm.get("Thermal expansivities"),
-                                                                                    options);
+          thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
           // Phenomenological parameters
           thermal_diffusivity = prm.get_double("Thermal diffusivity");

--- a/source/material_model/equation_of_state/multicomponent_compressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_compressible.cc
@@ -117,42 +117,29 @@ namespace aspect
       void
       MulticomponentCompressible<dim>::parse_parameters (ParameterHandler &prm)
       {
+        std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
         // Establish that a background field is required here
-        const bool has_background_field = true;
-
-        // Retrieve the list of composition names
-        const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+        compositional_field_names.insert(compositional_field_names.begin(),"background");
+        Utilities::MapParsing::Options options(compositional_field_names, "");
 
         // Parse multicomponent properties
-        reference_temperatures = Utilities::parse_map_to_double_array (prm.get("Reference temperatures"),
-                                                                       list_of_composition_names,
-                                                                       has_background_field,
-                                                                       "Reference temperatures");
+        options.property_name = "Reference temperatures";
+        reference_temperatures = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-        reference_densities = Utilities::parse_map_to_double_array (prm.get("Reference densities"),
-                                                                    list_of_composition_names,
-                                                                    has_background_field,
-                                                                    "Reference densities");
+        options.property_name = "Reference densities";
+        reference_densities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-        reference_isothermal_compressibilities = Utilities::parse_map_to_double_array (prm.get("Reference isothermal compressibilities"),
-                                                                                       list_of_composition_names,
-                                                                                       has_background_field,
-                                                                                       "Reference isothermal compressibilities");
+        options.property_name = "Reference isothermal compressibilities";
+        reference_isothermal_compressibilities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-        isothermal_bulk_modulus_pressure_derivatives = Utilities::parse_map_to_double_array (prm.get("Isothermal bulk modulus pressure derivatives"),
-                                                       list_of_composition_names,
-                                                       has_background_field,
-                                                       "Isothermal bulk modulus pressure derivatives");
+        options.property_name = "Isothermal bulk modulus pressure derivatives";
+        isothermal_bulk_modulus_pressure_derivatives = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-        reference_thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Reference thermal expansivities"),
-                                                                                list_of_composition_names,
-                                                                                has_background_field,
-                                                                                "Reference thermal expansivities");
+        options.property_name = "Reference thermal expansivities";
+        reference_thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-        isochoric_specific_heats = Utilities::parse_map_to_double_array (prm.get("Isochoric specific heats"),
-                                                                         list_of_composition_names,
-                                                                         has_background_field,
-                                                                         "Isochoric specific heats");
+        options.property_name = "Isochoric specific heats";
+        isochoric_specific_heats = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
       }
     }
   }

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -1170,75 +1170,48 @@ namespace aspect
                 AssertThrow (false, ExcNotImplemented());
             }
 
-          molar_masses = Utilities::parse_map_to_double_array (prm.get("Molar masses"),
-                                                               endmember_names,
-                                                               false,
-                                                               "Molar masses");
+          Utilities::MapParsing::Options options(endmember_names, "");
+          options.property_name = "Molar masses";
+          molar_masses = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          number_of_atoms = Utilities::parse_map_to_double_array (prm.get("Number of atoms"),
-                                                                  endmember_names,
-                                                                  false,
-                                                                  "Number of atoms");
+          options.property_name = "Number of atoms";
+          number_of_atoms = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_volumes = Utilities::parse_map_to_double_array (prm.get("Reference volumes"),
-                                                                    endmember_names,
-                                                                    false,
-                                                                    "Reference volumes");
+          options.property_name = "Reference volumes";
+          reference_volumes = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_thermal_expansivities = Utilities::parse_map_to_double_array (prm.get("Reference thermal expansivities"),
-                                                                                  endmember_names,
-                                                                                  false,
-                                                                                  "Reference thermal expansivities");
+          options.property_name = "Reference thermal expansivities";
+          reference_thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_bulk_moduli = Utilities::parse_map_to_double_array (prm.get("Reference bulk moduli"),
-                                                                        endmember_names,
-                                                                        false,
-                                                                        "Reference bulk moduli");
+          options.property_name = "Reference bulk moduli";
+          reference_bulk_moduli = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          bulk_modulus_pressure_derivatives = Utilities::parse_map_to_double_array (prm.get("First derivatives of the bulk modulus"),
-                                                                                    endmember_names,
-                                                                                    false,
-                                                                                    "First derivatives of the bulk modulus");
+          options.property_name = "First derivatives of the bulk modulus";
+          bulk_modulus_pressure_derivatives = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          bulk_modulus_second_pressure_derivatives = Utilities::parse_map_to_double_array (prm.get("Second derivatives of the bulk modulus"),
-                                                     endmember_names,
-                                                     false,
-                                                     "Second derivatives of the bulk modulus");
+          options.property_name = "Second derivatives of the bulk modulus";
+          bulk_modulus_second_pressure_derivatives = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          Einstein_temperatures = Utilities::parse_map_to_double_array (prm.get("Einstein temperatures"),
-                                                                        endmember_names,
-                                                                        false,
-                                                                        "Einstein temperatures");
+          options.property_name = "Einstein temperatures";
+          Einstein_temperatures = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_enthalpies = Utilities::parse_map_to_double_array (prm.get("Reference enthalpies"),
-                                                                       endmember_names,
-                                                                       false,
-                                                                       "Reference enthalpies");
+          options.property_name = "Reference enthalpies";
+          reference_enthalpies = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_entropies = Utilities::parse_map_to_double_array (prm.get("Reference entropies"),
-                                                                      endmember_names,
-                                                                      false,
-                                                                      "Reference entropies");
+          options.property_name = "Reference entropies";
+          reference_entropies = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          reference_specific_heats = Utilities::parse_map_to_double_array (prm.get("Reference specific heat capacities"),
-                                                                           endmember_names,
-                                                                           false,
-                                                                           "Reference specific heat capacities");
+          options.property_name = "Reference specific heat capacities";
+          reference_specific_heats = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          specific_heat_linear_coefficients = Utilities::parse_map_to_double_array (prm.get("Linear coefficients for specific heat polynomial"),
-                                                                                    endmember_names,
-                                                                                    false,
-                                                                                    "Linear coefficients for specific heat polynomial");
+          options.property_name = "Linear coefficients for specific heat polynomial";
+          specific_heat_linear_coefficients = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          specific_heat_second_coefficients = Utilities::parse_map_to_double_array (prm.get("Second coefficients for specific heat polynomial"),
-                                                                                    endmember_names,
-                                                                                    false,
-                                                                                    "Second coefficients for specific heat polynomial");
+          options.property_name = "Second coefficients for specific heat polynomial";
+          specific_heat_second_coefficients = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          specific_heat_third_coefficients = Utilities::parse_map_to_double_array (prm.get("Third coefficients for specific heat polynomial"),
-                                                                                   endmember_names,
-                                                                                   false,
-                                                                                   "Third coefficients for specific heat polynomial");
+          options.property_name = "Third coefficients for specific heat polynomial";
+          specific_heat_third_coefficients = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
           // Check all lists have the correct length.
           AssertThrow(endmember_names.size() == endmember_states.size(),

--- a/source/material_model/multicomponent_compressible.cc
+++ b/source/material_model/multicomponent_compressible.cc
@@ -126,21 +126,16 @@ namespace aspect
           viscosity_averaging = MaterialUtilities::parse_compositional_averaging_operation ("Viscosity averaging scheme",
                                 prm);
 
+          std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
           // Establish that a background field is required here
-          const bool has_background_field = true;
+          compositional_field_names.insert(compositional_field_names.begin(),"background");
+          Utilities::MapParsing::Options options(compositional_field_names, "");
 
-          // Retrieve the list of composition names
-          const std::vector<std::string> list_of_composition_names = this->introspection().get_composition_names();
+          options.property_name = "Viscosities";
+          viscosities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
 
-          viscosities = Utilities::parse_map_to_double_array (prm.get("Viscosities"),
-                                                              list_of_composition_names,
-                                                              has_background_field,
-                                                              "Viscosities");
-
-          thermal_conductivities = Utilities::parse_map_to_double_array (prm.get("Thermal conductivities"),
-                                                                         list_of_composition_names,
-                                                                         has_background_field,
-                                                                         "Thermal conductivities");
+          options.property_name = "Thermal conductivities";
+          thermal_conductivities = Utilities::MapParsing::parse_map_to_double_array (prm.get(options.property_name), options);
         }
         prm.leave_subsection();
       }

--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -93,7 +93,12 @@ namespace aspect
       check_diffusion_time_step(mesh_deformation_dof_handler, boundary_ids);
 
       // Set up constraints
+#if DEAL_II_VERSION_GTE(9,6,0)
+      AffineConstraints<double> matrix_constraints(mesh_locally_relevant, mesh_locally_relevant);
+#else
       AffineConstraints<double> matrix_constraints(mesh_locally_relevant);
+#endif
+
       DoFTools::make_hanging_node_constraints(mesh_deformation_dof_handler, matrix_constraints);
 
       std::set<types::boundary_id> periodic_boundary_indicators;
@@ -445,9 +450,7 @@ namespace aspect
       LinearAlgebra::Vector boundary_velocity;
 
       const IndexSet &mesh_locally_owned = mesh_deformation_dof_handler.locally_owned_dofs();
-      IndexSet mesh_locally_relevant;
-      DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler,
-                                               mesh_locally_relevant);
+      const IndexSet mesh_locally_relevant = DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler);
       boundary_velocity.reinit(mesh_locally_owned, mesh_locally_relevant,
                                this->get_mpi_communicator());
 

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -222,9 +222,7 @@ namespace aspect
       LinearAlgebra::Vector boundary_velocity;
 
       const IndexSet &mesh_locally_owned = mesh_deformation_dof_handler.locally_owned_dofs();
-      IndexSet mesh_locally_relevant;
-      DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler,
-                                               mesh_locally_relevant);
+      const IndexSet mesh_locally_relevant = DoFTools::extract_locally_relevant_dofs (mesh_deformation_dof_handler);
       boundary_velocity.reinit(mesh_locally_owned, mesh_locally_relevant,
                                this->get_mpi_communicator());
       project_velocity_onto_boundary(mesh_deformation_dof_handler, mesh_locally_owned,

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1572,8 +1572,12 @@ namespace aspect
       IndexSet system_index_set = dof_handler.locally_owned_dofs();
       introspection.index_sets.system_partitioning = system_index_set.split_by_block(introspection.system_dofs_per_block);
 
+#if DEAL_II_VERSION_GTE(9,7,0)
+      introspection.index_sets.system_relevant_set = DoFTools::extract_locally_relevant_dofs (dof_handler);
+#else
       DoFTools::extract_locally_relevant_dofs (dof_handler,
                                                introspection.index_sets.system_relevant_set);
+#endif
       introspection.index_sets.system_relevant_partitioning =
         introspection.index_sets.system_relevant_set.split_by_block(introspection.system_dofs_per_block);
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -850,7 +850,13 @@ namespace aspect
 
     vec.compress(VectorOperation::insert);
 
+#if DEAL_II_VERSION_GTE(9,7,0)
+    AffineConstraints<double> hanging_node_constraints(introspection.index_sets.system_relevant_set,
+                                                       introspection.index_sets.system_relevant_set);
+#else
     AffineConstraints<double> hanging_node_constraints(introspection.index_sets.system_relevant_set);
+#endif
+
     DoFTools::make_hanging_node_constraints(dof_handler, hanging_node_constraints);
     hanging_node_constraints.close();
 

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -23,217 +23,186 @@
 #include <deal.II/base/exceptions.h>
 
 
-TEST_CASE("Utilities::parse_map_to_double_array")
+TEST_CASE("Utilities::MapParsing::parse_map_to_double_array")
 {
   // Parse multicomponent properties
-  INFO("check 1: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500, background:0",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {0.0,100.0,200.0,300.0,400.0,500.0});
+  {
+    INFO("check 1: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500, background:0",
+                           options),
+    {0.0,100.0,200.0,300.0,400.0,500.0});
 
-  INFO("check 2: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("all:100",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {100.0,100.0,100.0,100.0,100.0,100.0});
+    INFO("check 2: ");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("all:100",options),
+    {100.0,100.0,100.0,100.0,100.0,100.0});
 
-  INFO("check 3: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("background:0, C1:100, C2:200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {0.0,100.0,200.0,300.0,400.0,500.0});
+    INFO("check 3: ");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("background:0, C1:100, C2:200, C3:300, C4:400, C5:500",
+                           options),
+    {0.0,100.0,200.0,300.0,400.0,500.0});
 
-  INFO("check 4: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("background:0, C2:200, C1:100, C4:400, C5:500, C3:300",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {0.0,100.0,200.0,300.0,400.0,500.0});
+    INFO("check 4: ");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("background:0, C2:200, C1:100, C4:400, C5:500, C3:300",
+                           options),
+    {0.0,100.0,200.0,300.0,400.0,500.0});
 
-  INFO("check 5: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, background:0, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {0.0,100.0,200.0,300.0,400.0,500.0});
+    INFO("check 5: ");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, background:0, C3:300, C4:400, C5:500",
+                           options),
+    {0.0,100.0,200.0,300.0,400.0,500.0});
+  }
 
-  INFO("check 6: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("100, 200, 300, 400, 500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField"),
-  {100.0,200.0,300.0,400.0,500.0});
+  {
+    INFO("check 6: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("100, 200, 300, 400, 500",
+                           options),
+    {100.0,200.0,300.0,400.0,500.0});
 
-  INFO("check 7: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField"),
-  {100.0,200.0,300.0,400.0,500.0});
+    INFO("check 7: ");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
+                           options),
+    {100.0,200.0,300.0,400.0,500.0});
+  }
 
-  INFO("check 8: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("background:0, C2:200, C1:100, C4:400, C5:500, C3:300",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"),
-  {0.0,100.0,200.0,300.0,400.0,500.0});
+  {
+    INFO("check 8: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("background:0, C2:200, C1:100, C4:400, C5:500, C3:300",
+                           options),
+    {0.0,100.0,200.0,300.0,400.0,500.0});
+  }
 
   {
     INFO("check 9: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
-
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|100, C3:300, C4:400, C5:500, background:0",
-    {"C1","C2","C3","C4","C5"},
-    true,
-    "TestField",
-    true,
-    n_values_per_key),
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    options.store_values_per_key = true;
+    options.allow_multiple_values_per_key = true;
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|100, C3:300, C4:400, C5:500, background:0",
+                           options),
     {0.0,100.0,200.0,100.0,300.0,400.0,500.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({1,1,2,1,1,1}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({1,1,2,1,1,1}));
   }
 
   {
     INFO("check 10: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
-
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|, C3:300, C4:400, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.store_values_per_key = true;
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|, C3:300, C4:400, C5:500",
+                           options),
     {100.0,200.0,300.0,400.0,500.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({1,1,1,1,1}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({1,1,1,1,1}));
   }
 
   {
     INFO("check 11: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.store_values_per_key = true;
+    options.allow_multiple_values_per_key = true;
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
+                           options),
     {100.0,200.0,300.0,300.0,400.0,500.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({1,2,1,1,1}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({1,2,1,1,1}));
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    options.store_values_per_key = false;
+    options.check_values_per_key = true;
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
+                           options),
     {100.0,200.0,300.0,300.0,400.0,500.0});
   }
 
   {
     INFO("check 12: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
+    aspect::Utilities::MapParsing::Options options({"C1","C2"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.store_values_per_key = true;
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("all:300|400",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("all:300|400",
+                           options),
     {300.0,400.0,300.0,400.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int> ({2,2}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int> ({2,2}));
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("all:100|200",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    options.store_values_per_key = false;
+    options.check_values_per_key = true;
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("all:100|200",
+                           options),
     {100.0,200.0,100.0,200.0});
   }
 
-  INFO("check 13: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("background:0, C1:100, C4:400, C5:500, C3:300",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField",
-  false,
-  nullptr,
-  true),
-  {0.0,100.0,300.0,400.0,500.0});
+  {
+    INFO("check 13: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_missing_keys = true;
 
-  INFO("check 14: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C4:400, C5:500, C3:300",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField",
-  false,
-  nullptr,
-  true),
-  {100.0,300.0,400.0,500.0});
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("background:0, C1:100, C4:400, C5:500, C3:300",
+                           options),
+    {0.0,100.0,300.0,400.0,500.0});
+  }
 
-  INFO("check 16: ");
-  compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField",
-  false,
-  nullptr,
-  true),
-  std::vector<double>());
+  {
+    INFO("check 14: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_missing_keys = true;
+
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C4:400, C5:500, C3:300",
+                           options),
+    {100.0,300.0,400.0,500.0});
+  }
+
+  {
+    INFO("check 16: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_missing_keys = true;
+
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("",
+                           options),
+                           std::vector<double>());
+  }
 
   {
     INFO("check 17: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.store_values_per_key = true;
+    options.allow_missing_keys = true;
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key,
-    true),
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C5:500",
+                           options),
     {100.0,200.0,300.0,300.0,500.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({1,2,1,0,1}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({1,2,1,0,1}));
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key,
-    true),
+    options.store_values_per_key = false;
+    options.check_values_per_key = true;
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C5:500",
+                           options),
     {100.0,200.0,300.0,300.0,500.0});
   }
 
   {
     INFO("check 18: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>(std::vector<unsigned int>({2,2}));
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:300|400, C2:200",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    aspect::Utilities::MapParsing::Options options({"C1","C2"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.check_values_per_key = true;
+    options.n_values_per_key = {2,2};
+
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:300|400, C2:200",
+                           options),
     {300.0,400.0,200.0,200.0});
 
     INFO("check 19: ");
 
     // still using the compare_vectors_approx defined before
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("200",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("200",
+                           options),
     {200.0,200.0,200.0,200.0});
   }
 
@@ -254,125 +223,134 @@ TEST_CASE("Utilities::parse_map_to_double_array")
 
 using Catch::Matchers::Contains;
 
-TEST_CASE("Utilities::parse_map_to_double_array FAIL ON PURPOSE")
+TEST_CASE("Utilities::MapParsing::parse_map_to_double_array FAIL ON PURPOSE")
 {
   // Purposefully fail Parse multicomponent properties
-  INFO("check fail 1: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField"), Contains("is listed multiple times"));
-
-
-  INFO("check fail 2: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"), Contains("The keyword <background> in TestField is not listed"));
-
-
-  INFO("check fail 3: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4;400, C5:500, bg:3",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"), Contains("does not have the expected format"));
-
-
-  INFO("check fail 4: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C24:500, bg:3",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"), Contains("does not match any entries"));
-
-  INFO("check fail 5: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200, C3:300, all:400, C5:500, bg:3",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"), Contains("The keyword `all' in the property TestField is only allowed if"));
-
-  INFO("check fail 6: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100",
-  {"C1","C2","C3","C4","C5"},
-  true,
-  "TestField"), Contains("The keyword <background> in TestField is not listed"));
-
-  // Subentries not allowed
-  INFO("check fail 7: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:100|200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField"), Contains("The keyword <C2> in TestField has multiple values"));
-
-  // Wrong subentry format
-  INFO("check fail 8: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:|200, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField",
-  true), Contains("does not have the expected format"));
-
-  // No subentries
-  INFO("check fail 9: ");
-  REQUIRE_THROWS_WITH(
-    aspect::Utilities::parse_map_to_double_array ("C1:100, C2:|, C3:300, C4:400, C5:500",
-  {"C1","C2","C3","C4","C5"},
-  false,
-  "TestField",
-  true), Contains("does not have the expected format"));
-
-  // Wrong input structure
   {
-    INFO("check fail 10: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
+    INFO("check fail 1: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4:400, C5:500",
+                                                                options), Contains("is listed multiple times"));
+  }
+
+  {
+    INFO("check fail 2: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C5:500",
+                                                                options), Contains("The keyword <background> in TestField is not listed"));
+  }
+
+  {
+    INFO("check fail 3: ");
+    aspect::Utilities::MapParsing::Options options({"bg","C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C1:200, C3:300, C4;400, C5:500, bg:3",
+                                                                options), Contains("does not have the expected format"));
+  }
+
+  {
+    INFO("check fail 4: ");
+    aspect::Utilities::MapParsing::Options options({"bg","C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, C3:300, C4:400, C24:500, bg:3",
+                                                                options), Contains("does not match any entries"));
+  }
+
+  {
+    INFO("check fail 5: ");
+    aspect::Utilities::MapParsing::Options options({"bg","C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200, C3:300, all:400, C5:500, bg:3",
+                                                                options), Contains("The keyword `all' in the property TestField is only allowed if"));
+  }
+
+  {
+    INFO("check fail 6: ");
+    aspect::Utilities::MapParsing::Options options({"background","C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100",
+                                                                options), Contains("The keyword <background> in TestField is not listed"));
+  }
+
+  {
+    // Subentries not allowed
+    INFO("check fail 7: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:100|200, C3:300, C4:400, C5:500",
+                                                                options), Contains("The keyword <C2> in TestField has multiple values"));
+  }
+
+  {
+    // Wrong subentry format
+    INFO("check fail 8: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:|200, C3:300, C4:400, C5:500",
+                                                                options), Contains("does not have the expected format"));
+  }
+
+  {
+    // No subentries
+    INFO("check fail 9: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+
+    REQUIRE_THROWS_WITH(
+      aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:|, C3:300, C4:400, C5:500",
+                                                                options), Contains("does not have the expected format"));
+  }
+
+  {
+    // Wrong input structure
+    INFO("check fail 10: ");
+    aspect::Utilities::MapParsing::Options options({"C1","C2","C3","C4","C5"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.store_values_per_key = true;
+
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100, C2:200|300, C3:300, C4:400, C5:500",
+                           options),
     {100.0,200.0,300.0,300.0,400.0,500.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({1,2,1,1,1}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({1,2,1,1,1}));
 
-    REQUIRE_THROWS_WITH(aspect::Utilities::parse_map_to_double_array ("C1:100|200, C2:300, C3:300, C4:400, C5:500",
-    {"C1","C2","C3","C4","C5"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
-    Contains("The key <C1> in <TestField> does not have the expected number"));
+    options.store_values_per_key = false;
+    options.check_values_per_key = true;
+
+    REQUIRE_THROWS_WITH(aspect::Utilities::MapParsing::parse_map_to_double_array ("C1:100|200, C2:300, C3:300, C4:400, C5:500",
+                                                                                  options),
+                        Contains("The key <C1> in <TestField> does not have the expected number"));
   }
 
   {
     INFO("check fail 11: ");
-    auto n_values_per_key = std::make_unique<std::vector<unsigned int>>();
+    aspect::Utilities::MapParsing::Options options({"C1","C2"}, "TestField");
+    options.allow_multiple_values_per_key = true;
+    options.store_values_per_key = true;
 
-    compare_vectors_approx(aspect::Utilities::parse_map_to_double_array ("all:300|400",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
+    compare_vectors_approx(aspect::Utilities::MapParsing::parse_map_to_double_array ("all:300|400",
+                           options),
     {300.0,400.0,300.0,400.0});
 
-    REQUIRE(*n_values_per_key == std::vector<unsigned int>({2,2}));
+    REQUIRE(options.n_values_per_key == std::vector<unsigned int>({2,2}));
 
-    REQUIRE_THROWS_WITH(aspect::Utilities::parse_map_to_double_array ("all:100|200|300",
-    {"C1","C2"},
-    false,
-    "TestField",
-    true,
-    n_values_per_key),
-    Contains("The key <C1> in <TestField> does not have the expected number"));
+    options.store_values_per_key = false;
+    options.check_values_per_key = true;
+
+    REQUIRE_THROWS_WITH(aspect::Utilities::MapParsing::parse_map_to_double_array ("all:100|200|300",
+                                                                                  options),
+                        Contains("The key <C1> in <TestField> does not have the expected number"));
   }
 }
 


### PR DESCRIPTION
Related to #6106. This PR enables deprecation warnings in the no unity build tester.