### PR TITLE
doc: fix a few problems

### DIFF
--- a/benchmarks/solitary_wave/doc/solitary_wave.md
+++ b/benchmarks/solitary_wave/doc/solitary_wave.md
@@ -57,7 +57,13 @@ This is only valid in the limit of small porosity $\phi_0 \ll 1$.
 ```{figure-md} fig:setup-solitary-wave
 <img src="setup.svg" style="width:65.0%" />
 
-Setup of the solitary wave benchmark. The domain is <span class="math inline">400</span> m high and includes a low porosity (<span class="math inline"><em>&#x3D5;</em>&#x2004;=&#x2004;0.001</span>) background with an initial perturbation (<span class="math inline"><em>&#x3D5;</em>&#x2004;=&#x2004;0.1</span>). The solid density is <span class="math inline">3300&#x2006;<em>k</em><em>g</em>/<em>m</em><sup>3</sup></span> and the melt density is <span class="math inline">2500&#x2006;<em>k</em><em>g</em>/<em>m</em><sup>3</sup></span>. We apply the negative phase speed of the solitary wave <span class="math inline"><strong>u</strong><sub><em>s</em></sub>&#x2004;=&#x2004;&#x2005;&#x2212;&#x2005;<em>c</em>&#x2006;<strong>e</strong><sub><em>z</em></sub></span> as velocity boundary condition, so that the wave will stay at its original position while the background is moving.
+Setup of the solitary wave benchmark. The domain is 400 m high and
+includes a low porosity ($\phi = 0.001$) background with an initial
+perturbation ($\phi = 0.1$). The solid density is 3300 kg/m$^3$ and
+the melt density is 2500 kg/m$^3$. We apply the negative phase speed of
+the solitary wave $ u_s = -c e_z$ as velocity boundary condition, so
+that the wave will stay at its original position while the background
+is moving.
 ```
 
 The parameter file and material model for this setup can be found in

--- a/cookbooks/burnman/doc/burnman.md
+++ b/cookbooks/burnman/doc/burnman.md
@@ -67,9 +67,9 @@ Visualizing material properties such as density, thermal expansivity or specific
 We can also visualize the gravity and the adiabatic profile, to ensure that the data we provided in the `data/adiabatic-conditions/ascii-data/isentrope_properties.txt` file is used in our model.
 
 ```{figure-md} fig:burnman-convection
-<img src="temperature.png" style="width:48.0%" alt="Compressible convection in a 2d spherical shell, using a reference profile exported form BurnMan, which is based on the Birch-Murnaghan equation of state. The figure shows the state at the end of the model evolution over 260&#x2006;Ma." />
+<img src="temperature.png" style="width:48.0%" alt="Compressible convection in a 2d spherical shell, using a reference profile exported from BurnMan, which is based on the Birch-Murnaghan equation of state. The figure shows the state at the end of the model evolution over 260 Ma." />
 
-Compressible convection in a 2d spherical shell, using a reference profile exported form BurnMan, which is based on the Birch-Murnaghan equation of state. The figure shows the state at the end of the model evolution over 260&#x2006;Ma.
+Compressible convection in a 2d spherical shell, using a reference profile exported from BurnMan, which is based on the Birch-Murnaghan equation of state. The figure shows the state at the end of the model evolution over 260 Ma.
 ```
 
 
@@ -99,7 +99,7 @@ They demonstrate that upwellings and downwellings may occur in slightly differen
 ```{figure-md} fig:burnman-comparison
 <img src="comparison.*" style="width:95.0%" />
 
-Comparison between the anelastic liquid approximation, the truncated anelastic liquid approximation and the isothermal compression approximation, showing the temperature distribution for the different models at the end of the model evolution at 260&#x2006;Ma.
+Comparison between the anelastic liquid approximation, the truncated anelastic liquid approximation and the isothermal compression approximation, showing the temperature distribution for the different models at the end of the model evolution at 260 Ma.
 ```
 
 ```{figure-md} fig:burnman-vrms


### PR DESCRIPTION
found while trying to compile a pdf version of the documentation. While the &#x2006; character works as a space in html, it does not in later.
