### PR TITLE
Fix clang tidy warnings

### DIFF
--- a/contrib/release/release-tasklist.md
+++ b/contrib/release/release-tasklist.md
@@ -48,6 +48,8 @@ and the links are working
   git commit -a -m "doxygen formatting, update copyright years"
   ```
 
+- Make sure all CI workflows on the main branch pass: https://github.com/geodynamics/aspect/actions?query=branch%3Amain
+
 - Create a pull request with the pre release tasks
 
 ## Create a release pull-request

--- a/include/aspect/particle/manager.h
+++ b/include/aspect/particle/manager.h
@@ -97,7 +97,7 @@ namespace aspect
          * Move constructor. This is required to be able to put instances
          * of this class into a std::vector.
          */
-        Manager(Manager &&);
+        Manager(Manager &&) noexcept;
 
         /**
          * Initialize the particle manager.

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -48,17 +48,18 @@ namespace aspect
       = default;
 
     template <int dim>
-    Manager<dim>::Manager(Manager &&other)
-      : generator(std::move(other.generator)),
-        integrator(std::move(other.integrator)),
-        interpolator(std::move(other.interpolator)),
-        particle_handler(std::move(other.particle_handler)),
-        particle_handler_backup(), // can not move
-        property_manager(std::move(other.property_manager)),
-        particle_load_balancing(other.particle_load_balancing),
-        min_particles_per_cell(other.min_particles_per_cell),
-        max_particles_per_cell(other.max_particles_per_cell),
-        particle_weight(other.particle_weight)
+    Manager<dim>::Manager(Manager &&other) noexcept
+  :
+    generator(std::move(other.generator)),
+              integrator(std::move(other.integrator)),
+              interpolator(std::move(other.interpolator)),
+              particle_handler(std::move(other.particle_handler)),
+              particle_handler_backup(), // can not move
+              property_manager(std::move(other.property_manager)),
+              particle_load_balancing(other.particle_load_balancing),
+              min_particles_per_cell(other.min_particles_per_cell),
+              max_particles_per_cell(other.max_particles_per_cell),
+              particle_weight(other.particle_weight)
     {}
 
 
@@ -467,8 +468,8 @@ namespace aspect
                                           solution_values.end());
 
       EvaluationFlags::EvaluationFlags evaluation_flags_union = EvaluationFlags::nothing;
-      for (unsigned int i=0; i<evaluation_flags.size(); ++i)
-        evaluation_flags_union |= evaluation_flags[i];
+      for (const auto &flag : evaluation_flags)
+        evaluation_flags_union |= flag;
 
       if (evaluation_flags_union & (EvaluationFlags::values | EvaluationFlags::gradients))
         {

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -289,8 +289,8 @@ namespace aspect
       {
         const Particle::Property::Manager<dim> &particle_property_manager = particle_managers[particle_manager].get_property_manager();
 
-        particle_property_indices.push_back(std::vector<std::pair<unsigned int, unsigned int>>());
-        property_mask.push_back(ComponentMask(particle_property_manager.get_data_info().n_components(),false));
+        particle_property_indices.emplace_back();
+        property_mask.emplace_back(particle_property_manager.get_data_info().n_components(),false);
 
         for (unsigned int advection_field=0; advection_field<advection_fields.size(); ++advection_field)
           {
@@ -309,7 +309,7 @@ namespace aspect
                                                                  + particle_property_and_component.second;
 
                     advection_field_has_been_found[advection_field] = true;
-                    particle_property_indices[particle_manager].push_back({advection_field, particle_property_index});
+                    particle_property_indices[particle_manager].emplace_back(advection_field, particle_property_index);
                     property_mask[particle_manager].set(particle_property_index,true);
                   }
               }
@@ -327,7 +327,7 @@ namespace aspect
                                        "more fields that are marked as particle advected than particle properties"));
 
                 advection_field_has_been_found[advection_field] = true;
-                particle_property_indices[particle_manager].push_back({advection_field,particle_property_index});
+                particle_property_indices[particle_manager].emplace_back(advection_field,particle_property_index);
                 property_mask[particle_manager].set(particle_property_index,true);
               }
           }
@@ -411,14 +411,14 @@ namespace aspect
               // to the particle field interpolated at these points
               cell->get_dof_indices (local_dof_indices);
               const unsigned int n_dofs_per_cell = finite_element.base_element(base_element_index).dofs_per_cell;
-              for (unsigned int j=0; j<particle_property_indices[particle_manager].size(); ++j)
+              for (const std::pair<unsigned int, unsigned int> &field_and_particle_property: particle_property_indices[particle_manager])
                 for (unsigned int i=0; i<n_dofs_per_cell; ++i)
                   {
                     const unsigned int system_local_dof
-                      = finite_element.component_to_system_index(advection_fields[particle_property_indices[particle_manager][j].first].component_index(introspection),
+                      = finite_element.component_to_system_index(advection_fields[field_and_particle_property.first].component_index(introspection),
                                                                  /*dof index within component=*/i);
 
-                    particle_solution(local_dof_indices[system_local_dof]) = particle_properties[i][particle_property_indices[particle_manager][j].second];
+                    particle_solution(local_dof_indices[system_local_dof]) = particle_properties[i][field_and_particle_property.second];
                   }
             }
         }


### PR DESCRIPTION
Our `clang-tidy` workflow is currently producing some warnings (see https://github.com/geodynamics/aspect/actions?query=branch%3Amain). This PR fixes the warnings by declaring a move constructor `noexcept` and by using range-based for loops in a number of places.