### PR TITLE
Update code style in dynamic core 2

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -344,7 +344,7 @@ namespace aspect
         /**
          * Max iterations for the core energy balance solver.
          */
-        int max_steps;
+        unsigned int max_steps;
 
         /**
          * Temperature correction value for adiabatic
@@ -409,8 +409,8 @@ namespace aspect
         double get_Ts(const double r) const;
 
         /**
-         * Compute the core solidus at certain pressure @p pressure
-         * and light element concentration @p X (in wt.%).
+         * Compute the core solidus at a given light element concentration @p X (in wt.%)
+         * and pressure @p pressure.
          */
         double get_solidus(const double X, const double pressure) const;
 
@@ -434,7 +434,7 @@ namespace aspect
         /**
          * Calculate Sn(B,R), referring to \cite NPB+04 .
          */
-        double fun_Sn(const double B, const double R, const double n) const;
+        double fun_Sn(const double B, const double R, const unsigned int n) const;
 
         /**
          * Calculate density at given radius @p r.

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -38,22 +38,211 @@ namespace aspect
 {
   namespace BoundaryTemperature
   {
+    template <int dim>
+    DynamicCore<dim>::DynamicCore()
+    {
+      is_first_call = true;
+      core_data.is_initialized = false;
+    }
+
+
 
     template <int dim>
-    double
-    DynamicCore<dim>::
-    boundary_temperature (const types::boundary_id boundary_indicator,
-                          const Point<dim> &/*location*/) const
+    void
+    DynamicCore<dim>::update()
     {
-      switch (boundary_indicator)
+      core_data.dt = this->get_timestep();
+      core_data.H  = get_radioheating_rate();
+
+      // It's a bit tricky here.
+      // Didn't use the initialize() function instead because the postprocess is initialized after boundary temperature.
+      // It is not available at the time initialize() function of boundary temperature is called.
+      if (is_first_call==true)
         {
-          case 0:
-            return inner_temperature;
-          case 1:
-            return outer_temperature;
-          default:
-            Assert (false, ExcMessage ("Unknown boundary indicator."));
-            return std::numeric_limits<double>::quiet_NaN();
+          AssertThrow(this->get_postprocess_manager().template has_matching_active_plugin<const Postprocess::CoreStatistics<dim>>(),
+                      ExcMessage ("Dynamic core boundary condition has to work with dynamic core statistics postprocessor."));
+
+          const Postprocess::CoreStatistics<dim> &core_statistics
+            = this->get_postprocess_manager().template get_matching_active_plugin<const Postprocess::CoreStatistics<dim>>();
+          // The restart data is stored in 'core statistics' postprocessor.
+          // If restart from checkpoint, extract data from there.
+          core_data = core_statistics.get_core_data();
+
+          // Read data of other energy source
+          read_data_OES();
+
+          const GeometryModel::SphericalShell<dim> &spherical_shell_geometry =
+            Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model());
+
+          Rc = spherical_shell_geometry.inner_radius();
+          Mc = get_mass(Rc);
+          P_Core = get_pressure(0);
+
+          // If the material model is incompressible, we have to get correction for the real core temperature
+          if (this->get_adiabatic_conditions().is_initialized() && !this->get_material_model().is_compressible())
+            {
+              Point<dim> p1;
+              p1(0) = spherical_shell_geometry.inner_radius();
+              dTa   = this->get_adiabatic_conditions().temperature(p1)
+                      - this->get_adiabatic_surface_temperature();
+            }
+          else
+            dTa   = 0.;
+
+          // Setup initial core data from prm input.
+          // If resumed from checkpoint, core_data is read from postprocess instead of set from prm file.
+          // (The boundary_temperature doesn't seem to support restart/resume, the data has to passed and
+          // stored in the postprocessor 'core statistics')
+          if (!core_data.is_initialized)
+            {
+              core_data.Ti = inner_temperature + dTa;
+              core_data.Ri = get_initial_Ri(core_data.Ti);
+              core_data.Xi = get_X(core_data.Ri);
+
+              core_data.Q = 0.;
+              core_data.dt = 0.;
+              core_data.dT_dt = init_dT_dt;
+              core_data.dR_dt = init_dR_dt;
+              core_data.dX_dt = init_dX_dt;
+              update_core_data();
+              core_data.is_initialized = true;
+              std::stringstream output;
+              output<<std::setiosflags(std::ios::left)
+                    <<"   Dynamic core initialized as:"<<std::endl
+                    <<"     "<<std::setw(15)<<"Tc(K)"<<std::setw(15)<<"Ri(km)"<<std::setw(15)<<"Xi"
+                    <<std::setw(15)<<"dT/dt(K/year)"<<std::setw(15)<<"dR/dt(km/year)"<<std::setw(15)<<"dX/dt(1/year)"<<std::endl
+                    <<"     "<<std::setprecision(6)<<std::setw(15)<<inner_temperature<<std::setw(15)<<core_data.Ri/1.e3<<std::setw(15)<<core_data.Xi
+                    <<std::setw(15)<<core_data.dT_dt *year_in_seconds<<std::setw(15)<<core_data.dR_dt/1.e3 *year_in_seconds
+                    <<std::setw(15)<<core_data.dX_dt *year_in_seconds<<std::endl;
+              this->get_pcout() << output.str();
+            }
+          is_first_call = false;
+        }
+
+      // Calculate core mantle boundary heat flow
+      {
+        const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.temperature;
+        FEFaceValues<dim> fe_face_values (this->get_mapping(),
+                                          this->get_fe(),
+                                          quadrature_formula,
+                                          update_gradients      | update_values |
+                                          update_normal_vectors |
+                                          update_quadrature_points       | update_JxW_values);
+
+        std::vector<Tensor<1,dim>> temperature_gradients (quadrature_formula.size());
+        std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
+
+        //std::map<types::boundary_id, double> local_boundary_fluxes;
+        double local_CMB_flux   = 0.;
+        double local_CMB_area   = 0.;
+
+        types::boundary_id CMB_id = 0;
+
+        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
+        // Do not request viscosity or reaction rates
+        in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties |
+                                  MaterialModel::MaterialProperties::thermal_conductivity;
+
+        // for every surface face on which it makes sense to compute a
+        // heat flux and that is owned by this processor,
+        // integrate the normal heat flux given by the formula
+        //   j =  - k * n . grad T
+        //
+        // for the spherical shell geometry, note that for the inner boundary,
+        // the normal vector points *into* the core, i.e. we compute the flux
+        // *out* of the mantle, not into it. we fix this when we add the local
+        // contribution to the global flux
+
+        for (const auto &cell : this->get_dof_handler().active_cell_iterators())
+          if (cell->is_locally_owned())
+            for (const unsigned int f : cell->face_indices())
+              if (cell->at_boundary(f))
+                if (cell->face(f)->boundary_id() == CMB_id)
+                  {
+                    fe_face_values.reinit (cell, f);
+
+                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution());
+
+                    fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
+                        temperature_gradients);
+
+                    this->get_material_model().evaluate(in, out);
+
+
+                    double local_normal_flux = 0;
+                    double local_face_area   = 0;
+                    for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
+                      {
+                        const double thermal_conductivity
+                          = out.thermal_conductivities[q];
+                        double adiabatic_flux = 0.;
+                        if (this->get_material_model().is_compressible()==false)
+                          {
+                            const double alpha = out.thermal_expansion_coefficients[q];
+                            const double cp = out.specific_heat[0];
+                            const double gravity = this->get_gravity_model().gravity_vector(in.position[q]).norm();
+                            if (cell->face(f)->boundary_id()==0)
+                              adiabatic_flux = - alpha * gravity / cp;
+                            else if (cell->face(f)->boundary_id()==1)
+                              adiabatic_flux = alpha * gravity / cp;
+                          }
+
+                        local_normal_flux += -thermal_conductivity *
+                                             (temperature_gradients[q] * fe_face_values.normal_vector(q)
+                                              + adiabatic_flux) * fe_face_values.JxW(q);
+                        local_face_area   += fe_face_values.JxW(q);
+
+                      }
+                    local_CMB_flux += local_normal_flux;
+                    local_CMB_area += local_face_area;
+                  }
+        // now communicate to get the global values
+        const double global_CMB_flux = Utilities::MPI::sum (local_CMB_flux, this->get_mpi_communicator());
+        const double global_CMB_area = Utilities::MPI::sum (local_CMB_area, this->get_mpi_communicator());
+
+        // Using area averaged heat-flux density times core mantle boundary area to calculate total heat-flux on the 3d sphere.
+        // By doing this, using dynamic core evolution with geometry other than 3d spherical shell becomes possible.
+        const double average_CMB_heatflux_density = global_CMB_flux / global_CMB_area;
+        core_data.Q = average_CMB_heatflux_density * 4. * numbers::PI * Rc * Rc;
+      }
+
+      core_data.Q_OES = get_OES(this->get_time());
+
+      if ((core_data.Q + core_data.Q_OES) * core_data.dt!=0.)
+        {
+          double X1,R1 = core_data.Ri,T1;
+          solve_time_step(X1,T1,R1);
+          if (core_data.dt != 0)
+            {
+              core_data.dR_dt = (R1-core_data.Ri)/core_data.dt;
+              core_data.dT_dt = (T1-core_data.Ti)/core_data.dt;
+              core_data.dX_dt = (X1-core_data.Xi)/core_data.dt;
+            }
+          else
+            {
+              core_data.dR_dt = 0.;
+              core_data.dT_dt = 0.;
+              core_data.dX_dt = 0.;
+            }
+          core_data.Xi = X1;
+          core_data.Ri = R1;
+          core_data.Ti = T1;
+        }
+
+      inner_temperature = core_data.Ti - dTa;
+      update_core_data();
+      if ((core_data.Q + core_data.Q_OES + core_data.Qr) * core_data.dt != 0.)
+        {
+          std::stringstream output;
+          output<<std::setiosflags(std::ios::left)
+                <<"   Dynamic core data updated."<<std::endl
+                <<"     "<<std::setw(15)<<"Tc(K)"<<std::setw(15)<<"Ri(km)"<<std::setw(15)<<"Xi"
+                <<std::setw(15)<<"dT/dt(K/year)"<<std::setw(15)<<"dR/dt(km/year)"<<std::setw(15)<<"dX/dt(1/year)"<<std::endl
+                <<"     "<<std::setprecision(6)<<std::setw(15)<<inner_temperature<<std::setw(15)<<core_data.Ri/1.e3<<std::setw(15)<<core_data.Xi
+                <<std::setw(15)<<core_data.dT_dt *year_in_seconds<<std::setw(15)<<core_data.dR_dt/1.e3 *year_in_seconds
+                <<std::setw(15)<<core_data.dX_dt *year_in_seconds<<std::endl;
+          this->get_pcout() << output.str();
         }
     }
 
