### PR TITLE
change usage of MPI::broadcast

### DIFF
--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1613,9 +1613,9 @@ namespace aspect
             {
               const std::string command = "lst setstripe -c " + std::to_string(lfs_stripe_count)
                                           + ' ' + output_directory;
-              const int error_code = system (command.c_str());
 
-              Utilities::MPI::broadcast(mpi_communicator, error_code, 0);
+              int error_code = system (command.c_str());
+              Utilities::MPI::broadcast(&error_code, 1, 0, mpi_communicator);
 
               AssertThrow (error_code == 0,
                            ExcMessage ("Could not successfully execute the LFS file striping "
@@ -1626,7 +1626,7 @@ namespace aspect
           else
             {
               int error_code;
-              error_code = Utilities::MPI::broadcast(mpi_communicator, error_code, 0);
+              Utilities::MPI::broadcast(&error_code, 1, 0, mpi_communicator);
 
               if (error_code != 0)
                 throw QuietException();


### PR DESCRIPTION
The current version produces warnings of the kind
```
/ssd/aspect-git2/source/simulator/parameters.cc:1629:53: warning:
‘error_code’ may be used uninitialized [-Wmaybe-uninitialized]
```
on my machine. There is no reason to use the broadcast() function from deal.II that is made for sending complicated objects that need to be packed if we just want to transfer an int. We could use MPI_Bcast() but I don't like manual error checking, which this new overload does (otherwise it is identical to MPI_Bcast here).
