### PR TITLE
Add warning to cookbook

### DIFF
--- a/cookbooks/mantle_convection_with_continents_in_annulus/doc/mantle_convection_in_annulus.md
+++ b/cookbooks/mantle_convection_with_continents_in_annulus/doc/mantle_convection_in_annulus.md
@@ -3,6 +3,12 @@
 
 *This section was contributed by Cedric Thieulot and Erik van der Wiel.*
 
+**UNDER CONSTRUCTION: This cookbook does currently not produce the results shown
+in the figures. The reason for that is that the original model of
+{cite:t}`vanderwiel:etal:2024a` used a more complicated parameter file and
+a different version of ASPECT. Do not rely on the results of this cookbook
+at the moment.**
+
 The setup for this experiment originates in {cite:t}`vanderwiel:etal:2024a`.
 The domain is an annulus with an inner radius of 3480 km and an outer radius of 6370 km.
 The Isentropic Compression Approximation (ICA) is used {cite}`gassmoller:etal:2020`, which is


### PR DESCRIPTION
This cookbook currently seems to not produce the result reported in its documentation as reported by @rhino1999. Add a warning to make users aware of this.

Related to https://community.geodynamics.org/t/no-subduction-when-running-mantle-convection-with-continents-in-an-annulus-cookbook/3691/7.

@cedrict are you ok with this change?

This PR needs to go into the release branch as well.