### PR TITLE
Unify assembly patterns

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -908,16 +908,19 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
 
       for (unsigned int q=0; q<n_q_points; ++q)
-        for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
-          {
-            if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
-              {
-                scratch.phi_p[i_stokes] = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
-                data.local_pressure_shape_function_integrals(i_stokes) += scratch.phi_p[i_stokes] * scratch.finite_element_values.JxW(q);
-                ++i_stokes;
-              }
-            ++i;
-          }
+        {
+          const double JxW = scratch.finite_element_values.JxW(q);
+          for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
+                {
+                  scratch.phi_p[i_stokes] = scratch.finite_element_values[introspection.extractors.pressure].value (i, q);
+                  data.local_pressure_shape_function_integrals(i_stokes) += scratch.phi_p[i_stokes] * JxW;
+                  ++i_stokes;
+                }
+              ++i;
+            }
+        }
     }
 
 
@@ -951,13 +954,14 @@ namespace aspect
                                      scratch.face_finite_element_values.quadrature_point(q),
                                      scratch.face_finite_element_values.normal_vector(q));
 
+              const double JxW = scratch.face_finite_element_values.JxW(q);
+
               for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
                 {
                   if (introspection.is_stokes_component(fe.system_to_component_index(i).first))
                     {
                       data.local_rhs(i_stokes) += scratch.face_finite_element_values[introspection.extractors.velocities].value(i,q) *
-                                                  traction *
-                                                  scratch.face_finite_element_values.JxW(q);
+                                                  traction * JxW;
                       ++i_stokes;
                     }
                   ++i;

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -606,6 +606,9 @@ namespace aspect
           const double K_D = this->get_melt_handler().limited_darcy_coefficient(melt_outputs->permeabilities[q] / melt_outputs->fluid_viscosities[q],
                                                                                 is_melt_cell);
 
+          const double JxW = scratch.face_finite_element_values.JxW(q);
+          const Tensor<1,dim> normal_vector = scratch.face_finite_element_values.normal_vector(q);
+
           for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
             {
               const unsigned int component_index_i = fe.system_to_component_index(i).first;
@@ -616,9 +619,9 @@ namespace aspect
                   data.local_rhs(i_stokes) += (scratch.face_finite_element_values[ex_p_f].value(i, q)
                                                * this->get_pressure_scaling() * K_D *
                                                (density_f
-                                                * (scratch.face_finite_element_values.normal_vector(q) * gravity)
+                                                * (normal_vector * gravity)
                                                 - grad_p_f[q])
-                                               * scratch.face_finite_element_values.JxW(q));
+                                               * JxW);
                   ++i_stokes;
                 }
               ++i;
@@ -842,6 +845,8 @@ namespace aspect
               density_c_P_melt = 1.0;
             }
 
+          const double JxW = scratch.finite_element_values.JxW(q);
+
           // do the actual assembly. note that we only need to loop over the advection
           // shape functions because these are the only contributions we compute here
           for (unsigned int i=0; i<advection_dofs_per_cell; ++i)
@@ -853,8 +858,7 @@ namespace aspect
                   * (gamma + melt_transport_RHS)
                   + scratch.phi_field[i]
                   * reaction_term)
-                 *
-                 scratch.finite_element_values.JxW(q);
+                 * JxW;
 
               for (unsigned int j=0; j<advection_dofs_per_cell; ++j)
                 {
@@ -869,8 +873,7 @@ namespace aspect
                           + (factor * scratch.phi_field[i] * scratch.phi_field[j])) *
                        (density_c_P_melt)
                        + time_step * scratch.phi_field[i] * scratch.phi_field[j] * melt_transport_LHS
-                     )
-                     * scratch.finite_element_values.JxW(q);
+                     ) * JxW;
                 }
             }
         }
@@ -990,18 +993,21 @@ namespace aspect
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
 
       for (unsigned int q=0; q<n_q_points; ++q)
-        for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
-          {
-            const unsigned int component_index_i = fe.system_to_component_index(i).first;
+        {
+          const double JxW = scratch.finite_element_values.JxW(q);
+          for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
+            {
+              const unsigned int component_index_i = fe.system_to_component_index(i).first;
 
-            if (is_velocity_or_pressures(introspection,p_c_component_index,p_f_component_index,component_index_i))
-              {
-                scratch.phi_p[i_stokes] = scratch.finite_element_values[ex_p_f].value (i, q);
-                data.local_pressure_shape_function_integrals(i_stokes) += scratch.phi_p[i_stokes] * scratch.finite_element_values.JxW(q);
-                ++i_stokes;
-              }
-            ++i;
-          }
+              if (is_velocity_or_pressures(introspection,p_c_component_index,p_f_component_index,component_index_i))
+                {
+                  scratch.phi_p[i_stokes] = scratch.finite_element_values[ex_p_f].value (i, q);
+                  data.local_pressure_shape_function_integrals(i_stokes) += scratch.phi_p[i_stokes] * JxW;
+                  ++i_stokes;
+                }
+              ++i;
+            }
+        }
     }
 
     template <int dim>
