### PR TITLE
Separate additional CXX arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,8 @@ if(ASPECT_WITH_WORLD_BUILDER)
 
       set(WB_TARGET "WorldBuilderDebug")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder/)
-      target_compile_options(WorldBuilderDebug PRIVATE "-g" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
+      separate_arguments(SEPARATED_FLAGS NATIVE_COMMAND ${ASPECT_ADDITIONAL_CXX_FLAGS})
+      target_compile_options(WorldBuilderDebug PRIVATE "-g" "${SEPARATED_FLAGS}")
 
       set(CMAKE_BUILD_TYPE ${_build_type})
     endif()
@@ -308,7 +309,9 @@ if(ASPECT_WITH_WORLD_BUILDER)
       set(WB_TARGET "WorldBuilderRelease")
       add_subdirectory("${WORLD_BUILDER_SOURCE_DIR}" ${CMAKE_BINARY_DIR}/world_builder_release/)
       target_compile_definitions(WorldBuilderRelease PUBLIC "NDEBUG")
-      target_compile_options(WorldBuilderRelease PRIVATE "-O3" "${ASPECT_ADDITIONAL_CXX_FLAGS}")
+
+      separate_arguments(SEPARATED_FLAGS NATIVE_COMMAND ${ASPECT_ADDITIONAL_CXX_FLAGS})
+      target_compile_options(WorldBuilderRelease PRIVATE "-O3" "${SEPARATED_FLAGS}")
 
       set(CMAKE_BUILD_TYPE ${_build_type})
     endif()


### PR DESCRIPTION
As part of the testing in #8366 I noticed that I cannot set more than one flag in `ASPECT_ADDITIONAL_CXX_FLAGS`, because of how we incorporate them into the compile flags for world builder. The call to `target_compile_options` expects a cmake list (a semicolon separated string), while the input string from cmake is a space separated string (as one would expect for command line arguments). It looks like the best way to convert this string into a list seems to be the `separate_arguments` command (https://stackoverflow.com/a/22148384).

This is only a problem for the world builder, because for ASPECT itself we append the the additional flags to the `DEAL_II_CXX_FLAGS_DEBUG` and `_RELEASE` strings which will be dealt with by deal.II macros.
