### PR TITLE
Update citation info on website 1

### DIFF
--- a/benchmarks/entropy_adiabat/README.md
+++ b/benchmarks/entropy_adiabat/README.md
@@ -6,3 +6,5 @@ contains a technical benchmark for the entropy advection method.
 The model setup is described in `entropy_adiabat.prm` and requires the shared
 libraries in the `plugins/` directory. In particular it requires a material
 model (`plugins/entropy_model.cc/h`) that is formulated using pressure and entropy as independent variables, a different assembler that assembles the entropy equation (`plugins/entropy_advection.cc/h`) and a different way to compute the adiabatic background profile (`plugins/compute_entropy_profile.cc/h`).
+
+The benchmark and its results are described in {cite:t}`dannberg:etal:2022`. Please remember to cite this paper when using the entropy advection method.

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -75,7 +75,8 @@ want_groups = {"kronbichler:etal:2012": "main",
                "fraters:etal:2019" : "NewtonSolver",
                "fraters_billen_2021_cpo" : "CPO",
                "dannberg:etal:2022" : "entropy",
-               "dannberg:grain:size" : "grainsize"
+               "dannberg:grain:size" : "grainsize",
+               "dannberg:etal:2021" : "boukaremelt"
 }
 
 want = []
@@ -110,7 +111,8 @@ bibformated = {
         "rose_freesurface" : "Ian Rose, Bruce Buffett, and Timo Heister. 2017. “Stability and Accuracy of Free Surface Time Integration in Viscous Flows.” Physics of the Earth and Planetary Interiors 262 (January): 90–100. doi:10.1016/j.pepi.2016.11.007. http://dx.doi.org/10.1016/j.pepi.2016.11.007.",
         "fraters_billen_2021_cpo" : "Fraters, M. R. T. and Billen, M. I. 2021. “On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling” Geochemistry, Geophysics, Geosystems 22 (10): e2021GC009846. doi:10.1029/2021GC009846. https://doi.org/10.1029/2021GC009846.",
         "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293.",
-        "dannberg:grain:size" : "Dannberg, J., Eilon, Z., Faul, U., Gassmöller, R., Moulik, P. and Myhill, R. 2017. The importance of grain size to mantle dynamics and seismological observations. Geochemistry, Geophysics, Geosystems, 18(8), pp.3034-3061. doi:10.1002/2017GC006944. https://doi.org/10.1002/2017GC006944."
+        "dannberg:grain:size" : "Dannberg, J., Eilon, Z., Faul, U., Gassmöller, R., Moulik, P. and Myhill, R. 2017. The importance of grain size to mantle dynamics and seismological observations. Geochemistry, Geophysics, Geosystems, 18(8), pp.3034-3061. doi:10.1002/2017GC006944. https://doi.org/10.1002/2017GC006944.",
+        "dannberg:etal:2021" : "Dannberg, J., Myhill, R., Gassmöller, R. and Cottaar, S., 2021. The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs. Geophysical Journal International, 227(2), pp.1028-1059."
 }
 
 

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -73,7 +73,8 @@ want_groups = {"kronbichler:etal:2012": "main",
                "fraters_menno_2020_3900603" : "GWB",
                "Fraters2019c" : "GWB",
                "fraters:etal:2019" : "NewtonSolver",
-               "fraters_billen_2021_cpo" : "CPO"
+               "fraters_billen_2021_cpo" : "CPO",
+               "dannberg:etal:2022" : "entropy"
 }
 
 want = []
