### PR TITLE
Rename reaction model include guards to align with folders

### DIFF
--- a/include/aspect/material_model/reaction_model/grain_size_evolution.h
+++ b/include/aspect/material_model/reaction_model/grain_size_evolution.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _aspect_material_model_reaction_grain_size_evolution_h
-#define _aspect_material_model_reaction_grain_size_evolution_h
+#ifndef _aspect_material_model_reaction_model_grain_size_evolution_h
+#define _aspect_material_model_reaction_model_grain_size_evolution_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>

--- a/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
+++ b/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
@@ -18,8 +18,8 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _aspect_material_reaction_melt_katz2003_mantle_melting_h
-#define _aspect_material_reaction_melt_katz2003_mantle_melting_h
+#ifndef _aspect_material_model_reaction_model_katz2003_mantle_melting_h
+#define _aspect_material_model_reaction_model_katz2003_mantle_melting_h
 
 #include <aspect/material_model/interface.h>
 #include <aspect/simulator_access.h>


### PR DESCRIPTION
Seen while looking through #6161: Rename the include guards of the reaction models to align with the folder structure. While a bit longer we do this consistently for all other plugins system, so we should keep it for the reaction model.