### PR TITLE
Create an original.wb when running ASPECT with the World Builder

### DIFF
--- a/doc/modules/changes/20241106_danieldouglas92
+++ b/doc/modules/changes/20241106_danieldouglas92
@@ -1,0 +1,5 @@
+Added: When using the Geodynamic World Builder, ASPECT will create a file
+called 'original.wb' in the output directory which contains the exact 
+worldbuilder file used to run the ASPECT model.
+<br>
+(Daniel Douglas, 2024/11/06)

--- a/source/main.cc
+++ b/source/main.cc
@@ -22,10 +22,6 @@
 #include <aspect/simulator.h>
 #include <aspect/utilities.h>
 
-#ifdef ASPECT_WITH_WORLD_BUILDER
-#include <world_builder/world.h>
-#endif
-
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
@@ -626,9 +622,13 @@ run_simulator(const std::string &raw_input_as_string,
           std::string world_builder_file = prm.get("World builder file");
           if (world_builder_file != "")
             {
-              std::stringstream json_input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(world_builder_file));
-              std::ofstream wb_file(output_directory + "original.wb");
-              wb_file << json_input_stream.str();
+              // TODO: We just want to make a copy of the file, but to do this
+              // platform-independently we need the C++17 filesystem header.
+              // Update this when we require C++17
+              std::ifstream  wb_source(world_builder_file, std::ios::binary);
+              std::ofstream  wb_destination(output_directory + "original.wb",   std::ios::binary);
+
+              wb_destination << wb_source.rdbuf();
             }
         }
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -22,6 +22,10 @@
 #include <aspect/simulator.h>
 #include <aspect/utilities.h>
 
+#ifdef ASPECT_WITH_WORLD_BUILDER
+#include <world_builder/world.h>
+#endif
+
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/multithread_info.h>
@@ -616,6 +620,16 @@ run_simulator(const std::string &raw_input_as_string,
 
           std::ofstream file(output_directory + "original.prm");
           file << raw_input_as_string;
+
+          // If using the Geodynamic World Builder, create output/original.wb
+          // containing the exact file used to create the world:
+          std::string world_builder_file = prm.get("World builder file");
+          if (world_builder_file != "")
+            {
+              std::stringstream json_input_stream(WorldBuilder::Utilities::read_and_distribute_file_content(world_builder_file));
+              std::ofstream wb_file(output_directory + "original.wb");
+              wb_file << json_input_stream.str();
+            }
         }
 
       simulator.run();

--- a/tests/original_wb.prm
+++ b/tests/original_wb.prm
@@ -1,6 +1,5 @@
 # test that output/original.wb is written correctly
 
 # based on world_builder_simple.prm:
-# set World builder file = $ASPECT_SOURCE_DIR/tests/world_builder_simple.wb
 include $ASPECT_SOURCE_DIR/tests/world_builder_simple.prm
 set World builder file                     = $ASPECT_SOURCE_DIR/tests/world_builder_simple.wb

--- a/tests/original_wb.prm
+++ b/tests/original_wb.prm
@@ -1,0 +1,6 @@
+# test that output/original.wb is written correctly
+
+# based on world_builder_simple.prm:
+# set World builder file = $ASPECT_SOURCE_DIR/tests/world_builder_simple.wb
+include $ASPECT_SOURCE_DIR/tests/world_builder_simple.prm
+set World builder file                     = $ASPECT_SOURCE_DIR/tests/world_builder_simple.wb

--- a/tests/original_wb/original.wb
+++ b/tests/original_wb/original.wb
@@ -1,0 +1,31 @@
+{
+  "version":"1.0",
+  "cross section":[[0,0],[100,0]],
+  "features":
+  [
+    {"model":"oceanic plate", "name":"oceanic plate", "coordinates":[[-1e3,-1e3],[1150e3,-1e3],[1150e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"plate model", "max depth":95e3, "bottom temperature":1600, "spreading velocity":0.005, "ridge coordinates":[[[100e3,-1e3],[100e3,1e3]]]}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max depth":10e3},
+                           {"model":"uniform", "compositions":[1], "min depth":10e3, "max depth":95e3}]},
+
+    {"model":"continental plate", "name":"continental plate", "coordinates":[[1150e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[1150e3,1e3]],
+     "temperature models":[{"model":"linear", "max depth":95e3, "bottom temperature":1600}],
+     "composition models":[{"model":"uniform", "compositions":[2], "max depth":30e3},
+                           {"model":"uniform", "compositions":[3], "min depth":30e3, "max depth":65e3}]},
+
+    {"model":"mantle layer", "name":"upper mantle", "min depth":95e3, "max depth":660e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"linear", "min depth":95e3, "max depth":660e3, "top temperature":1600, "bottom temperature":1820}],
+     "composition models":[{"model":"uniform", "compositions":[4]}]},
+
+    {"model":"mantle layer", "name":"lower mantle", "min depth":660e3, "max depth":1160e3, "coordinates":[[-1e3,-1e3],[2001e3,-1e3],[2001e3,1e3],[-1e3,1e3]],
+     "temperature models":[{"model":"linear", "min depth":660e3, "max depth":1160e3, "top temperature":1820, "bottom temperature":2000}],
+     "composition models":[{"model":"uniform", "compositions":[5]}]},
+
+    {"model":"subducting plate", "name":"Subducting plate", "coordinates":[[1150e3,-1e3],[1150e3,1e3]], "dip point":[2000e3,0],
+     "segments":[{"length":200e3, "thickness":[95e3], "angle":[0,45]}, {"length":200e3, "thickness":[95e3], "angle":[45]}, 
+                 {"length":200e3, "thickness":[95e3], "angle":[45,0]}, {"length":100e3, "thickness":[95e3], "angle":[0]}],
+     "temperature models":[{"model":"plate model", "density":3300, "plate velocity":0.01, "adiabatic heating":false}],
+     "composition models":[{"model":"uniform", "compositions":[0], "max distance slab top":10e3},
+                           {"model":"uniform", "compositions":[1], "min distance slab top":10e3, "max distance slab top":95e3 }]}
+  ]
+}

--- a/tests/original_wb/statistics
+++ b/tests/original_wb/statistics
@@ -1,0 +1,14 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 4225 0 0 36 38 38 output-original_wb/solution/solution-00000 


### PR DESCRIPTION
I and others who use the Geodynamic World Builder to run all models find that we occasionally modify a worldbuilder file and/or remove a worldbuilder file accidentally. This leaves the user struggling to remember the exact details of the .wb file when trying to recreate it, and to save future headaches for all ASPECT-GWB users I think it would be very helpful to generate a file called original.wb the same way we generate an original.prm file. This PR implements this functionality!

This is likely important for @MFraters to take a look at :)