### PR TITLE
Simplify Newton solver function arguments

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1300,14 +1300,6 @@ namespace aspect
        * "physical" pressure so that all following postprocessing
        * steps can use the latter.
        *
-       * In the case of the surface average, whether a face is part of
-       * the surface is determined by asking whether its depth of its
-       * midpoint (as determined by the geometry model) is less than
-       * 1/3*1/sqrt(dim-1)*diameter of the face. For reasonably curved
-       * boundaries, this rules out side faces that are perpendicular
-       * to the surface boundary but includes those faces that are
-       * along the boundary even if the real boundary is curved.
-       *
        * Whether the pressure should be normalized based on the
        * surface or volume average is decided by a parameter in the
        * input file.
@@ -1352,12 +1344,7 @@ namespace aspect
        * come out of GMRES, namely the one on which we later called
        * normalize_pressure().
        *
-       * This function modifies @p vector in-place. In some cases, we need
-       * locally_relevant values of the pressure. To avoid creating a new vector
-       * and transferring data, this function uses a second vector with relevant
-       * dofs (@p relevant_vector) for accessing these pressure values. Both
-       * @p vector and @p relevant_vector are expected to already contain
-       * the correct pressure values.
+       * This function modifies @p vector in-place.
        *
        * @note The adjustment made in this function is done using the
        * negative of the @p pressure_adjustment function argument that
@@ -1371,8 +1358,7 @@ namespace aspect
        * <code>source/simulator/helper_functions.cc</code>.
        */
       void denormalize_pressure(const double                      pressure_adjustment,
-                                LinearAlgebra::BlockVector       &vector,
-                                const LinearAlgebra::BlockVector &relevant_vector) const;
+                                LinearAlgebra::BlockVector       &vector) const;
 
       /**
        * Apply the bound preserving limiter to the discontinuous Galerkin solutions:
@@ -1780,7 +1766,7 @@ namespace aspect
        * Computes the initial Newton residual.
        */
       double
-      compute_initial_newton_residual (const LinearAlgebra::BlockVector &linearized_stokes_initial_guess);
+      compute_initial_newton_residual ();
 
       /**
        * This function computes the Eisenstat Walker linear tolerance used for the Newton iterations

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -855,8 +855,7 @@ namespace aspect
         // initial residual we could skip all of this stuff.
         distributed_stokes_solution.block(velocity_and_pressure_block) = solution.block(velocity_and_pressure_block);
         denormalize_pressure (this->last_pressure_normalization_adjustment,
-                              distributed_stokes_solution,
-                              solution);
+                              distributed_stokes_solution);
         current_stokes_constraints.set_zero (distributed_stokes_solution);
 
         // Undo the pressure scaling:
@@ -973,8 +972,7 @@ namespace aspect
             linearized_stokes_initial_guess.block (pressure_block_index) = current_linearization_point.block (pressure_block_index);
 
             denormalize_pressure (this->last_pressure_normalization_adjustment,
-                                  linearized_stokes_initial_guess,
-                                  current_linearization_point);
+                                  linearized_stokes_initial_guess);
           }
         else
           {

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -437,19 +437,13 @@ namespace aspect
                                               : introspection.block_indices.pressure;
     Assert(introspection.block_indices.velocities == 0, ExcNotImplemented());
     Assert(pressure_block_index == 1, ExcNotImplemented());
+    (void) pressure_block_index;
     Assert(!parameters.include_melt_transport
            || introspection.variable("compaction pressure").block_index == 1, ExcNotImplemented());
 
-    // create a completely distributed vector that will be used for
-    // the scaled and denormalized solution and later used as a
-    // starting guess for the linear solver
-    LinearAlgebra::BlockVector linearized_stokes_initial_guess(introspection.index_sets.stokes_partitioning, mpi_communicator);
-    linearized_stokes_initial_guess.block(introspection.block_indices.velocities) = current_linearization_point.block(introspection.block_indices.velocities);
-    linearized_stokes_initial_guess.block(pressure_block_index) = current_linearization_point.block(pressure_block_index);
-
     if (nonlinear_iteration == 0)
       {
-        dcr.initial_residual = compute_initial_newton_residual(linearized_stokes_initial_guess);
+        dcr.initial_residual = compute_initial_newton_residual();
         dcr.switch_initial_residual = dcr.initial_residual;
         dcr.residual_old = dcr.initial_residual;
         dcr.residual = dcr.initial_residual;
@@ -460,12 +454,6 @@ namespace aspect
     if (nonlinear_iteration == 0)
       {
         assemble_newton_stokes_system = assemble_newton_stokes_matrix = false;
-      }
-    else
-      {
-        denormalize_pressure (last_pressure_normalization_adjustment,
-                              linearized_stokes_initial_guess,
-                              current_linearization_point);
       }
 
     if (nonlinear_iteration <= 1)

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1919,8 +1919,7 @@ namespace aspect
         linearized_stokes_initial_guess.block (block_p) = sim.current_linearization_point.block (block_p);
 
         sim.denormalize_pressure (sim.last_pressure_normalization_adjustment,
-                                  linearized_stokes_initial_guess,
-                                  sim.current_linearization_point);
+                                  linearized_stokes_initial_guess);
       }
     else
       {


### PR DESCRIPTION
Still looking into the reason why #6116 changes test results I noticed a number of things that could be simplified around the newton solver. This PR does:
1. Update documentation that is out of date
2. Simplifies function arguments, in particular I do no longer assume the calling function already happens to have a copy of a vector if the called function needs a copy. If we need a backup copy of a vector in a function, the function should create and destroy that copy. This may cost 1-2 additional vector copies per nonlinear iteration, but it makes the code much easier to understand. I also think because of this complexity there is a bug in `compute_initial_newton_residual` that I will address in a follow up.

This PR should not change any test results, it contains only code style improvements.