### PR TITLE
[WIP] Revert one change of PR #5580 to improve Newton solver convergence

### DIFF
--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -175,11 +175,14 @@ namespace aspect
           else
             {
               const SymmetricTensor<2,dim> viscosity_derivative_wrt_strain_rate = derivatives->viscosity_derivative_wrt_strain_rate[q];
-              const SymmetricTensor<2,dim> effective_strain_rate =
-                elastic_out == nullptr ? deviator(scratch.material_model_inputs.strain_rate[q]) : elastic_out->viscoelastic_strain_rate[q];
-
               const typename Newton::Parameters::Stabilization
               preconditioner_stabilization = this->get_newton_handler().parameters.preconditioner_stabilization;
+
+              SymmetricTensor<2,dim> effective_strain_rate = scratch.material_model_inputs.strain_rate[q];
+              if (elastic_out != nullptr)
+                effective_strain_rate = elastic_out->viscoelastic_strain_rate[q];
+              else if ((preconditioner_stabilization & Newton::Parameters::Stabilization::PD) != Newton::Parameters::Stabilization::none)
+                effective_strain_rate = deviator(effective_strain_rate);
 
               // use the spd factor when the stabilization is PD or SPD
               const double alpha = (preconditioner_stabilization & Newton::Parameters::Stabilization::PD) != Newton::Parameters::Stabilization::none ?
@@ -400,9 +403,6 @@ namespace aspect
           const double pressure = scratch.material_model_inputs.pressure[q];
           const double velocity_divergence = scratch.velocity_divergence[q];
 
-          const SymmetricTensor<2,dim> effective_strain_rate =
-            elastic_out == nullptr ? deviator(scratch.material_model_inputs.strain_rate[q]) : elastic_out->viscoelastic_strain_rate[q];
-
           const Tensor<1,dim>
           gravity = this->get_gravity_model().gravity_vector (scratch.finite_element_values.quadrature_point(q));
 
@@ -478,6 +478,12 @@ namespace aspect
                   const double viscosity_derivative_wrt_pressure = derivatives->viscosity_derivative_wrt_pressure[q];
                   const Newton::Parameters::Stabilization velocity_block_stabilization
                     = this->get_newton_handler().parameters.velocity_block_stabilization;
+
+                  SymmetricTensor<2,dim> effective_strain_rate = scratch.material_model_inputs.strain_rate[q];
+                  if (elastic_out != nullptr)
+                    effective_strain_rate = elastic_out->viscoelastic_strain_rate[q];
+                  else if ((velocity_block_stabilization & Newton::Parameters::Stabilization::PD) != Newton::Parameters::Stabilization::none)
+                    effective_strain_rate = deviator(effective_strain_rate);
 
                   // use the spd factor when the stabilization is PD or SPD
                   const double alpha =  (velocity_block_stabilization & Newton::Parameters::Stabilization::PD)

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1424,8 +1424,11 @@ namespace aspect
 
                   for (unsigned int q=0; q<n_q_points; ++q)
                     {
-                      const SymmetricTensor<2,dim> effective_strain_rate =
-                        elastic_out == nullptr ? deviator(in.strain_rate[q]) : elastic_out->viscoelastic_strain_rate[q];
+                      SymmetricTensor<2,dim> effective_strain_rate = in.strain_rate[q];
+                      if (elastic_out != nullptr)
+                        effective_strain_rate = elastic_out->viscoelastic_strain_rate[q];
+                      else if ((sim.newton_handler->parameters.velocity_block_stabilization & Newton::Parameters::Stabilization::PD) != Newton::Parameters::Stabilization::none)
+                        effective_strain_rate = deviator(effective_strain_rate);
 
                       // use the spd factor when the stabilization is PD or SPD.
                       const double alpha =  (sim.newton_handler->parameters.velocity_block_stabilization

--- a/tests/spiegelman_fail_test/screen-output
+++ b/tests/spiegelman_fail_test/screen-output
@@ -29,75 +29,75 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG)... 0+1 iterations.
-      Newton system information: Norm of the rhs: 9.54798e+14, Derivative scaling factor: 1
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.12306
-      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.12306
+      Newton system information: Norm of the rhs: 9.16397e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.118111
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.118111
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG)... 0+1 iterations.
-      Newton system information: Norm of the rhs: 4.36974e+14, Derivative scaling factor: 1
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.0563199
-      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0563199
+      Newton system information: Norm of the rhs: 5.68132e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.33204e-16, 0.0732243
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0732243
 
 
 WARNING: The nonlinear solver in the current timestep failed to converge.
 Acting according to the parameter 'Nonlinear solver failure strategy'...
 Continuing to the next timestep even though solution is not fully converged.
    Postprocessing:
-     RMS, max velocity:                  6.76e-09 m/s, 1.5e-08 m/s
-     Pressure min/avg/max:               -7.019e+10 Pa, 1.063e+09 Pa, 2.587e+11 Pa
-     Mass fluxes through boundary parts: -0.03241 kg/s, -0.03241 kg/s, 0 kg/s, -1.728 kg/s
+     RMS, max velocity:                  2.14e-08 m/s, 2.44e-07 m/s
+     Pressure min/avg/max:               -7.28e+10 Pa, 1.519e+09 Pa, 2.899e+11 Pa
+     Mass fluxes through boundary parts: -0.03241 kg/s, -0.03241 kg/s, 0 kg/s, 4.106 kg/s
      Writing graphical output:           output-spiegelman_fail_test/solution/solution-00000
 
 *** Timestep 1:  t=1 seconds, dt=1 seconds
    Skipping temperature solve because RHS is zero.
-   Solving C_1 system ... 0 iterations.
-   Initial Newton Stokes residual = 8.60842e+15, v = 8.60842e+15, p = 3.41939e+12
+   Solving C_1 system ... 1 iterations.
+   Initial Newton Stokes residual = 8.84992e+15, v = 8.84992e+15, p = 2.98258e+12
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG)... 0+0 iterations.
-      Newton system information: Norm of the rhs: 4.36222e+14
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.2409e-13, 0.0506738
-      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0506738
+      Newton system information: Norm of the rhs: 5.52475e+14
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.43828e-12, 0.0624271
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.0624271
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG)... 0+1 iterations.
-      Newton system information: Norm of the rhs: 2.17689e+14, Derivative scaling factor: 0
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 7.2409e-13, 0.025288
-      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.025288
+      Newton system information: Norm of the rhs: 2.2942e+14, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.2658e-13, 0.0259234
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.0259234
 
    Skipping temperature solve because RHS is zero.
