### PR TITLE
Fix the heat flux file name based on udated heat flux postprocessor.

### DIFF
--- a/cookbooks/convection-box/tutorial-onset-of-convection/notebooks/tutorial_running.ipynb
+++ b/cookbooks/convection-box/tutorial-onset-of-convection/notebooks/tutorial_running.ipynb
@@ -370,7 +370,7 @@
     "    viz_data.append(fn(mesh_x,mesh_y))\n",
     "    \n",
     "# Get the heat flux output files\n",
-    "flux_files = sorted(glob.glob('output-convection-box2/heat_flux.*'))\n",
+    "flux_files = sorted(glob.glob('output-convection-box2/heat_flux_top.*'))\n",
     "flux_data = []\n",
     "#Comment these lines like above for limited memory computers.\n",
     "#for fname in flux_files[:99]:\n",


### PR DESCRIPTION
This PR fixes the filename in the tutorial notebook for convection box using the updated output files by the `heat_flux` postprocessor, i.e., `heat_flux_bottom.*` and `heat_flx_top.*` instead of `heat_flux.*` as done previously.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

