### PR TITLE
sphinx doc: add plugin for svg conversion

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -33,7 +33,8 @@ with open('../../VERSION', 'r') as file:
 extensions = [
     "myst_parser",
     "sphinxcontrib.bibtex",
-    "sphinxcontrib.tikz"
+    "sphinxcontrib.tikz",
+    "sphinxcontrib.cairosvgconverter"
 ]
 myst_enable_extensions = [
     "colon_fence",

--- a/doc/sphinx/environment.yml
+++ b/doc/sphinx/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pip>=20.1
   - pip:
     - sphinxcontrib-tikz
+    - sphinxcontrib-svg2pdfconverter[CairoSVG]


### PR DESCRIPTION
sphinx pdf can not handle svg images without converting them first.

part of #6178