@@ -75,6 +264,534 @@ namespace aspect
     maximal_temperature (const std::set<types::boundary_id> &/*fixed_boundary_ids*/) const
     {
       return std::max (inner_temperature, outer_temperature);
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::read_data_OES()
+    {
+      data_OES.clear();
+      if (name_OES.size() == 0)
+        return;
+      std::istringstream in(Utilities::read_and_distribute_file_content(name_OES,
+                                                                        this->get_mpi_communicator()));
+      if (in.good())
+        {
+          str_data_OES data_read;
+          std::string line;
+          while (!in.eof())
+            {
+              std::getline(in, line);
+              if (sscanf(line.data(), "%le\t%le\n", &data_read.t, &data_read.w)==2)
+                data_OES.push_back(data_read);
+            }
+        }
+      if (data_OES.size() != 0)
+        this->get_pcout() << "Other energy source is in use ( "
+                          << data_OES.size()
+                          << " data points is read)."
+                          << std::endl;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_OES(const double time) const
+    {
+      // The core evolution is quite slow, so the time units used here is billion years.
+      const double t = time / (1.e9*year_in_seconds);
+      double w = 0.;
+      for (unsigned i=1; i<data_OES.size(); ++i)
+        {
+          if (t>=data_OES[i-1].t && t<data_OES[i].t )
+            {
+              w = data_OES[i-1].w + ( t - data_OES[i-1].t)
+                  /(data_OES[i].t - data_OES[i-1].t)
+                  *(data_OES[i].w - data_OES[i-1].w);
+              break;
+            }
+        }
+      return w;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_initial_Ri(const double T) const
+    {
+      double r0 = 0.;
+      double r1 = Rc;
+      const double dT0 = get_T(T,r0) - get_solidus(get_X(r0),get_pressure(r0));
+      const double dT1 = get_T(T,r1) - get_solidus(get_X(r1),get_pressure(r1));
+
+      if (dT0<=0. && dT1<=0.)
+        return Rc;
+      if (dT0>=0. && dT1>=0.)
+        return 0.;
+      for (unsigned int i=0; i<max_steps; ++i)
+        {
+          const double rm = (r0+r1)/2.;
+          const double dTm = get_T(T,rm) - get_solidus(get_X(rm),get_pressure(rm));
+          if (dTm == 0.)
+            return rm;
+          if (dTm*dT0 < 0.)
+            {
+              r1=rm;
+            }
+          else if (dTm*dT1 < 0.)
+            {
+              r0=rm;
+            }
+        }
+      if (dT0>0 && dT1<0)
+        {
+          // Snowing core
+          AssertThrow(false, ExcMessage("[Dynamic core] You had a 'Snowing Core' (i.e., core is freezing from CMB), "
+                                        "the treatment is not available at the moment."));
+        }
+      return (r0+r1)/2.;
+    }
+
+    template <int dim>
+    bool
+    DynamicCore<dim>::solve_time_step(double &X, double &T, double &R) const
+    {
+      // When solving the change in core-mantle boundary temperature T, inner core radius R, and
+      //    light component (e.g. S, O, Si) composition X, the following relations has to be respected:
+      // 1. At the inner core boundary the adiabatic temperature should be equal to solidus temperature
+      // 2. The following energy production rate should be balanced in core:
+      //    Heat flux at core-mantle boundary         Q
+      //    Specific heat                             Qs*dT/dt
+      //    Radioactive heating                       Qr
+      //    Gravitational contribution                Qg*dR/dt
+      //    Latent heat                               Ql*dR/dt
+      //    So that         Q+Qs*dT/dt+Qr+Qg*dR/dt*Ql*dR/dt=0
+      // 3. The light component composition X depends on inner core radius (See function get_X() ),
+      //    and core solidus may dependent on X as well
+      // This becomes a small nonlinear problem. Directly iterating through the above three system doesn't
+      // converge well. Instead, we solve the inner core radius by bisection method.
+
+      unsigned int steps = 1;
+
+      // dT is the temperature difference between adiabatic temperature and solidus at
+      // inner-outer core boundary. If dT=0 then we found our solution.
+      double R_0 = 0.;
+      double R_1 = core_data.Ri;
+      double R_2 = Rc;
+      double dT0 = get_dT(R_0);
+      double dT1 = get_dT(R_1);
+      double dT2 = get_dT(R_2);
+
+      if (dT0 >= 0. && dT2 >= 0.)
+        {
+          // Fully molten core
+          R_1 = R_0;
+          dT1 = 0;
+        }
+      else if (dT2 <= 0. && dT0 <= 0. )
+        {
+          // Completely solid core
+          R_1 = R_2;
+          dT1 = 0;
+        }
+      else
+        while (!(dT1==0 || steps>max_steps))
+          {
+            // If solution is out of the interval, then something is wrong.
+            if (dT0*dT2>0)
+              {
+                this->get_pcout()<<"Step: "<<steps<<std::endl
+                                 <<" R=["<<R_0/1e3<<","<<R_2/1e3<<"]"<<"(km)"
+                                 <<" dT0="<<dT0<<", dT2="<<dT2<<std::endl
+                                 <<"Q_CMB="<<core_data.Q<<std::endl
+                                 <<"Warning: Solution for inner core radius can not be found! Mid-point is used."<<std::endl;
+                AssertThrow(dT0*dT2<=0,ExcMessage("No single solution for inner core!"));
+              }
+            else if (dT0*dT1 < 0.)
+              {
+                R_2 = R_1;
+                dT2 = dT1;
+              }
+            else if (dT2*dT1 < 0.)
+              {
+                R_0 = R_1;
+                dT0 = dT1;
+              }
+            R_1 = (R_0 + R_2) / 2.;
+            dT1 = get_dT(R_1);
+            ++steps;
+          }
+
+      // Calculate new R,T,X
+      R = R_1;
+      T = get_Tc(R);
+      X = get_X(R);
+
+      if (dT0<0. && dT2>0.)
+        {
+          // Normal solution
+          return true;
+        }
+      else if (dT0>0. && dT2<0.)
+        {
+          // Snowing core solution
+          return false;
+        }
+      else
+        {
+          // No solution found.
+          this->get_pcout() << "[Dynamic core] Step: " << steps << std::endl
+                            << " R=[" << R_0/1e3 << "," << R_2/1e3 << "]" << "(km)"
+                            << " dT0=" << dT0 << ", dT2=" << dT2 << std::endl
+                            << "Q_CMB=" << core_data.Q << std::endl;
+          AssertThrow(false, ExcMessage("[Dynamic core] No inner core radius solution found!"));
+        }
+
+      return false;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_Tc(const double r) const
+    {
+      // Using all Q values from last step.
+      // Qs & Qr is constant, while Qg & Ql depends on inner core radius Ri
+      // TODO: Use mid-point value for Q values.
+      return core_data.Ti - ( (core_data.Q + core_data.Qr + core_data.Q_OES) * core_data.dt
+                              + (core_data.Qg + core_data.Ql)*(r-core_data.Ri)
+                            ) / core_data.Qs;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_Ts(const double r) const
+    {
+      return get_solidus(get_X(r),get_pressure(r));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_dT(const double r) const
+    {
+      return get_T(get_Tc(r),r) - get_Ts(r);
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::update_core_data()
+    {
+      get_specific_heating(core_data.Ti,core_data.Qs,core_data.Es);
+      get_radio_heating(core_data.Ti,core_data.Qr,core_data.Er);
+      get_gravity_heating(core_data.Ti,core_data.Ri,core_data.Xi,core_data.Qg,core_data.Eg);
+      get_adiabatic_heating(core_data.Ti,core_data.Ek,core_data.Qk);
+      get_latent_heating(core_data.Ti,core_data.Ri,core_data.El,core_data.Ql);
+      get_heat_solution(core_data.Ti,core_data.Ri,core_data.Xi,core_data.Eh);
+    }
+
+
+
+    template <int dim>
+    const internal::CoreData &
+    DynamicCore<dim>::get_core_data() const
+    {
+      return core_data;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_solidus(const double X, const double pressure) const
+    {
+      if (use_bw11)
+        {
+          // Change X from weight percent to mole percent.
+          constexpr double x0 = 32./88.;
+          const double x = (X<x0) ? 56.*X/(32.*(1.-X)) : 1.;
+
+          // Change p from Pa to GPa
+          const double p = pressure * 1e-9;
+          const double p_square = p*p;
+          const double p_cube = p_square*p;
+          const double p_fourth = p_cube*p;
+
+          // Fe-FeS system solidus by Buono & Walker (2011)
+          return (-2.4724*p_fourth  + 28.025*p_cube + 9.1404*p_square + 581.71*p + 3394.8) * x*x*x*x
+                 +( 1.7978*p_fourth - 6.7881*p_cube - 197.69*p_square - 271.69*p - 8219.5) * x*x*x
+                 +(-0.1702*p_fourth - 9.3959*p_cube + 163.53*p_square - 319.35*p + 5698.6) * x*x
+                 +(-0.2308*p_fourth + 7.1000*p_cube - 64.118*p_square + 105.98*p - 1621.9) * x
+                 +( 0.2302*p_fourth - 5.3688*p_cube + 38.124*p_square - 46.681*p + 1813.8);
+
+        }
+      else
+        {
+          const double pressure_squared = pressure*pressure;
+          if (composition_dependency)
+            return (Tm0*(1-Theta*X) * (1 + Tm1*pressure + Tm2*pressure_squared));
+          else
+            return (Tm0*(1-Theta)   * (1 + Tm1*pressure + Tm2*pressure_squared));
+        }
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::get_X(const double r) const
+    {
+      const double xi_3 = Utilities::fixed_power<3>(r/Rc);
+      return X_init/(1-xi_3+Delta*xi_3);
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_mass(const double r) const
+    {
+      return 4.*numbers::PI*Rho_cen*(-std::pow(L,2)/2.*r*std::exp(-std::pow(r/L,2))+std::pow(L,3)/4.*std::sqrt(numbers::PI)*std::erf(r/L));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    fun_Sn(const double B, const double R, const unsigned int n) const
+    {
+      // TODO: sqrt_pi could be made constexpr, but std::sqrt is not a constexpr function
+      // for the MacOS tester at the moment
+      const double sqrt_pi = std::sqrt(numbers::PI);
+      double S = R/(2.*sqrt_pi);
+      for (unsigned int i=1; i<=n; ++i)
+        {
+          const double it = static_cast<double>(i);
+          S += (B/sqrt_pi) * (std::exp(-it*it/4.)/it) * std::sinh(it*R/B);
+        }
+      return S;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_pressure(const double r) const
+    {
+      return P_CMB-(4*numbers::PI*constants::big_g*std::pow(Rho_cen,2))/3
+             *((3*std::pow(r,2)/10.-std::pow(L,2)/5)*std::exp(-std::pow(r/L,2))
+               -(3*std::pow(Rc,2)/10-std::pow(L,2)/5)*std::exp(-std::pow(Rc/L,2)));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_rho(const double r) const
+    {
+      return Rho_cen*std::exp(-std::pow(r/L,2));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_g(const double r) const
+    {
+      return (4*numbers::PI/3)*constants::big_g*Rho_cen*r*(1-3*std::pow(r,2)/(5*std::pow(L,2)));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_T(const double Tc, const double r) const
+    {
+      return Tc*std::exp((std::pow(Rc,2)-std::pow(r,2))/std::pow(D,2));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_gravity_potential(const double r) const
+    {
+      return 2./3.*numbers::PI*constants::big_g*Rho_cen*(std::pow(r,2)*(1.-3.*std::pow(r,2)
+                                                                        /(10.*std::pow(L,2)))-std::pow(Rc,2)*(1.-3.*std::pow(Rc,2)/(10.*std::pow(L,2))));
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_specific_heating(const double Tc, double &Qs,double &Es) const
+    {
+      const double A = std::sqrt(1./(std::pow(L,-2)+std::pow(D,-2)));
+      const double Is = 4.*numbers::PI*get_T(Tc,0.)*Rho_cen*(-std::pow(A,2)*Rc/2.*std::exp(-std::pow(Rc/A,2))+std::pow(A,3)*std::sqrt(numbers::PI)/4.*std::erf(Rc/A));
+
+      Qs = -Cp/Tc*Is;
+      Es = Cp/Tc*(Mc-Is/Tc);
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_radio_heating(const double Tc, double &Qr, double &Er) const
+    {
+      double It = numbers::signaling_nan<double>();
+      if (D>L)
+        {
+          const double B = std::sqrt(1/(1/std::pow(L,2)-1/std::pow(D,2)));
+          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*Rc/2*std::exp(-std::pow(Rc/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(Rc/B));
+        }
+      else
+        {
+          const double B = std::sqrt(1/(std::pow(D,-2)-std::pow(L,-2)));
+          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*Rc/2*std::exp(std::pow(Rc/B,2))-std::pow(B,2)*fun_Sn(B,Rc,100)/2);
+        }
+
+      Qr = Mc*core_data.H;
+      Er = (Mc/Tc-It)*core_data.H;
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_heat_solution(const double Tc, const double r, const double X, double &Eh) const
+    {
+      double It = numbers::signaling_nan<double>();
+      if (D>L)
+        {
+          const double B = std::sqrt(1./(1./std::pow(L,2)-1./std::pow(D,2)));
+          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*Rc/2*std::exp(-std::pow(Rc/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(Rc/B));
+          It -= 4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*r/2*std::exp(-std::pow(r/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(r/B));
+        }
+      else
+        {
+          const double B = std::sqrt(1./(std::pow(D,-2)-std::pow(L,-2)));
+          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*Rc/2*std::exp(std::pow(Rc/B,2))-std::pow(B,2)*fun_Sn(B,Rc,100)/2);
+          It -= 4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*r/2*std::exp(std::pow(r/B,2))-std::pow(B,2)*fun_Sn(B,r,100)/2);
+        }
+      const double Cc = 4*numbers::PI*std::pow(r,2)*get_rho(r)*X/(Mc-get_mass(r));
+      Eh = Rh*(It-(Mc-get_mass(r))/get_T(Tc,r))*Cc;
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_gravity_heating(const double Tc, const double r, const double X, double &Qg, double &Eg) const
+    {
+      const double Cc = 4*numbers::PI*std::pow(r,2)*get_rho(r)*X/(Mc-get_mass(r));
+      const double C_2 = 3./16.*std::pow(L,2) - 0.5*std::pow(Rc,2)*(1.-3./10.*std::pow(Rc/L,2));
+      if (r==Rc)
+        Qg = 0.;
+      else
+        {
+          Qg = (8./3.*std::pow(numbers::PI*Rho_cen,2)*constants::big_g*(
+                  ((3./20.*std::pow(Rc,5)-std::pow(L,2)*std::pow(Rc,3)/8.-C_2*std::pow(L,2)*Rc)*std::exp(-std::pow(Rc/L,2))
+                   +C_2/2.*std::pow(L,3)*std::sqrt(numbers::PI)*std::erf(Rc/L))
+                  -((3./20.*std::pow(r,5)-std::pow(L,2)*std::pow(r,3)/8.-C_2*std::pow(L,2)*r)*std::exp(-std::pow(r/L,2))
+                    +C_2/2.*std::pow(L,3)*std::sqrt(numbers::PI)*std::erf(r/L)))
+                -(Mc-get_mass(r))*get_gravity_potential(r))*Beta_c*Cc;
+        }
+
+      Eg = Qg/Tc;
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_adiabatic_heating(const double Tc, double &Ek, double &Qk) const
+    {
+      Ek = 16*numbers::PI*k_c*std::pow(Rc,5)/5/std::pow(D,4);
+      Qk = 8*numbers::PI*std::pow(Rc,3)*k_c*Tc/std::pow(D,2);
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::
+    get_latent_heating(const double Tc, const double r, double &El, double &Ql) const
+    {
+      Ql = 4.*numbers::PI*std::pow(r,2)*Lh*get_rho(r);
+      El = Ql*(get_T(Tc,r)-Tc)/(Tc*get_T(Tc,r));
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    get_radioheating_rate() const
+    {
+      const double time = this->get_time()+0.5*this->get_timestep();
+
+      double Ht = 0;
+      for (unsigned i=0; i<n_radioheating_elements; ++i)
+        Ht += heating_rate[i]*initial_concentration[i]*1e-6*std::pow(0.5,time/half_life[i]/year_in_seconds/1e9);
+
+      return Ht;
+    }
+
+
+
+    template <int dim>
+    bool
+    DynamicCore<dim>::
+    is_OES_used() const
+    {
+      if (data_OES.size()>0)
+        return true;
+      else
+        return false;
+    }
+
+
+
+    template <int dim>
+    double
+    DynamicCore<dim>::
+    boundary_temperature (const types::boundary_id boundary_indicator,
+                          const Point<dim> &/*location*/) const
+    {
+      switch (boundary_indicator)
+        {
+          case 0:
+            return inner_temperature;
+          case 1:
+            return outer_temperature;
+          default:
+            Assert (false, ExcMessage ("Unknown boundary indicator."));
+        }
+
+      return std::numeric_limits<double>::quiet_NaN();
     }
 
 
@@ -264,8 +981,7 @@ namespace aspect
             Tm1           =  prm.get_double ("Tm1");
             Tm2           =  prm.get_double ("Tm2");
             Theta         =  prm.get_double ("Theta");
-            composition_dependency
-              =  prm.get_bool("Composition dependency");
+            composition_dependency = prm.get_bool("Composition dependency");
             use_bw11      =  prm.get_bool("Use BW11");
           }
           prm.leave_subsection ();
@@ -300,722 +1016,13 @@ namespace aspect
           }
           prm.leave_subsection ();
 
-          L=std::sqrt(3*K0*(std::log(Rho_cen/Rho_0)+1)/(2*numbers::PI*constants::big_g*Rho_0*Rho_cen));
-          D=std::sqrt(3*Cp/(2*numbers::PI*Alpha*Rho_cen*constants::big_g));
+          L = std::sqrt(3*K0*(std::log(Rho_cen/Rho_0)+1)/(2*numbers::PI*constants::big_g*Rho_0*Rho_cen));
+          D = std::sqrt(3*Cp/(2*numbers::PI*Alpha*Rho_cen*constants::big_g));
 
         }
         prm.leave_subsection ();
       }
       prm.leave_subsection ();
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::read_data_OES()
-    {
-      data_OES.clear();
-      if (name_OES.size()==0)
-        return;
-      std::istringstream in(Utilities::read_and_distribute_file_content(name_OES,
-                                                                        this->get_mpi_communicator()));
-      if (in.good())
-        {
-          str_data_OES data_read;
-          std::string line;
-          while (!in.eof())
-            {
-              std::getline(in, line);
-              if (sscanf(line.data(), "%le\t%le\n", &data_read.t, &data_read.w)==2)
-                data_OES.push_back(data_read);
-            }
-        }
-      if (data_OES.size()!=0)
-        this->get_pcout() << "Other energy source is in use ( "
-                          << data_OES.size()
-                          << " data points is read)."
-                          << std::endl;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_OES(const double time) const
-    {
-      // The core evolution is quite slow, so the time units used here is billion years.
-      const double t = time / (1.e9*year_in_seconds);
-      double w=0.;
-      for (unsigned i=1; i<data_OES.size(); ++i)
-        {
-          if (t>=data_OES[i-1].t && t<data_OES[i].t )
-            {
-              w = data_OES[i-1].w + ( t - data_OES[i-1].t)
-                  /(data_OES[i].t - data_OES[i-1].t)
-                  *(data_OES[i].w - data_OES[i-1].w);
-              break;
-            }
-        }
-      return w;
-    }
-
-
-
-    template <int dim>
-    DynamicCore<dim>::DynamicCore()
-    {
-      is_first_call = true;
-      core_data.is_initialized = false;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_initial_Ri(const double T) const
-    {
-      double r0 = 0.;
-      double r1 = Rc;
-      const double dT0 = get_T(T,r0) - get_solidus(get_X(r0),get_pressure(r0));
-      const double dT1 = get_T(T,r1) - get_solidus(get_X(r1),get_pressure(r1));
-
-      if (dT0<=0. && dT1<=0.)
-        return Rc;
-      if (dT0>=0. && dT1>=0.)
-        return 0.;
-      for (int i=0; i<max_steps; ++i)
-        {
-          const double rm = (r0+r1)/2.;
-          const double dTm = get_T(T,rm) - get_solidus(get_X(rm),get_pressure(rm));
-          if (dTm==0.)
-            return rm;
-          if (dTm*dT0<0.)
-            {
-              r1=rm;
-            }
-          else if (dTm*dT1<0.)
-            {
-              r0=rm;
-            }
-        }
-      if (dT0>0 && dT1<0)
-        {
-          // Snowing core
-          AssertThrow(false, ExcMessage("[Dynamic core] You had a 'Snowing Core' (i.e., core is freezing from CMB), "
-                                        "the treatment is not available at the moment."));
-        }
-      return (r0+r1)/2.;
-    }
-
-    template <int dim>
-    bool
-    DynamicCore<dim>::solve_time_step(double &X, double &T, double &R) const
-    {
-      // When solving the change in core-mantle boundary temperature T, inner core radius R, and
-      //    light component (e.g. S, O, Si) composition X, the following relations has to be respected:
-      // 1. At the inner core boundary the adiabatic temperature should be equal to solidus temperature
-      // 2. The following energy production rate should be balanced in core:
-      //    Heat flux at core-mantle boundary         Q
-      //    Specific heat                             Qs*dT/dt
-      //    Radioactive heating                       Qr
-      //    Gravitational contribution                Qg*dR/dt
-      //    Latent heat                               Ql*dR/dt
-      //    So that         Q+Qs*dT/dt+Qr+Qg*dR/dt*Ql*dR/dt=0
-      // 3. The light component composition X depends on inner core radius (See function get_X() ),
-      //    and core solidus may dependent on X as well
-      // This becomes a small nonlinear problem. Directly iterating through the above three system doesn't
-      // converge well. Instead, we solve the inner core radius by bisection method.
-
-      int steps=1;
-
-      // dT is the temperature difference between adiabatic temperature and solidus at
-      // inner-outer core boundary. If dT=0 then we found our solution.
-      double R_0 = 0.;
-      double R_1 = core_data.Ri;
-      double R_2 = Rc;
-      double dT0 = get_dT(R_0);
-      double dT1 = get_dT(R_1);
-      double dT2 = get_dT(R_2);
-
-      if (dT0 >= 0. && dT2 >= 0.)
-        {
-          // Fully molten core
-          R_1 = R_0;
-          dT1 = 0;
-        }
-      else if (dT2 <= 0. && dT0 <= 0. )
-        {
-          // Completely solid core
-          R_1 = R_2;
-          dT1 = 0;
-        }
-      else
-        while (!(dT1==0 || steps>max_steps))
-          {
-            // If solution is out of the interval, then something is wrong.
-            if (dT0*dT2>0)
-              {
-                this->get_pcout()<<"Step: "<<steps<<std::endl
-                                 <<" R=["<<R_0/1e3<<","<<R_2/1e3<<"]"<<"(km)"
-                                 <<" dT0="<<dT0<<", dT2="<<dT2<<std::endl
-                                 <<"Q_CMB="<<core_data.Q<<std::endl
-                                 <<"Warning: Solution for inner core radius can not be found! Mid-point is used."<<std::endl;
-                AssertThrow(dT0*dT2<=0,ExcMessage("No single solution for inner core!"));
-              }
-            else if (dT0*dT1<0.)
-              {
-                R_2 = R_1;
-                dT2 = dT1;
-              }
-            else if (dT2*dT1<0.)
-              {
-                R_0 = R_1;
-                dT0 = dT1;
-              }
-            R_1 = (R_0 + R_2) / 2.;
-            dT1 = get_dT(R_1);
-            ++steps;
-          }
-
-      // Calculate new R,T,X
-      R = R_1;
-      T = get_Tc(R);
-      X = get_X(R);
-
-      if (dT0<0. && dT2>0.)
-        {
-          // Normal solution
-          return true;
-        }
-      else if (dT0>0. && dT2<0.)
-        {
-          // Snowing core solution
-          return false;
-        }
-      else
-        {
-          // No solution found.
-          this->get_pcout() << "[Dynamic core] Step: " << steps << std::endl
-                            << " R=[" << R_0/1e3 << "," << R_2/1e3 << "]" << "(km)"
-                            << " dT0=" << dT0 << ", dT2=" << dT2 << std::endl
-                            << "Q_CMB=" << core_data.Q << std::endl;
-          AssertThrow(false, ExcMessage("[Dynamic core] No inner core radius solution found!"));
-        }
-
-      return false;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_Tc(const double r) const
-    {
-      // Using all Q values from last step.
-      // Qs & Qr is constant, while Qg & Ql depends on inner core radius Ri
-      // TODO: Use mid-point value for Q values.
-      return core_data.Ti - ( (core_data.Q + core_data.Qr + core_data.Q_OES) * core_data.dt
-                              + (core_data.Qg + core_data.Ql)*(r-core_data.Ri)
-                            ) / core_data.Qs;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_Ts(const double r) const
-    {
-      return get_solidus(get_X(r),get_pressure(r));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_dT(const double r) const
-    {
-      return get_T(get_Tc(r),r) - get_Ts(r);
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::update_core_data()
-    {
-      get_specific_heating(core_data.Ti,core_data.Qs,core_data.Es);
-      get_radio_heating(core_data.Ti,core_data.Qr,core_data.Er);
-      get_gravity_heating(core_data.Ti,core_data.Ri,core_data.Xi,core_data.Qg,core_data.Eg);
-      get_adiabatic_heating(core_data.Ti,core_data.Ek,core_data.Qk);
-      get_latent_heating(core_data.Ti,core_data.Ri,core_data.El,core_data.Ql);
-      get_heat_solution(core_data.Ti,core_data.Ri,core_data.Xi,core_data.Eh);
-    }
-
-
-
-    template <int dim>
-    const internal::CoreData &
-    DynamicCore<dim>::get_core_data() const
-    {
-      return core_data;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_solidus(const double X, const double pressure) const
-    {
-      if (use_bw11)
-        {
-          // Change X from weight percent to mole percent.
-          constexpr double x0 = 32./88.;
-          const double x = (X<x0) ? 56.*X/(32.*(1.-X)) : 1.;
-
-          // Change p from Pa to GPa
-          const double p = pressure * 1e-9;
-          const double p_square = p*p;
-          const double p_cube = p_square*p;
-          const double p_fourth = p_cube*p;
-
-          // Fe-FeS system solidus by Buono & Walker (2011)
-          return (-2.4724*p_fourth  + 28.025*p_cube + 9.1404*p_square + 581.71*p + 3394.8) * x*x*x*x
-                 +( 1.7978*p_fourth - 6.7881*p_cube - 197.69*p_square - 271.69*p - 8219.5) * x*x*x
-                 +(-0.1702*p_fourth - 9.3959*p_cube + 163.53*p_square - 319.35*p + 5698.6) * x*x
-                 +(-0.2308*p_fourth + 7.1000*p_cube - 64.118*p_square + 105.98*p - 1621.9) * x
-                 +( 0.2302*p_fourth - 5.3688*p_cube + 38.124*p_square - 46.681*p + 1813.8);
-
-        }
-      else
-        {
-          const double pressure_squared = pressure*pressure;
-          if (composition_dependency)
-            return (Tm0*(1-Theta*X) * (1 + Tm1*pressure + Tm2*pressure_squared));
-          else
-            return (Tm0*(1-Theta)   * (1 + Tm1*pressure + Tm2*pressure_squared));
-        }
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::get_X(const double r) const
-    {
-      const double xi_3 = Utilities::fixed_power<3>(r/Rc);
-      return X_init/(1-xi_3+Delta*xi_3);
-    }
-
-    template <int dim>
-    void
-    DynamicCore<dim>::update()
-    {
-      core_data.dt = this->get_timestep();
-      core_data.H  = get_radioheating_rate();
-
-      // It's a bit tricky here.
-      // Didn't use the initialize() function instead because the postprocess is initialized after boundary temperature.
-      // It is not available at the time initialize() function of boundary temperature is called.
-      if (is_first_call==true)
-        {
-          AssertThrow(this->get_postprocess_manager().template has_matching_active_plugin<const Postprocess::CoreStatistics<dim>>(),
-                      ExcMessage ("Dynamic core boundary condition has to work with dynamic core statistics postprocessor."));
-
-          const Postprocess::CoreStatistics<dim> &core_statistics
-            = this->get_postprocess_manager().template get_matching_active_plugin<const Postprocess::CoreStatistics<dim>>();
-          // The restart data is stored in 'core statistics' postprocessor.
-          // If restart from checkpoint, extract data from there.
-          core_data = core_statistics.get_core_data();
-
-          // Read data of other energy source
-          read_data_OES();
-
-          const GeometryModel::SphericalShell<dim> &spherical_shell_geometry =
-            Plugins::get_plugin_as_type<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model());
-
-          Rc=spherical_shell_geometry.inner_radius();
-          Mc=get_mass(Rc);
-          P_Core=get_pressure(0);
-
-          // If the material model is incompressible, we have to get correction for the real core temperature
-          if (this->get_adiabatic_conditions().is_initialized() && !this->get_material_model().is_compressible())
-            {
-              Point<dim> p1;
-              p1(0) = spherical_shell_geometry.inner_radius();
-              dTa   = this->get_adiabatic_conditions().temperature(p1)
-                      - this->get_adiabatic_surface_temperature();
-            }
-          else
-            dTa   = 0.;
-
-          // Setup initial core data from prm input.
-          // If resumed from checkpoint, core_data is read from postprocess instead of set from prm file.
-          // (The boundary_temperature doesn't seem to support restart/resume, the data has to passed and
-          // stored in the postprocessor 'core statistics')
-          if (!core_data.is_initialized)
-            {
-              core_data.Ti=inner_temperature + dTa;
-              core_data.Ri = get_initial_Ri(core_data.Ti);
-              core_data.Xi = get_X(core_data.Ri);
-
-              core_data.Q=0.;
-              core_data.dt=0.;
-              core_data.dT_dt=init_dT_dt;
-              core_data.dR_dt=init_dR_dt;
-              core_data.dX_dt=init_dX_dt;
-              update_core_data();
-              core_data.is_initialized = true;
-              std::stringstream output;
-              output<<std::setiosflags(std::ios::left)
-                    <<"   Dynamic core initialized as:"<<std::endl
-                    <<"     "<<std::setw(15)<<"Tc(K)"<<std::setw(15)<<"Ri(km)"<<std::setw(15)<<"Xi"
-                    <<std::setw(15)<<"dT/dt(K/year)"<<std::setw(15)<<"dR/dt(km/year)"<<std::setw(15)<<"dX/dt(1/year)"<<std::endl
-                    <<"     "<<std::setprecision(6)<<std::setw(15)<<inner_temperature<<std::setw(15)<<core_data.Ri/1.e3<<std::setw(15)<<core_data.Xi
-                    <<std::setw(15)<<core_data.dT_dt *year_in_seconds<<std::setw(15)<<core_data.dR_dt/1.e3 *year_in_seconds
-                    <<std::setw(15)<<core_data.dX_dt *year_in_seconds<<std::endl;
-              this->get_pcout() << output.str();
-            }
-          is_first_call = false;
-        }
-
-      // Calculate core mantle boundary heat flow
-      {
-        const Quadrature<dim-1> &quadrature_formula = this->introspection().face_quadratures.temperature;
-        FEFaceValues<dim> fe_face_values (this->get_mapping(),
-                                          this->get_fe(),
-                                          quadrature_formula,
-                                          update_gradients      | update_values |
-                                          update_normal_vectors |
-                                          update_quadrature_points       | update_JxW_values);
-
-        std::vector<Tensor<1,dim>> temperature_gradients (quadrature_formula.size());
-        std::vector<std::vector<double>> composition_values (this->n_compositional_fields(),std::vector<double> (quadrature_formula.size()));
-
-        //std::map<types::boundary_id, double> local_boundary_fluxes;
-        double local_CMB_flux   = 0.;
-        double local_CMB_area   = 0.;
-
-        types::boundary_id CMB_id = 0;
-
-        typename MaterialModel::Interface<dim>::MaterialModelInputs in(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-        typename MaterialModel::Interface<dim>::MaterialModelOutputs out(fe_face_values.n_quadrature_points, this->n_compositional_fields());
-        // Do not request viscosity or reaction rates
-        in.requested_properties = MaterialModel::MaterialProperties::equation_of_state_properties |
-                                  MaterialModel::MaterialProperties::thermal_conductivity;
-
-        // for every surface face on which it makes sense to compute a
-        // heat flux and that is owned by this processor,
-        // integrate the normal heat flux given by the formula
-        //   j =  - k * n . grad T
-        //
-        // for the spherical shell geometry, note that for the inner boundary,
-        // the normal vector points *into* the core, i.e. we compute the flux
-        // *out* of the mantle, not into it. we fix this when we add the local
-        // contribution to the global flux
-
-        for (const auto &cell : this->get_dof_handler().active_cell_iterators())
-          if (cell->is_locally_owned())
-            for (const unsigned int f : cell->face_indices())
-              if (cell->at_boundary(f))
-                if (cell->face(f)->boundary_id() == CMB_id)
-                  {
-                    fe_face_values.reinit (cell, f);
-
-                    in.reinit(fe_face_values, cell, this->introspection(), this->get_solution());
-
-                    fe_face_values[this->introspection().extractors.temperature].get_function_gradients (this->get_solution(),
-                        temperature_gradients);
-
-                    this->get_material_model().evaluate(in, out);
-
-
-                    double local_normal_flux = 0;
-                    double local_face_area   = 0;
-                    for (unsigned int q=0; q<fe_face_values.n_quadrature_points; ++q)
-                      {
-                        const double thermal_conductivity
-                          = out.thermal_conductivities[q];
-                        double adiabatic_flux=0.;
-                        if (this->get_material_model().is_compressible()==false)
-                          {
-                            const double alpha = out.thermal_expansion_coefficients[q];
-                            const double cp = out.specific_heat[0];
-                            const double gravity = this->get_gravity_model().gravity_vector(in.position[q]).norm();
-                            if (cell->face(f)->boundary_id()==0)
-                              adiabatic_flux = - alpha * gravity / cp;
-                            else if (cell->face(f)->boundary_id()==1)
-                              adiabatic_flux = alpha * gravity / cp;
-                          }
-
-                        local_normal_flux += -thermal_conductivity *
-                                             (temperature_gradients[q] * fe_face_values.normal_vector(q)
-                                              + adiabatic_flux) * fe_face_values.JxW(q);
-                        local_face_area   += fe_face_values.JxW(q);
-
-                      }
-                    local_CMB_flux += local_normal_flux;
-                    local_CMB_area += local_face_area;
-                  }
-        // now communicate to get the global values
-        const double global_CMB_flux = Utilities::MPI::sum (local_CMB_flux, this->get_mpi_communicator());
-        const double global_CMB_area = Utilities::MPI::sum (local_CMB_area, this->get_mpi_communicator());
-
-        // Using area averaged heat-flux density times core mantle boundary area to calculate total heat-flux on the 3d sphere.
-        // By doing this, using dynamic core evolution with geometry other than 3d spherical shell becomes possible.
-        const double average_CMB_heatflux_density = global_CMB_flux / global_CMB_area;
-        core_data.Q = average_CMB_heatflux_density * 4. * numbers::PI * Rc * Rc;
-      }
-
-      core_data.Q_OES = get_OES(this->get_time());
-
-      if ((core_data.Q + core_data.Q_OES) * core_data.dt!=0.)
-        {
-          double X1,R1=core_data.Ri,T1;
-          solve_time_step(X1,T1,R1);
-          if (core_data.dt!=0)
-            {
-              core_data.dR_dt=(R1-core_data.Ri)/core_data.dt;
-              core_data.dT_dt=(T1-core_data.Ti)/core_data.dt;
-              core_data.dX_dt=(X1-core_data.Xi)/core_data.dt;
-            }
-          else
-            {
-              core_data.dR_dt=0.;
-              core_data.dT_dt=0.;
-              core_data.dX_dt=0.;
-            }
-          core_data.Xi=X1;
-          core_data.Ri=R1;
-          core_data.Ti=T1;
-        }
-
-      inner_temperature = core_data.Ti - dTa;
-      update_core_data();
-      if ((core_data.Q + core_data.Q_OES + core_data.Qr) * core_data.dt!=0.)
-        {
-          std::stringstream output;
-          output<<std::setiosflags(std::ios::left)
-                <<"   Dynamic core data updated."<<std::endl
-                <<"     "<<std::setw(15)<<"Tc(K)"<<std::setw(15)<<"Ri(km)"<<std::setw(15)<<"Xi"
-                <<std::setw(15)<<"dT/dt(K/year)"<<std::setw(15)<<"dR/dt(km/year)"<<std::setw(15)<<"dX/dt(1/year)"<<std::endl
-                <<"     "<<std::setprecision(6)<<std::setw(15)<<inner_temperature<<std::setw(15)<<core_data.Ri/1.e3<<std::setw(15)<<core_data.Xi
-                <<std::setw(15)<<core_data.dT_dt *year_in_seconds<<std::setw(15)<<core_data.dR_dt/1.e3 *year_in_seconds
-                <<std::setw(15)<<core_data.dX_dt *year_in_seconds<<std::endl;
-          this->get_pcout() << output.str();
-        }
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_mass(const double r) const
-    {
-      return 4.*numbers::PI*Rho_cen*(-std::pow(L,2)/2.*r*std::exp(-std::pow(r/L,2))+std::pow(L,3)/4.*std::sqrt(numbers::PI)*std::erf(r/L));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    fun_Sn(const double B, const double R, const double n) const
-    {
-      double S=R/(2.*std::sqrt(numbers::PI));
-      for (unsigned int i=1; i<=n; ++i)
-        S+=B/std::sqrt(numbers::PI)*std::exp(-std::pow(i,2)/4.)/i*std::sinh(i*R/B);
-      return S;
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_pressure(const double r) const
-    {
-      return P_CMB-(4*numbers::PI*constants::big_g*std::pow(Rho_cen,2))/3
-             *((3*std::pow(r,2)/10.-std::pow(L,2)/5)*std::exp(-std::pow(r/L,2))
-               -(3*std::pow(Rc,2)/10-std::pow(L,2)/5)*std::exp(-std::pow(Rc/L,2)));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_rho(const double r) const
-    {
-      return Rho_cen*std::exp(-std::pow(r/L,2));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_g(const double r) const
-    {
-      return (4*numbers::PI/3)*constants::big_g*Rho_cen*r*(1-3*std::pow(r,2)/(5*std::pow(L,2)));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_T(const double Tc, const double r) const
-    {
-      return Tc*std::exp((std::pow(Rc,2)-std::pow(r,2))/std::pow(D,2));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_gravity_potential(const double r) const
-    {
-      return 2./3.*numbers::PI*constants::big_g*Rho_cen*(std::pow(r,2)*(1.-3.*std::pow(r,2)
-                                                                        /(10.*std::pow(L,2)))-std::pow(Rc,2)*(1.-3.*std::pow(Rc,2)/(10.*std::pow(L,2))));
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_specific_heating(const double Tc, double &Qs,double &Es) const
-    {
-      const double A = std::sqrt(1./(std::pow(L,-2)+std::pow(D,-2)));
-      const double Is = 4.*numbers::PI*get_T(Tc,0.)*Rho_cen*(-std::pow(A,2)*Rc/2.*std::exp(-std::pow(Rc/A,2))+std::pow(A,3)*std::sqrt(numbers::PI)/4.*std::erf(Rc/A));
-
-      Qs=-Cp/Tc*Is;
-      Es=Cp/Tc*(Mc-Is/Tc);
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_radio_heating(const double Tc, double &Qr, double &Er) const
-    {
-      double B,It;
-      if (D>L)
-        {
-          B=std::sqrt(1/(1/std::pow(L,2)-1/std::pow(D,2)));
-          It=4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*Rc/2*std::exp(-std::pow(Rc/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(Rc/B));
-        }
-      else
-        {
-          B=std::sqrt(1/(std::pow(D,-2)-std::pow(L,-2)));
-          It=4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*Rc/2*std::exp(std::pow(Rc/B,2))-std::pow(B,2)*fun_Sn(B,Rc,100)/2);
-        }
-
-      Qr=Mc*core_data.H;
-      Er=(Mc/Tc-It)*core_data.H;
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_heat_solution(const double Tc, const double r, const double X, double &Eh) const
-    {
-      double B,It;
-      if (D>L)
-        {
-          B=std::sqrt(1/(1/std::pow(L,2)-1/std::pow(D,2)));
-          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*Rc/2*std::exp(-std::pow(Rc/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(Rc/B));
-          It -= 4*numbers::PI*Rho_cen/get_T(Tc,0)*(-std::pow(B,2)*r/2*std::exp(-std::pow(r/B,2))+std::pow(B,3)/std::sqrt(numbers::PI)/4*std::erf(r/B));
-        }
-      else
-        {
-          B = std::sqrt(1/(std::pow(D,-2)-std::pow(L,-2)));
-          It = 4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*Rc/2*std::exp(std::pow(Rc/B,2))-std::pow(B,2)*fun_Sn(B,Rc,100)/2);
-          It -= 4*numbers::PI*Rho_cen/get_T(Tc,0)*(std::pow(B,2)*r/2*std::exp(std::pow(r/B,2))-std::pow(B,2)*fun_Sn(B,r,100)/2);
-        }
-      const double Cc = 4*numbers::PI*std::pow(r,2)*get_rho(r)*X/(Mc-get_mass(r));
-      Eh = Rh*(It-(Mc-get_mass(r))/get_T(Tc,r))*Cc;
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_gravity_heating(const double Tc, const double r, const double X, double &Qg, double &Eg) const
-    {
-      const double Cc = 4*numbers::PI*std::pow(r,2)*get_rho(r)*X/(Mc-get_mass(r));
-      const double C_2 = 3./16.*std::pow(L,2) - 0.5*std::pow(Rc,2)*(1.-3./10.*std::pow(Rc/L,2));
-      if (r==Rc)
-        Qg=0.;
-      else
-        {
-          Qg=(8./3.*std::pow(numbers::PI*Rho_cen,2)*constants::big_g*(
-                ((3./20.*std::pow(Rc,5)-std::pow(L,2)*std::pow(Rc,3)/8.-C_2*std::pow(L,2)*Rc)*std::exp(-std::pow(Rc/L,2))
-                 +C_2/2.*std::pow(L,3)*std::sqrt(numbers::PI)*std::erf(Rc/L))
-                -((3./20.*std::pow(r,5)-std::pow(L,2)*std::pow(r,3)/8.-C_2*std::pow(L,2)*r)*std::exp(-std::pow(r/L,2))
-                  +C_2/2.*std::pow(L,3)*std::sqrt(numbers::PI)*std::erf(r/L)))
-              -(Mc-get_mass(r))*get_gravity_potential(r))*Beta_c*Cc;
-        }
-
-      Eg = Qg/Tc;
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_adiabatic_heating(const double Tc, double &Ek, double &Qk) const
-    {
-      Ek = 16*numbers::PI*k_c*std::pow(Rc,5)/5/std::pow(D,4);
-      Qk = 8*numbers::PI*std::pow(Rc,3)*k_c*Tc/std::pow(D,2);
-    }
-
-
-
-    template <int dim>
-    void
-    DynamicCore<dim>::
-    get_latent_heating(const double Tc, const double r, double &El, double &Ql) const
-    {
-      Ql = 4.*numbers::PI*std::pow(r,2)*Lh*get_rho(r);
-      El = Ql*(get_T(Tc,r)-Tc)/(Tc*get_T(Tc,r));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
-    get_radioheating_rate() const
-    {
-      const double time=this->get_time()+0.5*this->get_timestep();
-
-      double Ht=0;
-      for (unsigned i=0; i<n_radioheating_elements; ++i)
-        Ht+=heating_rate[i]*initial_concentration[i]*1e-6*std::pow(0.5,time/half_life[i]/year_in_seconds/1e9);
-
-      return Ht;
-    }
-
-
-
-    template <int dim>
-    bool
-    DynamicCore<dim>::
-    is_OES_used() const
-    {
-      if (data_OES.size()>0)
-        return true;
-      else
-        return false;
     }
   }
 }


### PR DESCRIPTION
Follow up to #6177, this PR does the following:
- Address the comments in #6177 (the variable `n` that was a `double` before was meant to be and also treated like an unsigned int, I checked the original reference)
- Reorder functions in our usual structure (constructor -> initialize/update -> everything else -> declare_parameters -> parse_parameters)
- Added lots of spaces around equal signs and some operators to improve readability

I think I will make at least one additional follow-up, but I will separate the PRs, because this PR should be purely code structure changes while the next one may actually affect results