@@ -106,7 +107,8 @@ bibformated = {
         "gassmoller:etal:2020" : "Rene Gassmöller, Juliane Dannberg, Wolfgang Bangerth, Timo Heister, and Robert Myhill. 2020. “On Formulations of Compressible Mantle Convection.” Geophysical Journal International 221 (2) (February 13): 1264–1280. doi:10.1093/gji/ggaa078. http://dx.doi.org/10.1093/gji/ggaa078.",
         "heister:etal:2017" : "Timo Heister, Juliane Dannberg, Rene Gassmöller, and Wolfgang Bangerth. 2017. “High Accuracy Mantle Convection Simulation through Modern Numerical Methods – II: Realistic Models and Problems.” Geophysical Journal International 210 (2) (May 9): 833–851. doi:10.1093/gji/ggx195. http://dx.doi.org/10.1093/gji/ggx195.",
         "rose_freesurface" : "Ian Rose, Bruce Buffett, and Timo Heister. 2017. “Stability and Accuracy of Free Surface Time Integration in Viscous Flows.” Physics of the Earth and Planetary Interiors 262 (January): 90–100. doi:10.1016/j.pepi.2016.11.007. http://dx.doi.org/10.1016/j.pepi.2016.11.007.",
-        "fraters_billen_2021_cpo" : "Fraters, M. R. T. and Billen, M. I. 2021. “On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling” Geochemistry, Geophysics, Geosystems 22 (10): e2021GC009846. doi:10.1029/2021GC009846. https://doi.org/10.1029/2021GC009846."
+        "fraters_billen_2021_cpo" : "Fraters, M. R. T. and Billen, M. I. 2021. “On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling” Geochemistry, Geophysics, Geosystems 22 (10): e2021GC009846. doi:10.1029/2021GC009846. https://doi.org/10.1029/2021GC009846.",
+        "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293."
 }
 
 

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -77,7 +77,8 @@ want_groups = {"kronbichler:etal:2012": "main",
                "dannberg:etal:2022" : "entropy",
                "dannberg:grain:size" : "grainsize",
                "dannberg:etal:2021" : "boukaremelt",
-               "neuharth:etal:2022" : "fastscape"
+               "neuharth:etal:2022" : "fastscape",
+               "dannberg:gassmoeller:etal:2024" : "cbfheatflux"
 }
 
 want = []
@@ -114,7 +115,8 @@ bibformated = {
         "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293.",
         "dannberg:grain:size" : "Dannberg, J., Eilon, Z., Faul, U., Gassmöller, R., Moulik, P. and Myhill, R. 2017. The importance of grain size to mantle dynamics and seismological observations. Geochemistry, Geophysics, Geosystems, 18(8), pp.3034-3061. doi:10.1002/2017GC006944. https://doi.org/10.1002/2017GC006944.",
         "dannberg:etal:2021" : "Dannberg, J., Myhill, R., Gassmöller, R. and Cottaar, S., 2021. The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs. Geophysical Journal International, 227(2), pp.1028-1059.",
-        "neuharth:etal:2022" : "Neuharth, D., Brune, S., Wrona, T., Glerum, A., Braun, J. and Yuan, X. 2022. Evolution of rift systems and their fault networks in response to surface processes. Tectonics, 41(3), e2021TC007166. doi:10.1029/2021TC007166. https://doi.org/10.1029/2021TC007166."
+        "neuharth:etal:2022" : "Neuharth, D., Brune, S., Wrona, T., Glerum, A., Braun, J. and Yuan, X. 2022. Evolution of rift systems and their fault networks in response to surface processes. Tectonics, 41(3), e2021TC007166. doi:10.1029/2021TC007166. https://doi.org/10.1029/2021TC007166.",
+        "dannberg:gassmoeller:etal:2024" : "Dannberg, J., Gassmöller, R., Thallner, D., LaCombe, F. and Sprain, C. 2024. Changes in core–mantle boundary heat flux patterns throughout the supercontinent cycle. Geophysical Journal International, 237(3), pp.1251-1274. doi:10.1093/gji/ggae075. https://doi.org/10.1093/gji/ggae075."
 }
 
 

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -76,7 +76,8 @@ want_groups = {"kronbichler:etal:2012": "main",
                "fraters_billen_2021_cpo" : "CPO",
                "dannberg:etal:2022" : "entropy",
                "dannberg:grain:size" : "grainsize",
-               "dannberg:etal:2021" : "boukaremelt"
+               "dannberg:etal:2021" : "boukaremelt",
+               "neuharth:etal:2022" : "fastscape"
 }
 
 want = []
