### PR TITLE
Rename phase transition index

### DIFF
--- a/doc/modules/changes/20241201_lhy11009
+++ b/doc/modules/changes/20241201_lhy11009
@@ -1,0 +1,6 @@
+Changed: Renamed the variable 'PhaseFunctionInputs::phase_index' to
+PhaseFunctionInputs::phase_transition_index'. The new variable name
+is more precise since it is used to index phase transitions rather than phases.
+Material models that make use of the old name will have to be adjusted.
+<br>
+(Haoyuan Li, 2024/12/01)

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -528,7 +528,7 @@ namespace aspect
                             const double pressure,
                             const double depth,
                             const double pressure_depth_derivative,
-                            const unsigned int phase_index);
+                            const unsigned int phase_transition_index);
 
         double temperature;
         double pressure;
@@ -546,7 +546,7 @@ namespace aspect
          * which only has information that there are two phase functions
          * and what their properties are.
          */
-        unsigned int phase_index;
+        unsigned int phase_transition_index;
       };
 
       /**
@@ -775,14 +775,14 @@ namespace aspect
 
           /**
            * Return the Clapeyron slope (dp/dT of the transition) for
-           * phase transition number @p phase_index.
+           * phase transition number @p phase_transition_index.
            */
-          double get_transition_slope (const unsigned int phase_index) const;
+          double get_transition_slope (const unsigned int phase_transition_index) const;
 
           /**
-           * Return the depth for phase transition number @p phase_index.
+           * Return the depth for phase transition number @p phase_transition_index.
            */
-          double get_transition_depth (const unsigned int phase_index) const;
+          double get_transition_depth (const unsigned int phase_transition_index) const;
 
           /**
            * Return how many phase transitions there are for each chemical composition.

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -576,7 +576,7 @@ namespace aspect
 
                   for (unsigned int k=0; k<n_phase_transitions; ++k)
                     {
-                      phase_inputs.phase_index = k;
+                      phase_inputs.phase_transition_index = k;
                       phase_function_values[k] = phase_function->compute_value(phase_inputs);
                     }
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -80,7 +80,7 @@ namespace aspect
 
           for (unsigned int j=0; j < phase_function.n_phase_transitions(); ++j)
             {
-              phase_inputs.phase_index = j;
+              phase_inputs.phase_transition_index = j;
               phase_function_values[j] = phase_function.compute_value(phase_inputs);
             }
         }
@@ -141,7 +141,7 @@ namespace aspect
           // Compute value of phase functions
           for (unsigned int j=0; j < phase_function.n_phase_transitions(); ++j)
             {
-              phase_inputs.phase_index = j;
+              phase_inputs.phase_transition_index = j;
               phase_function_values[j] = phase_function.compute_value(phase_inputs);
             }
 
@@ -209,7 +209,7 @@ namespace aspect
                 {
                   for (unsigned int j=0; j < phase_function_discrete->n_phase_transitions(); ++j)
                     {
-                      phase_inputs.phase_index = j;
+                      phase_inputs.phase_transition_index = j;
                       phase_function_discrete_values[j] = phase_function_discrete->compute_value(phase_inputs);
                     }
                   isostrain_viscosities =

--- a/tests/composite_viscous_outputs_phases.cc
+++ b/tests/composite_viscous_outputs_phases.cc
@@ -169,7 +169,7 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
           // Compute value of phase functions
           for (unsigned int j=0; j < phase_function.n_phase_transitions(); ++j)
             {
-              phase_inputs.phase_index = j;
+              phase_inputs.phase_transition_index = j;
               phase_function_values[j] = phase_function.compute_value(phase_inputs);
             }
 


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

Renamed the variable phase_index to phase_transition_index across 
affected functions and structures. The new variable name, phase_transition_index, 
provides a more precise and descriptive representation of its role, 
emphasizing its purpose in indexing phase transitions rather than phases.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
