### PR TITLE
remove std::ofstream default arg

### DIFF
--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -174,7 +174,7 @@ namespace aspect
               else
                 {
                   const std::string filename (this->get_output_directory() + "depth_average.txt");
-                  std::ofstream f(filename, std::ofstream::out);
+                  std::ofstream f(filename);
 
                   // Write the header
                   f << "#       time" << "        depth";


### PR DESCRIPTION
``ofstream`` always sets ``out`` so it doesn't need to be specified.