### PR TITLE
Include utilities namespace wherever necessary

### DIFF
--- a/include/aspect/coordinate_systems.h
+++ b/include/aspect/coordinate_systems.h
@@ -25,6 +25,22 @@ namespace aspect
 {
   namespace Utilities
   {
+    /**
+     * Because many places in ASPECT assume that all functions in the namespace
+     * <code>dealii::Utilities</code> are available without qualification as
+     * <code>Utilities::function</code>, just as all the function in the
+     * namespace <code>aspect::Utilities</code>, we make sure all these functions
+     * are available inside <code>aspect::Utilities</code>. This is maybe not
+     * the cleanest solution, but it is most compatible with a lot of existing
+     * code, and also allows to migrate ASPECT functions into deal.II when
+     * useful without introducing incompatibilities.
+     *
+     * We need to do this in every header that introduces something into the
+     * namespace <code>aspect::Utilities</code>, because it needs to happen
+     * no matter which header files of ASPECT are included.
+     */
+    using namespace dealii::Utilities;
+
     namespace Coordinates
     {
       /**

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -33,6 +33,20 @@ namespace aspect
   template <int dim> class SimulatorAccess;
   namespace Utilities
   {
+    /**
+    * Because many places in ASPECT assume that all functions in the namespace
+    * <code>dealii::Utilities</code> are available without qualification as
+    * <code>Utilities::function</code>, just as all the function in the
+    * namespace <code>aspect::Utilities</code>, we make sure all these functions
+    * are available inside <code>aspect::Utilities</code>. This is maybe not
+    * the cleanest solution, but it is most compatible with a lot of existing
+    * code, and also allows to migrate ASPECT functions into deal.II when
+    * useful without introducing incompatibilities.
+    *
+    * We need to do this in every header that introduces something into the
+    * namespace <code>aspect::Utilities</code>, because it needs to happen
+    * no matter which header files of ASPECT are included.
+    */
     using namespace dealii::Utilities;
 
     template <int dim>

--- a/include/aspect/particle/property/elastic_tensor_decomposition.h
+++ b/include/aspect/particle/property/elastic_tensor_decomposition.h
@@ -29,6 +29,21 @@ namespace aspect
       namespace Utilities
       {
         /**
+         * Because many places in ASPECT assume that all functions in the namespace
+         * <code>aspect::Utilities</code> are available without qualification as
+         * <code>Utilities::function</code>, we make sure all these functions
+         * are also available inside <code>aspect::Particle::Property::Utilities</code>.
+         * This is maybe not the cleanest solution, but it is most compatible
+         * with a lot of existing code.
+         *
+         * We need to do this in every header that creates a new namespace named
+         * <code>Utilities</code>, because otherwise the compiler may not find
+         * the requested function in the current namespace and issue an error, even
+         * though the function is available in the namespace <code>aspect::Utilities</code>.
+         */
+        using namespace aspect::Utilities;
+
+        /**
          * Return an even permutation based on an index. This is an internal
          * utilities function, also used by the unit tester.
          */

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -32,6 +32,22 @@ namespace aspect
   namespace Utilities
   {
     /**
+     * Because many places in ASPECT assume that all functions in the namespace
+     * <code>dealii::Utilities</code> are available without qualification as
+     * <code>Utilities::function</code>, just as all the function in the
+     * namespace <code>aspect::Utilities</code>, we make sure all these functions
+     * are available inside <code>aspect::Utilities</code>. This is maybe not
+     * the cleanest solution, but it is most compatible with a lot of existing
+     * code, and also allows to migrate ASPECT functions into deal.II when
+     * useful without introducing incompatibilities.
+     *
+     * We need to do this in every header that introduces something into the
+     * namespace <code>aspect::Utilities</code>, because it needs to happen
+     * no matter which header files of ASPECT are included.
+     */
+    using namespace dealii::Utilities;
+
+    /**
      * StructuredDataLookup (formerly AsciiDataLookup) represents structured
      * data that can be read from files including in ascii format.
      *

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -53,6 +53,20 @@ namespace aspect
    */
   namespace Utilities
   {
+    /**
+    * Because many places in ASPECT assume that all functions in the namespace
+    * <code>dealii::Utilities</code> are available without qualification as
+    * <code>Utilities::function</code>, just as all the function in the
+    * namespace <code>aspect::Utilities</code>, we make sure all these functions
+    * are available inside <code>aspect::Utilities</code>. This is maybe not
+    * the cleanest solution, but it is most compatible with a lot of existing
+    * code, and also allows to migrate ASPECT functions into deal.II when
+    * useful without introducing incompatibilities.
+    *
+    * We need to do this in every header that introduces something into the
+    * namespace <code>aspect::Utilities</code>, because it needs to happen
+    * no matter which header files of ASPECT are included.
+    */
     using namespace dealii::Utilities;
 
 

--- a/include/aspect/volume_of_fluid/utilities.h
+++ b/include/aspect/volume_of_fluid/utilities.h
@@ -32,6 +32,21 @@ namespace aspect
     namespace Utilities
     {
       /**
+       * Because many places in ASPECT assume that all functions in the namespace
+       * <code>aspect::Utilities</code> are available without qualification as
+       * <code>Utilities::function</code>, we make sure all these functions
+       * are also available inside <code>aspect::Particle::Property::Utilities</code>.
+       * This is maybe not the cleanest solution, but it is most compatible
+       * with a lot of existing code.
+       *
+       * We need to do this in every header that creates a new namespace named
+       * <code>Utilities</code>, because otherwise the compiler may not find
+       * the requested function in the current namespace and issue an error, even
+       * though the function is available in the namespace <code>aspect::Utilities</code>.
+       */
+      using namespace aspect::Utilities;
+
+      /**
        * Function to calculate volume fraction contained by indicator function
        * H(d-normal*(x'-x_{cen}')) on the [0, 1]^dim unit cell where x_{cen} is
        * the unit cell center.


### PR DESCRIPTION
This PR fixes an issue that appeared in #6215: Not all of ASPECT's namespaces named `Utilities` contain a directive `using namespace dealii::Utilities`. This can lead to hard to understand error messages like that `Utilities::MPI:...` cannot be found, even if the ASPECT file in question was not changed at all (e.g. because it was grouped into a different unity build file that contained a new `Utilities` namespace). This PR introduces `using namespace dealii::Utilities` into every file that introduces an `Utility` namespace.