### PR TITLE
Remove a comment that's no longer correct.

### DIFF
--- a/doc/sphinx/user/extending/plugin-types/temp-bc.md
+++ b/doc/sphinx/user/extending/plugin-types/temp-bc.md
@@ -2,9 +2,7 @@
 # Temperature boundary conditions
 
 The boundary conditions are responsible for describing the temperature values
-at those parts of the boundary at which the temperature is fixed (see
-{ref}`sec:extending:plugin-types:geometry-models` for how it is determined which
-parts of the boundary this applies to).
+at those parts of the boundary at which the temperature is fixed.
 
 To implement a new boundary conditions model, you need to overload the
 `aspect::BoundaryTemperature::Interface` class and use the


### PR DESCRIPTION
It used to be the case that we decided which boundaries correspond to which boundary conditions in the geometry model. But that is no longer so -- we do that in the input file. Fix a long-wrong comment in the manual about this.