### PR TITLE
Enable deprecation warnings when building and in user plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -774,12 +774,17 @@ if (${FORCE_COLORED_OUTPUT})
   endif()
 endif()
 
+# deal.II versions >=9.5 disable deprecation warnings in user code. Enable
+# the warnings again by removing the flag that disables them.
+string(REPLACE "-Wno-deprecated-declarations" "" DEAL_II_WARNING_FLAGS "${DEAL_II_WARNING_FLAGS}")
+
 set(ASPECT_ADDITIONAL_CXX_FLAGS "" CACHE STRING "Additional CMAKE_CXX_FLAGS applied after the deal.II options.")
 
 if(NOT ASPECT_ADDITIONAL_CXX_FLAGS STREQUAL "")
   message(STATUS "Appending ASPECT_ADDITIONAL_CXX_FLAGS: '${ASPECT_ADDITIONAL_CXX_FLAGS}':")
   string(APPEND DEAL_II_CXX_FLAGS_DEBUG " ${ASPECT_ADDITIONAL_CXX_FLAGS}")
   string(APPEND DEAL_II_CXX_FLAGS_RELEASE " ${ASPECT_ADDITIONAL_CXX_FLAGS}")
+  message(STATUS "  DEAL_II_WARNING_FLAGS: ${DEAL_II_WARNING_FLAGS}")
   message(STATUS "  DEAL_II_CXX_FLAGS_DEBUG: ${DEAL_II_CXX_FLAGS_DEBUG}")
   message(STATUS "  DEAL_II_CXX_FLAGS_RELEASE: ${DEAL_II_CXX_FLAGS_RELEASE}")
 endif()

