### PR TITLE
remove two unnecessary lines

### DIFF
--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -538,9 +538,6 @@ namespace aspect
             prm.leave_subsection();
           }
 
-        // scale recrystallized grain size, diffusion creep and grain growth prefactor accordingly
-        grain_growth_rate_constant[grain_growth_rate_constant.size()-1] *= std::pow(1.0,grain_growth_exponent[grain_growth_exponent.size()-1]);
-
         // TODO: Remove deprecated parameters in next release.
         const double pv_grain_size_scaling         = prm.get_double ("Lower mantle grain size scaling");
         AssertThrow(pv_grain_size_scaling == 1.0,


### PR DESCRIPTION
I think these lines are left from an earlier refactoring. I can't remember what they were supposed to do; it looks like they just multiply something by 1. So this was not actually doing anything, and we removed the functionality of what it did in the past (scaling viscosity in the lower mantle) during the last hack anyway. 

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).