### PR TITLE
Remove unnecessary lines

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -846,12 +846,7 @@ namespace aspect
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
-          {
-            // Before postprocessing, we need to copy the actual solution into the solution vector
-            // (which is used for postprocessing)
-            solution = current_linearization_point;
-            postprocess ();
-          }
+          postprocess ();
 
         ++nonlinear_iteration;
       }
@@ -861,10 +856,6 @@ namespace aspect
 
     // Reset the linear tolerance to what it was at the beginning of the time step.
     parameters.linear_stokes_solver_tolerance = begin_linear_tolerance;
-
-    // When we are finished iterating, we need to set the final solution to the current linearization point,
-    // because the solution vector is used in the postprocess.
-    solution = current_linearization_point;
 
     signals.post_nonlinear_solver(nonlinear_solver_control);
   }
@@ -1170,12 +1161,7 @@ namespace aspect
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
-          {
-            // Before postprocessing, we need to copy the actual solution into the solution vector
-            // (which is used for postprocessing)
-            solution = current_linearization_point;
-            postprocess ();
-          }
+          postprocess ();
 
         ++nonlinear_iteration;
       }
@@ -1187,10 +1173,6 @@ namespace aspect
 
     // Reset the linear tolerance to what it was at the beginning of the time step.
     parameters.linear_stokes_solver_tolerance = begin_linear_tolerance;
-
-    // When we are finished iterating, we need to set the final solution to the current linearization point,
-    // because the solution vector is used in the postprocess.
-    solution = current_linearization_point;
 
     AssertThrow(nonlinear_solver_control.last_check() != SolverControl::failure, ExcNonlinearSolverNoConvergence());
 
@@ -1279,12 +1261,7 @@ namespace aspect
               << std::endl;
 
         if (parameters.run_postprocessors_on_nonlinear_iterations)
-          {
-            // Before postprocessing, we need to copy the actual solution into the solution vector
-            // (which is used for postprocessing)
-            solution = current_linearization_point;
-            postprocess ();
-          }
+          postprocess ();
 
         ++nonlinear_iteration;
       }
@@ -1296,10 +1273,6 @@ namespace aspect
 
     // Reset the linear tolerance to what it was at the beginning of the time step.
     parameters.linear_stokes_solver_tolerance = begin_linear_tolerance;
-
-    // When we are finished iterating, we need to set the final solution to the current linearization point,
-    // because the solution vector is used in the postprocess.
-    solution = current_linearization_point;
 
     AssertThrow(nonlinear_solver_control.last_check() != SolverControl::failure, ExcNonlinearSolverNoConvergence());
 


### PR DESCRIPTION
With the changes of #6135 these lines should be unnecessary. `solution` will be set to the correct value inside the function `do_one_defect_correction_Stokes_step` and we do not need to worry about its content outside of that function. If this is correct, no tests should change.