### PR TITLE
Also document boundary composition plugins.

### DIFF
--- a/doc/sphinx/user/extending/plugin-types/temp-bc.md
+++ b/doc/sphinx/user/extending/plugin-types/temp-bc.md
@@ -1,16 +1,26 @@
 
-# Temperature boundary conditions
+# Temperature and compositional boundary conditions
 
-The boundary conditions are responsible for describing the temperature values
-at those parts of the boundary at which the temperature is fixed.
+Boundary conditions for the temperature (and compositional fields, if
+present) are responsible for describing the fields' values at those
+parts of the boundary at which the temperature or composition is
+fixed, as well as at inflow boundaries.
 
-To implement a new boundary conditions model, you need to overload the
+To implement a new a boundary conditions model for the temperature, you need to overload the
 `aspect::BoundaryTemperature::Interface` class and use the
 `ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL` macro to register your new class.
 The implementation of the new class should be in namespace
 `aspect::BoundaryTemperature`.
 
-The principle function you need to overload needs to provide the fixed temperature at a
+Correspondingly, for a boundary conditions model for compositional fields, you need to overload the
+`aspect::BoundaryComposition::Interface` class and use the
+`ASPECT_REGISTER_BOUNDARY_COMPOSITION_MODEL` macro to register your new class.
+The implementation of the new class should be in namespace
+`aspect::BoundaryComposition`.
+
+In either case,
+the principle function of the respective `Interface` class that you need to overload
+provides the prescribed temperature or composition at a
 given point. The boundary indicator of the particular
 piece of boundary on which the point is located is also given as a hint in
 determining where this point may be located; this may, for example, be used to

--- a/doc/sphinx/user/extending/plugin-types/temp-bc.md
+++ b/doc/sphinx/user/extending/plugin-types/temp-bc.md
@@ -6,7 +6,7 @@ present) are responsible for describing the fields' values at those
 parts of the boundary at which the temperature or composition is
 fixed, as well as at inflow boundaries.
 
-To implement a new a boundary conditions model for the temperature, you need to overload the
+To implement a new boundary conditions model for the temperature, you need to overload the
 `aspect::BoundaryTemperature::Interface` class and use the
 `ASPECT_REGISTER_BOUNDARY_TEMPERATURE_MODEL` macro to register your new class.
 The implementation of the new class should be in namespace


### PR DESCRIPTION
As part of the open point of #1775, I'm going through the documentation files for plugin systems. There is a number that are not documented at the moment, and I'll get there eventually. One of those is boundary conditions for compositional fields. In one of the other files, we are discussing temperature and compositional fields at the same time, so we might as well do the same for compositional fields. This patch does that.