-   Solving C_1 system ... 0 iterations.
+   Solving C_1 system ... 1 iterations.
    Switching from defect correction form of Picard to the Newton solver scheme.
    The linear solver tolerance is set to 0.843263. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
-   Solving Stokes system (AMG)... 0+1 iterations.
-      Newton system information: Norm of the rhs: 1.35994e+14, Derivative scaling factor: 1
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.76328e-13, 0.0157978
-      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0157978
+   Solving Stokes system (AMG)... 0+3 iterations.
+      Newton system information: Norm of the rhs: 1.92576e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 1.59356e-12, 0.0217602
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0217602
 
    Skipping temperature solve because RHS is zero.
    Solving C_1 system ... 0 iterations.
    The linear solver tolerance is set to 0.758936. Stabilization Preconditioner is none and A block is none.
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG)... 0+1 iterations.
-      Newton system information: Norm of the rhs: 7.18526e+13, Derivative scaling factor: 1
-      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 5.87227e-13, 0.00834678
-      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00834678
+      Newton system information: Norm of the rhs: 1.08722e+14, Derivative scaling factor: 1
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 2.92488e-13, 0.0122851
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0122851
 
 
 WARNING: The nonlinear solver in the current timestep failed to converge.
 Acting according to the parameter 'Nonlinear solver failure strategy'...
 Continuing to the next timestep even though solution is not fully converged.
    Postprocessing:
-     RMS, max velocity:                  2.71e-09 m/s, 8.03e-09 m/s
-     Pressure min/avg/max:               -2.037e+10 Pa, 1.602e+08 Pa, 3.381e+10 Pa
-     Mass fluxes through boundary parts: -0.03241 kg/s, -0.03241 kg/s, 0 kg/s, -1.176 kg/s
+     RMS, max velocity:                  2.94e-09 m/s, 1.54e-08 m/s
+     Pressure min/avg/max:               -2.771e+10 Pa, 3.617e+08 Pa, 6.167e+10 Pa
+     Mass fluxes through boundary parts: -0.03241 kg/s, -0.03241 kg/s, 0 kg/s, -0.1108 kg/s
 
 Termination requested by criterion: end time
 


### PR DESCRIPTION
This is a result of #6159. I would like to discuss reverting this change that happened originally in #5580. The difference between the `strain_rate` and `effective_strain_rate` is for most models (that dont use elasticity) that `effective_strain_rate` is simply the deviatoric part of the strain rate. I do not understand why we use the deviatoric strain rate here (it will be used to assemble the Newton matrix, i.e. the Jacobian). Maybe I just didnt follow the discussion in #5580 closely enough. From my understanding this should be the full strain rate, and at least the benchmark in #6159 massively benefits from my change here:

These are the relevant results from the benchmark in #6159 pre #5580:

![figure_4_pre_5580](https://github.com/user-attachments/assets/7ace097b-6de0-40c1-9757-0a678492d10f)

These are the relevant results post #5580. You can see you the stabilized version / dots converge faster, but the unstabilized version / lines are much worse:

![figure_4_post_5580](https://github.com/user-attachments/assets/1a6f8d22-5ce1-494b-adc7-850a6810bf39)

Now these are the relevant results post #5580 but with the change I propose in this PR. The unstabilized models are reverted to their original (better) convergence, and even the stabilized models gain another small boost:

![figure_4_post_5580_real_eps](https://github.com/user-attachments/assets/85cf3880-5096-4bf4-bd1b-845e829b552d)

I think this change may be responsible for some of the changes in #6159 that I couldnt explain. I will have to rerun more benchmarks, but in the meantime @YiminJin and @MFraters could you remind me why we did this change originally?
