### PR TITLE
Fix tacc docker image workflow

### DIFF
--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -6,35 +6,42 @@ LABEL maintainer <rene.gassmoeller@mailbox.org>
 # we need to disable the key check.
 RUN echo 'deb [trusted=yes] https://apt.repos.intel.com/mpi all main' > /etc/apt/sources.list.d/intel-mpi.list
 
-RUN apt-get update && apt-get -yq upgrade && apt-get -yq install \
+RUN apt-get update && apt-get -yq upgrade && apt-get -yq install --no-install-recommends \
     libblas-dev \
     liblapack-dev \
     git \
     zlib1g-dev \
     numdiff \
     bc \
-    ninja-build
+    ninja-build \
+    && rm -rf /var/lib/apt/lists/*
 
+# Build deal.II dependencies
 RUN cd /opt && \
     git clone https://github.com/dealii/candi.git && \
     cd candi && \
     echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
     echo "DEAL_II_VERSION=v9.6.0" >> local.cfg && \
-    echo "USE_DEAL_II_CMAKE_MPI_COMPILER=ON" >> local.cfg && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
     echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
     echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \
-    ./candi.sh -j 32 --packages="once:cmake once:hdf5 once:netcdf once:sundials once:p4est once:trilinos dealii" -p /opt && \
+    ./candi.sh -j 4 --packages="once:cmake once:hdf5 once:netcdf once:sundials once:p4est once:trilinos" -p /opt && \
     rm -rf /opt/tmp
 
-# Build aspect, replace git checkout command to create image for release
+# Build deal.II
+RUN source /opt/configuration/enable.sh && \
+    cd /opt/candi && \
+    ./candi.sh -j 4 --packages="dealii" -p /opt && \
+    rm -rf /opt/tmp
+
+# Build aspect
 ENV Aspect_DIR /opt/aspect
 RUN source /opt/configuration/enable.sh && \
     git clone https://github.com/geodynamics/aspect.git $Aspect_DIR && \
     mkdir ${Aspect_DIR}/build && \
     cd ${Aspect_DIR}/build && \
     cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
-    -DASPECT_INSTALL_EXAMPLES=ON .. && \
-    make -j 32 && make install && make clean
+    -DASPECT_INSTALL_EXAMPLES=OFF .. && \
+    make -j4 && make install && make clean
 
 ENV PATH ${Aspect_DIR}/bin:${PATH}

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -1,14 +1,16 @@
-FROM tacc/tacc-ubuntu18-impi19.0.7-common:latest
+FROM tacc/tacc-base:ubuntu22.04-impi19.0.9-common
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 
-# we need a newer version of cmake to support unity builds:
+# As of 2024/12/02 the GPG key in the docker image is not public. To avoid the error
+# we need to disable the key check.
+RUN echo 'deb [trusted=yes] https://apt.repos.intel.com/mpi all main' > /etc/apt/sources.list.d/intel-mpi.list
+
 RUN apt-get update && apt-get -yq upgrade && apt-get -yq install \
     libblas-dev \
     liblapack-dev \
     git \
-    wget \
-    python \
+    zlib1g-dev \
     numdiff \
     bc \
     ninja-build
@@ -17,11 +19,11 @@ RUN cd /opt && \
     git clone https://github.com/dealii/candi.git && \
     cd candi && \
     echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
-    echo "DEAL_II_VERSION=v9.4.2" >> local.cfg && \
+    echo "DEAL_II_VERSION=v9.5.2" >> local.cfg && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
     echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
     echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \
-    ./candi.sh -j 4 --packages="once:cmake once:p4est once:trilinos once:hdf5 once:netcdf once:sundials dealii" -p /opt && \
+    ./candi.sh -j 32 --packages="once:cmake once:hdf5 once:netcdf once:sundials once:p4est once:trilinos dealii" -p /opt && \
     rm -rf /opt/tmp
 
 # Build aspect, replace git checkout command to create image for release
@@ -32,6 +34,6 @@ RUN source /opt/configuration/enable.sh && \
     cd ${Aspect_DIR}/build && \
     cmake -DCMAKE_BUILD_TYPE=DebugRelease -DCMAKE_INSTALL_PREFIX=$Aspect_DIR \
     -DASPECT_INSTALL_EXAMPLES=ON .. && \
-    make -j 4 && make install && make clean
+    make -j 32 && make install && make clean
 
 ENV PATH ${Aspect_DIR}/bin:${PATH}

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -20,6 +20,7 @@ RUN cd /opt && \
     cd candi && \
     echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
     echo "DEAL_II_VERSION=v9.6.0" >> local.cfg && \
+    echo "USE_DEAL_II_CMAKE_MPI_COMPILER=ON" >> local.cfg && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
     echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
     echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \

--- a/contrib/docker/docker_tacc/Dockerfile
+++ b/contrib/docker/docker_tacc/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /opt && \
     git clone https://github.com/dealii/candi.git && \
     cd candi && \
     echo "NATIVE_OPTIMIZATIONS=ON" >> local.cfg && \
-    echo "DEAL_II_VERSION=v9.5.2" >> local.cfg && \
+    echo "DEAL_II_VERSION=v9.6.0" >> local.cfg && \
     echo "BUILD_EXAMPLES=OFF" >> local.cfg && \
     echo "USE_64_BIT_INDICES=ON" >> local.cfg && \
     echo "DEAL_CONFOPTS='-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DDEAL_II_WITH_LAPACK=ON'" >> local.cfg && \


### PR DESCRIPTION
Our docker image for the TACC systems has been broken for a while: https://github.com/geodynamics/aspect/actions/workflows/docker.yml. 

This PR fixes a few issues to fix the workflow:

- update to a newer base image with a supported ubuntu version
- fix an issue with the GPG key of the intel MPI repo
- update deal.II version
- split stages for compiling deal.II and dependencies (mostly for convenience when debugging the build process)
- disable ASPECT examples

I had to disable the ASPECT examples, because I couldnt get them to compile as part of the general build process. They would always try to use the non MPI compiler and fail with:
```
make[1]: *** [CMakeFiles/Makefile2:1949: benchmarks/diffusion_of_hill/CMakeFiles/analytical_topography.dir/all] Error 2
In file included from /opt/deal.II-v9.6.0/include/deal.II/base/mpi.h:18,
                 from /opt/aspect/include/aspect/global.h:28,
                 from /opt/aspect/include/aspect/material_model/interface.h:24,
                 from /opt/aspect/include/aspect/material_model/simple.h:24,
                 from /opt/aspect/benchmarks/finite_strain/../../cookbooks/finite_strain/finite_strain.cc:21,
                 from /opt/aspect/benchmarks/finite_strain/finite_strain.cc:20:
/opt/deal.II-v9.6.0/include/deal.II/base/config.h:606:12: fatal error: mpi.h: No such file or directory
  606 | #  include <mpi.h>
      |            ^~~~~~~
compilation terminated.
```

I am pretty sure this is somehow related to https://github.com/dealii/candi/pull/207 but no matter how I set `USE_DEAL_II_CMAKE_MPI_COMPILER` the problem persists. Additionally, if I start the resulting docker image and manually compile the example plugins everything works fine, so it is only related to using `DASPECT_INSTALL_EXAMPLES=ON` in the full ASPECT build process. After a few hours of digging through the problem I gave up and decided to disable compiling the examples. I think this is fair, because the use case of this image is to run large-scale models on the TACC systems, not to make it easy to run our examples.