--- a/benchmarks/annulus/plugin/annulus.cc
+++ b/benchmarks/annulus/plugin/annulus.cc
@@ -615,7 +615,7 @@ namespace aspect
         compute_dynamic_topography_error() const
         {
           const Postprocess::DynamicTopography<dim> &dynamic_topography =
-            this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::DynamicTopography<dim>>();
+            this->get_postprocess_manager().template get_matching_active_plugin<Postprocess::DynamicTopography<dim>>();
 
           const AnnulusMaterial<dim> &material_model
             = Plugins::get_plugin_as_type<const AnnulusMaterial<dim>>(this->get_material_model());

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -600,7 +600,7 @@ namespace aspect
     {
       const unsigned int dim = 3;
       const Postprocess::DynamicTopography<dim> &dynamic_topography =
-        this->get_postprocess_manager().template get_matching_postprocessor<Postprocess::DynamicTopography<dim>>();
+        this->get_postprocess_manager().template get_matching_active_plugin<Postprocess::DynamicTopography<dim>>();
 
       const HollowSphereMaterial<dim> &material_model
         = Plugins::get_plugin_as_type<const HollowSphereMaterial<dim>>(this->get_material_model());

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -712,7 +712,7 @@ namespace aspect
 
       const PlaneWaveMeltBandsInitialCondition<dim> &initial_composition
         = this->get_initial_composition_manager().template
-          get_matching_initial_composition_model<PlaneWaveMeltBandsInitialCondition<dim>> ();
+          get_matching_active_plugin<PlaneWaveMeltBandsInitialCondition<dim>> ();
 
       amplitude           = initial_composition.get_wave_amplitude();
       initial_band_angle  = initial_composition.get_initial_band_angle();

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -391,7 +391,7 @@ namespace aspect
           // solitary wave initial condition.
           const SolitaryWaveInitialCondition<dim> &initial_composition =
             initial_composition_manager->template
-            get_matching_initial_composition_model<SolitaryWaveInitialCondition<dim>>();
+            get_matching_active_plugin<SolitaryWaveInitialCondition<dim>>();
 
           return reference_permeability * std::pow(initial_composition.get_background_porosity(), 3.0) / eta_f;
 
@@ -706,7 +706,7 @@ namespace aspect
       // then get the parameters we need
 
       const SolitaryWaveInitialCondition<dim> &initial_composition
-        = this->get_initial_composition_manager().template get_matching_initial_composition_model<SolitaryWaveInitialCondition<dim>> ();
+        = this->get_initial_composition_manager().template get_matching_active_plugin<SolitaryWaveInitialCondition<dim>> ();
 
       amplitude           = initial_composition.get_amplitude();
       background_porosity = initial_composition.get_background_porosity();

--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -359,7 +359,7 @@ namespace aspect
            << material_model.parameter_a();
 
     // pad the first line to the same number ooutputcolumns as the data below to make MATLAB happy
-    for (unsigned int i=4; i<7+this->get_heating_model_manager().get_active_heating_models().size(); ++i)
+    for (unsigned int i=4; i<7+this->get_heating_model_manager().get_active_plugin_names().size(); ++i)
       output<< " -1";
 
     output<< std::endl;
@@ -376,7 +376,7 @@ namespace aspect
     MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
     MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
 
-    const std::list<std::unique_ptr<HeatingModel::Interface<dim>>> &heating_model_objects = this->get_heating_model_manager().get_active_heating_models();
+    const std::list<std::unique_ptr<HeatingModel::Interface<dim>>> &heating_model_objects = this->get_heating_model_manager().get_active_plugins();
 
     std::vector<HeatingModel::HeatingModelOutputs> heating_model_outputs (heating_model_objects.size(),
                                                                           HeatingModel::HeatingModelOutputs (n_q_points, this->n_compositional_fields()));

--- a/cmake/AspectConfig.cmake.in
+++ b/cmake/AspectConfig.cmake.in
@@ -37,6 +37,10 @@ macro(ASPECT_SETUP_PLUGIN _target)
   message(STATUS "  name <${_target}>")
   message(STATUS "  using ASPECT_DIR ${Aspect_DIR}")
 
+  # deal.II versions >=9.5 disable deprecation warnings in user code. Enable
+  # the warnings again by removing the flag that disables them.
+  string(REPLACE "-Wno-deprecated-declarations" "" DEAL_II_WARNING_FLAGS "${DEAL_II_WARNING_FLAGS}")
+
   # We create lib${_target}.debug.so, lib${_target}.release.so, or both
   # depending on the compilation mode of ASPECT. Note that the user already
   # created the target under the name ${_target}, so we only need to create

--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
@@ -306,7 +306,7 @@ namespace aspect
         out.template get_additional_output<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>();
 
       const InitialTemperature::AdiabaticBoundary<dim> &adiabatic_boundary =
-        initial_temperature_manager->template get_matching_initial_temperature_model<InitialTemperature::AdiabaticBoundary<dim>>();
+        initial_temperature_manager->template get_matching_active_plugin<InitialTemperature::AdiabaticBoundary<dim>>();
 
       const unsigned int surface_boundary_id = this->get_geometry_model().translate_symbolic_boundary_name_to_id("outer");
 
@@ -897,7 +897,7 @@ namespace aspect
           = this->get_initial_temperature_manager_pointer();
 
       const InitialTemperature::AdiabaticBoundary<dim> &adiabatic_boundary =
-        initial_temperature_manager->template get_matching_initial_temperature_model<InitialTemperature::AdiabaticBoundary<dim>>();
+        initial_temperature_manager->template get_matching_active_plugin<InitialTemperature::AdiabaticBoundary<dim>>();
 
       // This function will fill the outputs for grain size, viscosity, and dislocation viscosity
       if (in.requests_property(MaterialProperties::viscosity))


### PR DESCRIPTION
This PR fixes #6106. Independent of whether we decide to enable these warnings in deal.II again, I think it would be a good idea to have them enabled for ASPECT. Otherwise our users do not notice if their plugins use deprecated features (this will likely already cause confusion because some of the deprecated features I removed in #6083 and #6084 may not have emitted any warnings with deal.II 9.5 or 9.6). 