@@ -1050,6 +1056,8 @@ namespace aspect
                                      scratch.face_finite_element_values.quadrature_point(q),
                                      scratch.face_finite_element_values.normal_vector(q));
 
+              const double JxW = scratch.face_finite_element_values.JxW(q);
+
               for (unsigned int i=0, i_stokes=0; i_stokes<stokes_dofs_per_cell; /*increment at end of loop*/)
                 {
                   const unsigned int component_index_i = fe.system_to_component_index(i).first;
@@ -1058,7 +1066,7 @@ namespace aspect
                     {
                       data.local_rhs(i_stokes) += scratch.face_finite_element_values[introspection.extractors.velocities].value(i,q) *
                                                   traction *
-                                                  scratch.face_finite_element_values.JxW(q);
+                                                  JxW;
                       ++i_stokes;
                     }
                   ++i;
@@ -1910,8 +1918,17 @@ namespace aspect
                 const Tensor<1,dim> n_hat = scratch.face_finite_element_values.normal_vector(q_point);
                 const Tensor<1,dim> g_hat = (g_norm == 0.0 ? Tensor<1,dim>() : gravity/g_norm);
 
+                small_vector<double> phi_u_times_g_hat(stokes_dofs_per_cell);
+                small_vector<double> phi_u_times_n_hat(stokes_dofs_per_cell);
+                for (unsigned int i=0; i<stokes_dofs_per_cell; ++i)
+                  {
+                    phi_u_times_g_hat[i] = scratch.phi_u[i] * g_hat;
+                    phi_u_times_n_hat[i] = scratch.phi_u[i] * n_hat;
+                  }
+
                 const double pressure_perturbation = scratch.face_material_model_outputs.densities[q_point] *
                                                      this->get_timestep() * free_surface_theta * g_norm;
+                const double JxW = scratch.face_finite_element_values.JxW(q_point);
 
                 // see Kaus et al 2010 for details of the stabilization term
                 for (unsigned int i=0; i< stokes_dofs_per_cell; ++i)
@@ -1919,8 +1936,8 @@ namespace aspect
                     {
                       // The fictive stabilization stress is (phi_u[i].g)*(phi_u[j].n)
                       const double stress_value = - pressure_perturbation
-                                                  * (scratch.phi_u[i] * g_hat) * (scratch.phi_u[j] * n_hat)
-                                                  * scratch.face_finite_element_values.JxW(q_point);
+                                                  * phi_u_times_g_hat[i] * phi_u_times_n_hat[j]
+                                                  * JxW;
 
                       data.local_matrix(i,j) += stress_value;
                     }

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2891,26 +2891,29 @@ namespace aspect
 
             cell_vector = 0;
             local_mass_matrix = 0;
-            for (unsigned int point=0; point<n_q_points; ++point)
-              for (unsigned int i=0; i<dofs_per_cell; ++i)
-                {
-                  if (dof_handler.get_fe().system_to_component_index(i).first == component_index)
-                    cell_vector(i) +=
-                      rhs_values[point] *
-                      fe_values[extractor].value(i,point) *
-                      fe_values.JxW(point);
+            for (unsigned int q=0; q<n_q_points; ++q)
+              {
+                const double JxW = fe_values.JxW(q);
+                for (unsigned int i=0; i<dofs_per_cell; ++i)
+                  {
+                    if (dof_handler.get_fe().system_to_component_index(i).first == component_index)
+                      cell_vector(i) +=
+                        rhs_values[q] *
+                        fe_values[extractor].value(i,q) *
+                        JxW;
 
-                  for (unsigned int j=0; j<dofs_per_cell; ++j)
-                    if ((dof_handler.get_fe().system_to_component_index(i).first ==
-                         component_index)
-                        &&
-                        (dof_handler.get_fe().system_to_component_index(j).first ==
-                         component_index))
-                      local_mass_matrix(j,i) += (fe_values[extractor].value(i,point) * fe_values[extractor].value(j,point) *
-                                                 fe_values.JxW(point));
-                    else if (i == j)
-                      local_mass_matrix(i,j) = 1.;
-                }
+                    for (unsigned int j=0; j<dofs_per_cell; ++j)
+                      if ((dof_handler.get_fe().system_to_component_index(i).first ==
+                           component_index)
+                          &&
+                          (dof_handler.get_fe().system_to_component_index(j).first ==
+                           component_index))
+                        local_mass_matrix(j,i) += (fe_values[extractor].value(i,q) * fe_values[extractor].value(j,q) *
+                                                   JxW);
+                      else if (i == j)
+                        local_mass_matrix(i,j) = 1.;
+                  }
+              }
 
             // now invert the local mass matrix and multiply it with the rhs
             local_mass_matrix.gauss_jordan();

--- a/source/volume_of_fluid/assembler.cc
+++ b/source/volume_of_fluid/assembler.cc
@@ -97,6 +97,8 @@ namespace aspect
 
       for (unsigned int q = 0; q< n_q_points; ++q)
         {
+          const double JxW = scratch.finite_element_values.JxW(q);
+
           // Init FE field vals
           for (unsigned int k=0; k<volume_of_fluid_dofs_per_cell; ++k)
             scratch.phi_field[k] = scratch.finite_element_values[solution_field].value(main_fe.component_to_system_index(solution_component, k), q);
@@ -104,13 +106,13 @@ namespace aspect
           for (unsigned int i = 0; i<volume_of_fluid_dofs_per_cell; ++i)
             {
               data.local_rhs[i] += scratch.old_field_values[q] *
-                                   scratch.finite_element_values.JxW(q);
+                                   JxW;
               for (unsigned int j=0; j<volume_of_fluid_dofs_per_cell; ++j)
                 data.local_matrix (i, j) += scratch.phi_field[i] *
                                             scratch.phi_field[j] *
-                                            scratch.finite_element_values.JxW(q);
+                                            JxW;
             }
-          scratch.volume += scratch.finite_element_values.JxW(q);
+          scratch.volume += JxW;
         }
 
       for (const unsigned int face_no : cell->face_indices())

--- a/source/volume_of_fluid/setup_initial_conditions.cc
+++ b/source/volume_of_fluid/setup_initial_conditions.cc
@@ -100,12 +100,13 @@ namespace aspect
         double volume_of_fluid_val = 0.0;
         double cell_vol = 0.0;
 
-        for (unsigned int i = 0; i < fe_init.n_quadrature_points; ++i)
+        for (unsigned int q = 0; q < fe_init.n_quadrature_points; ++q)
           {
-            const double fraction_at_point = this->get_initial_composition_manager().initial_composition(fe_init.quadrature_point(i),
+            const double fraction_at_point = this->get_initial_composition_manager().initial_composition(fe_init.quadrature_point(q),
                                              field.composition_index);
-            volume_of_fluid_val += fraction_at_point * fe_init.JxW (i);
-            cell_vol += fe_init.JxW(i);
+            const double JxW = fe_init.JxW(q);
+            volume_of_fluid_val += fraction_at_point * JxW;
+            cell_vol += JxW;
           }
 
         volume_of_fluid_val /= cell_vol;
@@ -184,11 +185,11 @@ namespace aspect
           {
 
             // For each quadrature point compute an approximation to the fluid fraction in the surrounding region
-            for (unsigned int i = 0; i < fe_init.n_quadrature_points; ++i)
+            for (unsigned int q = 0; q < fe_init.n_quadrature_points; ++q)
               {
                 double d = 0.0;
                 Tensor<1, dim, double> grad;
-                Point<dim> xU = quadrature.point (i);
+                Point<dim> xU = quadrature.point (q);
 
                 // Get an approximation to local normal at the closest interface (level set gradient)
                 // and the distance to the closest interface (value of level set function)
@@ -208,8 +209,9 @@ namespace aspect
                   }
                 // Use the basic fluid fraction formula to compute an approximation to the fluid fraction
                 const double fraction_at_point = VolumeOfFluid::Utilities::compute_fluid_fraction (grad, d);
-                volume_of_fluid_val += fraction_at_point * fe_init.JxW (i);
-                cell_vol += fe_init.JxW (i);
+                const double JxW = fe_init.JxW(q);
+                volume_of_fluid_val += fraction_at_point * JxW;
+                cell_vol += JxW;
               }
             volume_of_fluid_val /= cell_vol;
           }


### PR DESCRIPTION
This PR is mostly improving code quality, although it could also lead to small performance improvements for a few models.
It does the following things:
- consistently name the loop variable over quadrature points `q` like we do almost everywhere
- pre-compute `JxW` outside of assembly loops over degrees of freedom wherever possible. In many places that just assemble a right hand side (single loop over DoF) this likely doesnt make a difference, but a few places assemble matrices where this change might matter. Also I would just like to establish this as a pattern in as many places as possible so that future copy-paste code will copy the correct pattern
- while doing the `JxW` conversion also change a few places that can pre-compute values of shape functions or other expensive items from the inner loop. I dont expect huge performance gains, but it is a pattern we use in many places already, and if it is simple we should save the compute time where possible.