@@ -112,7 +113,8 @@ bibformated = {
         "fraters_billen_2021_cpo" : "Fraters, M. R. T. and Billen, M. I. 2021. “On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling” Geochemistry, Geophysics, Geosystems 22 (10): e2021GC009846. doi:10.1029/2021GC009846. https://doi.org/10.1029/2021GC009846.",
         "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293.",
         "dannberg:grain:size" : "Dannberg, J., Eilon, Z., Faul, U., Gassmöller, R., Moulik, P. and Myhill, R. 2017. The importance of grain size to mantle dynamics and seismological observations. Geochemistry, Geophysics, Geosystems, 18(8), pp.3034-3061. doi:10.1002/2017GC006944. https://doi.org/10.1002/2017GC006944.",
-        "dannberg:etal:2021" : "Dannberg, J., Myhill, R., Gassmöller, R. and Cottaar, S., 2021. The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs. Geophysical Journal International, 227(2), pp.1028-1059."
+        "dannberg:etal:2021" : "Dannberg, J., Myhill, R., Gassmöller, R. and Cottaar, S., 2021. The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs. Geophysical Journal International, 227(2), pp.1028-1059.",
+        "neuharth:etal:2022" : "Neuharth, D., Brune, S., Wrona, T., Glerum, A., Braun, J. and Yuan, X. 2022. Evolution of rift systems and their fault networks in response to surface processes. Tectonics, 41(3), e2021TC007166. doi:10.1029/2021TC007166. https://doi.org/10.1029/2021TC007166."
 }
 
 

--- a/doc/make_cite_html.py
+++ b/doc/make_cite_html.py
@@ -74,7 +74,8 @@ want_groups = {"kronbichler:etal:2012": "main",
                "Fraters2019c" : "GWB",
                "fraters:etal:2019" : "NewtonSolver",
                "fraters_billen_2021_cpo" : "CPO",
-               "dannberg:etal:2022" : "entropy"
+               "dannberg:etal:2022" : "entropy",
+               "dannberg:grain:size" : "grainsize"
 }
 
 want = []
@@ -108,7 +109,8 @@ bibformated = {
         "heister:etal:2017" : "Timo Heister, Juliane Dannberg, Rene Gassmöller, and Wolfgang Bangerth. 2017. “High Accuracy Mantle Convection Simulation through Modern Numerical Methods – II: Realistic Models and Problems.” Geophysical Journal International 210 (2) (May 9): 833–851. doi:10.1093/gji/ggx195. http://dx.doi.org/10.1093/gji/ggx195.",
         "rose_freesurface" : "Ian Rose, Bruce Buffett, and Timo Heister. 2017. “Stability and Accuracy of Free Surface Time Integration in Viscous Flows.” Physics of the Earth and Planetary Interiors 262 (January): 90–100. doi:10.1016/j.pepi.2016.11.007. http://dx.doi.org/10.1016/j.pepi.2016.11.007.",
         "fraters_billen_2021_cpo" : "Fraters, M. R. T. and Billen, M. I. 2021. “On the Implementation and Usability of Crystal Preferred Orientation Evolution in Geodynamic Modeling” Geochemistry, Geophysics, Geosystems 22 (10): e2021GC009846. doi:10.1029/2021GC009846. https://doi.org/10.1029/2021GC009846.",
-        "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293."
+        "dannberg:etal:2022" : "Dannberg, J., Gassmöller, R., Li, R., Lithgow-Bertelloni, C. and Stixrude, L. 2022. An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage. Geophysical Journal International, 231(3), pp.1833-1849. doi:10.1093/gji/ggac293. https://doi.org/10.1093/gji/ggac293.",
+        "dannberg:grain:size" : "Dannberg, J., Eilon, Z., Faul, U., Gassmöller, R., Moulik, P. and Myhill, R. 2017. The importance of grain size to mantle dynamics and seismological observations. Geochemistry, Geophysics, Geosystems, 18(8), pp.3034-3061. doi:10.1002/2017GC006944. https://doi.org/10.1002/2017GC006944."
 }
 
 

--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -309,6 +309,21 @@ volume    = {115},
 publisher = {National Acad Sciences},
 }
 
