### PR TITLE
Reintroduce old manual front page for the pdf manual

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -90,16 +90,6 @@ html_theme_options = {
 }
 
 latex_engine = 'xelatex'
-latex_elements = {
-# Additional stuff for the LaTeX preamble.
-'preamble': r'''
-% to allow for the degree symbol
-\usepackage{gensymb}
-\usepackage{siunitx}
-\usepackage{etoolbox}
-\pretocmd{\hyperlink}{\protect}{}{}
-'''
-}
 
 bibtex_bibfiles = ["references.bib"]
 bibtex_default_style = "alpha"
@@ -122,3 +112,196 @@ html_last_updated_fmt = ""
 linkcheck_allowed_redirects = {r'https://doi.org/*': r'https://*',
                                r'https://youtu.be/*': r'https://youtube.com/*',
                                r'https://www.github.com/*': r'https://github.com/*'}
+
+latex_elements = {
+# The paper size ('letterpaper' or 'a4paper').
+'papersize': 'a4paper',
+'babel': '\\usepackage[english]{babel}',
+
+# The font size ('10pt', '11pt' or '12pt').
+'pointsize': '11pt',
+
+# Additional stuff for the LaTeX preamble.
+'preamble': r'''
+% to allow for the degree symbol
+\usepackage{gensymb}
+\usepackage{siunitx}
+\usepackage{etoolbox}
+\pretocmd{\hyperlink}{\protect}{}{}
+
+\usepackage{graphicx}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{5pt}
+\usepackage{textpos}
+
+% use the listings package for code snippets
+\usepackage{listings}
+
+\definecolor{dkgreen}{rgb}{0,0.6,0}
+\definecolor{gray}{rgb}{0.5,0.5,0.5}
+\definecolor{mauve}{rgb}{0.58,0,0.82}
+  ''',
+
+# Additional stuff for the LaTeX preamble.
+'maketitle': r'''
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% START OF CIG MANUAL COVER TEMPLATE %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% This should be pasted at the start of manuals and appropriate strings entered at locations indicated with FILL.
+% Be sure the TeX file includes the following packages.
+% \usepackage{graphicx}
+% \usepackage{times}
+% \usepackage{textpos}
+
+\definecolor{dark_grey}{gray}{0.3}
+\definecolor{aspect_blue}{rgb}{0.3125,0.6875,0.9375}
+\definecolor{aspect_red}{rgb}{0.522,0.0,0.0}
+
+%LINE 1%
+{
+\renewcommand{\familydefault}{\sfdefault}
+\newcommand{\aspect}{\textsc{ASPECT}}
+
+\pagenumbering{gobble}
+\begin{center}
+\resizebox{\textwidth}{!}{\textcolor{dark_grey}{\fontfamily{\sfdefault}\selectfont
+COMPUTATIONAL INFRASTRUCTURE FOR GEODYNAMICS (CIG)
+}}
+
+\hrule
+
+%LINE 2%
+\color{dark_grey}
+\rule{\textwidth}{2pt}
+
+%LINE 3%
+\color{dark_grey}
+% FILL: additional organizations
+% e.g.: {\Large Organization 1\\Organization 2}
+{\Large }
+\end{center}
+
+%COLOR AND CODENAME BLOCK%
+\begin{center}
+\resizebox{\textwidth}{!}{\colorbox
+% FILL: color of code name text box
+% e.g. blue
+{aspect_red}{\fontfamily{\rmdefault}\selectfont \textcolor{white} {
+% FILL: name of the code
+% You may want to add \hspace to both sides of the codename to better center it, such as:
+% \newcommand{\codename}{\hspace{0.1in}CodeName\hspace{0.1in}}
+\hspace{0.1in}\aspect{}\hspace{0.1in}
+}}}
+\\[12pt]
+{\Large Advanced Solver for Planetary Evolution, Convection, and Tectonics}
+\end{center}
+
+{
+  \parindent 0pt
+  % Place the Logo into a box of width 0 and position it at the given
+  % (x,y) within this box.
+  \begin{textblock*}{0in}(0.0in,0.8in)
+    \begin{center}
+      \vspace{1em}
+        \includegraphics[width=4.5in]{{aspect_logo}.png}
+      \hspace{5em}
+    \end{center}
+  \end{textblock*}
+
+  % Then overlay some text into another textblock* environment that is
+  % as wide as the page. We use \raggedright, so everything is shown
+  % on the right side of the page. The y-coordinate of the anchor
+  % (0.3in) is the same as for the picture, aligning the text nicely
+  % to the image.
+  \begin{textblock*}{\textwidth}(0in,0.3in)
+    \vspace{1em}
+    \color{dark_grey}
+    \hfill{\Huge \fontfamily{\sfdefault}\selectfont User Manual \\
+      \raggedleft \huge \fontfamily{\sfdefault}\selectfont Version
+      % keep the following line as is so that we can replace this using a script:
+      %VERSION-INFO%
+      \\
+      \large(generated \today)
+      \\[16pt]
+        {\Large
+          Wolfgang Bangerth \\
+          Juliane Dannberg \\
+          Menno Fraters \\
+          Rene Gassm{\"o}ller \\
+          Anne Glerum \\
+          Timo Heister \\
+          Bob Myhill \\
+          John Naliboff\\}
+    }
+  \end{textblock*}
+}
+
+
+%AUTHOR(S) & WEBSITE%
+\null
+\vfill
+\color{dark_grey}
+{\fontfamily{\sfdefault}\selectfont
+% FILL: author list
+% e.g. Author One\\Author Two\\Author Three\\
+% be sure to have a newline (\\) after the final author
+\large
+\noindent with contributions by: \\
+    Jacqueline Austermann,
+    Magali Billen,
+    Markus B{\"u}rg,
+    Thomas Clevenger,
+    Samuel Cox,
+    William Durkin,
+    Grant Euen,
+    Thomas Geenen,
+    Ryan Grove,
+    Eric Heien,
+    Ludovic Jeanniot,
+    Louise Kellogg,
+    Scott King,
+    Martin Kronbichler,
+    Marine Lasbleis,
+    Haoyuan Li,
+    Shangxin Liu,
+    Hannah Mark,
+    Elvira Mulyukova,
+    Bart Niday,
+    Jonathan Perry-Houts,
+    Elbridge Gerry Puckett,
+    Tahiry Rajaonarison,
+    Fred Richards,
+    Jonathan Robey,
+    Ian Rose,
+    Max Rudolph,
+    Stephanie Sparks,
+    D.~Sarah Stamps,
+    Cedric Thieulot,
+    Wanying Wang,
+    Iris van Zelst,
+    Siqi Zhang\\
+\vspace{0.5em}
+}
+
+{\noindent
+{\fontfamily{\sfdefault}\selectfont \href{https://geodynamics.org}{geodynamics.org}}
+}
+
+%LINE%
+{\noindent
+\color{dark_grey}
+\rule{\textwidth}{2pt}
+}
+
+}
+
+\pagebreak
+\pagenumbering{arabic}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%   END OF CIG MANUAL COVER TEMPLATE    %%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+'''
+}
+
+latex_elements['maketitle'] = latex_elements['maketitle'].replace("%VERSION-INFO%", release)


### PR DESCRIPTION
This PR reintroduces the old manual front page into the pdf version of our documentation. The current online version is available here: https://aspect-documentation.readthedocs.io/_/downloads/en/latest/pdf/ and looks like this:

![Screenshot from 2025-01-13 15-55-25](https://github.com/user-attachments/assets/64c65f47-8c2c-4196-ada8-78e21b8090ed)


The way it is set up in this PR looks like this (we can change and discuss how to display all authors):

![Screenshot from 2025-01-13 15-53-25](https://github.com/user-attachments/assets/a7d49d17-eb6a-4774-9eda-008d2fb27652)