+@article{dannberg:etal:2022,
+author = {Dannberg, Juliane and Gassmöller, Rene and Li, Ranpeng and Lithgow-Bertelloni, Carolina and Stixrude, Lars},
+title = {An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage},
+journal = {Geophysical Journal International},
+volume = {231},
+number = {3},
+pages = {1833-1849},
+year = {2022},
+month = {07},
+issn = {0956-540X},
+doi = {10.1093/gji/ggac293},
+url = {https://doi.org/10.1093/gji/ggac293},
+eprint = {https://academic.oup.com/gji/article-pdf/231/3/1833/46842522/ggac293.pdf},
+}
+
 @article{vanderwiel2024,
 title={Quantifying mantle mixing through configurational Entropy},
 author={van der Wiel, Erik and Thieulot, Cedric and van Hinsbergen, Douwe JJ},

--- a/doc/manual/citing_aspect.bib
+++ b/doc/manual/citing_aspect.bib
@@ -161,6 +161,21 @@ title = {The importance of grain size to mantle dynamics and seismological obser
 journal = {Geochemistry,  Geophysics,  Geosystems}
 }
 
+@article{dannberg2021morphology,
+    author = {Dannberg, Juliane and Myhill, Robert and Gassmöller, Rene and Cottaar, Sanne},
+    title = {The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs},
+    journal = {Geophysical Journal International},
+    volume = {227},
+    number = {2},
+    pages = {1028-1059},
+    year = {2021},
+    month = {06},
+    issn = {0956-540X},
+    doi = {10.1093/gji/ggab242},
+    url = {https://doi.org/10.1093/gji/ggab242},
+    eprint = {https://academic.oup.com/gji/article-pdf/227/2/1028/39556563/ggab242.pdf},
+}
+
 @Article{Heister2017,
 author  = {Heister, Timo and Dannberg, Juliane and Gassm{\"{o}}ller, Rene and Bangerth, Wolfgang},
 journal = {Geophysical Journal International},

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -12160,6 +12160,21 @@ doi = {10.1016/j.pepi.2008.04.015}
   eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2017GC006944}
 }
 
+@article{dannberg:etal:2021,
+    author = {Dannberg, Juliane and Myhill, Robert and Gassmöller, René and Cottaar, Sanne},
+    title = {The morphology, evolution and seismic visibility of partial melt at the core–mantle boundary: implications for ULVZs},
+    journal = {Geophysical Journal International},
+    volume = {227},
+    number = {2},
+    pages = {1028-1059},
+    year = {2021},
+    month = {06},
+    issn = {0956-540X},
+    doi = {10.1093/gji/ggab242},
+    url = {https://doi.org/10.1093/gji/ggab242},
+    eprint = {https://academic.oup.com/gji/article-pdf/227/2/1028/39556563/ggab242.pdf},
+}
+
 @article{simmons:etal:2019,
   title={Resolution and covariance of the {LLNL-G3D-JPS} global seismic tomography model: applications to travel time uncertainty and tomographic filtering of geodynamic models},
   author={Simmons, Nathan A and Schuberth, Bernhard SA and Myers, Steve C and Knapp, Doug R},

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -12264,7 +12264,7 @@ doi = {10.1016/0040-1951(85)90225-2},
 year = {1985}
 }
 
- @article{Dannberg:Sobolev:2015, 
+@article{Dannberg:Sobolev:2015, 
    title={Low-buoyancy thermochemical plumes resolve controversy of classical mantle plume concept}, 
    author={Dannberg, Juliane and Sobolev, Stephan V.}, 
    year={2015},
@@ -12273,7 +12273,23 @@ year = {1985}
    number={11}, 
    journal={Nature Communications}, 
    publisher={Nature Publishing Group}, 
-   pages={6960} }
+   pages={6960}
+}
+
+@article{dannberg:etal:2022,
+author = {Dannberg, Juliane and Gassmöller, Rene and Li, Ranpeng and Lithgow-Bertelloni, Carolina and Stixrude, Lars},
+title = {An entropy method for geodynamic modelling of phase transitions: capturing sharp and broad transitions in a multiphase assemblage},
+journal = {Geophysical Journal International},
+volume = {231},
+number = {3},
+pages = {1833-1849},
+year = {2022},
+month = {07},
+issn = {0956-540X},
+doi = {10.1093/gji/ggac293},
+url = {https://doi.org/10.1093/gji/ggac293},
+eprint = {https://academic.oup.com/gji/article-pdf/231/3/1833/46842522/ggac293.pdf},
+}
 
 @article{stixrude:Lithgow:2022,
   title={Thermal expansivity, heat capacity and bulk modulus of the mantle},

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -11986,6 +11986,21 @@ Year = {1968}}
   journal = {Geophysical Journal International}
 }
 
+@article{dannberg:gassmoeller:etal:2024,
+author = {Dannberg, Juliane and Gassmöller, Rene and Thallner, Daniele and LaCombe, Frederick and Sprain, Courtney},
+title = "{Changes in core-mantle boundary heat flux patterns throughout the supercontinent cycle}",
+journal = {Geophysical Journal International},
+volume = {237},
+number = {3},
+pages = {1251-1274},
+year = {2024},
+month = {02},
+issn = {0956-540X},
+doi = {10.1093/gji/ggae075},
+url = {https://doi.org/10.1093/gji/ggae075},
+eprint = {https://academic.oup.com/gji/article-pdf/237/3/1251/57214885/ggae075.pdf}
+}
+
 @Article{Fraters2019c,
 AUTHOR = {Fraters, M. and Thieulot, C. and van den Berg, A. and Spakman, W.},
 TITLE = {The Geodynamic World Builder: a solution for complex initial conditions in numerical modeling},

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -12154,7 +12154,10 @@ doi = {10.1016/j.pepi.2008.04.015}
   number={8},
   pages={3034--3061},
   year={2017},
-  publisher={Wiley Online Library}
+  publisher={Wiley Online Library},
+  doi = {https://doi.org/10.1002/2017GC006944},
+  url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1002/2017GC006944},
+  eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1002/2017GC006944}
 }
 
 @article{simmons:etal:2019,

--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -12352,3 +12352,18 @@ eprint = {https://academic.oup.com/gji/article-pdf/231/3/1833/46842522/ggac293.p
   year={2016},
   publisher={Wiley Online Library}
 }
+
+@article{neuharth:etal:2022,
+author = {Neuharth, Derek and Brune, Sascha and Wrona, Thilo and Glerum, Anne and Braun, Jean and Yuan, Xiaoping},
+title = {Evolution of Rift Systems and Their Fault Networks in Response to Surface Processes},
+journal = {Tectonics},
+volume = {41},
+number = {3},
+pages = {e2021TC007166},
+keywords = {rifts, fault network, surface processes, geodynamics},
+doi = {https://doi.org/10.1029/2021TC007166},
+url = {https://agupubs.onlinelibrary.wiley.com/doi/abs/10.1029/2021TC007166},
+eprint = {https://agupubs.onlinelibrary.wiley.com/doi/pdf/10.1029/2021TC007166},
+note = {e2021TC007166 2021TC007166},
+year = {2022}
+}

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -23,6 +23,7 @@
 #define _aspect_global_h
 
 #include <aspect/config.h>
+#include <aspect/citation_info.h>
 
 #include <deal.II/base/mpi.h>
 

--- a/include/aspect/postprocess/heat_flux_densities.h
+++ b/include/aspect/postprocess/heat_flux_densities.h
@@ -42,6 +42,12 @@ namespace aspect
     {
       public:
         /**
+         * Initialize the postprocessor.
+         */
+        void
+        initialize() override;
+
+        /**
          * Evaluate.
          */
         std::pair<std::string,std::string>

--- a/include/aspect/postprocess/heat_flux_map.h
+++ b/include/aspect/postprocess/heat_flux_map.h
@@ -41,6 +41,13 @@ namespace aspect
        * The consistent Galerkin FEM for computing derived boundary quantities in thermal and or fluids
        * problems. International Journal for Numerical Methods in Fluids, 7(4), 371-394.
        *
+       * The implementation of the method is benchmarked in
+       *
+       * Juliane Dannberg, Rene Gassmöller, Daniele Thallner, Frederick LaCombe, Courtney Sprain (2024).
+       * Changes in core–mantle boundary heat flux patterns throughout the supercontinent cycle,
+       * Geophysical Journal International, Volume 237, Issue 3, June 2024, Pages 1251–1274,
+       * https://doi.org/10.1093/gji/ggae075.
+       *
        * In summary, the method solves the temperature equation again on the boundary faces, with known
        * temperatures and solving for the boundary fluxes that satisfy the equation. Since the
        * equation is only formed on the faces and it can be solved using only diagonal matrices,
@@ -83,6 +90,12 @@ namespace aspect
     class HeatFluxMap : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
       public:
+        /**
+         * Initialize the postprocessor.
+         */
+        void
+        initialize() override;
+
         /**
          * Evaluate the solution for the heat flux.
          */

--- a/include/aspect/postprocess/heat_flux_statistics.h
+++ b/include/aspect/postprocess/heat_flux_statistics.h
@@ -41,6 +41,12 @@ namespace aspect
     {
       public:
         /**
+         * Initialize the postprocessor.
+         */
+        void
+        initialize() override;
+
+        /**
          * Evaluate the solution for some heat_flux statistics.
          */
         std::pair<std::string,std::string>

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -44,7 +44,16 @@ namespace aspect
           public Interface<dim>
       {
         public:
+          /**
+           * Constructor.
+           */
           HeatFluxMap();
+
+          /**
+           * Initialize the postprocessor.
+           */
+          void
+          initialize() override;
 
           /**
            * Fill the temporary storage variables with the

--- a/source/initial_composition/world_builder.cc
+++ b/source/initial_composition/world_builder.cc
@@ -23,7 +23,6 @@
 #ifdef ASPECT_WITH_WORLD_BUILDER
 #include <aspect/initial_composition/world_builder.h>
 #include <aspect/geometry_model/interface.h>
-#include <aspect/citation_info.h>
 
 #include <world_builder/world.h>
 

--- a/source/initial_temperature/world_builder.cc
+++ b/source/initial_temperature/world_builder.cc
@@ -25,7 +25,6 @@
 #include <aspect/initial_temperature/world_builder.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/gravity_model/interface.h>
-#include <aspect/citation_info.h>
 
 #include <world_builder/world.h>
 

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -71,6 +71,8 @@ namespace aspect
     void
     EntropyModel<dim>::initialize()
     {
+      CitationInfo::add("entropy");
+
       AssertThrow (this->get_parameters().formulation_mass_conservation ==
                    Parameters<dim>::Formulation::MassConservation::projected_density_field,
                    ExcMessage("The 'entropy model' material model was only tested with the "

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -83,6 +83,8 @@ namespace aspect
     void
     GrainSize<dim>::initialize()
     {
+      CitationInfo::add("grainsize");
+
       n_material_data = material_file_names.size();
       for (unsigned i = 0; i < n_material_data; ++i)
         {

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -71,6 +71,8 @@ namespace aspect
     void
     MeltBoukare<dim>::initialize()
     {
+      CitationInfo::add("boukaremelt");
+
       // Compute parameters for the modified Tait equation of state for the different endmembers
       // derived from the isothermal bulk modulus and its two first pressure derivatives.
       // This corresponds to Equation 4 from Holland and Powell, 2011 (https://doi.org/10.1111/j.1525-1314.2010.00923.x).

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -85,6 +85,8 @@ namespace aspect
       void
       GrainSizeEvolution<dim>::initialize_phase_function(std::shared_ptr<MaterialUtilities::PhaseFunction<dim>> &phase_function_)
       {
+        CitationInfo::add("grainsize");
+
         phase_function = phase_function_;
         n_phase_transitions = phase_function->n_phases_for_each_composition()[0] - 1;
       }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -191,6 +191,8 @@ namespace aspect
     void
     FastScape<dim>::initialize ()
     {
+      CitationInfo::add("fastscape");
+
       AssertThrow(Plugins::plugin_type_matches<const GeometryModel::Box<dim>>(this->get_geometry_model()),
                   ExcMessage("FastScape can only be run with a box geometry model."));
 

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -21,7 +21,6 @@
 #include <aspect/particle/manager.h>
 #include <aspect/global.h>
 #include <aspect/utilities.h>
-#include <aspect/citation_info.h>
 #include <aspect/simulator.h>
 #include <aspect/melt.h>
 

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -20,7 +20,6 @@
 
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/geometry_model/interface.h>
-#include <aspect/citation_info.h>
 #include <aspect/utilities.h>
 
 #include <world_builder/grains.h>

--- a/source/particle/property/grain_size.cc
+++ b/source/particle/property/grain_size.cc
@@ -41,6 +41,8 @@ namespace aspect
       void
       GrainSize<dim>::initialize ()
       {
+        CitationInfo::add("grainsize");
+
         material_inputs  = MaterialModel::MaterialModelInputs<dim>(1, this->n_compositional_fields());
         material_outputs = MaterialModel::MaterialModelOutputs<dim>(1, this->n_compositional_fields());
 

--- a/source/postprocess/dynamic_topography.cc
+++ b/source/postprocess/dynamic_topography.cc
@@ -505,6 +505,8 @@ namespace aspect
     void
     DynamicTopography<dim>::parse_parameters (ParameterHandler &prm)
     {
+      CitationInfo::add("geoid");
+
       prm.enter_subsection("Postprocess");
       {
         prm.enter_subsection("Dynamic topography");

--- a/source/postprocess/geoid.cc
+++ b/source/postprocess/geoid.cc
@@ -30,8 +30,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
 
-#include <aspect/citation_info.h>
-
 
 namespace aspect
 {

--- a/source/postprocess/heat_flux_densities.cc
+++ b/source/postprocess/heat_flux_densities.cc
@@ -34,6 +34,15 @@ namespace aspect
   namespace Postprocess
   {
     template <int dim>
+    void
+    HeatFluxDensities<dim>::initialize ()
+    {
+      CitationInfo::add("cbfheatflux");
+    }
+
+
+
+    template <int dim>
     std::pair<std::string,std::string>
     HeatFluxDensities<dim>::execute (TableHandler &statistics)
     {

--- a/source/postprocess/heat_flux_map.cc
+++ b/source/postprocess/heat_flux_map.cc
@@ -452,6 +452,13 @@ namespace aspect
       }
     }
 
+    template <int dim>
+    void
+    HeatFluxMap<dim>::initialize ()
+    {
+      CitationInfo::add("cbfheatflux");
+    }
+
 
 
     template <int dim>

--- a/source/postprocess/heat_flux_statistics.cc
+++ b/source/postprocess/heat_flux_statistics.cc
@@ -34,6 +34,15 @@ namespace aspect
   namespace Postprocess
   {
     template <int dim>
+    void
+    HeatFluxStatistics<dim>::initialize ()
+    {
+      CitationInfo::add("cbfheatflux");
+    }
+
+
+
+    template <int dim>
     std::pair<std::string,std::string>
     HeatFluxStatistics<dim>::execute (TableHandler &statistics)
     {

--- a/source/postprocess/visualization/geoid.cc
+++ b/source/postprocess/visualization/geoid.cc
@@ -23,7 +23,6 @@
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/postprocess/visualization/geoid.h>
-#include <aspect/citation_info.h>
 
 
 

--- a/source/postprocess/visualization/heat_flux_map.cc
+++ b/source/postprocess/visualization/heat_flux_map.cc
@@ -46,6 +46,15 @@ namespace aspect
 
       template <int dim>
       void
+      HeatFluxMap<dim>::initialize ()
+      {
+        CitationInfo::add("cbfheatflux");
+      }
+
+
+
+      template <int dim>
+      void
       HeatFluxMap<dim>::update ()
       {
         if (output_point_wise_heat_flux)

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -23,7 +23,6 @@
 #include <aspect/utilities.h>
 #include <aspect/compat.h>
 #include <aspect/simulator_access.h>
-#include <aspect/citation_info.h>
 
 #include <aspect/simulator/assemblers/interface.h>
 #include <aspect/melt.h>

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -27,7 +27,6 @@
 #include <aspect/newton.h>
 #include <aspect/stokes_matrix_free.h>
 #include <aspect/mesh_deformation/interface.h>
-#include <aspect/citation_info.h>
 #include <aspect/postprocess/particles.h>
 
 #ifdef ASPECT_WITH_WORLD_BUILDER

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -22,7 +22,6 @@
 #include <aspect/melt.h>
 #include <aspect/simulator.h>
 #include <aspect/utilities.h>
-#include <aspect/citation_info.h>
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/simulator/assemblers/advection.h>
 #include <deal.II/base/signaling_nan.h>

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -24,7 +24,6 @@
 #include <aspect/simulator/assemblers/stokes.h>
 
 #include <aspect/simulator.h>
-#include <aspect/citation_info.h>
 
 namespace aspect
 {

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/stokes_matrix_free.h>
-#include <aspect/citation_info.h>
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/melt.h>


### PR DESCRIPTION
In the past years I have not paid much attention to keeping the citation info on the website https://aspect.geodynamics.org/citing.html?ver=release&src=www updated. Thus, we have a number of new methods that are based on published papers, which are not listed. This PR fixes this for the plugins for which I know the related papers. If anyone is aware of other papers that are connected to individual methods in ASPECT feel free to let me know. I will open the corresponding PR for the website branch next.