### PR TITLE
Improve dealii namespace inclusion

### DIFF
--- a/benchmarks/advection_in_annulus/advection_in_annulus.cc
+++ b/benchmarks/advection_in_annulus/advection_in_annulus.cc
@@ -45,8 +45,6 @@ namespace aspect
    */
   namespace AdvectionInAnnulus
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       const double A=2.0, B=-3.0/std::log(2.0), C=-1;
@@ -109,8 +107,6 @@ namespace aspect
 {
   namespace PrescribedStokesSolution
   {
-    using namespace dealii;
-
     /**
      * A class that implements the flow field of the annulus benchmark.
      *

--- a/benchmarks/annulus/plugin/annulus.cc
+++ b/benchmarks/annulus/plugin/annulus.cc
@@ -53,7 +53,6 @@ namespace aspect
    */
   namespace AnnulusBenchmark
   {
-    using namespace dealii;
     using namespace aspect::Utilities::Coordinates;
 
     /**

--- a/benchmarks/burstedde/burstedde.cc
+++ b/benchmarks/burstedde/burstedde.cc
@@ -51,8 +51,6 @@ namespace aspect
    */
   namespace BursteddeBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       Tensor<1,3>

--- a/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
+++ b/benchmarks/davies_et_al/case-2.3-plugin/VoT.cc
@@ -27,9 +27,6 @@
 #include <cmath>
 
 
-using namespace dealii;
-
-
 namespace aspect
 {
   namespace MaterialModel

--- a/benchmarks/doneahuerta/doneahuerta.cc
+++ b/benchmarks/doneahuerta/doneahuerta.cc
@@ -36,8 +36,6 @@ namespace aspect
 {
   namespace DoneaHuertaBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
 

--- a/benchmarks/hollow_sphere/hollow_sphere.cc
+++ b/benchmarks/hollow_sphere/hollow_sphere.cc
@@ -43,8 +43,6 @@ namespace aspect
    */
   namespace HollowSphereBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       const double gammma = 1.0;

--- a/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.h
+++ b/benchmarks/inclusion/compositional_fields/inclusion_compositional_fields.h
@@ -9,8 +9,6 @@ namespace aspect
 {
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     template <int dim>
     class InclusionCompositionalMaterial : public InclusionMaterial<dim>
     {

--- a/benchmarks/inclusion/inclusion.h
+++ b/benchmarks/inclusion/inclusion.h
@@ -36,8 +36,6 @@ namespace aspect
    */
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       // based on http://geodynamics.org/hg/cs/AMR/Discontinuous_Stokes with permission

--- a/benchmarks/infill_density/infill_ascii_data.cc
+++ b/benchmarks/infill_density/infill_ascii_data.cc
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed traction boundary conditions determined
      * from pressures given in an AsciiData input file.

--- a/benchmarks/king2dcompressible/plugin/code.cc
+++ b/benchmarks/king2dcompressible/plugin/code.cc
@@ -27,8 +27,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   /**
    * This benchmark is from the article
    * @code

--- a/benchmarks/layeredflow/layeredflow.cc
+++ b/benchmarks/layeredflow/layeredflow.cc
@@ -36,8 +36,6 @@ namespace aspect
 {
   namespace LayeredFlowBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
 

--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model based on a simple power law rheology and
      * implementing the derivatives needed for the Newton method.
@@ -109,8 +107,6 @@ namespace aspect
 }
 
 
-
-using namespace dealii;
 
 namespace aspect
 {

--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -37,8 +37,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * The same material model as Drucker Prager, but this one supports multiple
      * compositions. Designed to run the Spiegelman et al. 2016 benchmark.
@@ -170,8 +168,6 @@ namespace aspect
 
 #include <aspect/utilities.h>
 #include <aspect/parameters.h>
-
-using namespace dealii;
 
 namespace aspect
 {

--- a/benchmarks/nsinker/nsinker.cc
+++ b/benchmarks/nsinker/nsinker.cc
@@ -39,8 +39,6 @@ namespace aspect
    */
   namespace NSinkerBenchmark
   {
-    using namespace dealii;
-
     /**
      * @note This benchmark only talks about the flow field, not about a
      * temperature field. All quantities related to the temperature are

--- a/benchmarks/nsinker_spherical_shell/nsinker.cc
+++ b/benchmarks/nsinker_spherical_shell/nsinker.cc
@@ -32,8 +32,6 @@ namespace aspect
    */
   namespace NSinkerBenchmark
   {
-    using namespace dealii;
-
     /**
      * @note This benchmark only talks about the flow field, not about a
      * temperature field. All quantities related to the temperature are

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class ExponentialDecay : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
@@ -64,8 +62,6 @@ namespace aspect
 
   namespace HeatingModel
   {
-    using namespace dealii;
-
     template <int dim>
     class ExponentialDecayHeating : public HeatingModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class ExponentialDecay : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {
@@ -64,8 +62,6 @@ namespace aspect
 
   namespace HeatingModel
   {
-    using namespace dealii;
-
     template <int dim>
     class ExponentialDecayHeating : public HeatingModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {

--- a/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
+++ b/benchmarks/rayleigh_taylor_instability/rayleigh_taylor_instability.cc
@@ -36,8 +36,6 @@ namespace aspect
 {
   namespace RTinstabilityBenchmark
   {
-    using namespace dealii;
-
     /**
      * @note This benchmark only talks about the flow field, not about a
      * temperature field. All quantities related to the temperature are

--- a/benchmarks/rigid_shear/plugin/rigid_shear.cc
+++ b/benchmarks/rigid_shear/plugin/rigid_shear.cc
@@ -39,8 +39,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace RigidShearBenchmark
   {
     /**

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -59,9 +59,6 @@ namespace aspect
    */
   namespace ShearBands
   {
-    using namespace dealii;
-
-
     /**
      * @note This benchmark only talks about the flow field, not about a
      * temperature field. All quantities related to the temperature are

--- a/benchmarks/sinking_block/sinking_block.cc
+++ b/benchmarks/sinking_block/sinking_block.cc
@@ -35,8 +35,6 @@ namespace aspect
 {
   namespace SinkingBlockBenchmark
   {
-    using namespace dealii;
-
     /**
      * @note This benchmark only talks about the flow field, not about a
      * temperature field. All quantities related to the temperature are

--- a/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
+++ b/benchmarks/solcx/compositional_fields/solcx_compositional_fields.h
@@ -9,8 +9,6 @@ namespace aspect
 {
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     template <int dim>
     class SolCxCompositionalMaterial : public SolCxMaterial<dim>
     {

--- a/benchmarks/solcx/solcx.h
+++ b/benchmarks/solcx/solcx.h
@@ -36,8 +36,6 @@ namespace aspect
    */
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       // based on http://geodynamics.org/hg/cs/AMR/Discontinuous_Stokes with permission

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -117,8 +117,6 @@ namespace aspect
    */
   namespace SolitaryWaveBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       // vectors to store the porosity field and the corresponding coordinate in

--- a/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
+++ b/benchmarks/solkz/compositional_fields/solkz_compositional_fields.h
@@ -10,8 +10,6 @@ namespace aspect
 {
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     template <int dim>
     class SolKzCompositionalMaterial : public SolKzMaterial<dim>
     {

--- a/benchmarks/solkz/solkz.h
+++ b/benchmarks/solkz/solkz.h
@@ -36,8 +36,6 @@ namespace aspect
    */
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       // based on http://geodynamics.org/hg/cs/AMR/Discontinuous_Stokes with permission

--- a/benchmarks/solubility/plugin/solubility.cc
+++ b/benchmarks/solubility/plugin/solubility.cc
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Volatiles material model.
      * @ingroup MaterialModels

--- a/benchmarks/tangurnis/code/tangurnis.cc
+++ b/benchmarks/tangurnis/code/tangurnis.cc
@@ -39,10 +39,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
-
-
   /**
    * This benchmark is from the article
    * @code

--- a/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
+++ b/benchmarks/time_dependent_annulus/plugin/time_dependent_annulus.h
@@ -112,8 +112,6 @@ namespace aspect
 
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class TimeDependentAnnulus : public MaterialModel::Interface<dim>
     {

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -60,9 +60,6 @@ namespace aspect
    */
   namespace TosiBenchmark
   {
-    using namespace dealii;
-
-
     /**
      * @ingroup MaterialModels
      */

--- a/benchmarks/viscosity_grooves/viscosity_grooves.cc
+++ b/benchmarks/viscosity_grooves/viscosity_grooves.cc
@@ -37,8 +37,6 @@ namespace aspect
 {
   namespace ViscosityGroovesBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
 

--- a/benchmarks/yamauchi_takei_2016_anelasticity/anelasticity_temperature.h
+++ b/benchmarks/yamauchi_takei_2016_anelasticity/anelasticity_temperature.h
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that describes an initial temperature field for a 2D or 3D shear wave velocity (Vs) model.
      * Vs values are converted to temperature using the anelasticity parameterization of Yamauchi & Takei (2016).

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -63,8 +63,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for anisotropic viscosities to be added to
      * the MaterialModel::MaterialModelOutputs structure and filled in the

--- a/cookbooks/finite_strain/finite_strain.cc
+++ b/cookbooks/finite_strain/finite_strain.cc
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class FiniteStrain : public MaterialModel::Simple<dim>
     {

--- a/cookbooks/free_surface_with_crust/plugin/simpler_with_crust.cc
+++ b/cookbooks/free_surface_with_crust/plugin/simpler_with_crust.cc
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model similar to the "simpler" material model, but where the
      * viscosity has two different values dependent on whether we are above or

--- a/cookbooks/inner_core_convection/inner_core_convection.cc
+++ b/cookbooks/inner_core_convection/inner_core_convection.cc
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class InnerCore : public MaterialModel::Simple<dim>
     {
@@ -357,8 +355,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a constant radiogenic heating rate.
      *

--- a/cookbooks/kinematically_driven_subduction_2d/subduction_plate_cooling.h
+++ b/cookbooks/kinematically_driven_subduction_2d/subduction_plate_cooling.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that prescribes the initial temperature field according to the plate cooling model
      * and plate geometries implemented in Quinquis (2014).

--- a/cookbooks/magnetic_stripes/magnetic_stripes.cc
+++ b/cookbooks/magnetic_stripes/magnetic_stripes.cc
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class MagneticStripes : public MaterialModel::CompositionReaction<dim>
     {

--- a/cookbooks/morency_doin_2004/morency_doin.h
+++ b/cookbooks/morency_doin_2004/morency_doin.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model based on the rheology described in (Morency and Doin,
      * 2004): Brittle-ductile rheology with a viscosity strongly depending on

--- a/cookbooks/prescribed_velocity/prescribed_velocity.cc
+++ b/cookbooks/prescribed_velocity/prescribed_velocity.cc
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   // Global variables (to be set by parameters)
   bool prescribe_internal_velocities;
 

--- a/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
+++ b/cookbooks/prescribed_velocity_ascii_data/prescribed_velocity_ascii_data.cc
@@ -29,8 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   // Global variables (to be set by parameters)
   bool prescribe_internal_velocities;
   bool prescribed_velocity_ascii_file_loaded;

--- a/cookbooks/tomography_based_plate_motions/plugins/reference_profile.h
+++ b/cookbooks/tomography_based_plate_motions/plugins/reference_profile.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * A model similar to the compute profile model
      * in which the adiabatic profile is

--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
@@ -33,8 +33,6 @@
 
 #include <iostream>
 
-using namespace dealii;
-
 namespace aspect
 {
   namespace MaterialModel

--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.h
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.h
@@ -33,9 +33,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
-
     /**
      * A material model to set up mantle flow models based on
      * an input tomography model and a temperature model.

--- a/cookbooks/vankeken_subduction/plugin/van_Keken_mesh.cc
+++ b/cookbooks/vankeken_subduction/plugin/van_Keken_mesh.cc
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     /**
      * A geometry model based on the 2D Cartesian van Keken 2008 subduction
      * benchmark. A custom mesh that is better suited to deal with

--- a/include/aspect/adiabatic_conditions/ascii_data.h
+++ b/include/aspect/adiabatic_conditions/ascii_data.h
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * A simple class that reads adiabatic conditions from a file.
      */

--- a/include/aspect/adiabatic_conditions/compute_entropy_profile.h
+++ b/include/aspect/adiabatic_conditions/compute_entropy_profile.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * A model in which the adiabatic profile is
      * calculated by solving the hydrostatic equations for

--- a/include/aspect/adiabatic_conditions/compute_profile.h
+++ b/include/aspect/adiabatic_conditions/compute_profile.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * A model in which the adiabatic profile is calculated by solving the
      * hydrostatic equations for pressure and temperature in depth. The

--- a/include/aspect/adiabatic_conditions/function.h
+++ b/include/aspect/adiabatic_conditions/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * A simple class that sets the adiabatic conditions based on given
      * a given function with three components: temperature, pressure, density.

--- a/include/aspect/adiabatic_conditions/interface.h
+++ b/include/aspect/adiabatic_conditions/interface.h
@@ -39,8 +39,6 @@ namespace aspect
    */
   namespace AdiabaticConditions
   {
-    using namespace dealii;
-
     /**
      * Base class for classes that describe adiabatic conditions,
      * i.e. that starts at the top of the domain and integrate

--- a/include/aspect/boundary_composition/ascii_data.h
+++ b/include/aspect/boundary_composition/ascii_data.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed boundary conditions determined from
      * a AsciiData input file.

--- a/include/aspect/boundary_composition/function.h
+++ b/include/aspect/boundary_composition/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements boundary composition based on a functional
      * description provided in the input file.

--- a/include/aspect/boundary_composition/interface.h
+++ b/include/aspect/boundary_composition/interface.h
@@ -44,8 +44,6 @@ namespace aspect
    */
   namespace BoundaryComposition
   {
-    using namespace dealii;
-
     /**
      * Base class for classes that describe composition boundary values.
      *

--- a/include/aspect/boundary_fluid_pressure/interface.h
+++ b/include/aspect/boundary_fluid_pressure/interface.h
@@ -36,8 +36,6 @@ namespace aspect
    */
   namespace BoundaryFluidPressure
   {
-    using namespace dealii;
-
     /**
      * Base class
      *

--- a/include/aspect/boundary_heat_flux/function.h
+++ b/include/aspect/boundary_heat_flux/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryHeatFlux
   {
-    using namespace dealii;
-
     /**
      * A class that implements heat flux boundary conditions based on a
      * functional description provided in the input file.

--- a/include/aspect/boundary_heat_flux/interface.h
+++ b/include/aspect/boundary_heat_flux/interface.h
@@ -35,8 +35,6 @@ namespace aspect
    */
   namespace BoundaryHeatFlux
   {
-    using namespace dealii;
-
     /**
      * Base class
      *

--- a/include/aspect/boundary_temperature/ascii_data.h
+++ b/include/aspect/boundary_temperature/ascii_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace BoundaryTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed data boundary conditions determined
      * from a AsciiData input file.

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements boundary temperature based on a functional
      * description provided in the input file.

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -46,8 +46,6 @@ namespace aspect
    */
   namespace BoundaryTemperature
   {
-    using namespace dealii;
-
     /**
      * Base class for classes that describe temperature boundary values.
      *

--- a/include/aspect/boundary_traction/ascii_data.h
+++ b/include/aspect/boundary_traction/ascii_data.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed traction boundary conditions determined
      * from pressures given in an AsciiData input file.

--- a/include/aspect/boundary_traction/function.h
+++ b/include/aspect/boundary_traction/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A class that implements traction boundary conditions based on a
      * functional description provided in the input file.

--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A class that implements traction boundary conditions by prescribing
      * the lithostatic pressure as the normal traction component.

--- a/include/aspect/boundary_traction/interface.h
+++ b/include/aspect/boundary_traction/interface.h
@@ -38,8 +38,6 @@ namespace aspect
    */
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A base class for parameterizations of traction boundary conditions.
      *

--- a/include/aspect/boundary_traction/zero_traction.h
+++ b/include/aspect/boundary_traction/zero_traction.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace BoundaryTraction
   {
-    using namespace dealii;
-
     /**
      * A class that implements zero traction boundary conditions. This
      * is equivalent to an open boundary condition in domains where

--- a/include/aspect/boundary_velocity/ascii_data.h
+++ b/include/aspect/boundary_velocity/ascii_data.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed velocity boundary conditions
      * determined from a AsciiData input file.

--- a/include/aspect/boundary_velocity/function.h
+++ b/include/aspect/boundary_velocity/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
-    using namespace dealii;
-
     /**
      * A class that implements velocity boundary conditions based on a
      * functional description provided in the input file.

--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
-    using namespace dealii;
-
     namespace internal
     {
       /**

--- a/include/aspect/boundary_velocity/interface.h
+++ b/include/aspect/boundary_velocity/interface.h
@@ -44,8 +44,6 @@ namespace aspect
    */
   namespace BoundaryVelocity
   {
-    using namespace dealii;
-
     /**
      * A base class for parameterizations of velocity boundary conditions.
      *

--- a/include/aspect/boundary_velocity/zero_velocity.h
+++ b/include/aspect/boundary_velocity/zero_velocity.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace BoundaryVelocity
   {
-    using namespace dealii;
-
     /**
      * A class that implements zero velocity (stick) boundary conditions.
      *

--- a/include/aspect/fe_variable_collection.h
+++ b/include/aspect/fe_variable_collection.h
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   /**
    * A structure to describe everything necessary to define a single variable
    * of the finite element system in isolation. It groups the FiniteElement<dim> with other

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     /**
      * A class that describes a box geometry of certain width, height, and
      * depth (in 3d), and, possibly, topography.

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -34,8 +34,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     namespace internal
     {
       /**

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     namespace internal
     {
       /**

--- a/include/aspect/geometry_model/initial_topography_model/ascii_data.h
+++ b/include/aspect/geometry_model/initial_topography_model/ascii_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialTopographyModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements topography determined
      * from an AsciiData input file.

--- a/include/aspect/geometry_model/initial_topography_model/function.h
+++ b/include/aspect/geometry_model/initial_topography_model/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialTopographyModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial topography based
      * on a user-defined function..

--- a/include/aspect/geometry_model/initial_topography_model/interface.h
+++ b/include/aspect/geometry_model/initial_topography_model/interface.h
@@ -41,8 +41,6 @@ namespace aspect
    */
   namespace InitialTopographyModel
   {
-    using namespace dealii;
-
     /**
      * Base class for classes that describe particular initial topographies
      * for the domain.

--- a/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
+++ b/include/aspect/geometry_model/initial_topography_model/prm_polygon.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTopographyModel
   {
-    using namespace dealii;
-
     /**
      * A class that describes an initial topography for the geometry model,
      * by defining a set of polygons on the surface from the prm file. It

--- a/include/aspect/geometry_model/initial_topography_model/zero_topography.h
+++ b/include/aspect/geometry_model/initial_topography_model/zero_topography.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace InitialTopographyModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements zero initial topography.
      *

--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -46,8 +46,6 @@ namespace aspect
    */
   namespace GeometryModel
   {
-    using namespace dealii;
-
     /**
      * Base class for classes that describe particular geometries for the
      * domain. These classes must also be able to create coarse meshes and

--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     template <int dim>
     class Sphere : public Interface<dim>, public SimulatorAccess<dim>
     {

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     namespace internal
     {
       /**

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
     /**
      * A class that describes a box geometry of certain width, height, and
      * depth (in 3d) and adds two (four in 3D) additional boundary indicators

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -34,9 +34,6 @@ namespace aspect
 {
   namespace GeometryModel
   {
-    using namespace dealii;
-
-
     /**
      * A geometry model class that describes a chunk of a spherical shell,
      * but with two boundary indicators per side boundary. This allows

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -43,6 +43,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 namespace aspect
 {
   /**
+   * Make sure that we can use the deal.II classes and utilities
+   * without prefixing them with "dealii::".
+   */
+  using namespace dealii;
+
+  /**
    * The following are a set of global constants which may be used by ASPECT:
    * (for sources of data and values used by ASPECT, see source/global.cc)
    */

--- a/include/aspect/gravity_model/ascii_data.h
+++ b/include/aspect/gravity_model/ascii_data.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace GravityModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a gravity description based on
      * an AsciiData input file.

--- a/include/aspect/gravity_model/function.h
+++ b/include/aspect/gravity_model/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace GravityModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements gravity based on a functional description
      * provided in the input file.

--- a/include/aspect/gravity_model/interface.h
+++ b/include/aspect/gravity_model/interface.h
@@ -36,8 +36,6 @@ namespace aspect
    */
   namespace GravityModel
   {
-    using namespace dealii;
-
     /**
      * A base class for parameterizations of gravity models.
      *

--- a/include/aspect/gravity_model/radial.h
+++ b/include/aspect/gravity_model/radial.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace GravityModel
   {
-    using namespace dealii;
-
     /**
      * A class that describes gravity as a radial vector of constant
      * magnitude. The magnitude's value is read from the input file.

--- a/include/aspect/gravity_model/vertical.h
+++ b/include/aspect/gravity_model/vertical.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace GravityModel
   {
-    using namespace dealii;
-
     /**
      * A class that describes gravity as a vector of constant magnitude
      * pointing vertically down.

--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard adiabatic heating rate.
      *

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard adiabatic heating rate
      * for partially molten material.

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a heating model where each compositional field
      * is assigned a user-defined internal heating value.

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a constant radiogenic heating rate.
      *

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a heating model based on a functional
      * description provided in the input file.

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -45,8 +45,6 @@ namespace aspect
    */
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A data structure with the output field of the
      * HeatingModel::Interface::evaluate() function. The vectors are the

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard formulation of latent heat.
      * This includes a left hand side and a right hand side term:

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard formulation of latent heat
      * of melting. This assumes that there is a compositional field

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a heating model based on radioactive decay.
      *

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard shear heating rate.
      *

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace HeatingModel
   {
-    using namespace dealii;
-
     /**
      * A class that implements a standard shear heating rate for dissipation
      * heating of partially molten material.

--- a/include/aspect/initial_composition/adiabatic_density.h
+++ b/include/aspect/initial_composition/adiabatic_density.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial conditions for the compositional fields
      * based on the adiabatic density profile. Note that only the field

--- a/include/aspect/initial_composition/ascii_data.h
+++ b/include/aspect/initial_composition/ascii_data.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements the prescribed compositional fields determined
      * from a AsciiData input file.

--- a/include/aspect/initial_composition/ascii_data_layered.h
+++ b/include/aspect/initial_composition/ascii_data_layered.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements prescribed compositional fields determined from
      * AsciiData input files. Each file defines a layer boundary as a grid of points.

--- a/include/aspect/initial_composition/entropy_table_lookup.h
+++ b/include/aspect/initial_composition/entropy_table_lookup.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial conditions for the entropy field
      * Note that this plugin only

--- a/include/aspect/initial_composition/function.h
+++ b/include/aspect/initial_composition/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial conditions for the compositional fields
      * based on a functional description provided in the input file.

--- a/include/aspect/initial_composition/interface.h
+++ b/include/aspect/initial_composition/interface.h
@@ -45,8 +45,6 @@ namespace aspect
    */
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A base class for parameterizations of initial conditions.
      *

--- a/include/aspect/initial_composition/porosity.h
+++ b/include/aspect/initial_composition/porosity.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial conditions for the porosity field
      * by computing the equilibrium melt fraction for the given initial

--- a/include/aspect/initial_composition/slab_model.h
+++ b/include/aspect/initial_composition/slab_model.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements subducted slab geometries as a compositional
      * field determined from an input file. The file defines the depth to

--- a/include/aspect/initial_composition/world_builder.h
+++ b/include/aspect/initial_composition/world_builder.h
@@ -38,8 +38,6 @@ namespace aspect
 {
   namespace InitialComposition
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial conditions for the compositional fields
      * based on a functional description provided in the input file through the

--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     namespace internal
     {
       namespace S40RTS

--- a/include/aspect/initial_temperature/SAVANI_perturbation.h
+++ b/include/aspect/initial_temperature/SAVANI_perturbation.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     namespace internal
     {
       namespace SAVANI

--- a/include/aspect/initial_temperature/adiabatic.h
+++ b/include/aspect/initial_temperature/adiabatic.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A namespace for selecting how to determine the age of a
      * boundary layer. Current options are:

--- a/include/aspect/initial_temperature/adiabatic_boundary.h
+++ b/include/aspect/initial_temperature/adiabatic_boundary.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that computes an initial temperature field based
      * on a user-defined adiabatic boundary. It discretizes the model domain into

--- a/include/aspect/initial_temperature/ascii_data.h
+++ b/include/aspect/initial_temperature/ascii_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements a prescribed temperature field determined from
      * a AsciiData input file.

--- a/include/aspect/initial_temperature/ascii_data_layered.h
+++ b/include/aspect/initial_temperature/ascii_data_layered.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements an initial temperature field determined from
      * AsciiData input files. Each file defines an isotherm as a grid of points.

--- a/include/aspect/initial_temperature/ascii_profile.h
+++ b/include/aspect/initial_temperature/ascii_profile.h
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements a prescribed temperature field determined from
      * a AsciiDataProfile input file.

--- a/include/aspect/initial_temperature/box.h
+++ b/include/aspect/initial_temperature/box.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that describes a perturbed initial temperature field for a box
      * geometry.

--- a/include/aspect/initial_temperature/function.h
+++ b/include/aspect/initial_temperature/function.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements temperature initial conditions based on a
      * functional description provided in the input file.

--- a/include/aspect/initial_temperature/harmonic_perturbation.h
+++ b/include/aspect/initial_temperature/harmonic_perturbation.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that describes a perturbed initially constant temperature field
      * for any geometry model or dimension in shape of a harmonic function.

--- a/include/aspect/initial_temperature/interface.h
+++ b/include/aspect/initial_temperature/interface.h
@@ -45,8 +45,6 @@ namespace aspect
    */
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A base class for parameterizations of initial conditions.
      *

--- a/include/aspect/initial_temperature/lithosphere_mask.h
+++ b/include/aspect/initial_temperature/lithosphere_mask.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     namespace LABDepth
     {
       template <int dim>

--- a/include/aspect/initial_temperature/patch_on_S40RTS.h
+++ b/include/aspect/initial_temperature/patch_on_S40RTS.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements a prescribed temperature field determined from
      * an upper mantle Vs model (input as an ascii file) above a specified depth

--- a/include/aspect/initial_temperature/prescribed_temperature.h
+++ b/include/aspect/initial_temperature/prescribed_temperature.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class sets the initial temperature to the precribed temperature
      * outputs computed by the material model.

--- a/include/aspect/initial_temperature/random_gaussian_perturbation.h
+++ b/include/aspect/initial_temperature/random_gaussian_perturbation.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that describes a perturbation to a zero temperature field
      * by placing several Gaussians with a given magnitude and width at

--- a/include/aspect/initial_temperature/spherical_shell.h
+++ b/include/aspect/initial_temperature/spherical_shell.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that describes a perturbed initial temperature field for the
      * spherical shell.

--- a/include/aspect/initial_temperature/world_builder.h
+++ b/include/aspect/initial_temperature/world_builder.h
@@ -39,8 +39,6 @@ namespace aspect
 {
   namespace InitialTemperature
   {
-    using namespace dealii;
-
     /**
      * A class that implements temperature initial conditions based on a
      * functional description provided in the input file through the

--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -35,8 +35,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   /**
    * Helper function to construct the default list of variables to use
    * based on the given set of @p parameters.

--- a/include/aspect/lateral_averaging.h
+++ b/include/aspect/lateral_averaging.h
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace internal
   {
     /**

--- a/include/aspect/material_model/ascii_reference_profile.h
+++ b/include/aspect/material_model/ascii_reference_profile.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that reads in a reference profile from an ascii file
      * and computes properties based on this profile.

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * An enum to define what kind of averaging operations are implemented.
      * These are:

--- a/include/aspect/material_model/composition_reaction.h
+++ b/include/aspect/material_model/composition_reaction.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that consists of globally constant values for all
      * material parameters except that the density decays linearly with the

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that applies a depth-dependent viscosity to a ''base model''
      * chosen from any of the other available material models. This depth-dependent

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model based on a viscous rheology including diffusion and
      * dislocation creep.

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that consists of globally constant values for all
      * material parameters except density and viscosity.

--- a/include/aspect/material_model/entropy_model.h
+++ b/include/aspect/material_model/entropy_model.h
@@ -34,7 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
     /**
      * A material model that is designed to use pressure and entropy (rather
      * than pressure and temperature) as independent variables. It will look up

--- a/include/aspect/material_model/equation_of_state/interface.h
+++ b/include/aspect/material_model/equation_of_state/interface.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A data structure containing output fields that can be filled by the
      * evaluate() function of an EquationOfState model. It contains those

--- a/include/aspect/material_model/equation_of_state/linearized_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/linearized_incompressible.h
@@ -32,8 +32,6 @@ namespace aspect
   {
     namespace EquationOfState
     {
-      using namespace dealii;
-
       /**
        * A simplified, incompressible equation of state where the density depends linearly
        * on temperature and composition, using the equation

--- a/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
@@ -32,8 +32,6 @@ namespace aspect
   {
     namespace EquationOfState
     {
-      using namespace dealii;
-
       /**
        * A compressible equation of state that is intended for use with multiple compositional
        * fields. For each material property, the user supplies a comma delimited list of

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -32,8 +32,6 @@ namespace aspect
   {
     namespace EquationOfState
     {
-      using namespace dealii;
-
       /**
        * An incompressible equation of state that is intended for use with multiple compositional
        * fields and potentially phases. For each material property, the user supplies a comma

--- a/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
+++ b/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
@@ -32,8 +32,6 @@ namespace aspect
   {
     namespace EquationOfState
     {
-      using namespace dealii;
-
       /**
        * An equation of state class that reads thermodynamic properties
        * from pressure-temperature tables in input files. These input files

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -37,8 +37,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for the dislocation viscosity parameters
      * to be added to the MaterialModel::MaterialModelOutputs structure

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -52,8 +52,6 @@ namespace aspect
    */
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A namespace whose enum members are used in querying the nonlinear
      * dependence of physical parameters on other solution variables.

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that implements a standard approximation of the latent
      * heat terms following Christensen \& Yuen, 1986. The change of entropy

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that implements latent heat of melting for two
      * materials: peridotite and pyroxenite. The density and thermal

--- a/include/aspect/material_model/melt_boukare.h
+++ b/include/aspect/material_model/melt_boukare.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for the melt boukare material model.
      */

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that implements a simple formulation of the
      * material parameters required for the modeling of melt transport

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that implements a simple formulation of the
      * material parameters required for the modeling of melt transport,

--- a/include/aspect/material_model/modified_tait.h
+++ b/include/aspect/material_model/modified_tait.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A compressible material model that implements the thermal modified Tait
      * equation of state as written in the paper of Holland and Powell, 2011

--- a/include/aspect/material_model/multicomponent.h
+++ b/include/aspect/material_model/multicomponent.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * An incompressible material model which is intended for use with multiple
      * compositional fields. Each compositional field is meant to be a single

--- a/include/aspect/material_model/multicomponent_compressible.h
+++ b/include/aspect/material_model/multicomponent_compressible.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model which is intended for use with multiple compositional
      * fields. Each compositional field is meant to be a single rock type,

--- a/include/aspect/material_model/nondimensional.h
+++ b/include/aspect/material_model/nondimensional.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model for incompressible (using the Boussinesq approximation)
      * and compressible computations (with ALA or TALA) for a nondimensionalized

--- a/include/aspect/material_model/perplex_lookup.h
+++ b/include/aspect/material_model/perplex_lookup.h
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that calls the thermodynamic software PerpleX
      * in order to evaluate material properties at a given point, namely

--- a/include/aspect/material_model/prescribed_viscosity.h
+++ b/include/aspect/material_model/prescribed_viscosity.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that applies a viscosity to a ''base model'' chosen from any of
      * the other available material models. This prescribed viscosity material model

--- a/include/aspect/material_model/reaction_model/grain_size_evolution.h
+++ b/include/aspect/material_model/reaction_model/grain_size_evolution.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace ReactionModel
     {
       /**

--- a/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
+++ b/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace ReactionModel
     {
 

--- a/include/aspect/material_model/reactive_fluid_transport.h
+++ b/include/aspect/material_model/reactive_fluid_transport.h
@@ -38,7 +38,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
     /**
      * A material model that simulates both fluid-rock interactions
      * and the advection of fluids. It is designed to be composited with another material

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that applies a given constant viscosity in the lithosphere.
      * Viscosity below this is taken from a ''base model'' chosen from any of the

--- a/include/aspect/material_model/rheology/ascii_depth_profile.h
+++ b/include/aspect/material_model/rheology/ascii_depth_profile.h
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
 

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -34,8 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/constant_viscosity.h
+++ b/include/aspect/material_model/rheology/constant_viscosity.h
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       class ConstantViscosity

--- a/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/diffusion_dislocation.h
+++ b/include/aspect/material_model/rheology/diffusion_dislocation.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/drucker_prager_power.h
+++ b/include/aspect/material_model/rheology/drucker_prager_power.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
 

--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for the elastic shear modulus to be added to
      * the MaterialModel::MaterialModelOutputs structure and filled in the

--- a/include/aspect/material_model/rheology/frank_kamenetskii.h
+++ b/include/aspect/material_model/rheology/frank_kamenetskii.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/friction_models.h
+++ b/include/aspect/material_model/rheology/friction_models.h
@@ -34,7 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace Rheology
     {
       /**

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -42,8 +42,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for the plastic parameters weakened (or hardened)
      * by strain to be added to the MaterialModel::MaterialModelOutputs structure

--- a/include/aspect/material_model/simple.h
+++ b/include/aspect/material_model/simple.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that consists of globally constant values for all
      * material parameters except density and viscosity.

--- a/include/aspect/material_model/simple_compressible.h
+++ b/include/aspect/material_model/simple_compressible.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that consists of globally constant values for the
      * viscosity, thermal conductivity, thermal expansivity

--- a/include/aspect/material_model/simpler.h
+++ b/include/aspect/material_model/simpler.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that consists of globally constant values for all
      * material parameters except the density, which depends linearly on the

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     namespace internal
     {
       /**

--- a/include/aspect/material_model/thermal_conductivity/constant.h
+++ b/include/aspect/material_model/thermal_conductivity/constant.h
@@ -30,8 +30,6 @@ namespace aspect
   {
     namespace ThermalConductivity
     {
-      using namespace dealii;
-
       /**
        * A class that implements a constant thermal conductivity.
        *

--- a/include/aspect/material_model/thermal_conductivity/interface.h
+++ b/include/aspect/material_model/thermal_conductivity/interface.h
@@ -32,8 +32,6 @@ namespace aspect
   {
     namespace ThermalConductivity
     {
-      using namespace dealii;
-
       /**
        * A base class for parametrizations of the thermal conductivity. Classes derived
        * from this class will need to implement a function that computes the thermal

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -33,7 +33,6 @@ namespace aspect
   template <int dim> class SimulatorAccess;
   namespace Utilities
   {
-    using namespace dealii;
     using namespace dealii::Utilities;
 
     template <int dim>
@@ -41,8 +40,6 @@ namespace aspect
   }
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim> class MaterialModelOutputs;
     template <int dim> struct EquationOfStateOutputs;
 

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model combining viscous and plastic deformation, with
      * the option to also include viscoelastic deformation.

--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * An implementation of a simple linear viscoelastic rheology that only
      * includes the deviatoric components of elasticity. Specifically, the

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -30,8 +30,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MaterialModel
   {
     /**

--- a/include/aspect/mesh_deformation/ascii_data.h
+++ b/include/aspect/mesh_deformation/ascii_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MeshDeformation
   {
-    using namespace dealii;
-
     /**
      * A class that implements initial topography determined
      * from an AsciiData input file.

--- a/include/aspect/mesh_deformation/diffusion.h
+++ b/include/aspect/mesh_deformation/diffusion.h
@@ -29,9 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
-
   namespace MeshDeformation
   {
     /**

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -29,8 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MeshDeformation
   {
     /**

--- a/include/aspect/mesh_deformation/free_surface.h
+++ b/include/aspect/mesh_deformation/free_surface.h
@@ -30,8 +30,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MeshDeformation
   {
     /**

--- a/include/aspect/mesh_deformation/function.h
+++ b/include/aspect/mesh_deformation/function.h
@@ -29,8 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MeshDeformation
   {
     /**

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -40,8 +40,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace Assemblers
   {
     /**

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -34,8 +34,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim> class Simulator;
   template <int dim> class SimulatorAccess;
 

--- a/include/aspect/newton.h
+++ b/include/aspect/newton.h
@@ -31,8 +31,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MaterialModel
   {
     /**

--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -30,8 +30,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   struct CompositionalFieldDescription;
 
   // forward declaration:

--- a/include/aspect/particle/generator/uniform_radial.h
+++ b/include/aspect/particle/generator/uniform_radial.h
@@ -31,8 +31,6 @@ namespace aspect
   {
     namespace Generator
     {
-      using namespace dealii;
-
       /**
        * Generate a uniform radial distribution of particles over the entire
        * simulation domain. Uniform here means

--- a/include/aspect/particle/integrator/interface.h
+++ b/include/aspect/particle/integrator/interface.h
@@ -34,7 +34,6 @@ namespace aspect
   {
     namespace Integrator
     {
-      using namespace dealii;
       using namespace dealii::Particles;
 
       /**

--- a/include/aspect/particle/interpolator/interface.h
+++ b/include/aspect/particle/interpolator/interface.h
@@ -37,7 +37,6 @@ namespace aspect
   {
     namespace Interpolator
     {
-      using namespace dealii;
       using namespace dealii::Particles;
 
       /**

--- a/include/aspect/particle/manager.h
+++ b/include/aspect/particle/manager.h
@@ -52,7 +52,6 @@ namespace aspect
 
   namespace Particle
   {
-    using namespace dealii;
     using namespace dealii::Particles;
 
     namespace Generator

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -46,8 +46,6 @@ namespace aspect
 
   namespace Plugins
   {
-    using namespace dealii;
-
     /**
      * This function returns if a given plugin (e.g. a material model returned
      * from SimulatorAccess::get_material_model() ) matches a certain plugin
@@ -114,9 +112,6 @@ namespace aspect
 
   namespace Plugins
   {
-    using namespace dealii;
-
-
     /**
      * A base class for all plugin systems. The class ensures that a
      * common set of functions is declared as `virtual` (namely, the
@@ -426,10 +421,6 @@ namespace aspect
      */
     namespace Plugins
     {
-      using namespace dealii;
-
-
-
       /**
        * An internal class that is used in the definition of the
        * ASPECT_REGISTER_* macros. Given a registration function, a classname,

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -38,8 +38,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim> class Simulator;
   template <int dim> class SimulatorAccess;
 

--- a/include/aspect/postprocess/visualization/boundary_strain_rate_residual.h
+++ b/include/aspect/postprocess/visualization/boundary_strain_rate_residual.h
@@ -35,7 +35,6 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
-      using namespace dealii;
       /**
        * A class derived from DataPostprocessor that takes an output vector
        * and computes a variable that represents the residual between

--- a/include/aspect/postprocess/visualization/boundary_velocity_residual.h
+++ b/include/aspect/postprocess/visualization/boundary_velocity_residual.h
@@ -35,7 +35,6 @@ namespace aspect
   {
     namespace VisualizationPostprocessors
     {
-      using namespace dealii;
       /**
        * A class derived from DataPostprocessor that takes an output vector
        * and computes a variable that represents the velocity residual between

--- a/include/aspect/prescribed_stokes_solution/ascii_data.h
+++ b/include/aspect/prescribed_stokes_solution/ascii_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace PrescribedStokesSolution
   {
-    using namespace dealii;
-
     /**
      * A class that implements a prescribed velocity field determined from
      * a AsciiData input file.

--- a/include/aspect/prescribed_stokes_solution/circle.h
+++ b/include/aspect/prescribed_stokes_solution/circle.h
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace PrescribedStokesSolution
   {
-    using namespace dealii;
-
     /**
      * A class that implements a circular, divergence-free flow field
      * around the origin of the coordinate system.

--- a/include/aspect/prescribed_stokes_solution/function.h
+++ b/include/aspect/prescribed_stokes_solution/function.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace PrescribedStokesSolution
   {
-    using namespace dealii;
-
     /**
      * A class that implements velocity and pressure solutions based on a
      * functional description provided in the input file.

--- a/include/aspect/prescribed_stokes_solution/interface.h
+++ b/include/aspect/prescribed_stokes_solution/interface.h
@@ -40,8 +40,6 @@ namespace aspect
    */
   namespace PrescribedStokesSolution
   {
-    using namespace dealii;
-
     /**
      * This plugin allows the user to prescribe a Stokes solution and can be
      * thought of as velocity and pressure's equivalent of the initial

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -75,8 +75,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   class MeltHandler;
 

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -29,8 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   class Simulator;
 

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -42,8 +42,6 @@ namespace WorldBuilder
 
 namespace aspect
 {
-  using namespace dealii;
-
   // forward declarations:
   template <int dim> class Simulator;
   template <int dim> struct SimulatorSignals;

--- a/include/aspect/solution_evaluator.h
+++ b/include/aspect/solution_evaluator.h
@@ -33,8 +33,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace internal
   {
     /**

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -51,8 +51,6 @@ using GMGNumberType = double;
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace internal
   {
     /**

--- a/include/aspect/structured_data.h
+++ b/include/aspect/structured_data.h
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace Utilities
   {
-    using namespace dealii;
-
     /**
      * StructuredDataLookup (formerly AsciiDataLookup) represents structured
      * data that can be read from files including in ascii format.

--- a/include/aspect/termination_criteria/interface.h
+++ b/include/aspect/termination_criteria/interface.h
@@ -32,8 +32,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim> class Simulator;
 
 

--- a/include/aspect/time_stepping/conduction_time_step.h
+++ b/include/aspect/time_stepping/conduction_time_step.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace TimeStepping
   {
-    using namespace dealii;
-
     /**
      * Compute the conduction time step based on the current solution and
      * return this as the time step.

--- a/include/aspect/time_stepping/convection_time_step.h
+++ b/include/aspect/time_stepping/convection_time_step.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace TimeStepping
   {
-    using namespace dealii;
-
     /**
      * Compute the convection time step based on the current solution and
      * return it.

--- a/include/aspect/time_stepping/function.h
+++ b/include/aspect/time_stepping/function.h
@@ -29,8 +29,6 @@ namespace aspect
 {
   namespace TimeStepping
   {
-    using namespace dealii;
-
     /**
      * A class that implements a time stepping plugin on a function
      * description provided in the input file.

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   /**
    * A namespace containing all class related to the time stepping plugin system.
    */

--- a/include/aspect/time_stepping/repeat_on_cutback.h
+++ b/include/aspect/time_stepping/repeat_on_cutback.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace TimeStepping
   {
-    using namespace dealii;
-
     /**
      * A class that implements a time stepping plugin to repeat a time step if the
      * next time step is significantly smaller than the last step.

--- a/include/aspect/time_stepping/repeat_on_nonlinear_fail.h
+++ b/include/aspect/time_stepping/repeat_on_nonlinear_fail.h
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace TimeStepping
   {
-    using namespace dealii;
-
     /**
      * A class that implements a time stepping plugin to repeat a time step if the
      * nonlinear solver failed to converge in the specified number of iterations.

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -53,7 +53,6 @@ namespace aspect
    */
   namespace Utilities
   {
-    using namespace dealii;
     using namespace dealii::Utilities;
 
 

--- a/include/aspect/volume_of_fluid/assembly.h
+++ b/include/aspect/volume_of_fluid/assembly.h
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   class Simulator;
 

--- a/include/aspect/volume_of_fluid/field.h
+++ b/include/aspect/volume_of_fluid/field.h
@@ -23,8 +23,6 @@
 
 #include <aspect/fe_variable_collection.h>
 
-using namespace dealii;
-
 namespace aspect
 {
   namespace VolumeOfFluid

--- a/include/aspect/volume_of_fluid/handler.h
+++ b/include/aspect/volume_of_fluid/handler.h
@@ -28,8 +28,6 @@
 
 #include <boost/serialization/map.hpp>
 
-using namespace dealii;
-
 namespace aspect
 {
   /**

--- a/include/aspect/volume_of_fluid/utilities.h
+++ b/include/aspect/volume_of_fluid/utilities.h
@@ -31,8 +31,6 @@ namespace aspect
   {
     namespace Utilities
     {
-      using namespace dealii;
-
       /**
        * Function to calculate volume fraction contained by indicator function
        * H(d-normal*(x'-x_{cen}')) on the [0, 1]^dim unit cell where x_{cen} is

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -28,8 +28,6 @@
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
 
-using namespace dealii;
-
 namespace aspect
 {
   namespace MaterialModel

--- a/source/postprocess/particle_count_statistics.cc
+++ b/source/postprocess/particle_count_statistics.cc
@@ -37,7 +37,7 @@ namespace aspect
       unsigned int local_min_particles = std::numeric_limits<unsigned int>::max();
       unsigned int local_max_particles = 0;
 
-      Particle::types::particle_index global_particles = 0;
+      types::particle_index global_particles = 0;
       for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
         global_particles += this->get_particle_manager(particle_manager_index).n_global_particles();
 

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -31,8 +31,6 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/mapping_cartesian.h>
 
-using namespace dealii;
-
 namespace aspect
 {
   namespace internal

--- a/source/volume_of_fluid/reconstruct.cc
+++ b/source/volume_of_fluid/reconstruct.cc
@@ -25,8 +25,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <>
   void VolumeOfFluidHandler<2>::update_volume_of_fluid_normals (const VolumeOfFluidField<2> &field,
                                                                 LinearAlgebra::BlockVector &solution)

--- a/source/volume_of_fluid/setup_initial_conditions.cc
+++ b/source/volume_of_fluid/setup_initial_conditions.cc
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   void VolumeOfFluidHandler<dim>::set_initial_volume_fractions ()
   {

--- a/source/volume_of_fluid/utilities.cc
+++ b/source/volume_of_fluid/utilities.cc
@@ -26,9 +26,6 @@ namespace aspect
   {
     namespace Utilities
     {
-      using namespace dealii;
-
-
       double compute_fluid_fraction (const Tensor<1, 2> normal,
                                      const double d)
       {

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -34,7 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
     template <int dim>
     class AdditionalOutputs1 : public AdditionalMaterialOutputs<dim>
     {

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -34,7 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
     template <int dim>
     class AdditionalOutputs1 : public AdditionalMaterialOutputs<dim>
     {

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -604,8 +604,6 @@ namespace aspect
 
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class Anisotropic : public MaterialModel::Simple<dim>
     {

--- a/tests/artificial_postprocess.cc
+++ b/tests/artificial_postprocess.cc
@@ -34,8 +34,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   class EVPostprocessor : public Postprocess::Interface<dim>, public ::aspect::SimulatorAccess<dim>
   {

--- a/tests/ascii_boundary_member.cc
+++ b/tests/ascii_boundary_member.cc
@@ -34,7 +34,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
   /**
    * A boundary velocity plugin that uses an AsciiDataBoundary object as member
    */

--- a/tests/boundary_heatflux_update.cc
+++ b/tests/boundary_heatflux_update.cc
@@ -30,8 +30,6 @@ namespace aspect
 {
   namespace BoundaryHeatFlux
   {
-    using namespace dealii;
-
     /**
      * A class that implements heat flux boundary conditions based on a
      * functional description provided in the input file.

--- a/tests/box_initial_mesh_deformation.cc
+++ b/tests/box_initial_mesh_deformation.cc
@@ -25,8 +25,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MeshDeformation
   {
     template <int dim>

--- a/tests/burstedde_stokes_rhs.cc
+++ b/tests/burstedde_stokes_rhs.cc
@@ -49,8 +49,6 @@ namespace aspect
    */
   namespace BursteddeBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       Tensor<1,3>

--- a/tests/cell_reference.cc
+++ b/tests/cell_reference.cc
@@ -22,8 +22,6 @@
 #include <aspect/global.h>
 #include <aspect/material_model/simpler.h>
 
-using namespace dealii;
-
 namespace aspect
 {
   namespace MaterialModel

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -60,7 +60,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/check_compositional_field_names.cc
+++ b/tests/check_compositional_field_names.cc
@@ -65,7 +65,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -22,189 +22,193 @@
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-  // This function tests whether the composite creep rheology is producing
-  // the correct composite viscosity and partial strain rates corresponding to
-  // the different creep mechanisms incorporated into the rheology.
-  // It is assumed that each individual creep mechanism has already been tested.
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
+  {
+    // This function tests whether the composite creep rheology is producing
+    // the correct composite viscosity and partial strain rates corresponding to
+    // the different creep mechanisms incorporated into the rheology.
+    // It is assumed that each individual creep mechanism has already been tested.
 
-  using namespace aspect::MaterialModel;
+    using namespace aspect::MaterialModel;
 
-  // First, we set up a few objects which are used by the rheology model.
-  aspect::ParameterHandler prm;
-  const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
-  auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
-  const unsigned int composition = 0;
-  const std::vector<double> volume_fractions = {1.};
-  const std::vector<double> phase_function_values = std::vector<double>();
-  const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
+    // First, we set up a few objects which are used by the rheology model.
+    aspect::ParameterHandler prm;
+    const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
+    auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
+    const unsigned int composition = 0;
+    const std::vector<double> volume_fractions = {1.};
+    const std::vector<double> phase_function_values = std::vector<double>();
+    const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
 
-  // Next, we initialise instances of the composite rheology and
-  // individual creep mechanisms.
-  std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
-  composite_creep->initialize_simulator (simulator_access.get_simulator());
-  composite_creep->declare_parameters(prm);
-  prm.set("Viscosity averaging scheme", "isostrain");
-  prm.set("Include diffusion creep in composite rheology", "true");
-  prm.set("Include dislocation creep in composite rheology", "true");
-  prm.set("Include Peierls creep in composite rheology", "true");
-  prm.set("Include Drucker Prager plasticity in composite rheology", "true");
-  prm.set("Peierls creep flow law", "viscosity approximation");
-  prm.set("Maximum yield stress", "5e8");
-  composite_creep->parse_parameters(prm);
+    // Next, we initialise instances of the composite rheology and
+    // individual creep mechanisms.
+    std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
+    composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+    composite_creep->initialize_simulator (simulator_access.get_simulator());
+    composite_creep->declare_parameters(prm);
+    prm.set("Viscosity averaging scheme", "isostrain");
+    prm.set("Include diffusion creep in composite rheology", "true");
+    prm.set("Include dislocation creep in composite rheology", "true");
+    prm.set("Include Peierls creep in composite rheology", "true");
+    prm.set("Include Drucker Prager plasticity in composite rheology", "true");
+    prm.set("Peierls creep flow law", "viscosity approximation");
+    prm.set("Maximum yield stress", "5e8");
+    composite_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
-  diffusion_creep->initialize_simulator (simulator_access.get_simulator());
-  diffusion_creep->declare_parameters(prm);
-  diffusion_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
+    diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
+    diffusion_creep->initialize_simulator (simulator_access.get_simulator());
+    diffusion_creep->declare_parameters(prm);
+    diffusion_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
-  dislocation_creep->initialize_simulator (simulator_access.get_simulator());
-  dislocation_creep->declare_parameters(prm);
-  dislocation_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
+    dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
+    dislocation_creep->initialize_simulator (simulator_access.get_simulator());
+    dislocation_creep->declare_parameters(prm);
+    dislocation_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
-  peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
-  peierls_creep->initialize_simulator (simulator_access.get_simulator());
-  peierls_creep->declare_parameters(prm);
-  peierls_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
+    peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
+    peierls_creep->initialize_simulator (simulator_access.get_simulator());
+    peierls_creep->declare_parameters(prm);
+    peierls_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
-  drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
-  drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
-  drucker_prager_power->declare_parameters(prm);
-  prm.set("Maximum yield stress", "5e8");
-  drucker_prager_power->parse_parameters(prm);
-  Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+    std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
+    drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
+    drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
+    drucker_prager_power->declare_parameters(prm);
+    prm.set("Maximum yield stress", "5e8");
+    drucker_prager_power->parse_parameters(prm);
+    Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
-  // The creep components are arranged in series with each other.
-  // This package of components is then arranged in parallel with
-  // a strain rate limiter with a constant viscosity lim_visc.
-  // The whole system is then arranged in series with a viscosity limiter with
-  // viscosity max_visc.
-  // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
-  double min_visc = prm.get_double("Minimum viscosity");
-  double max_visc = prm.get_double("Maximum viscosity");
-  double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
+    // The creep components are arranged in series with each other.
+    // This package of components is then arranged in parallel with
+    // a strain rate limiter with a constant viscosity lim_visc.
+    // The whole system is then arranged in series with a viscosity limiter with
+    // viscosity max_visc.
+    // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
+    double min_visc = prm.get_double("Minimum viscosity");
+    double max_visc = prm.get_double("Maximum viscosity");
+    double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
 
-  // Assign values to the variables which will be passed to compute_viscosity
-  // The test involves pure shear calculations at 1 GPa and variable temperature
-  double temperature;
-  const double pressure = 1.e9;
-  const double grain_size = 1.e-3;
-  SymmetricTensor<2,dim> strain_rate;
-  strain_rate[0][0] = -1e-11;
-  strain_rate[0][1] = 0.;
-  strain_rate[1][1] = 1e-11;
-  strain_rate[2][0] = 0.;
-  strain_rate[2][1] = 0.;
-  strain_rate[2][2] = 0.;
+    // Assign values to the variables which will be passed to compute_viscosity
+    // The test involves pure shear calculations at 1 GPa and variable temperature
+    double temperature;
+    const double pressure = 1.e9;
+    const double grain_size = 1.e-3;
+    SymmetricTensor<2,dim> strain_rate;
+    strain_rate[0][0] = -1e-11;
+    strain_rate[0][1] = 0.;
+    strain_rate[1][1] = 1e-11;
+    strain_rate[2][0] = 0.;
+    strain_rate[2][1] = 0.;
+    strain_rate[2][2] = 0.;
 
-  std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
+    std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
 
-  // Loop through strain rates, tracking whether there is a discrepancy in
-  // the decomposed strain rates.
-  bool error = false;
-  double viscosity;
-  double total_strain_rate;
-  double creep_strain_rate;
-  double creep_stress;
-  double diff_stress;
-  double disl_stress;
-  double prls_stress;
-  double drpr_stress;
-  std::vector<double> partial_strain_rates(5, 0.);
+    // Loop through strain rates, tracking whether there is a discrepancy in
+    // the decomposed strain rates.
+    bool error = false;
+    double viscosity;
+    double total_strain_rate;
+    double creep_strain_rate;
+    double creep_stress;
+    double diff_stress;
+    double disl_stress;
+    double prls_stress;
+    double drpr_stress;
+    std::vector<double> partial_strain_rates(5, 0.);
 
-  for (unsigned int i=0; i <= 10; i++)
-    {
-      temperature = 1000. + i*100.;
+    for (unsigned int i=0; i <= 10; i++)
+      {
+        temperature = 1000. + i*100.;
 
-      // Compute the viscosity
-      viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
-      total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
+        // Compute the viscosity
+        viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
+        total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
 
-      // The creep strain rate is calculated by subtracting the strain rate
-      // of the max viscosity dashpot from the total strain rate
-      // The creep stress is then calculated by subtracting the stress running
-      // through the strain rate limiter from the total stress
-      creep_strain_rate = total_strain_rate - partial_strain_rates[4];
-      creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
+        // The creep strain rate is calculated by subtracting the strain rate
+        // of the max viscosity dashpot from the total strain rate
+        // The creep stress is then calculated by subtracting the stress running
+        // through the strain rate limiter from the total stress
+        creep_strain_rate = total_strain_rate - partial_strain_rates[4];
+        creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
 
-      // Print the output
-      std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
-      for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
-        {
-          std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
-        }
-      std::cout << std::endl;
+        // Print the output
+        std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
+        for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
+          {
+            std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
+          }
+        std::cout << std::endl;
 
-      // The following lines test that each individual creep mechanism
-      // experiences the same creep stress
+        // The following lines test that each individual creep mechanism
+        // experiences the same creep stress
 
-      // Each creep mechanism should experience the same stress
-      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
-      disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
-      prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
-      if (partial_strain_rates[3] > 0.)
-        {
-          drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
-                        p.angle_internal_friction,
-                        pressure,
-                        partial_strain_rates[3],
-                        p.max_yield_stress);
-        }
-      else
-        {
-          drpr_stress = creep_stress;
-        }
+        // Each creep mechanism should experience the same stress
+        diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
+        disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
+        prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
+        if (partial_strain_rates[3] > 0.)
+          {
+            drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
+                          p.angle_internal_friction,
+                          pressure,
+                          partial_strain_rates[3],
+                          p.max_yield_stress);
+          }
+        else
+          {
+            drpr_stress = creep_stress;
+          }
 
-      if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
-        {
-          error = true;
-          std::cout << "   creep stress: " << creep_stress;
-          std::cout << " diffusion stress: " << diff_stress;
-          std::cout << " dislocation stress: " << disl_stress;
-          std::cout << " peierls stress: " << prls_stress;
-          std::cout << " drucker prager stress: " << drpr_stress << std::endl;
-        }
-    }
+        if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
+          {
+            error = true;
+            std::cout << "   creep stress: " << creep_stress;
+            std::cout << " diffusion stress: " << diff_stress;
+            std::cout << " dislocation stress: " << disl_stress;
+            std::cout << " peierls stress: " << prls_stress;
+            std::cout << " drucker prager stress: " << drpr_stress << std::endl;
+          }
+      }
 
-  if (error)
-    {
-      std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
+    if (error)
+      {
+        std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
+  }
+
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
+
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/composite_viscous_outputs.cc
+++ b/tests/composite_viscous_outputs.cc
@@ -200,7 +200,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composite_viscous_outputs_isostress.cc
+++ b/tests/composite_viscous_outputs_isostress.cc
@@ -23,215 +23,219 @@
 #include <aspect/simulator_signals.h>
 #include <iostream>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-  // This function tests whether the composite creep rheology is producing
-  // the correct composite viscosity and partial strain rates corresponding to
-  // the different creep mechanisms incorporated into the rheology.
-  // It is assumed that each individual creep mechanism has already been tested.
-
-  using namespace aspect::MaterialModel;
-
-  // First, we set up a few objects which are used by the rheology model.
-  aspect::ParameterHandler prm;
-
-  const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
-  auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
-  const unsigned int composition = 0;
-  const std::vector<double> volume_fractions = {0.6, 0.4};
-  const std::vector<double> phase_function_values = std::vector<double>();
-  const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
-
-  // Next, we initialise instances of the composite rheology and
-  // individual creep mechanisms.
-  std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
-  composite_creep->initialize_simulator (simulator_access.get_simulator());
-  composite_creep->declare_parameters(prm);
-  prm.set("Viscosity averaging scheme", "isostress");
-  prm.set("Include diffusion creep in composite rheology", "true");
-  prm.set("Include dislocation creep in composite rheology", "true");
-  prm.set("Include Peierls creep in composite rheology", "true");
-  prm.set("Include Drucker Prager plasticity in composite rheology", "true");
-  prm.set("Peierls creep flow law", "viscosity approximation");
-  prm.set("Maximum yield stress", "5e8");
-  composite_creep->parse_parameters(prm);
-
-  std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
-  diffusion_creep->initialize_simulator (simulator_access.get_simulator());
-  diffusion_creep->declare_parameters(prm);
-  diffusion_creep->parse_parameters(prm);
-
-  std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
-  dislocation_creep->initialize_simulator (simulator_access.get_simulator());
-  dislocation_creep->declare_parameters(prm);
-  dislocation_creep->parse_parameters(prm);
-
-  std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
-  peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
-  peierls_creep->initialize_simulator (simulator_access.get_simulator());
-  peierls_creep->declare_parameters(prm);
-  peierls_creep->parse_parameters(prm);
-
-  std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
-  drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
-  drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
-  drucker_prager_power->declare_parameters(prm);
-  prm.set("Maximum yield stress", "5e8");
-  drucker_prager_power->parse_parameters(prm);
-  Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
-
-  // The creep components are arranged in series with each other.
-  // This package of components is then arranged in parallel with
-  // a strain rate limiter with a constant viscosity lim_visc.
-  // The whole system is then arranged in series with a viscosity limiter with
-  // viscosity max_visc.
-  // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
-  double min_visc = prm.get_double("Minimum viscosity");
-  double max_visc = prm.get_double("Maximum viscosity");
-  double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
-
-  // Assign values to the variables which will be passed to compute_viscosity
-  // The test involves pure shear calculations at 1 GPa and variable temperature
-  double temperature;
-  const double pressure = 1.e9;
-  const double grain_size = 1.e-3;
-  SymmetricTensor<2,dim> strain_rate;
-  strain_rate[0][0] = -1e-11;
-  strain_rate[0][1] = 0.;
-  strain_rate[1][1] = 1e-11;
-  strain_rate[2][0] = 0.;
-  strain_rate[2][1] = 0.;
-  strain_rate[2][2] = 0.;
-
-  std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
-
-  // Loop through strain rates, tracking whether there is a discrepancy in
-  // the decomposed strain rates.
-  bool error = false;
-  double viscosity;
-  double total_strain_rate;
-  double creep_strain_rate;
-  double creep_stress;
-  double diff_stress;
-  double disl_stress;
-  double prls_stress;
-  double drpr_stress;
-  std::vector<double> partial_strain_rates(5, 0.);
-
-  for (unsigned int i=0; i <= 10; i++)
-    {
-      temperature = 1000. + i*100.;
-
-      // Compute the viscosity
-      viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
-      total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
-
-      // The creep strain rate is calculated by subtracting the strain rate
-      // of the max viscosity dashpot from the total strain rate
-      // The creep stress is then calculated by subtracting the stress running
-      // through the strain rate limiter from the total stress
-      creep_strain_rate = total_strain_rate - partial_strain_rates[4];
-      creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
-
-      // Print the output
-      std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
-      for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
-        {
-          std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
-        }
-      std::cout << std::endl;
-
-      // The following lines test that each individual creep mechanism
-      // experiences the same creep stress
-
-      // Each creep mechanism should experience the same stress
-      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
-      disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
-      prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
-      if (partial_strain_rates[3] > 0.)
-        {
-          drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
-                        p.angle_internal_friction,
-                        pressure,
-                        partial_strain_rates[3],
-                        p.max_yield_stress);
-        }
-      else
-        {
-          drpr_stress = creep_stress;
-        }
-
-      if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
-        {
-          error = true;
-          std::cout << "   creep stress: " << creep_stress;
-          std::cout << " diffusion stress: " << diff_stress;
-          std::cout << " dislocation stress: " << disl_stress;
-          std::cout << " peierls stress: " << prls_stress;
-          std::cout << " drucker prager stress: " << drpr_stress << std::endl;
-        }
-    }
-
-  if (error)
-    {
-      std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
-}
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-
-using namespace aspect;
-
-
-void declare_parameters(const unsigned int dim,
-                        ParameterHandler &prm)
-{
-  prm.enter_subsection("Compositional fields");
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
   {
-    prm.declare_entry("Number of fields","1", Patterns::Integer());
+    // This function tests whether the composite creep rheology is producing
+    // the correct composite viscosity and partial strain rates corresponding to
+    // the different creep mechanisms incorporated into the rheology.
+    // It is assumed that each individual creep mechanism has already been tested.
+
+    using namespace aspect::MaterialModel;
+
+    // First, we set up a few objects which are used by the rheology model.
+    aspect::ParameterHandler prm;
+
+    const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
+    auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
+    const unsigned int composition = 0;
+    const std::vector<double> volume_fractions = {0.6, 0.4};
+    const std::vector<double> phase_function_values = std::vector<double>();
+    const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
+
+    // Next, we initialise instances of the composite rheology and
+    // individual creep mechanisms.
+    std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
+    composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+    composite_creep->initialize_simulator (simulator_access.get_simulator());
+    composite_creep->declare_parameters(prm);
+    prm.set("Viscosity averaging scheme", "isostress");
+    prm.set("Include diffusion creep in composite rheology", "true");
+    prm.set("Include dislocation creep in composite rheology", "true");
+    prm.set("Include Peierls creep in composite rheology", "true");
+    prm.set("Include Drucker Prager plasticity in composite rheology", "true");
+    prm.set("Peierls creep flow law", "viscosity approximation");
+    prm.set("Maximum yield stress", "5e8");
+    composite_creep->parse_parameters(prm);
+
+    std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
+    diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
+    diffusion_creep->initialize_simulator (simulator_access.get_simulator());
+    diffusion_creep->declare_parameters(prm);
+    diffusion_creep->parse_parameters(prm);
+
+    std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
+    dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
+    dislocation_creep->initialize_simulator (simulator_access.get_simulator());
+    dislocation_creep->declare_parameters(prm);
+    dislocation_creep->parse_parameters(prm);
+
+    std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
+    peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
+    peierls_creep->initialize_simulator (simulator_access.get_simulator());
+    peierls_creep->declare_parameters(prm);
+    peierls_creep->parse_parameters(prm);
+
+    std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
+    drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
+    drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
+    drucker_prager_power->declare_parameters(prm);
+    prm.set("Maximum yield stress", "5e8");
+    drucker_prager_power->parse_parameters(prm);
+    Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+
+    // The creep components are arranged in series with each other.
+    // This package of components is then arranged in parallel with
+    // a strain rate limiter with a constant viscosity lim_visc.
+    // The whole system is then arranged in series with a viscosity limiter with
+    // viscosity max_visc.
+    // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
+    double min_visc = prm.get_double("Minimum viscosity");
+    double max_visc = prm.get_double("Maximum viscosity");
+    double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
+
+    // Assign values to the variables which will be passed to compute_viscosity
+    // The test involves pure shear calculations at 1 GPa and variable temperature
+    double temperature;
+    const double pressure = 1.e9;
+    const double grain_size = 1.e-3;
+    SymmetricTensor<2,dim> strain_rate;
+    strain_rate[0][0] = -1e-11;
+    strain_rate[0][1] = 0.;
+    strain_rate[1][1] = 1e-11;
+    strain_rate[2][0] = 0.;
+    strain_rate[2][1] = 0.;
+    strain_rate[2][2] = 0.;
+
+    std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
+
+    // Loop through strain rates, tracking whether there is a discrepancy in
+    // the decomposed strain rates.
+    bool error = false;
+    double viscosity;
+    double total_strain_rate;
+    double creep_strain_rate;
+    double creep_stress;
+    double diff_stress;
+    double disl_stress;
+    double prls_stress;
+    double drpr_stress;
+    std::vector<double> partial_strain_rates(5, 0.);
+
+    for (unsigned int i=0; i <= 10; i++)
+      {
+        temperature = 1000. + i*100.;
+
+        // Compute the viscosity
+        viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
+        total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
+
+        // The creep strain rate is calculated by subtracting the strain rate
+        // of the max viscosity dashpot from the total strain rate
+        // The creep stress is then calculated by subtracting the stress running
+        // through the strain rate limiter from the total stress
+        creep_strain_rate = total_strain_rate - partial_strain_rates[4];
+        creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
+
+        // Print the output
+        std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
+        for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
+          {
+            std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
+          }
+        std::cout << std::endl;
+
+        // The following lines test that each individual creep mechanism
+        // experiences the same creep stress
+
+        // Each creep mechanism should experience the same stress
+        diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
+        disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
+        prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
+        if (partial_strain_rates[3] > 0.)
+          {
+            drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
+                          p.angle_internal_friction,
+                          pressure,
+                          partial_strain_rates[3],
+                          p.max_yield_stress);
+          }
+        else
+          {
+            drpr_stress = creep_stress;
+          }
+
+        if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
+          {
+            error = true;
+            std::cout << "   creep stress: " << creep_stress;
+            std::cout << " diffusion stress: " << diff_stress;
+            std::cout << " dislocation stress: " << disl_stress;
+            std::cout << " peierls stress: " << prls_stress;
+            std::cout << " drucker prager stress: " << drpr_stress << std::endl;
+          }
+      }
+
+    if (error)
+      {
+        std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
   }
-  prm.leave_subsection();
+
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
+
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
+
+
+  using namespace aspect;
+
+
+  void declare_parameters(const unsigned int dim,
+                          ParameterHandler &prm)
+  {
+    prm.enter_subsection("Compositional fields");
+    {
+      prm.declare_entry("Number of fields","1", Patterns::Integer());
+    }
+    prm.leave_subsection();
+  }
+
+
+
+  void parameter_connector ()
+  {
+    SimulatorSignals<2>::declare_additional_parameters.connect (&declare_parameters);
+    SimulatorSignals<3>::declare_additional_parameters.connect (&declare_parameters);
+  }
+
+
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
+  ASPECT_REGISTER_SIGNALS_PARAMETER_CONNECTOR(parameter_connector)
+
 }
-
-
-
-void parameter_connector ()
-{
-  SimulatorSignals<2>::declare_additional_parameters.connect (&declare_parameters);
-  SimulatorSignals<3>::declare_additional_parameters.connect (&declare_parameters);
-}
-
-
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)
-ASPECT_REGISTER_SIGNALS_PARAMETER_CONNECTOR(parameter_connector)

--- a/tests/composite_viscous_outputs_isostress.cc
+++ b/tests/composite_viscous_outputs_isostress.cc
@@ -202,7 +202,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composite_viscous_outputs_limited.cc
+++ b/tests/composite_viscous_outputs_limited.cc
@@ -211,7 +211,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composite_viscous_outputs_limited.cc
+++ b/tests/composite_viscous_outputs_limited.cc
@@ -22,200 +22,204 @@
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-  // This function tests whether the composite creep rheology is producing
-  // the correct composite viscosity and partial strain rates corresponding to
-  // the different creep mechanisms incorporated into the rheology.
-  // It is assumed that each individual creep mechanism has already been tested.
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
+  {
+    // This function tests whether the composite creep rheology is producing
+    // the correct composite viscosity and partial strain rates corresponding to
+    // the different creep mechanisms incorporated into the rheology.
+    // It is assumed that each individual creep mechanism has already been tested.
 
-  using namespace aspect::MaterialModel;
+    using namespace aspect::MaterialModel;
 
-  // First, we set up a few objects which are used by the rheology model.
-  aspect::ParameterHandler prm;
-  const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
-  auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
-  const unsigned int composition = 0;
-  const std::vector<double> volume_fractions = {1.};
-  const std::vector<double> phase_function_values = std::vector<double>();
-  const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
+    // First, we set up a few objects which are used by the rheology model.
+    aspect::ParameterHandler prm;
+    const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
+    auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
+    const unsigned int composition = 0;
+    const std::vector<double> volume_fractions = {1.};
+    const std::vector<double> phase_function_values = std::vector<double>();
+    const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
 
-  // Next, we initialise instances of the composite rheology and
-  // individual creep mechanisms.
-  std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
-  composite_creep->initialize_simulator (simulator_access.get_simulator());
-  composite_creep->declare_parameters(prm);
-  prm.set("Viscosity averaging scheme", "isostrain");
-  prm.set("Include diffusion creep in composite rheology", "true");
-  prm.set("Include dislocation creep in composite rheology", "true");
-  prm.set("Include Peierls creep in composite rheology", "true");
-  prm.set("Include Drucker Prager plasticity in composite rheology", "true");
-  prm.set("Peierls creep flow law", "viscosity approximation");
-  prm.set("Maximum yield stress", "5e8");
-  prm.set("Minimum viscosity", "1e18");
-  prm.set("Maximum viscosity", "4e18");
-  composite_creep->parse_parameters(prm);
+    // Next, we initialise instances of the composite rheology and
+    // individual creep mechanisms.
+    std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
+    composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+    composite_creep->initialize_simulator (simulator_access.get_simulator());
+    composite_creep->declare_parameters(prm);
+    prm.set("Viscosity averaging scheme", "isostrain");
+    prm.set("Include diffusion creep in composite rheology", "true");
+    prm.set("Include dislocation creep in composite rheology", "true");
+    prm.set("Include Peierls creep in composite rheology", "true");
+    prm.set("Include Drucker Prager plasticity in composite rheology", "true");
+    prm.set("Peierls creep flow law", "viscosity approximation");
+    prm.set("Maximum yield stress", "5e8");
+    prm.set("Minimum viscosity", "1e18");
+    prm.set("Maximum viscosity", "4e18");
+    composite_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
-  diffusion_creep->initialize_simulator (simulator_access.get_simulator());
-  diffusion_creep->declare_parameters(prm);
-  diffusion_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
+    diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
+    diffusion_creep->initialize_simulator (simulator_access.get_simulator());
+    diffusion_creep->declare_parameters(prm);
+    diffusion_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
-  dislocation_creep->initialize_simulator (simulator_access.get_simulator());
-  dislocation_creep->declare_parameters(prm);
-  dislocation_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
+    dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
+    dislocation_creep->initialize_simulator (simulator_access.get_simulator());
+    dislocation_creep->declare_parameters(prm);
+    dislocation_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
-  peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
-  peierls_creep->initialize_simulator (simulator_access.get_simulator());
-  peierls_creep->declare_parameters(prm);
-  peierls_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
+    peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
+    peierls_creep->initialize_simulator (simulator_access.get_simulator());
+    peierls_creep->declare_parameters(prm);
+    peierls_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
-  drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
-  drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
-  drucker_prager_power->declare_parameters(prm);
-  prm.set("Maximum yield stress", "5e8");
-  drucker_prager_power->parse_parameters(prm);
-  Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+    std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
+    drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
+    drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
+    drucker_prager_power->declare_parameters(prm);
+    prm.set("Maximum yield stress", "5e8");
+    drucker_prager_power->parse_parameters(prm);
+    Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
-  // The creep components are arranged in series with each other.
-  // This package of components is then arranged in parallel with
-  // a strain rate limiter with a constant viscosity lim_visc.
-  // The whole system is then arranged in series with a viscosity limiter with
-  // viscosity maximum_viscosity.
-  // lim_visc is equal to (minimum_viscosity*maximum_viscosity)/(maximum_viscosity - minimum_viscosity)
-  double minimum_viscosity = prm.get_double("Minimum viscosity");
-  double maximum_viscosity = prm.get_double("Maximum viscosity");
+    // The creep components are arranged in series with each other.
+    // This package of components is then arranged in parallel with
+    // a strain rate limiter with a constant viscosity lim_visc.
+    // The whole system is then arranged in series with a viscosity limiter with
+    // viscosity maximum_viscosity.
+    // lim_visc is equal to (minimum_viscosity*maximum_viscosity)/(maximum_viscosity - minimum_viscosity)
+    double minimum_viscosity = prm.get_double("Minimum viscosity");
+    double maximum_viscosity = prm.get_double("Maximum viscosity");
 
-  AssertThrow(minimum_viscosity > 0,
-              ExcMessage("Minimum viscosity needs to be larger than zero."));
+    AssertThrow(minimum_viscosity > 0,
+                ExcMessage("Minimum viscosity needs to be larger than zero."));
 
-  AssertThrow(maximum_viscosity > 1.1 * minimum_viscosity,
-              ExcMessage("The maximum viscosity needs to be at least ten percent larger than the minimum viscosity. "
-                         "If you require an isoviscous model consider a different rheology, or set the "
-                         "parameters of the active flow laws to be independent of temperature, pressure, grain size, and stress."));
+    AssertThrow(maximum_viscosity > 1.1 * minimum_viscosity,
+                ExcMessage("The maximum viscosity needs to be at least ten percent larger than the minimum viscosity. "
+                           "If you require an isoviscous model consider a different rheology, or set the "
+                           "parameters of the active flow laws to be independent of temperature, pressure, grain size, and stress."));
 
-  double lim_visc = (minimum_viscosity*maximum_viscosity)/(maximum_viscosity - minimum_viscosity);
+    double lim_visc = (minimum_viscosity*maximum_viscosity)/(maximum_viscosity - minimum_viscosity);
 
-  // Assign values to the variables which will be passed to compute_viscosity
-  // The test involves pure shear calculations at 1 GPa and variable temperature
-  double temperature;
-  const double pressure = 1.e9;
-  const double grain_size = 1.e-3;
-  SymmetricTensor<2,dim> strain_rate;
-  strain_rate[0][0] = -1e-11;
-  strain_rate[0][1] = 0.;
-  strain_rate[1][1] = 1e-11;
-  strain_rate[2][0] = 0.;
-  strain_rate[2][1] = 0.;
-  strain_rate[2][2] = 0.;
+    // Assign values to the variables which will be passed to compute_viscosity
+    // The test involves pure shear calculations at 1 GPa and variable temperature
+    double temperature;
+    const double pressure = 1.e9;
+    const double grain_size = 1.e-3;
+    SymmetricTensor<2,dim> strain_rate;
+    strain_rate[0][0] = -1e-11;
+    strain_rate[0][1] = 0.;
+    strain_rate[1][1] = 1e-11;
+    strain_rate[2][0] = 0.;
+    strain_rate[2][1] = 0.;
+    strain_rate[2][2] = 0.;
 
-  std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
+    std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
 
-  // Loop through strain rates, tracking whether there is a discrepancy in
-  // the decomposed strain rates.
-  bool error = false;
-  double viscosity;
-  double total_strain_rate;
-  double creep_strain_rate;
-  double creep_stress;
-  double diff_stress;
-  double disl_stress;
-  double prls_stress;
-  double drpr_stress;
-  std::vector<double> partial_strain_rates(5, 0.);
+    // Loop through strain rates, tracking whether there is a discrepancy in
+    // the decomposed strain rates.
+    bool error = false;
+    double viscosity;
+    double total_strain_rate;
+    double creep_strain_rate;
+    double creep_stress;
+    double diff_stress;
+    double disl_stress;
+    double prls_stress;
+    double drpr_stress;
+    std::vector<double> partial_strain_rates(5, 0.);
 
-  for (unsigned int i=0; i <= 10; i++)
-    {
-      temperature = 1000. + i*100.;
+    for (unsigned int i=0; i <= 10; i++)
+      {
+        temperature = 1000. + i*100.;
 
-      // Compute the viscosity
-      viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
-      total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
+        // Compute the viscosity
+        viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
+        total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
 
-      // The creep strain rate is calculated by subtracting the strain rate
-      // of the max viscosity dashpot from the total strain rate
-      // The creep stress is then calculated by subtracting the stress running
-      // through the strain rate limiter from the total stress
-      creep_strain_rate = total_strain_rate - partial_strain_rates[4];
-      creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
+        // The creep strain rate is calculated by subtracting the strain rate
+        // of the max viscosity dashpot from the total strain rate
+        // The creep stress is then calculated by subtracting the stress running
+        // through the strain rate limiter from the total stress
+        creep_strain_rate = total_strain_rate - partial_strain_rates[4];
+        creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
 
-      // Print the output
-      std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
-      for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
-        {
-          std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
-        }
-      std::cout << std::endl;
+        // Print the output
+        std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
+        for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
+          {
+            std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
+          }
+        std::cout << std::endl;
 
-      // The following lines test that each individual creep mechanism
-      // experiences the same creep stress
+        // The following lines test that each individual creep mechanism
+        // experiences the same creep stress
 
-      // Each creep mechanism should experience the same stress
-      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
-      disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
-      prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
-      if (partial_strain_rates[3] > 0.)
-        {
-          drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
-                        p.angle_internal_friction,
-                        pressure,
-                        partial_strain_rates[3],
-                        p.max_yield_stress);
-        }
-      else
-        {
-          drpr_stress = creep_stress;
-        }
+        // Each creep mechanism should experience the same stress
+        diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
+        disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
+        prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
+        if (partial_strain_rates[3] > 0.)
+          {
+            drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
+                          p.angle_internal_friction,
+                          pressure,
+                          partial_strain_rates[3],
+                          p.max_yield_stress);
+          }
+        else
+          {
+            drpr_stress = creep_stress;
+          }
 
-      if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
-        {
-          error = true;
-          std::cout << "   creep stress: " << creep_stress;
-          std::cout << " diffusion stress: " << diff_stress;
-          std::cout << " dislocation stress: " << disl_stress;
-          std::cout << " peierls stress: " << prls_stress;
-          std::cout << " drucker prager stress: " << drpr_stress << std::endl;
-        }
-    }
+        if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
+          {
+            error = true;
+            std::cout << "   creep stress: " << creep_stress;
+            std::cout << " diffusion stress: " << diff_stress;
+            std::cout << " dislocation stress: " << disl_stress;
+            std::cout << " peierls stress: " << prls_stress;
+            std::cout << " drucker prager stress: " << drpr_stress << std::endl;
+          }
+      }
 
-  if (error)
-    {
-      std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
+    if (error)
+      {
+        std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
+  }
+
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
+
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/composite_viscous_outputs_no_peierls.cc
+++ b/tests/composite_viscous_outputs_no_peierls.cc
@@ -21,180 +21,183 @@
 #include <aspect/simulator.h>
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-  // This function tests whether the composite creep rheology is producing
-  // the correct composite viscosity and partial strain rates corresponding to
-  // the different creep mechanisms incorporated into the rheology.
-  // It is assumed that each individual creep mechanism has already been tested.
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
+  {
+    // This function tests whether the composite creep rheology is producing
+    // the correct composite viscosity and partial strain rates corresponding to
+    // the different creep mechanisms incorporated into the rheology.
+    // It is assumed that each individual creep mechanism has already been tested.
 
-  using namespace aspect::MaterialModel;
+    using namespace aspect::MaterialModel;
 
-  // First, we set up a few objects which are used by the rheology model.
-  aspect::ParameterHandler prm;
+    // First, we set up a few objects which are used by the rheology model.
+    aspect::ParameterHandler prm;
 
-  const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
-  auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
-  const unsigned int composition = 0;
-  const std::vector<double> volume_fractions = {1.};
-  const std::vector<double> phase_function_values = std::vector<double>();
-  const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
+    const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
+    auto n_phases = std::make_unique<std::vector<unsigned int>>(1); // 1 phase per composition
+    const unsigned int composition = 0;
+    const std::vector<double> volume_fractions = {1.};
+    const std::vector<double> phase_function_values = std::vector<double>();
+    const std::vector<unsigned int> n_phase_transitions_per_composition = std::vector<unsigned int>(1);
 
-  // Next, we initialise instances of the composite rheology and
-  // individual creep mechanisms.
-  std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
-  composite_creep->initialize_simulator (simulator_access.get_simulator());
-  composite_creep->declare_parameters(prm);
-  prm.set("Viscosity averaging scheme", "isostrain");
-  prm.set("Include diffusion creep in composite rheology", "true");
-  prm.set("Include dislocation creep in composite rheology", "true");
-  prm.set("Include Peierls creep in composite rheology", "false");
-  prm.set("Include Drucker Prager plasticity in composite rheology", "true");
-  prm.set("Peierls creep flow law", "viscosity approximation");
-  prm.set("Maximum yield stress", "5e8");
-  composite_creep->parse_parameters(prm);
+    // Next, we initialise instances of the composite rheology and
+    // individual creep mechanisms.
+    std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
+    composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+    composite_creep->initialize_simulator (simulator_access.get_simulator());
+    composite_creep->declare_parameters(prm);
+    prm.set("Viscosity averaging scheme", "isostrain");
+    prm.set("Include diffusion creep in composite rheology", "true");
+    prm.set("Include dislocation creep in composite rheology", "true");
+    prm.set("Include Peierls creep in composite rheology", "false");
+    prm.set("Include Drucker Prager plasticity in composite rheology", "true");
+    prm.set("Peierls creep flow law", "viscosity approximation");
+    prm.set("Maximum yield stress", "5e8");
+    composite_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
-  diffusion_creep->initialize_simulator (simulator_access.get_simulator());
-  diffusion_creep->declare_parameters(prm);
-  diffusion_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
+    diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
+    diffusion_creep->initialize_simulator (simulator_access.get_simulator());
+    diffusion_creep->declare_parameters(prm);
+    diffusion_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
-  dislocation_creep->initialize_simulator (simulator_access.get_simulator());
-  dislocation_creep->declare_parameters(prm);
-  dislocation_creep->parse_parameters(prm);
+    std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
+    dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
+    dislocation_creep->initialize_simulator (simulator_access.get_simulator());
+    dislocation_creep->declare_parameters(prm);
+    dislocation_creep->parse_parameters(prm);
 
-  std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
-  drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
-  drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
-  drucker_prager_power->declare_parameters(prm);
-  prm.set("Maximum yield stress", "5e8");
-  drucker_prager_power->parse_parameters(prm);
-  Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+    std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
+    drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
+    drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
+    drucker_prager_power->declare_parameters(prm);
+    prm.set("Maximum yield stress", "5e8");
+    drucker_prager_power->parse_parameters(prm);
+    Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
-  // The creep components are arranged in series with each other.
-  // This package of components is then arranged in parallel with
-  // a strain rate limiter with a constant viscosity lim_visc.
-  // The whole system is then arranged in series with a viscosity limiter with
-  // viscosity max_visc.
-  // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
-  double min_visc = prm.get_double("Minimum viscosity");
-  double max_visc = prm.get_double("Maximum viscosity");
-  double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
+    // The creep components are arranged in series with each other.
+    // This package of components is then arranged in parallel with
+    // a strain rate limiter with a constant viscosity lim_visc.
+    // The whole system is then arranged in series with a viscosity limiter with
+    // viscosity max_visc.
+    // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
+    double min_visc = prm.get_double("Minimum viscosity");
+    double max_visc = prm.get_double("Maximum viscosity");
+    double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
 
-  // Assign values to the variables which will be passed to compute_viscosity
-  // The test involves pure shear calculations at 1 GPa and variable temperature
-  double temperature;
-  const double pressure = 1.e9;
-  const double grain_size = 1.e-3;
-  SymmetricTensor<2,dim> strain_rate;
-  strain_rate[0][0] = -1e-11;
-  strain_rate[0][1] = 0.;
-  strain_rate[1][1] = 1e-11;
-  strain_rate[2][0] = 0.;
-  strain_rate[2][1] = 0.;
-  strain_rate[2][2] = 0.;
+    // Assign values to the variables which will be passed to compute_viscosity
+    // The test involves pure shear calculations at 1 GPa and variable temperature
+    double temperature;
+    const double pressure = 1.e9;
+    const double grain_size = 1.e-3;
+    SymmetricTensor<2,dim> strain_rate;
+    strain_rate[0][0] = -1e-11;
+    strain_rate[0][1] = 0.;
+    strain_rate[1][1] = 1e-11;
+    strain_rate[2][0] = 0.;
+    strain_rate[2][1] = 0.;
+    strain_rate[2][2] = 0.;
 
-  std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
+    std::cout << "temperature (K)   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
 
-  // Loop through strain rates, tracking whether there is a discrepancy in
-  // the decomposed strain rates.
-  bool error = false;
-  double viscosity;
-  double total_strain_rate;
-  double creep_strain_rate;
-  double creep_stress;
-  double diff_stress;
-  double disl_stress;
-  double drpr_stress;
-  std::vector<double> partial_strain_rates(5, 0.);
+    // Loop through strain rates, tracking whether there is a discrepancy in
+    // the decomposed strain rates.
+    bool error = false;
+    double viscosity;
+    double total_strain_rate;
+    double creep_strain_rate;
+    double creep_stress;
+    double diff_stress;
+    double disl_stress;
+    double drpr_stress;
+    std::vector<double> partial_strain_rates(5, 0.);
 
-  for (unsigned int i=0; i <= 10; i++)
-    {
-      temperature = 1000. + i*100.;
+    for (unsigned int i=0; i <= 10; i++)
+      {
+        temperature = 1000. + i*100.;
 
-      // Compute the viscosity
-      viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
-      total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
+        // Compute the viscosity
+        viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates);
+        total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
 
-      // The creep strain rate is calculated by subtracting the strain rate
-      // of the max viscosity dashpot from the total strain rate
-      // The creep stress is then calculated by subtracting the stress running
-      // through the strain rate limiter from the total stress
-      creep_strain_rate = total_strain_rate - partial_strain_rates[4];
-      creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
+        // The creep strain rate is calculated by subtracting the strain rate
+        // of the max viscosity dashpot from the total strain rate
+        // The creep stress is then calculated by subtracting the stress running
+        // through the strain rate limiter from the total stress
+        creep_strain_rate = total_strain_rate - partial_strain_rates[4];
+        creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
 
-      // Print the output
-      std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
-      for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
-        {
-          std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
-        }
-      std::cout << std::endl;
+        // Print the output
+        std::cout << temperature << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
+        for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
+          {
+            std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
+          }
+        std::cout << std::endl;
 
-      // The following lines test that each individual creep mechanism
-      // experiences the same creep stress
+        // The following lines test that each individual creep mechanism
+        // experiences the same creep stress
 
-      // Each creep mechanism should experience the same stress
-      diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
-      disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
-      if (partial_strain_rates[3] > 0.)
-        {
-          drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
-                        p.angle_internal_friction,
-                        pressure,
-                        partial_strain_rates[3],
-                        p.max_yield_stress);
-        }
-      else
-        {
-          drpr_stress = creep_stress;
-        }
+        // Each creep mechanism should experience the same stress
+        diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
+        disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
+        if (partial_strain_rates[3] > 0.)
+          {
+            drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
+                          p.angle_internal_friction,
+                          pressure,
+                          partial_strain_rates[3],
+                          p.max_yield_stress);
+          }
+        else
+          {
+            drpr_stress = creep_stress;
+          }
 
-      if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
-          || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
-        {
-          error = true;
-          std::cout << "   creep stress: " << creep_stress;
-          std::cout << " diffusion stress: " << diff_stress;
-          std::cout << " dislocation stress: " << disl_stress;
-          std::cout << " drucker prager stress: " << drpr_stress << std::endl;
-        }
-    }
+        if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
+            || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
+          {
+            error = true;
+            std::cout << "   creep stress: " << creep_stress;
+            std::cout << " diffusion stress: " << diff_stress;
+            std::cout << " dislocation stress: " << disl_stress;
+            std::cout << " drucker prager stress: " << drpr_stress << std::endl;
+          }
+      }
 
-  if (error)
-    {
-      std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
+    if (error)
+      {
+        std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
 
+  }
+
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
+
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/composite_viscous_outputs_no_peierls.cc
+++ b/tests/composite_viscous_outputs_no_peierls.cc
@@ -190,7 +190,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composite_viscous_outputs_phases.cc
+++ b/tests/composite_viscous_outputs_phases.cc
@@ -23,238 +23,241 @@
 #include <aspect/material_model/rheology/composite_visco_plastic.h>
 #include <aspect/simulator_signals.h>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-  // This function tests whether the composite creep rheology is producing
-  // the correct composite viscosity and partial strain rates corresponding to
-  // the different creep mechanisms incorporated into the rheology.
-  // It is assumed that each individual creep mechanism has already been tested.
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
+  {
+    // This function tests whether the composite creep rheology is producing
+    // the correct composite viscosity and partial strain rates corresponding to
+    // the different creep mechanisms incorporated into the rheology.
+    // It is assumed that each individual creep mechanism has already been tested.
 
-  using namespace aspect::MaterialModel;
+    using namespace aspect::MaterialModel;
 
-  // First, we set up a few objects which are used by the rheology model.
-  aspect::ParameterHandler prm;
-  const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
-  MaterialUtilities::PhaseFunction<dim> phase_function;
-  phase_function.initialize_simulator (simulator_access.get_simulator());
-  phase_function.declare_parameters (prm);
-  prm.set("Define transition by depth instead of pressure", "false");
-  prm.set("Phase transition pressures", "3e9");
-  prm.set("Phase transition pressure widths", "1e9");
-  prm.set("Phase transition temperatures", "273");
-  prm.set("Phase transition Clapeyron slopes", "0");
-  phase_function.parse_parameters (prm);
+    // First, we set up a few objects which are used by the rheology model.
+    aspect::ParameterHandler prm;
+    const std::vector<std::string> list_of_composition_names = simulator_access.introspection().get_composition_names();
+    MaterialUtilities::PhaseFunction<dim> phase_function;
+    phase_function.initialize_simulator (simulator_access.get_simulator());
+    phase_function.declare_parameters (prm);
+    prm.set("Define transition by depth instead of pressure", "false");
+    prm.set("Phase transition pressures", "3e9");
+    prm.set("Phase transition pressure widths", "1e9");
+    prm.set("Phase transition temperatures", "273");
+    prm.set("Phase transition Clapeyron slopes", "0");
+    phase_function.parse_parameters (prm);
 
-  std::vector<unsigned int> n_phases_for_each_composition = phase_function.n_phases_for_each_composition();
-  // Currently, phase_function.n_phases_for_each_composition() returns a list of length
-  // equal to the total number of compositions, whether or not they are chemical compositions.
-  // The equation_of_state (multicomponent incompressible) requires a list only for
-  // chemical compositions.
-  std::vector<unsigned int> n_phases_for_each_chemical_composition = {n_phases_for_each_composition[0]};
-  std::vector<unsigned int> n_phase_transitions_for_each_chemical_composition = {n_phases_for_each_composition[0] - 1};
-  unsigned int n_phases = n_phases_for_each_composition[0];
-  for (auto i : simulator_access.introspection().chemical_composition_field_indices())
-    {
-      n_phases_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1]);
-      n_phase_transitions_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1] - 1);
-      n_phases += n_phases_for_each_composition[i+1];
-    }
+    std::vector<unsigned int> n_phases_for_each_composition = phase_function.n_phases_for_each_composition();
+    // Currently, phase_function.n_phases_for_each_composition() returns a list of length
+    // equal to the total number of compositions, whether or not they are chemical compositions.
+    // The equation_of_state (multicomponent incompressible) requires a list only for
+    // chemical compositions.
+    std::vector<unsigned int> n_phases_for_each_chemical_composition = {n_phases_for_each_composition[0]};
+    std::vector<unsigned int> n_phase_transitions_for_each_chemical_composition = {n_phases_for_each_composition[0] - 1};
+    unsigned int n_phases = n_phases_for_each_composition[0];
+    for (auto i : simulator_access.introspection().chemical_composition_field_indices())
+      {
+        n_phases_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1]);
+        n_phase_transitions_for_each_chemical_composition.push_back(n_phases_for_each_composition[i+1] - 1);
+        n_phases += n_phases_for_each_composition[i+1];
+      }
 
-  const unsigned int composition = 0;
-  const std::vector<double> volume_fractions = {1.};
-  std::vector<double> phase_function_values = {0.};
-  const std::vector<unsigned int> n_phase_transitions_per_composition = n_phase_transitions_for_each_chemical_composition;
+    const unsigned int composition = 0;
+    const std::vector<double> volume_fractions = {1.};
+    std::vector<double> phase_function_values = {0.};
+    const std::vector<unsigned int> n_phase_transitions_per_composition = n_phase_transitions_for_each_chemical_composition;
 
-  // Next, we initialise instances of the composite rheology and
-  // individual creep mechanisms.
-  std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
-  composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
-  composite_creep->initialize_simulator (simulator_access.get_simulator());
-  composite_creep->declare_parameters(prm);
-  MaterialUtilities::PhaseFunction<dim>::declare_parameters(prm);
-  prm.set("Viscosity averaging scheme", "isostrain");
-  prm.set("Include diffusion creep in composite rheology", "true");
-  prm.set("Include dislocation creep in composite rheology", "true");
-  prm.set("Include Peierls creep in composite rheology", "true");
-  prm.set("Include Drucker Prager plasticity in composite rheology", "true");
-  prm.set("Peierls creep flow law", "viscosity approximation");
-  prm.set("Cohesions", "background:1e9|5e8");
-  prm.set("Maximum yield stress", "5e10");
-  composite_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
+    // Next, we initialise instances of the composite rheology and
+    // individual creep mechanisms.
+    std::unique_ptr<Rheology::CompositeViscoPlastic<dim>> composite_creep;
+    composite_creep = std::make_unique<Rheology::CompositeViscoPlastic<dim>>();
+    composite_creep->initialize_simulator (simulator_access.get_simulator());
+    composite_creep->declare_parameters(prm);
+    MaterialUtilities::PhaseFunction<dim>::declare_parameters(prm);
+    prm.set("Viscosity averaging scheme", "isostrain");
+    prm.set("Include diffusion creep in composite rheology", "true");
+    prm.set("Include dislocation creep in composite rheology", "true");
+    prm.set("Include Peierls creep in composite rheology", "true");
+    prm.set("Include Drucker Prager plasticity in composite rheology", "true");
+    prm.set("Peierls creep flow law", "viscosity approximation");
+    prm.set("Cohesions", "background:1e9|5e8");
+    prm.set("Maximum yield stress", "5e10");
+    composite_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
 
-  std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
-  diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
-  diffusion_creep->initialize_simulator (simulator_access.get_simulator());
-  diffusion_creep->declare_parameters(prm);
-  diffusion_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
+    std::unique_ptr<Rheology::DiffusionCreep<dim>> diffusion_creep;
+    diffusion_creep = std::make_unique<Rheology::DiffusionCreep<dim>>();
+    diffusion_creep->initialize_simulator (simulator_access.get_simulator());
+    diffusion_creep->declare_parameters(prm);
+    diffusion_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
 
-  std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
-  dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
-  dislocation_creep->initialize_simulator (simulator_access.get_simulator());
-  dislocation_creep->declare_parameters(prm);
-  dislocation_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
+    std::unique_ptr<Rheology::DislocationCreep<dim>> dislocation_creep;
+    dislocation_creep = std::make_unique<Rheology::DislocationCreep<dim>>();
+    dislocation_creep->initialize_simulator (simulator_access.get_simulator());
+    dislocation_creep->declare_parameters(prm);
+    dislocation_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
 
-  std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
-  peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
-  peierls_creep->initialize_simulator (simulator_access.get_simulator());
-  peierls_creep->declare_parameters(prm);
-  peierls_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
+    std::unique_ptr<Rheology::PeierlsCreep<dim>> peierls_creep;
+    peierls_creep = std::make_unique<Rheology::PeierlsCreep<dim>>();
+    peierls_creep->initialize_simulator (simulator_access.get_simulator());
+    peierls_creep->declare_parameters(prm);
+    peierls_creep->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
 
-  std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
-  drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
-  drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
-  drucker_prager_power->declare_parameters(prm);
-  prm.set("Cohesions", "background:1e9|5e8");
-  prm.set("Maximum yield stress", "5e10");
-  drucker_prager_power->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
+    std::unique_ptr<Rheology::DruckerPragerPower<dim>> drucker_prager_power;
+    drucker_prager_power = std::make_unique<Rheology::DruckerPragerPower<dim>>();
+    drucker_prager_power->initialize_simulator (simulator_access.get_simulator());
+    drucker_prager_power->declare_parameters(prm);
+    prm.set("Cohesions", "background:1e9|5e8");
+    prm.set("Maximum yield stress", "5e10");
+    drucker_prager_power->parse_parameters(prm, std::make_unique<std::vector<unsigned int>>(n_phases_for_each_chemical_composition));
 
-  // The creep components are arranged in series with each other.
-  // This package of components is then arranged in parallel with
-  // a strain rate limiter with a constant viscosity lim_visc.
-  // The whole system is then arranged in series with a viscosity limiter with
-  // viscosity max_visc.
-  // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
-  double min_visc = prm.get_double("Minimum viscosity");
-  double max_visc = prm.get_double("Maximum viscosity");
-  double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
+    // The creep components are arranged in series with each other.
+    // This package of components is then arranged in parallel with
+    // a strain rate limiter with a constant viscosity lim_visc.
+    // The whole system is then arranged in series with a viscosity limiter with
+    // viscosity max_visc.
+    // lim_visc is equal to (min_visc*max_visc)/(max_visc - min_visc)
+    double min_visc = prm.get_double("Minimum viscosity");
+    double max_visc = prm.get_double("Maximum viscosity");
+    double lim_visc = (min_visc*max_visc)/(max_visc - min_visc);
 
-  // Assign values to the variables which will be passed to compute_viscosity
-  // The test involves pure shear calculations at variable pressure and temperature
-  double temperature;
-  double pressure;
-  const double grain_size = 1.e-3;
-  SymmetricTensor<2,dim> strain_rate;
-  strain_rate[0][0] = -1e-11;
-  strain_rate[0][1] = 0.;
-  strain_rate[1][1] = 1e-11;
-  strain_rate[2][0] = 0.;
-  strain_rate[2][1] = 0.;
-  strain_rate[2][2] = 0.;
+    // Assign values to the variables which will be passed to compute_viscosity
+    // The test involves pure shear calculations at variable pressure and temperature
+    double temperature;
+    double pressure;
+    const double grain_size = 1.e-3;
+    SymmetricTensor<2,dim> strain_rate;
+    strain_rate[0][0] = -1e-11;
+    strain_rate[0][1] = 0.;
+    strain_rate[1][1] = 1e-11;
+    strain_rate[2][0] = 0.;
+    strain_rate[2][1] = 0.;
+    strain_rate[2][2] = 0.;
 
-  std::cout << "temperature (K)   phase transition progress   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
+    std::cout << "temperature (K)   phase transition progress   eta (Pas)   creep stress (Pa)   edot_ii (/s)   edot_ii fractions (diff, disl, prls, drpr, max)" << std::endl;
 
-  // Loop through strain rates, tracking whether there is a discrepancy in
-  // the decomposed strain rates.
-  bool error = false;
-  double viscosity;
-  double total_strain_rate;
-  double creep_strain_rate;
-  double creep_stress;
-  double diff_stress;
-  double disl_stress;
-  double prls_stress;
-  double drpr_stress;
-  std::vector<double> partial_strain_rates(5, 0.);
+    // Loop through strain rates, tracking whether there is a discrepancy in
+    // the decomposed strain rates.
+    bool error = false;
+    double viscosity;
+    double total_strain_rate;
+    double creep_strain_rate;
+    double creep_stress;
+    double diff_stress;
+    double disl_stress;
+    double prls_stress;
+    double drpr_stress;
+    std::vector<double> partial_strain_rates(5, 0.);
 
-  for (unsigned int i=0; i <= 2; i++)
-    {
-      pressure = 1.e9 + i*2.e9;
-      std::cout << "pressure: " << pressure / 1.e9 << " GPa" << std::endl;
-      for (unsigned int j = 0; j <= 10; j++)
-        {
-          temperature = 1000. + j*100.;
+    for (unsigned int i=0; i <= 2; i++)
+      {
+        pressure = 1.e9 + i*2.e9;
+        std::cout << "pressure: " << pressure / 1.e9 << " GPa" << std::endl;
+        for (unsigned int j = 0; j <= 10; j++)
+          {
+            temperature = 1000. + j*100.;
 
-          // Compute the phase function values
-          // The depth and gravity are set to zero because they are unused
-          // when phase functions are calculated by pressure.
-          // The phase index is set to invalid_unsigned_int, because it is only used internally
-          // in phase_average_equation_of_state_outputs to loop over all existing phases
-          MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(temperature,
-                                                                   pressure,
-                                                                   0., 0.,
-                                                                   numbers::invalid_unsigned_int);
+            // Compute the phase function values
+            // The depth and gravity are set to zero because they are unused
+            // when phase functions are calculated by pressure.
+            // The phase index is set to invalid_unsigned_int, because it is only used internally
+            // in phase_average_equation_of_state_outputs to loop over all existing phases
+            MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(temperature,
+                                                                     pressure,
+                                                                     0., 0.,
+                                                                     numbers::invalid_unsigned_int);
 
-          // Compute value of phase functions
-          for (unsigned int j=0; j < phase_function.n_phase_transitions(); ++j)
-            {
-              phase_inputs.phase_transition_index = j;
-              phase_function_values[j] = phase_function.compute_value(phase_inputs);
-            }
+            // Compute value of phase functions
+            for (unsigned int j=0; j < phase_function.n_phase_transitions(); ++j)
+              {
+                phase_inputs.phase_transition_index = j;
+                phase_function_values[j] = phase_function.compute_value(phase_inputs);
+              }
 
-          Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
+            Rheology::DruckerPragerParameters p = drucker_prager_power->compute_drucker_prager_parameters(composition, phase_function_values, n_phase_transitions_per_composition);
 
-          // Compute the viscosity
-          viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates, phase_function_values, n_phase_transitions_per_composition);
-          total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
+            // Compute the viscosity
+            viscosity = composite_creep->compute_viscosity(pressure, temperature, grain_size, volume_fractions, strain_rate, partial_strain_rates, phase_function_values, n_phase_transitions_per_composition);
+            total_strain_rate = std::accumulate(partial_strain_rates.begin(), partial_strain_rates.end(), 0.);
 
-          // The creep strain rate is calculated by subtracting the strain rate
-          // of the max viscosity dashpot from the total strain rate
-          // The creep stress is then calculated by subtracting the stress running
-          // through the strain rate limiter from the total stress
-          creep_strain_rate = total_strain_rate - partial_strain_rates[4];
-          creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
+            // The creep strain rate is calculated by subtracting the strain rate
+            // of the max viscosity dashpot from the total strain rate
+            // The creep stress is then calculated by subtracting the stress running
+            // through the strain rate limiter from the total stress
+            creep_strain_rate = total_strain_rate - partial_strain_rates[4];
+            creep_stress = 2.*(viscosity*total_strain_rate - lim_visc*creep_strain_rate);
 
-          // Print the output
-          std::cout << temperature << ' ' << phase_function_values[0] << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
-          for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
-            {
-              std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
-            }
-          std::cout << std::endl;
+            // Print the output
+            std::cout << temperature << ' ' << phase_function_values[0] << ' ' << viscosity << ' ' << creep_stress << ' ' << total_strain_rate;
+            for (unsigned int i=0; i < partial_strain_rates.size(); ++i)
+              {
+                std::cout << ' ' << partial_strain_rates[i]/total_strain_rate;
+              }
+            std::cout << std::endl;
 
-          // The following lines test that each individual creep mechanism
-          // experiences the same creep stress
+            // The following lines test that each individual creep mechanism
+            // experiences the same creep stress
 
-          // Each creep mechanism should experience the same stress
-          diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
-          disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
-          prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
-          if (partial_strain_rates[3] > 0.)
-            {
-              drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
-                            p.angle_internal_friction,
-                            pressure,
-                            partial_strain_rates[3],
-                            p.max_yield_stress);
-            }
-          else
-            {
-              drpr_stress = creep_stress;
-            }
+            // Each creep mechanism should experience the same stress
+            diff_stress = 2.*partial_strain_rates[0]*diffusion_creep->compute_viscosity(pressure, temperature, grain_size, composition);
+            disl_stress = 2.*partial_strain_rates[1]*dislocation_creep->compute_viscosity(partial_strain_rates[1], pressure, temperature, composition);
+            prls_stress = 2.*partial_strain_rates[2]*peierls_creep->compute_viscosity(partial_strain_rates[2], pressure, temperature, composition);
+            if (partial_strain_rates[3] > 0.)
+              {
+                drpr_stress = 2.*partial_strain_rates[3]*drucker_prager_power->compute_viscosity(p.cohesion,
+                              p.angle_internal_friction,
+                              pressure,
+                              partial_strain_rates[3],
+                              p.max_yield_stress);
+              }
+            else
+              {
+                drpr_stress = creep_stress;
+              }
 
-          if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
-              || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
-              || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
-              || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
-            {
-              error = true;
-              std::cout << "   creep stress: " << creep_stress;
-              std::cout << " diffusion stress: " << diff_stress;
-              std::cout << " dislocation stress: " << disl_stress;
-              std::cout << " peierls stress: " << prls_stress;
-              std::cout << " drucker prager stress: " << drpr_stress << std::endl;
-            }
-        }
-    }
+            if ((std::fabs((diff_stress - creep_stress)/creep_stress) > 1e-6)
+                || (std::fabs((disl_stress - creep_stress)/creep_stress) > 1e-6)
+                || (std::fabs((prls_stress - creep_stress)/creep_stress) > 1e-6)
+                || (std::fabs((drpr_stress - creep_stress)/creep_stress) > 1e-6))
+              {
+                error = true;
+                std::cout << "   creep stress: " << creep_stress;
+                std::cout << " diffusion stress: " << diff_stress;
+                std::cout << " dislocation stress: " << disl_stress;
+                std::cout << " peierls stress: " << prls_stress;
+                std::cout << " drucker prager stress: " << drpr_stress << std::endl;
+              }
+          }
+      }
 
-  if (error)
-    {
-      std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
+    if (error)
+      {
+        std::cout << "   Error: The individual creep stresses differ by more than the required tolerance." << std::endl;
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+  }
+
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
+
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
+
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/composite_viscous_outputs_phases.cc
+++ b/tests/composite_viscous_outputs_phases.cc
@@ -250,7 +250,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/composition_active_with_melt.cc
+++ b/tests/composition_active_with_melt.cc
@@ -29,8 +29,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   class SimpleWithMelt:
     public MaterialModel::MeltInterface<dim>

--- a/tests/composition_reaction_iterated_IMPES.cc
+++ b/tests/composition_reaction_iterated_IMPES.cc
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class IteratedReaction : public MaterialModel::CompositionReaction<dim>
     {

--- a/tests/compressibility.cc
+++ b/tests/compressibility.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class Compressibility : public MaterialModel::Simple<dim>
     {

--- a/tests/compressibility_iterated_stokes.cc
+++ b/tests/compressibility_iterated_stokes.cc
@@ -26,8 +26,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class CompressibilityIteratedStokes : public MaterialModel::Simple<dim>
     {

--- a/tests/compression_heating.cc
+++ b/tests/compression_heating.cc
@@ -27,8 +27,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class Compression : public MaterialModel::MeltGlobal<dim>
     {

--- a/tests/cookbook_simpler_with_crust.cc
+++ b/tests/cookbook_simpler_with_crust.cc
@@ -31,8 +31,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model similar to the "simpler" material model, but where the
      * viscosity has two different values dependent on whether we are above or

--- a/tests/coordinate_transformation.cc
+++ b/tests/coordinate_transformation.cc
@@ -23,71 +23,74 @@
 
 #include <iostream>
 
-using namespace aspect::Utilities;
+namespace aspect
+{
+  using namespace aspect::Utilities;
 // Check various conversions between cartesian and spherical coordinates
 
-template <typename T, unsigned int dim>
-void check_point(T point1, T point2)
-{
-  std::cout << std::endl << "Point 1: ";
-  for (unsigned int i = 0; i < dim; ++i)
-    std::cout << point1[i] << ' ';
+  template <typename T, unsigned int dim>
+  void check_point(T point1, T point2)
+  {
+    std::cout << std::endl << "Point 1: ";
+    for (unsigned int i = 0; i < dim; ++i)
+      std::cout << point1[i] << ' ';
 
-  std::cout << std::endl << "Point 2: ";
-  for (unsigned int i = 0; i < dim; ++i)
-    std::cout << point2[i] << ' ';
+    std::cout << std::endl << "Point 2: ";
+    for (unsigned int i = 0; i < dim; ++i)
+      std::cout << point2[i] << ' ';
 
-  std::cout << std::endl;
+    std::cout << std::endl;
+  }
+
+  int f()
+  {
+    const dealii::Point<2> origin2(0,0);
+    const dealii::Point<3> origin3(0,0,0);
+
+    const std::array<double,2> sorigin2 = {{0,0}};
+    const std::array<double,3> sorigin3 = {{0,0,0}};
+
+    const dealii::Point<2> one2(1,1);
+    const dealii::Point<3> one3(1,1,1);
+
+    const std::array<double,2> sone2 = {{std::sqrt(2),numbers::PI/4}};
+    const std::array<double,3> sone3 = {{std::sqrt(3),numbers::PI/4,std::acos(1/std::sqrt(3))}};
+
+    const dealii::Point<3> x(1,0,0);
+    const dealii::Point<3> y(0,1,0);
+    const dealii::Point<3> z(0,0,1);
+
+    const std::array<double,3> sx = {{1,0,numbers::PI/2}};
+    const std::array<double,3> sy = {{1,numbers::PI/2,numbers::PI/2}};
+    const std::array<double,3> sz = {{1,0,0}};
+
+    check_point<const std::array<double,2>,2>(Coordinates::cartesian_to_spherical_coordinates(origin2),sorigin2);
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(origin3),sorigin3);
+    check_point<const Point<2>,2>(origin2, Coordinates::spherical_to_cartesian_coordinates<2>(sorigin2));
+    check_point<const Point<3>,3>(origin3, Coordinates::spherical_to_cartesian_coordinates<3>(sorigin3));
+
+    check_point<const std::array<double,2>,2>(Coordinates::cartesian_to_spherical_coordinates(one2),sone2);
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(one3),sone3);
+    check_point<const Point<2>,2>(one2, Coordinates::spherical_to_cartesian_coordinates<2>(sone2));
+    check_point<const Point<3>,3>(one3, Coordinates::spherical_to_cartesian_coordinates<3>(sone3));
+
+    check_point<const Point<3>,3>(x, Coordinates::spherical_to_cartesian_coordinates<3>(sx));
+    check_point<const Point<3>,3>(y, Coordinates::spherical_to_cartesian_coordinates<3>(sy));
+    check_point<const Point<3>,3>(z, Coordinates::spherical_to_cartesian_coordinates<3>(sz));
+
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(x),sx);
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(y),sy);
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(z),sz);
+
+    const dealii::Point<3> dateline(0,-1,0);
+    const std::array<double,3> sdateline = {{1,3*numbers::PI/2,numbers::PI/2}};
+
+    check_point<const Point<3>,3>(dateline, Coordinates::spherical_to_cartesian_coordinates<3>(sdateline));
+    check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(dateline),sdateline);
+
+
+    return 42;
+  }
+
+  int i = f();
 }
-
-int f()
-{
-  const dealii::Point<2> origin2(0,0);
-  const dealii::Point<3> origin3(0,0,0);
-
-  const std::array<double,2> sorigin2 = {{0,0}};
-  const std::array<double,3> sorigin3 = {{0,0,0}};
-
-  const dealii::Point<2> one2(1,1);
-  const dealii::Point<3> one3(1,1,1);
-
-  const std::array<double,2> sone2 = {{std::sqrt(2),numbers::PI/4}};
-  const std::array<double,3> sone3 = {{std::sqrt(3),numbers::PI/4,std::acos(1/std::sqrt(3))}};
-
-  const dealii::Point<3> x(1,0,0);
-  const dealii::Point<3> y(0,1,0);
-  const dealii::Point<3> z(0,0,1);
-
-  const std::array<double,3> sx = {{1,0,numbers::PI/2}};
-  const std::array<double,3> sy = {{1,numbers::PI/2,numbers::PI/2}};
-  const std::array<double,3> sz = {{1,0,0}};
-
-  check_point<const std::array<double,2>,2>(Coordinates::cartesian_to_spherical_coordinates(origin2),sorigin2);
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(origin3),sorigin3);
-  check_point<const Point<2>,2>(origin2, Coordinates::spherical_to_cartesian_coordinates<2>(sorigin2));
-  check_point<const Point<3>,3>(origin3, Coordinates::spherical_to_cartesian_coordinates<3>(sorigin3));
-
-  check_point<const std::array<double,2>,2>(Coordinates::cartesian_to_spherical_coordinates(one2),sone2);
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(one3),sone3);
-  check_point<const Point<2>,2>(one2, Coordinates::spherical_to_cartesian_coordinates<2>(sone2));
-  check_point<const Point<3>,3>(one3, Coordinates::spherical_to_cartesian_coordinates<3>(sone3));
-
-  check_point<const Point<3>,3>(x, Coordinates::spherical_to_cartesian_coordinates<3>(sx));
-  check_point<const Point<3>,3>(y, Coordinates::spherical_to_cartesian_coordinates<3>(sy));
-  check_point<const Point<3>,3>(z, Coordinates::spherical_to_cartesian_coordinates<3>(sz));
-
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(x),sx);
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(y),sy);
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(z),sz);
-
-  const dealii::Point<3> dateline(0,-1,0);
-  const std::array<double,3> sdateline = {{1,3*numbers::PI/2,numbers::PI/2}};
-
-  check_point<const Point<3>,3>(dateline, Coordinates::spherical_to_cartesian_coordinates<3>(sdateline));
-  check_point<const std::array<double,3>,3>(Coordinates::cartesian_to_spherical_coordinates(dateline),sdateline);
-
-
-  return 42;
-}
-
-int i = f();

--- a/tests/coordinate_transformation.cc
+++ b/tests/coordinate_transformation.cc
@@ -23,7 +23,6 @@
 
 #include <iostream>
 
-using namespace dealii;
 using namespace aspect::Utilities;
 // Check various conversions between cartesian and spherical coordinates
 

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -33,214 +33,217 @@
 
 #include <iostream>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-
-  std::cout << std::endl << "Testing DruckerPrager derivatives against finite difference derivatives " << std::endl;
-
-  using namespace aspect::MaterialModel;
-
-  // first set all material model values
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 2e12;
-
-  /**
-   * We can't take to small strain-rates, because then the difference in the
-   * visocisty will be too small for the double accuracy which stores
-   * the visocity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 4.9e-21;
-  in_base.strain_rate[3][0][1] = 4.9e-21;
-  in_base.strain_rate[3][0][0] = 4.9e-21;
-
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = 1e-11;
-
-  // initialize some variables we will need later.
-  const double finite_difference_accuracy = 1e-7;
-  const double finite_difference_factor = 1+finite_difference_accuracy;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
-
-  MaterialModelOutputs<dim> out_base(5,3);
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
-
-  // initialize the material we want to test.
-  aspect::ParameterHandler prm;
-
-  const aspect::MaterialModel::DruckerPrager<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::DruckerPrager<dim> &>(simulator_access.get_material_model());
-  aspect::MaterialModel::DruckerPrager<dim> material_model = const_cast<aspect::MaterialModel::DruckerPrager<dim> &>(const_material_model);
-
-  material_model.declare_parameters(prm);
-
-  prm.enter_subsection("Material model");
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
   {
-    prm.enter_subsection ("Drucker Prager");
+
+    std::cout << std::endl << "Testing DruckerPrager derivatives against finite difference derivatives " << std::endl;
+
+    using namespace aspect::MaterialModel;
+
+    // first set all material model values
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 2200;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 2e12;
+
+    /**
+     * We can't take to small strain-rates, because then the difference in the
+     * visocisty will be too small for the double accuracy which stores
+     * the visocity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 4.9e-21;
+    in_base.strain_rate[3][0][1] = 4.9e-21;
+    in_base.strain_rate[3][0][0] = 4.9e-21;
+
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = 1e-11;
+
+    // initialize some variables we will need later.
+    const double finite_difference_accuracy = 1e-7;
+    const double finite_difference_factor = 1+finite_difference_accuracy;
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
+
+    MaterialModelOutputs<dim> out_base(5,3);
+    MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
+
+    // initialize the material we want to test.
+    aspect::ParameterHandler prm;
+
+    const aspect::MaterialModel::DruckerPrager<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::DruckerPrager<dim> &>(simulator_access.get_material_model());
+    aspect::MaterialModel::DruckerPrager<dim> material_model = const_cast<aspect::MaterialModel::DruckerPrager<dim> &>(const_material_model);
+
+    material_model.declare_parameters(prm);
+
+    prm.enter_subsection("Material model");
     {
-      prm.enter_subsection ("Viscosity");
+      prm.enter_subsection ("Drucker Prager");
       {
-        prm.set ("Reference strain rate", "1e-20");
-        prm.set ("Angle of internal friction", "30");
+        prm.enter_subsection ("Viscosity");
+        {
+          prm.set ("Reference strain rate", "1e-20");
+          prm.set ("Angle of internal friction", "30");
+        }
+        prm.leave_subsection();
       }
       prm.leave_subsection();
     }
     prm.leave_subsection();
+
+    const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    simulator_access.get_material_model().evaluate(in_base, out_base);
+
+    // set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    double temp;
+
+    // have a bool so we know whether the test has succeed or not.
+    bool Error = false;
+
+    // test the pressure derivative.
+    MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+    in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+    simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+        if (in_base.pressure[i] != 0)
+          {
+            temp /= (in_base.pressure[i] * finite_difference_accuracy);
+          }
+        std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+          {
+            std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    // test the strain-rate derivative.
+    for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
+      {
+        const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                      + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                      * finite_difference_accuracy
+                                                      * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
+          }
+
+
+        simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // prevent division by zero. If it is zero, the test has passed, because or
+            // the finite difference and the analytical result match perfectly, or (more
+            // likely) the material model in independent of this variable.
+            temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+            if (temp != 0)
+              {
+                temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+              }
+            std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+            if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+              {
+                std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+                Error = true;
+              }
+
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
   }
-  prm.leave_subsection();
 
-  const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+  template <>
+  void f(const aspect::SimulatorAccess<3> &,
+         aspect::Assemblers::Manager<3> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
 
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
 
-  simulator_access.get_material_model().evaluate(in_base, out_base);
-
-  // set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
-  double temp;
-
-  // have a bool so we know whether the test has succeed or not.
-  bool Error = false;
-
-  // test the pressure derivative.
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
-      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  // test the strain-rate derivative.
-  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
-    {
-      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
-                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
-                                                    * finite_difference_accuracy
-                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
-        }
-
-
-      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // prevent division by zero. If it is zero, the test has passed, because or
-          // the finite difference and the analytical result match perfectly, or (more
-          // likely) the material model in independent of this variable.
-          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
-          if (temp != 0)
-            {
-              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
-            }
-          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
-          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
-            {
-              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-              Error = true;
-            }
-
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<3> &,
-       aspect::Assemblers::Manager<3> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -236,7 +236,6 @@ void f(const aspect::SimulatorAccess<3> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -251,7 +251,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -33,229 +33,232 @@
 
 #include <iostream>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &)
+namespace aspect
 {
-
-  std::cout << std::endl << "Testing DruckerPrager derivatives against finite difference derivatives " << std::endl;
-
-  using namespace aspect::MaterialModel;
-
-  // first set all material model values
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 2e12;
-
-  /**
-   * We can't take to small strain-rates, because then the difference in the
-   * visocisty will be too small for the double accuracy which stores
-   * the visocity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-  in_base.strain_rate[0][2][0] = 1e-12;
-  in_base.strain_rate[0][2][1] = 1e-12;
-  in_base.strain_rate[0][2][2] = 1e-11;
-
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-  in_base.strain_rate[1][2][0] = -5.42647e-12;
-  in_base.strain_rate[1][2][1] = -5.22647e-12;
-  in_base.strain_rate[1][2][2] = 4.21668e-14;
-
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-  in_base.strain_rate[2][2][0] = 1e-11;
-  in_base.strain_rate[2][2][1] = 1e-11;
-  in_base.strain_rate[2][2][2] = -1e-12;
-
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 4.9e-21;
-  in_base.strain_rate[3][0][1] = 4.9e-21;
-  in_base.strain_rate[3][0][0] = 4.9e-21;
-  in_base.strain_rate[3][2][0] = 4.9e-21;
-  in_base.strain_rate[3][2][1] = 4.9e-21;
-  in_base.strain_rate[3][2][2] = 4.9e-21;
-
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = 1e-11;
-  in_base.strain_rate[4][2][0] = 1e-11;
-  in_base.strain_rate[4][2][1] = 1e-11;
-  in_base.strain_rate[4][2][2] = 1e-11;
-
-  // initialize some variables we will need later.
-  const double finite_difference_accuracy = 1e-7;
-  const double finite_difference_factor = 1+finite_difference_accuracy;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
-
-  MaterialModelOutputs<dim> out_base(5,3);
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
-
-  // initialize the material we want to test.
-  aspect::ParameterHandler prm;
-
-  const aspect::MaterialModel::DruckerPrager<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::DruckerPrager<dim> &>(simulator_access.get_material_model());
-  aspect::MaterialModel::DruckerPrager<dim> material_model = const_cast<aspect::MaterialModel::DruckerPrager<dim> &>(const_material_model);
-
-  material_model.declare_parameters(prm);
-
-  prm.enter_subsection("Material model");
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &)
   {
-    prm.enter_subsection ("Drucker Prager");
+
+    std::cout << std::endl << "Testing DruckerPrager derivatives against finite difference derivatives " << std::endl;
+
+    using namespace aspect::MaterialModel;
+
+    // first set all material model values
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 2200;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 2e12;
+
+    /**
+     * We can't take to small strain-rates, because then the difference in the
+     * visocisty will be too small for the double accuracy which stores
+     * the visocity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+    in_base.strain_rate[0][2][0] = 1e-12;
+    in_base.strain_rate[0][2][1] = 1e-12;
+    in_base.strain_rate[0][2][2] = 1e-11;
+
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+    in_base.strain_rate[1][2][0] = -5.42647e-12;
+    in_base.strain_rate[1][2][1] = -5.22647e-12;
+    in_base.strain_rate[1][2][2] = 4.21668e-14;
+
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+    in_base.strain_rate[2][2][0] = 1e-11;
+    in_base.strain_rate[2][2][1] = 1e-11;
+    in_base.strain_rate[2][2][2] = -1e-12;
+
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 4.9e-21;
+    in_base.strain_rate[3][0][1] = 4.9e-21;
+    in_base.strain_rate[3][0][0] = 4.9e-21;
+    in_base.strain_rate[3][2][0] = 4.9e-21;
+    in_base.strain_rate[3][2][1] = 4.9e-21;
+    in_base.strain_rate[3][2][2] = 4.9e-21;
+
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = 1e-11;
+    in_base.strain_rate[4][2][0] = 1e-11;
+    in_base.strain_rate[4][2][1] = 1e-11;
+    in_base.strain_rate[4][2][2] = 1e-11;
+
+    // initialize some variables we will need later.
+    const double finite_difference_accuracy = 1e-7;
+    const double finite_difference_factor = 1+finite_difference_accuracy;
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
+
+    MaterialModelOutputs<dim> out_base(5,3);
+    MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
+
+    // initialize the material we want to test.
+    aspect::ParameterHandler prm;
+
+    const aspect::MaterialModel::DruckerPrager<dim> const_material_model = dynamic_cast<const aspect::MaterialModel::DruckerPrager<dim> &>(simulator_access.get_material_model());
+    aspect::MaterialModel::DruckerPrager<dim> material_model = const_cast<aspect::MaterialModel::DruckerPrager<dim> &>(const_material_model);
+
+    material_model.declare_parameters(prm);
+
+    prm.enter_subsection("Material model");
     {
-      prm.enter_subsection ("Viscosity");
+      prm.enter_subsection ("Drucker Prager");
       {
-        prm.set ("Reference strain rate", "1e-20");
-        prm.set ("Angle of internal friction", "30");
+        prm.enter_subsection ("Viscosity");
+        {
+          prm.set ("Reference strain rate", "1e-20");
+          prm.set ("Angle of internal friction", "30");
+        }
+        prm.leave_subsection();
       }
       prm.leave_subsection();
     }
     prm.leave_subsection();
+
+    const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    simulator_access.get_material_model().evaluate(in_base, out_base);
+
+    // set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    double temp;
+
+    // have a bool so we know whether the test has succeed or not.
+    bool Error = false;
+
+    // test the pressure derivative.
+    MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+    in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+    simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+        if (in_base.pressure[i] != 0)
+          {
+            temp /= (in_base.pressure[i] * finite_difference_accuracy);
+          }
+        std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+          {
+            std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    // test the strain-rate derivative.
+    for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
+      {
+        const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                      + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                      * finite_difference_accuracy
+                                                      * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
+          }
+
+
+        simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // prevent division by zero. If it is zero, the test has passed, because or
+            // the finite difference and the analytical result match perfectly, or (more
+            // likely) the material model in independent of this variable.
+            temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+            if (temp != 0)
+              {
+                temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+              }
+            std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+            if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+              {
+                std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+                Error = true;
+              }
+
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
   }
-  prm.leave_subsection();
 
-  const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &)
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
 
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+  }
 
-  simulator_access.get_material_model().evaluate(in_base, out_base);
-
-  // set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
-  double temp;
-
-  // have a bool so we know whether the test has succeed or not.
-  bool Error = false;
-
-  // test the pressure derivative.
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
-      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  // test the strain-rate derivative.
-  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
-    {
-      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
-                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
-                                                    * finite_difference_accuracy
-                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
-        }
-
-
-      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // prevent division by zero. If it is zero, the test has passed, because or
-          // the finite difference and the analytical result match perfectly, or (more
-          // likely) the material model in independent of this variable.
-          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
-          if (temp != 0)
-            {
-              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
-            }
-          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
-          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
-            {
-              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-              Error = true;
-            }
-
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &)
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/edit_parameters.cc
+++ b/tests/edit_parameters.cc
@@ -25,8 +25,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   // Global variables (to be set by parameters)
   unsigned int switch_step;
   bool switched;

--- a/tests/ellipsoidal_chunk_geometry.cc
+++ b/tests/ellipsoidal_chunk_geometry.cc
@@ -26,8 +26,6 @@
 #include <iostream>
 
 using namespace aspect;
-using namespace dealii;
-
 bool test_point(const GeometryModel::internal::EllipsoidalChunkGeometry<3> ellipsoidal_manifold,
                 const Point<3> &test_point)
 {

--- a/tests/free_surface_blob_melt.cc
+++ b/tests/free_surface_blob_melt.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class MeltFreeSurface : public MaterialModel::MeltFractionModel<dim>, public MaterialModel::MeltInterface<dim>, public ::aspect::SimulatorAccess<dim>
     {

--- a/tests/global_refine_amr.cc
+++ b/tests/global_refine_amr.cc
@@ -25,9 +25,6 @@
 #include <math.h>
 
 
-using namespace dealii;
-
-
 namespace aspect
 {
   template <int dim>

--- a/tests/grain_size_latent_heat.cc
+++ b/tests/grain_size_latent_heat.cc
@@ -32,8 +32,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * A material model that behaves in the same way as the grain size model, but is modified to
      * resemble the latent heat benchmark. Due to the nature of the benchmark the model needs to be

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -60,8 +60,6 @@ namespace aspect
 
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class Advection : public MaterialModel::MeltGlobal<dim>
     {

--- a/tests/latent_heat_enthalpy.cc
+++ b/tests/latent_heat_enthalpy.cc
@@ -33,8 +33,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class LatentHeatEnthalpy : public MaterialModel::Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -28,8 +28,6 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <iostream>
 
-using namespace dealii;
-
 namespace aspect
 {
 

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -33,9 +33,6 @@
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
 
-using namespace dealii;
-
-
 namespace aspect
 {
   template <int dim>

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -37,8 +37,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * Additional output fields for the plastic parameters weakened (or hardened)
      * by strain to be added to the MaterialModel::MaterialModelOutputs structure
@@ -252,8 +250,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-
-    using namespace dealii;
 
     namespace
     {

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -32,9 +32,6 @@
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
 
-using namespace dealii;
-
-
 namespace aspect
 {
   template <int dim>

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/no_adiabatic_heating.cc
+++ b/tests/no_adiabatic_heating.cc
@@ -26,8 +26,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class NoAdiabaticHeating : public CompressibilityIteratedStokes<dim>
     {

--- a/tests/no_adiabatic_heating_02.cc
+++ b/tests/no_adiabatic_heating_02.cc
@@ -26,8 +26,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class NoAdiabaticHeating : public CompressibilityIteratedStokes<dim>
     {

--- a/tests/no_adiabatic_heating_03.cc
+++ b/tests/no_adiabatic_heating_03.cc
@@ -26,8 +26,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class NoAdiabaticHeating : public CompressibilityIteratedStokes<dim>
     {

--- a/tests/own_gravity.cc
+++ b/tests/own_gravity.cc
@@ -22,9 +22,6 @@
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
 
-using namespace dealii;
-
-
 template <int dim>
 class MyGravity :
   public aspect::GravityModel::Interface<dim>

--- a/tests/own_gravity.cc
+++ b/tests/own_gravity.cc
@@ -22,20 +22,23 @@
 #include <aspect/global.h>
 #include <aspect/gravity_model/interface.h>
 
-template <int dim>
-class MyGravity :
-  public aspect::GravityModel::Interface<dim>
+namespace aspect
 {
-  public:
-    virtual Tensor<1,dim> gravity_vector (const Point<dim> &position) const
-    {
-      Tensor<1,dim> ret;
-      ret[0] = position[1];
-      ret[1] = 42.0;
-      return ret;
-    }
-};
+  template <int dim>
+  class MyGravity :
+    public aspect::GravityModel::Interface<dim>
+  {
+    public:
+      virtual Tensor<1,dim> gravity_vector (const Point<dim> &position) const
+      {
+        Tensor<1,dim> ret;
+        ret[0] = position[1];
+        ret[1] = 42.0;
+        return ret;
+      }
+  };
 
 
 // explicit instantiation
-ASPECT_REGISTER_GRAVITY_MODEL(MyGravity, "my gravity", "no description")
+  ASPECT_REGISTER_GRAVITY_MODEL(MyGravity, "my gravity", "no description")
+}

--- a/tests/prescribed_dilation.cc
+++ b/tests/prescribed_dilation.cc
@@ -34,8 +34,6 @@ namespace aspect
 {
   namespace Benchmark
   {
-    using namespace dealii;
-
     /**
      * u = cos(y), sin(x)+xy
      * p = 2/3 eta x

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/prescribed_field_temperature.cc
+++ b/tests/prescribed_field_temperature.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedFieldMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/prescribed_temperature.cc
+++ b/tests/prescribed_temperature.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedTemperatureMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/prescribed_temperature_in_field.cc
+++ b/tests/prescribed_temperature_in_field.cc
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   // Declare and parse additional parameters
   bool prescribe_internal_temperature;
   std::vector <std::string> fixed_compositional_fields;

--- a/tests/prescribed_temperature_with_diffusion.cc
+++ b/tests/prescribed_temperature_with_diffusion.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class PrescribedTemperatureMaterial : public MaterialModel::Simple<dim>
     {

--- a/tests/prescribed_velocity_boundary.cc
+++ b/tests/prescribed_velocity_boundary.cc
@@ -36,8 +36,6 @@ namespace aspect
 {
   namespace InclusionBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
       // based on http://geodynamics.org/hg/cs/AMR/Discontinuous_Stokes with permission

--- a/tests/prescribed_velocity_dgp.cc
+++ b/tests/prescribed_velocity_dgp.cc
@@ -27,8 +27,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   // Global variables (to be set by parameters)
   bool prescribe_internal_velocities;
 

--- a/tests/pressure_constraint.cc
+++ b/tests/pressure_constraint.cc
@@ -26,8 +26,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   template <int dim>
   void modify_constraints (const SimulatorAccess<dim> &simulator_access,
                            AffineConstraints<double> &current_constraints)

--- a/tests/prm_distance_polygon.cc
+++ b/tests/prm_distance_polygon.cc
@@ -24,54 +24,57 @@
 
 #include <iostream>
 
-int f()
+namespace aspect
 {
-  using namespace aspect::Utilities;
+  int f()
+  {
+    using namespace aspect::Utilities;
 
-  const int dim=3;
+    const int dim=3;
 
-  // A square polygon
-  std::vector<Point<2>> polygon(4);
-  polygon[0] = Point<2>(0.0,0.0);
-  polygon[1] = Point<2>(1.0,0.0);
-  polygon[2] = Point<2>(1.0,1.0);
-  polygon[3] = Point<2>(0.0,1.0);
+    // A square polygon
+    std::vector<Point<2>> polygon(4);
+    polygon[0] = Point<2>(0.0,0.0);
+    polygon[1] = Point<2>(1.0,0.0);
+    polygon[2] = Point<2>(1.0,1.0);
+    polygon[3] = Point<2>(0.0,1.0);
 
-  // A concave polygon
-  std::vector<Point<2>> concave_polygon(5);
-  concave_polygon[0] = Point<2>(0.0,0.0);
-  concave_polygon[1] = Point<2>(1.0,0.0);
-  concave_polygon[2] = Point<2>(1.0,1.0);
-  concave_polygon[3] = Point<2>(0.5,0.5);
-  concave_polygon[4] = Point<2>(0.0,1.0);
+    // A concave polygon
+    std::vector<Point<2>> concave_polygon(5);
+    concave_polygon[0] = Point<2>(0.0,0.0);
+    concave_polygon[1] = Point<2>(1.0,0.0);
+    concave_polygon[2] = Point<2>(1.0,1.0);
+    concave_polygon[3] = Point<2>(0.5,0.5);
+    concave_polygon[4] = Point<2>(0.0,1.0);
 
-  // A selfcrossing polygon
-  std::vector<Point<2>> crossing_polygon(4);
-  crossing_polygon[0] = Point<2>(0.0,0.0);
-  crossing_polygon[1] = Point<2>(1.0,0.0);
-  crossing_polygon[2] = Point<2>(1.0,-1.0);
-  crossing_polygon[3] = Point<2>(0.0,1.0);
+    // A selfcrossing polygon
+    std::vector<Point<2>> crossing_polygon(4);
+    crossing_polygon[0] = Point<2>(0.0,0.0);
+    crossing_polygon[1] = Point<2>(1.0,0.0);
+    crossing_polygon[2] = Point<2>(1.0,-1.0);
+    crossing_polygon[3] = Point<2>(0.0,1.0);
 
 
-  // Some points inside and outside the polygon
-  Point<2> points[] = {Point<2>(0.5,-1), Point<2>(0.5,0.5), Point<2>(0.001,0.2), Point<2>(2.0,2.0), Point<2>(0.25,0.70)};
+    // Some points inside and outside the polygon
+    Point<2> points[] = {Point<2>(0.5,-1), Point<2>(0.5,0.5), Point<2>(0.001,0.2), Point<2>(2.0,2.0), Point<2>(0.25,0.70)};
 
-  std::cout << "Testing distance to polygon function with the following parameters: (polygon 1) "
-            << polygon[0] << ", " << polygon[1] << ", " << polygon[2] << ", " << polygon[3] << ", "
-            << "(polygon 2) " << concave_polygon[0] << ", " << concave_polygon[1] << ", " << concave_polygon[2] << ", " << concave_polygon[3] << ", " << concave_polygon[4] << ", "
-            << "(polygon 3) " << crossing_polygon[0] << ", " << crossing_polygon[1] << ", " << crossing_polygon[2] << ", " << crossing_polygon[3]
-            << ", (points) "
-            << points[0] << ", " << points[1] << ", " << points[2] << ", " << points[3] << ", " << points[4] << std::endl;
+    std::cout << "Testing distance to polygon function with the following parameters: (polygon 1) "
+              << polygon[0] << ", " << polygon[1] << ", " << polygon[2] << ", " << polygon[3] << ", "
+              << "(polygon 2) " << concave_polygon[0] << ", " << concave_polygon[1] << ", " << concave_polygon[2] << ", " << concave_polygon[3] << ", " << concave_polygon[4] << ", "
+              << "(polygon 3) " << crossing_polygon[0] << ", " << crossing_polygon[1] << ", " << crossing_polygon[2] << ", " << crossing_polygon[3]
+              << ", (points) "
+              << points[0] << ", " << points[1] << ", " << points[2] << ", " << points[3] << ", " << points[4] << std::endl;
 
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      std::cout << "Minimal distance of point " << points[i] << " to polygon 1 = " << signed_distance_to_polygon<dim>(polygon,points[i]) << std::endl;
-      std::cout << "Minimal distance of point " << points[i] << " to polygon 2 = " << signed_distance_to_polygon<dim>(concave_polygon,points[i]) << std::endl;
-      std::cout << "Minimal distance of point " << points[i] << " to polygon 3 = " << signed_distance_to_polygon<dim>(crossing_polygon,points[i]) << std::endl;
-    }
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        std::cout << "Minimal distance of point " << points[i] << " to polygon 1 = " << signed_distance_to_polygon<dim>(polygon,points[i]) << std::endl;
+        std::cout << "Minimal distance of point " << points[i] << " to polygon 2 = " << signed_distance_to_polygon<dim>(concave_polygon,points[i]) << std::endl;
+        std::cout << "Minimal distance of point " << points[i] << " to polygon 3 = " << signed_distance_to_polygon<dim>(crossing_polygon,points[i]) << std::endl;
+      }
 
-  exit(0);
-  return 42;
-}
+    exit(0);
+    return 42;
+  }
 // run this function by initializing a global variable by it
-int i = f();
+  int i = f();
+}

--- a/tests/q1_q1.cc
+++ b/tests/q1_q1.cc
@@ -39,8 +39,6 @@ namespace aspect
 {
   namespace DoneaHuertaBenchmark
   {
-    using namespace dealii;
-
     namespace AnalyticSolutions
     {
 

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -28,8 +28,6 @@
 
 namespace aspect
 {
-  using namespace dealii;
-
   namespace MaterialModel
   {
     /**

--- a/tests/rising_melt_blob.cc
+++ b/tests/rising_melt_blob.cc
@@ -32,9 +32,6 @@
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
 
-using namespace dealii;
-
-
 namespace aspect
 {
   template <int dim>

--- a/tests/shear_thinning.cc
+++ b/tests/shear_thinning.cc
@@ -25,8 +25,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class ShearThinning : public MaterialModel::Simple<dim>
     {

--- a/tests/signal_fem.cc
+++ b/tests/signal_fem.cc
@@ -27,8 +27,6 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <iostream>
 
-using namespace dealii;
-
 namespace aspect
 {
 

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -30,224 +30,228 @@
 
 #include "../benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc"
 
-template <int dim>
-int f(double parameter)
+namespace aspect
 {
-
-  std::cout << std::endl << "Test for p = " << parameter << " with dimension " << dim << std::endl;
-
-  using namespace aspect::MaterialModel;
-
-  // first set all material model values
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 2e12;
-
-  /**
-   * We can't take to small strain-rates, because then the difference in the
-   * viscosity will be too small for the double accuracy which stores
-   * the viscosity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-  if (dim == 3)
-    {
-      in_base.strain_rate[0][2][0] = 1e-12;
-      in_base.strain_rate[0][2][1] = 1e-12;
-      in_base.strain_rate[0][2][2] = 1e-11;
-    }
-
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-  if (dim == 3)
-    {
-      in_base.strain_rate[1][2][0] = -5.42647e-12;
-      in_base.strain_rate[1][2][1] = -5.22647e-12;
-      in_base.strain_rate[1][2][2] = 4.21668e-14;
-    }
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-  if (dim == 3)
-    {
-      in_base.strain_rate[2][2][0] = 1e-11;
-      in_base.strain_rate[2][2][1] = 1e-11;
-      in_base.strain_rate[2][2][2] = -1e-12;
-    }
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 4.9e-21;
-  in_base.strain_rate[3][0][1] = 4.9e-21;
-  in_base.strain_rate[3][0][0] = 4.9e-21;
-  if (dim == 3)
-    {
-      in_base.strain_rate[3][2][0] = 4.9e-21;
-      in_base.strain_rate[3][2][1] = 4.9e-21;
-      in_base.strain_rate[3][2][2] = 4.9e-21;
-    }
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = 1e-11;
-  if (dim == 3)
-    {
-      in_base.strain_rate[4][2][0] = 1e-11;
-      in_base.strain_rate[4][2][1] = 1e-11;
-      in_base.strain_rate[4][2][2] = 1e-11;
-    }
-
-  // initialize some variables we will need later.
-  double finite_difference_accuracy = 1e-7;
-  double finite_difference_factor = 1+finite_difference_accuracy;
-
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
-
-  MaterialModelOutputs<dim> out_base(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
-
-  if (out_base.template get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
-    throw "error";
-
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
-
-  // initialize the material we want to test.
-  SimpleNonlinear<dim> mat;
-  ParameterHandler prm;
-  mat.declare_parameters(prm);
-
-  prm.enter_subsection("Compositional fields");
+  template <int dim>
+  int f(double parameter)
   {
-    prm.set("Number of fields","3");
-  }
-  prm.leave_subsection();
-  prm.enter_subsection("Material model");
-  {
-    prm.enter_subsection ("Simple nonlinear");
+
+    std::cout << std::endl << "Test for p = " << parameter << " with dimension " << dim << std::endl;
+
+    using namespace aspect::MaterialModel;
+
+    // first set all material model values
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 2200;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 2e12;
+
+    /**
+     * We can't take to small strain-rates, because then the difference in the
+     * viscosity will be too small for the double accuracy which stores
+     * the viscosity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+    if (dim == 3)
+      {
+        in_base.strain_rate[0][2][0] = 1e-12;
+        in_base.strain_rate[0][2][1] = 1e-12;
+        in_base.strain_rate[0][2][2] = 1e-11;
+      }
+
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+    if (dim == 3)
+      {
+        in_base.strain_rate[1][2][0] = -5.42647e-12;
+        in_base.strain_rate[1][2][1] = -5.22647e-12;
+        in_base.strain_rate[1][2][2] = 4.21668e-14;
+      }
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+    if (dim == 3)
+      {
+        in_base.strain_rate[2][2][0] = 1e-11;
+        in_base.strain_rate[2][2][1] = 1e-11;
+        in_base.strain_rate[2][2][2] = -1e-12;
+      }
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 4.9e-21;
+    in_base.strain_rate[3][0][1] = 4.9e-21;
+    in_base.strain_rate[3][0][0] = 4.9e-21;
+    if (dim == 3)
+      {
+        in_base.strain_rate[3][2][0] = 4.9e-21;
+        in_base.strain_rate[3][2][1] = 4.9e-21;
+        in_base.strain_rate[3][2][2] = 4.9e-21;
+      }
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = 1e-11;
+    if (dim == 3)
+      {
+        in_base.strain_rate[4][2][0] = 1e-11;
+        in_base.strain_rate[4][2][1] = 1e-11;
+        in_base.strain_rate[4][2][2] = 1e-11;
+      }
+
+    // initialize some variables we will need later.
+    double finite_difference_accuracy = 1e-7;
+    double finite_difference_factor = 1+finite_difference_accuracy;
+
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
+
+    MaterialModelOutputs<dim> out_base(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
+
+    if (out_base.template get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
+      throw "error";
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    // initialize the material we want to test.
+    SimpleNonlinear<dim> mat;
+    ParameterHandler prm;
+    mat.declare_parameters(prm);
+
+    prm.enter_subsection("Compositional fields");
     {
-      prm.set ("Viscosity prefactor", "1e-37,1e-36,1e-35,5e-36");
-      prm.set ("Viscosity averaging p", std::to_string(parameter));
-      prm.set ("Minimum strain rate", 1.4e-20);
+      prm.set("Number of fields","3");
     }
     prm.leave_subsection();
+    prm.enter_subsection("Material model");
+    {
+      prm.enter_subsection ("Simple nonlinear");
+      {
+        prm.set ("Viscosity prefactor", "1e-37,1e-36,1e-35,5e-36");
+        prm.set ("Viscosity averaging p", std::to_string(parameter));
+        prm.set ("Minimum strain rate", 1.4e-20);
+      }
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+
+    mat.parse_parameters(prm);
+
+    mat.evaluate(in_base, out_base);
+
+    // set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    double temp;
+
+    // have a bool so we know whether the test has succeed or not.
+    bool Error = false;
+
+    // this material is not pressure dependent, so we do not test it.
+
+    // test the strain-rate derivative.
+    for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
+      {
+        const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                      + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                      * finite_difference_accuracy
+                                                      * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
+          }
+
+
+        mat.evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // prevent division by zero. If it is zero, the test has passed, because or
+            // the finite difference and the analytical result match perfectly, or (more
+            // likely) the material model in independent of this variable.
+            temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+            if (temp != 0)
+              {
+                temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+              }
+            std::cout << "strain-rate: component = " << component << ", point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+            if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+              {
+                std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+                Error = true;
+              }
+
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
+    return 42;
   }
-  prm.leave_subsection();
 
-  mat.parse_parameters(prm);
-
-  mat.evaluate(in_base, out_base);
-
-  // set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
-  double temp;
-
-  // have a bool so we know whether the test has succeed or not.
-  bool Error = false;
-
-  // this material is not pressure dependent, so we do not test it.
-
-  // test the strain-rate derivative.
-  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
-    {
-      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
-                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
-                                                    * finite_difference_accuracy
-                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
-        }
-
-
-      mat.evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // prevent division by zero. If it is zero, the test has passed, because or
-          // the finite difference and the analytical result match perfectly, or (more
-          // likely) the material model in independent of this variable.
-          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
-          if (temp != 0)
-            {
-              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
-            }
-          std::cout << "strain-rate: component = " << component << ", point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
-          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
-            {
-              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-              Error = true;
-            }
-
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
-  return 42;
-}
-
-int exit_function()
-{
-  exit(0);
-  return 42;
-}
+  int exit_function()
+  {
+    exit(0);
+    return 42;
+  }
 // run this function by initializing a global variable by it
 // test 2D
-int ii2 = f<2>(-1000); // Testing min function
-int iz2 = f<2>(-2); // Testing generalized p norm mean with negative p
-int ij2 = f<2>(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik2 = f<2>(-1); // Testing harmonic mean
-int ji2 = f<2>(0); // Testing geometric mean
-int jj2 = f<2>(1); // Testing arithmetic mean
-int jk2 = f<2>(2); // Testing generalized p norm mean with positive p
-int kj2 = f<2>(1000); // Testing max function
+  int ii2 = f<2>(-1000); // Testing min function
+  int iz2 = f<2>(-2); // Testing generalized p norm mean with negative p
+  int ij2 = f<2>(-1.5); // Testing generalized p norm mean with negative, non int p
+  int ik2 = f<2>(-1); // Testing harmonic mean
+  int ji2 = f<2>(0); // Testing geometric mean
+  int jj2 = f<2>(1); // Testing arithmetic mean
+  int jk2 = f<2>(2); // Testing generalized p norm mean with positive p
+  int kj2 = f<2>(1000); // Testing max function
 // test 3D
-int ii3 = f<3>(-1000); // Testing min function
-int iz3 = f<3>(-2); // Testing generalized p norm mean with negative p
-int ij3 = f<3>(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik3 = f<3>(-1); // Testing harmonic mean
-int ji3 = f<3>(0); // Testing geometric mean
-int jj3 = f<3>(1); // Testing arithmetic mean
-int jk3 = f<3>(2); // Testing generalized p norm mean with positive p
-int kj3 = f<3>(1000); // Testing max function
+  int ii3 = f<3>(-1000); // Testing min function
+  int iz3 = f<3>(-2); // Testing generalized p norm mean with negative p
+  int ij3 = f<3>(-1.5); // Testing generalized p norm mean with negative, non int p
+  int ik3 = f<3>(-1); // Testing harmonic mean
+  int ji3 = f<3>(0); // Testing geometric mean
+  int jj3 = f<3>(1); // Testing arithmetic mean
+  int jk3 = f<3>(2); // Testing generalized p norm mean with positive p
+  int kj3 = f<3>(1000); // Testing max function
 // exit
-int kl2 = exit_function();
+  int kl2 = exit_function();
+
+}

--- a/tests/simple_shear.cc
+++ b/tests/simple_shear.cc
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class FiniteStrain : public MaterialModel::Simple<dim>
     {

--- a/tests/simple_shear_output_the_mobility.cc
+++ b/tests/simple_shear_output_the_mobility.cc
@@ -28,8 +28,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     template <int dim>
     class FiniteStrain : public MaterialModel::Simple<dim>
     {

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -34,8 +34,6 @@ namespace aspect
 {
   namespace MaterialModel
   {
-    using namespace dealii;
-
     /**
      * The same material model as Drucker Prager, but this one supports multiple
      * compositions in a way to reproduce the Spiegelman 2016 paper.

--- a/tests/spiegelman_material.cc
+++ b/tests/spiegelman_material.cc
@@ -20,284 +20,288 @@
 
 #include "../tests/spiegelman_fail_test.cc"
 
-int f(double parameter)
+namespace aspect
 {
-
-  std::cout << std::endl << "Test for p = " << parameter << std::endl;
-
-  const int dim=2;
-  using namespace aspect::MaterialModel;
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 2e12;
-
-  /**
-   * We can't take to small strain-rates, because then the difference in the
-   * viscosity will be too small for the double accuracy which stores
-   * the viscosity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 1e-22;
-  in_base.strain_rate[3][0][1] = 1e-22;
-  in_base.strain_rate[3][0][0] = -1e-22;
-  /**
-   * We can get it working with these values:
-   *
-   * in_base.strain_rate[3][1][1] = 9e-16;
-   * in_base.strain_rate[3][0][1] = 9e-16;
-   * in_base.strain_rate[3][0][0] = -9e-16;
-   *
-   * With very low strain-rates the differences between the finite difference and
-   * analytical solution grow. We  interpent this as that the finite difference
-   * method we use becomes unaccurate for very low strain-rates.
-   */
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = 1e-11;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 2200;
-
-  SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
-  SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
-
-  zerozero[0][0] = 1;
-  onezero[1][0]  = 0.5; // because symmetry doubles this entry
-  oneone[1][1]   = 1;
-
-  double finite_difference_accuracy = 1e-7;
-  double finite_difference_factor = 1+finite_difference_accuracy;
-
-  bool Error = false;
-
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
-  MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
-
-  in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
-  in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
-  in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
-  in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
-
-  MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
-  in_dviscositydtemperature.temperature[0] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[1] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[2] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[3] *= 1.0000000001;
-  in_dviscositydtemperature.temperature[4] *= 1.0000000001;
-
-
-  MaterialModelOutputs<dim> out_base(5,3);
-
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
-  MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
-
-  if (out_base.get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
-    throw "error";
-
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
-
-  SpiegelmanMaterial<dim> mat;
-  ParameterHandler prm;
-  mat.declare_parameters(prm);
-
-  prm.enter_subsection("Compositional fields");
+  int f(double parameter)
   {
-    prm.set("Number of fields","3");
-    prm.set("List of conductivities","2.25");
-    prm.set("List of capacities","1250");
-    prm.set("List of reference densities","2700.0");
-    prm.set("List of cohesions","1e8,0,1e8,1e8");
-    prm.set("List of angles of internal friction","30.0");
-    prm.set("List of initial viscosities","1e20");
-    prm.set("List of constant viscosities","0,1e21,0,0");
-  }
-  prm.leave_subsection();
-  prm.enter_subsection("Material model");
-  {
-    prm.enter_subsection ("Spiegelman 2016");
+
+    std::cout << std::endl << "Test for p = " << parameter << std::endl;
+
+    const int dim=2;
+    using namespace aspect::MaterialModel;
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 2e12;
+
+    /**
+     * We can't take to small strain-rates, because then the difference in the
+     * viscosity will be too small for the double accuracy which stores
+     * the viscosity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 1e-22;
+    in_base.strain_rate[3][0][1] = 1e-22;
+    in_base.strain_rate[3][0][0] = -1e-22;
+    /**
+     * We can get it working with these values:
+     *
+     * in_base.strain_rate[3][1][1] = 9e-16;
+     * in_base.strain_rate[3][0][1] = 9e-16;
+     * in_base.strain_rate[3][0][0] = -9e-16;
+     *
+     * With very low strain-rates the differences between the finite difference and
+     * analytical solution grow. We  interpent this as that the finite difference
+     * method we use becomes unaccurate for very low strain-rates.
+     */
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = 1e-11;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 2200;
+
+    SymmetricTensor<2,dim> zerozero = SymmetricTensor<2,dim>();
+    SymmetricTensor<2,dim> onezero = SymmetricTensor<2,dim>();
+    SymmetricTensor<2,dim> oneone = SymmetricTensor<2,dim>();
+
+    zerozero[0][0] = 1;
+    onezero[1][0]  = 0.5; // because symmetry doubles this entry
+    oneone[1][1]   = 1;
+
+    double finite_difference_accuracy = 1e-7;
+    double finite_difference_factor = 1+finite_difference_accuracy;
+
+    bool Error = false;
+
+    MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+    in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate_zerozero(in_base);
+    MaterialModelInputs<dim> in_dviscositydstrainrate_onezero(in_base);
+    MaterialModelInputs<dim> in_dviscositydstrainrate_oneone(in_base);
+
+    in_dviscositydstrainrate_zerozero.strain_rate[0] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[0][0][0]) * finite_difference_accuracy * zerozero;
+    in_dviscositydstrainrate_zerozero.strain_rate[1] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[1][0][0]) * finite_difference_accuracy * zerozero;
+    in_dviscositydstrainrate_zerozero.strain_rate[2] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[2][0][0]) * finite_difference_accuracy * zerozero;
+    in_dviscositydstrainrate_zerozero.strain_rate[3] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[3][0][0]) * finite_difference_accuracy * zerozero;
+    in_dviscositydstrainrate_zerozero.strain_rate[4] += std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[4][0][0]) * finite_difference_accuracy * zerozero;
+    in_dviscositydstrainrate_onezero.strain_rate[0]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[0][1][0]) * finite_difference_accuracy * onezero;
+    in_dviscositydstrainrate_onezero.strain_rate[1]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[1][1][0]) * finite_difference_accuracy * onezero;
+    in_dviscositydstrainrate_onezero.strain_rate[2]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[2][1][0]) * finite_difference_accuracy * onezero;
+    in_dviscositydstrainrate_onezero.strain_rate[3]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[3][1][0]) * finite_difference_accuracy * onezero;
+    in_dviscositydstrainrate_onezero.strain_rate[4]  += std::fabs(in_dviscositydstrainrate_onezero.strain_rate[4][1][0]) * finite_difference_accuracy * onezero;
+    in_dviscositydstrainrate_oneone.strain_rate[0]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[0][1][1]) * finite_difference_accuracy * oneone;
+    in_dviscositydstrainrate_oneone.strain_rate[1]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[1][1][1]) * finite_difference_accuracy * oneone;
+    in_dviscositydstrainrate_oneone.strain_rate[2]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[2][1][1]) * finite_difference_accuracy * oneone;
+    in_dviscositydstrainrate_oneone.strain_rate[3]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[3][1][1]) * finite_difference_accuracy * oneone;
+    in_dviscositydstrainrate_oneone.strain_rate[4]   += std::fabs(in_dviscositydstrainrate_oneone.strain_rate[4][1][1]) * finite_difference_accuracy * oneone;
+
+    MaterialModelInputs<dim> in_dviscositydtemperature(in_base);
+    in_dviscositydtemperature.temperature[0] *= 1.0000000001;
+    in_dviscositydtemperature.temperature[1] *= 1.0000000001;
+    in_dviscositydtemperature.temperature[2] *= 1.0000000001;
+    in_dviscositydtemperature.temperature[3] *= 1.0000000001;
+    in_dviscositydtemperature.temperature[4] *= 1.0000000001;
+
+
+    MaterialModelOutputs<dim> out_base(5,3);
+
+    MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate_zerozero(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate_onezero(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
+    MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
+
+    if (out_base.get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
+      throw "error";
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    SpiegelmanMaterial<dim> mat;
+    ParameterHandler prm;
+    mat.declare_parameters(prm);
+
+    prm.enter_subsection("Compositional fields");
     {
-      prm.set("Use deviator of strain-rate", "false");
-      prm.set("Use analytical derivative", "true");
-      prm.set ("Viscosity averaging p", std::to_string(parameter));
+      prm.set("Number of fields","3");
+      prm.set("List of conductivities","2.25");
+      prm.set("List of capacities","1250");
+      prm.set("List of reference densities","2700.0");
+      prm.set("List of cohesions","1e8,0,1e8,1e8");
+      prm.set("List of angles of internal friction","30.0");
+      prm.set("List of initial viscosities","1e20");
+      prm.set("List of constant viscosities","0,1e21,0,0");
     }
     prm.leave_subsection();
+    prm.enter_subsection("Material model");
+    {
+      prm.enter_subsection ("Spiegelman 2016");
+      {
+        prm.set("Use deviator of strain-rate", "false");
+        prm.set("Use analytical derivative", "true");
+        prm.set ("Viscosity averaging p", std::to_string(parameter));
+      }
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+
+    mat.parse_parameters(prm);
+
+    mat.evaluate(in_base, out_base);
+    mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
+    mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
+    mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
+    mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
+    mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
+
+    //set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim>>();
+
+    double temp;
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+        if (in_base.pressure[i] != 0)
+          {
+            temp /= (in_base.pressure[i] * finite_difference_accuracy);
+          }
+
+        std::cout << "pressure on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i] << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+          {
+            std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
+        if (temp != 0)
+          {
+            temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
+          }
+        std::cout << "zerozero on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0] << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
+          {
+            std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+
+
+      }
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
+        if (temp != 0)
+          {
+            temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
+          }
+        std::cout << "onezero on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
+          {
+            std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+      }
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
+        if (temp != 0)
+          {
+            temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
+          }
+        std::cout << "oneone on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
+          {
+            std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
+    return 42;
   }
-  prm.leave_subsection();
 
-  mat.parse_parameters(prm);
-
-  mat.evaluate(in_base, out_base);
-  mat.evaluate(in_dviscositydpressure, out_dviscositydpressure);
-  mat.evaluate(in_dviscositydstrainrate_zerozero, out_dviscositydstrainrate_zerozero);
-  mat.evaluate(in_dviscositydstrainrate_onezero, out_dviscositydstrainrate_onezero);
-  mat.evaluate(in_dviscositydstrainrate_oneone, out_dviscositydstrainrate_oneone);
-  mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
-
-  //set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim>>();
-
-  double temp;
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
-
-      std::cout << "pressure on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i] << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        {
-          std::cout << "Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_zerozero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_zerozero.strain_rate[i][0][0]) * finite_difference_accuracy;
-        }
-      std::cout << "zerozero on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][0][0] << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][0][0]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][0][0])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-
-
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_onezero.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_onezero.strain_rate[i][1][0]) * finite_difference_accuracy;
-        }
-      std::cout << "onezero on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]   << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][0]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][0])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-    }
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = out_dviscositydstrainrate_oneone.viscosities[i] - out_base.viscosities[i];
-      if (temp != 0)
-        {
-          temp /= std::fabs(in_dviscositydstrainrate_oneone.strain_rate[i][1][1]) * finite_difference_accuracy;
-        }
-      std::cout << "oneone on quadrature point " << i << ": Finite difference = " << temp << ". Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][1][1]) > 1e-3 * 0.5 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][1][1])) )
-        {
-          std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
-  return 42;
-}
-
-int exit_function()
-{
-  exit(0);
-  return 42;
-}
+  int exit_function()
+  {
+    exit(0);
+    return 42;
+  }
 // run this function by initializing a global variable by it
-int ii = f(-1000); // Testing min function
-int iz = f(-2); // Testing generalized p norm mean with negative p
-int ij = f(-1.5); // Testing generalized p norm mean with negative, non int p
-int ik = f(-1); // Testing harmonic mean
-int ji = f(0); // Testing geometric mean
-int jj = f(1); // Testing arithmetic mean
-int jk = f(2); // Testing generalized p norm mean with positive p
-int kj = f(1000); // Testing max function
-int kl = exit_function();
+  int ii = f(-1000); // Testing min function
+  int iz = f(-2); // Testing generalized p norm mean with negative p
+  int ij = f(-1.5); // Testing generalized p norm mean with negative, non int p
+  int ik = f(-1); // Testing harmonic mean
+  int ji = f(0); // Testing geometric mean
+  int jj = f(1); // Testing arithmetic mean
+  int jk = f(2); // Testing generalized p norm mean with positive p
+  int kj = f(1000); // Testing max function
+  int kl = exit_function();
+
+}

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -247,7 +247,6 @@ void f(const aspect::SimulatorAccess<3> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -34,240 +34,243 @@
 
 #include <iostream>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &,
-       std::string averaging_parameter)
+namespace aspect
 {
-
-  std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
-
-  using namespace aspect::MaterialModel;
-
-  // first set all material model values
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 600;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 5e8;
-
-  in_base.position[0] = Point<dim>();
-  in_base.position[1] = Point<dim>();
-  in_base.position[2] = Point<dim>();
-  in_base.position[3] = Point<dim>();
-  in_base.position[4] = Point<dim>();
-
-  /**
-   * We can't take too small strain-rates, because then the difference in the
-   * viscosity will be too small for the double accuracy which stores
-   * the viscosity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 4.9e-21;
-  in_base.strain_rate[3][0][1] = 4.9e-21;
-  in_base.strain_rate[3][0][0] = 4.9e-21;
-
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = -1e-11;
-
-
-  // initialize some variables we will need later.
-  double finite_difference_accuracy = 1e-7;
-  double finite_difference_factor = 1+finite_difference_accuracy;
-
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
-
-  MaterialModelOutputs<dim> out_base(5,3);
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
-
-  // initialize the material we want to test.
-  aspect::ParameterHandler prm;
-
-  const aspect::MaterialModel::ViscoPlastic<dim> &const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
-  aspect::MaterialModel::ViscoPlastic<dim> &material_model = const_cast<aspect::MaterialModel::ViscoPlastic<dim> &>(const_material_model);
-
-  material_model.declare_parameters(prm);
-
-  prm.enter_subsection("Material model");
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &,
+         std::string averaging_parameter)
   {
-    prm.enter_subsection ("Visco Plastic");
+
+    std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
+
+    using namespace aspect::MaterialModel;
+
+    // first set all material model values
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 600;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 5e8;
+
+    in_base.position[0] = Point<dim>();
+    in_base.position[1] = Point<dim>();
+    in_base.position[2] = Point<dim>();
+    in_base.position[3] = Point<dim>();
+    in_base.position[4] = Point<dim>();
+
+    /**
+     * We can't take too small strain-rates, because then the difference in the
+     * viscosity will be too small for the double accuracy which stores
+     * the viscosity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 4.9e-21;
+    in_base.strain_rate[3][0][1] = 4.9e-21;
+    in_base.strain_rate[3][0][0] = 4.9e-21;
+
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = -1e-11;
+
+
+    // initialize some variables we will need later.
+    double finite_difference_accuracy = 1e-7;
+    double finite_difference_factor = 1+finite_difference_accuracy;
+
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
+
+    MaterialModelOutputs<dim> out_base(5,3);
+    MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
+
+    // initialize the material we want to test.
+    aspect::ParameterHandler prm;
+
+    const aspect::MaterialModel::ViscoPlastic<dim> &const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
+    aspect::MaterialModel::ViscoPlastic<dim> &material_model = const_cast<aspect::MaterialModel::ViscoPlastic<dim> &>(const_material_model);
+
+    material_model.declare_parameters(prm);
+
+    prm.enter_subsection("Material model");
     {
-      prm.set ("Viscosity averaging scheme", averaging_parameter);
-      prm.set ("Angles of internal friction", "30");
+      prm.enter_subsection ("Visco Plastic");
+      {
+        prm.set ("Viscosity averaging scheme", averaging_parameter);
+        prm.set ("Angles of internal friction", "30");
+      }
+      prm.leave_subsection();
     }
     prm.leave_subsection();
+
+    const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    simulator_access.get_material_model().evaluate(in_base, out_base);
+
+    // set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    double temp;
+
+    // have a bool so we know whether the test has succeed or not.
+    bool Error = false;
+
+    // test the pressure derivative.
+    MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+    in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+    simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+        if (in_base.pressure[i] != 0)
+          {
+            temp /= (in_base.pressure[i] * finite_difference_accuracy);
+          }
+        std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+          {
+            std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    // test the strain-rate derivative.
+    for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
+      {
+        const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+            // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+            // derivative
+            in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                      + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                      * (component > dim-1 ? 0.5 : 1 )
+                                                      * finite_difference_accuracy
+                                                      * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
+          }
+
+
+        simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // prevent division by zero. If it is zero, the test has passed, because or
+            // the finite difference and the analytical result match perfectly, or (more
+            // likely) the material model in independent of this variable.
+            temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+            if (temp != 0)
+              {
+                temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+              }
+            std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+            if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+              {
+                std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+                Error = true;
+              }
+
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
   }
-  prm.leave_subsection();
 
-  const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+  template <>
+  void f(const aspect::SimulatorAccess<3> &,
+         aspect::Assemblers::Manager<3> &,
+         std::string )
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
 
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "harmonic"));
 
-  simulator_access.get_material_model().evaluate(in_base, out_base);
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "geometric"));
 
-  // set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
-  double temp;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "arithmetic"));
 
-  // have a bool so we know whether the test has succeed or not.
-  bool Error = false;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "maximum composition"));
+  }
 
-  // test the pressure derivative.
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
-      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  // test the strain-rate derivative.
-  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
-    {
-      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
-          // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
-          // derivative
-          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
-                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
-                                                    * (component > dim-1 ? 0.5 : 1 )
-                                                    * finite_difference_accuracy
-                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
-        }
-
-
-      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // prevent division by zero. If it is zero, the test has passed, because or
-          // the finite difference and the analytical result match perfectly, or (more
-          // likely) the material model in independent of this variable.
-          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
-          if (temp != 0)
-            {
-              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
-            }
-          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
-          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
-            {
-              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-              Error = true;
-            }
-
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<3> &,
-       aspect::Assemblers::Manager<3> &,
-       std::string )
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "harmonic"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "geometric"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "arithmetic"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "maximum composition"));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -262,7 +262,6 @@ void f(const aspect::SimulatorAccess<2> &,
 template <int dim>
 void signal_connector (aspect::SimulatorSignals<dim> &signals)
 {
-  using namespace dealii;
   std::cout << "* Connecting signals" << std::endl;
   signals.set_assemblers.connect (std::bind(&f<dim>,
                                             std::placeholders::_1,

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -34,255 +34,258 @@
 
 #include <iostream>
 
-template <int dim>
-void f(const aspect::SimulatorAccess<dim> &simulator_access,
-       aspect::Assemblers::Manager<dim> &,
-       std::string averaging_parameter)
+namespace aspect
 {
-
-  std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
-
-  using namespace aspect::MaterialModel;
-
-  // first set all material model values
-  MaterialModelInputs<dim> in_base(5,3);
-  in_base.composition[0][0] = 0;
-  in_base.composition[0][1] = 0;
-  in_base.composition[0][2] = 0;
-  in_base.composition[1][0] = 0.75;
-  in_base.composition[1][1] = 0.15;
-  in_base.composition[1][2] = 0.10;
-  in_base.composition[2][0] = 0;
-  in_base.composition[2][1] = 0.2;
-  in_base.composition[2][2] = 0.4;
-  in_base.composition[3][0] = 0;
-  in_base.composition[3][1] = 0.2;
-  in_base.composition[3][2] = 0.4;
-  in_base.composition[4][0] = 1;
-  in_base.composition[4][1] = 0;
-  in_base.composition[4][2] = 0;
-
-  in_base.temperature[0] = 293;
-  in_base.temperature[1] = 1600;
-  in_base.temperature[2] = 2000;
-  in_base.temperature[3] = 2100;
-  in_base.temperature[4] = 600;
-
-  in_base.pressure[0] = 1e9;
-  in_base.pressure[1] = 5e9;
-  in_base.pressure[2] = 2e10;
-  in_base.pressure[3] = 2e11;
-  in_base.pressure[4] = 5e8;
-
-  in_base.position[0] = Point<dim>();
-  in_base.position[1] = Point<dim>();
-  in_base.position[2] = Point<dim>();
-  in_base.position[3] = Point<dim>();
-  in_base.position[4] = Point<dim>();
-
-  /**
-   * We can't take too small strain-rates, because then the difference in the
-   * viscosity will be too small for the double accuracy which stores
-   * the viscosity solutions and the finite difference solution.
-   */
-  in_base.strain_rate[0] = SymmetricTensor<2,dim>();
-  in_base.strain_rate[0][0][0] = 1e-12;
-  in_base.strain_rate[0][0][1] = 1e-12;
-  in_base.strain_rate[0][1][1] = 1e-11;
-  in_base.strain_rate[0][2][0] = 1e-12;
-  in_base.strain_rate[0][2][1] = 1e-12;
-  in_base.strain_rate[0][2][2] = 1e-11;
-
-  in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[1][0][0] = -1.71266e-13;
-  in_base.strain_rate[1][0][1] = -5.82647e-12;
-  in_base.strain_rate[1][1][1] = 4.21668e-14;
-  in_base.strain_rate[1][2][0] = -5.42647e-12;
-  in_base.strain_rate[1][2][1] = -5.22647e-12;
-  in_base.strain_rate[1][2][2] = 4.21668e-14;
-
-  in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[2][1][1] = 1e-13;
-  in_base.strain_rate[2][0][1] = 1e-11;
-  in_base.strain_rate[2][0][0] = -1e-12;
-  in_base.strain_rate[2][2][0] = 1e-11;
-  in_base.strain_rate[2][2][1] = 1e-11;
-  in_base.strain_rate[2][2][2] = -1e-12;
-
-  in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[3][1][1] = 4.9e-21;
-  in_base.strain_rate[3][0][1] = 4.9e-21;
-  in_base.strain_rate[3][0][0] = 4.9e-21;
-  in_base.strain_rate[3][2][0] = 4.9e-21;
-  in_base.strain_rate[3][2][1] = 4.9e-21;
-  in_base.strain_rate[3][2][2] = 4.9e-21;
-
-  in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
-  in_base.strain_rate[4][1][1] = 1e-11;
-  in_base.strain_rate[4][0][1] = 1e-11;
-  in_base.strain_rate[4][0][0] = -5e-12;
-  in_base.strain_rate[4][2][0] = 1e-11;
-  in_base.strain_rate[4][2][1] = 1e-11;
-  in_base.strain_rate[4][2][2] = -5e-12;
-
-
-  // initialize some variables we will need later.
-  double finite_difference_accuracy = 1e-7;
-  double finite_difference_factor = 1+finite_difference_accuracy;
-
-
-  MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
-
-  MaterialModelOutputs<dim> out_base(5,3);
-  MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
-  MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
-
-  // initialize the material we want to test.
-  aspect::ParameterHandler prm;
-
-  const aspect::MaterialModel::ViscoPlastic<dim> &const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
-  aspect::MaterialModel::ViscoPlastic<dim> &material_model = const_cast<aspect::MaterialModel::ViscoPlastic<dim> &>(const_material_model);
-
-  material_model.declare_parameters(prm);
-
-  prm.enter_subsection("Material model");
+  template <int dim>
+  void f(const aspect::SimulatorAccess<dim> &simulator_access,
+         aspect::Assemblers::Manager<dim> &,
+         std::string averaging_parameter)
   {
-    prm.enter_subsection ("Visco Plastic");
+
+    std::cout << std::endl << "Testing ViscoPlastic derivatives against analytical derivatives for averaging parameter " << averaging_parameter << std::endl;
+
+    using namespace aspect::MaterialModel;
+
+    // first set all material model values
+    MaterialModelInputs<dim> in_base(5,3);
+    in_base.composition[0][0] = 0;
+    in_base.composition[0][1] = 0;
+    in_base.composition[0][2] = 0;
+    in_base.composition[1][0] = 0.75;
+    in_base.composition[1][1] = 0.15;
+    in_base.composition[1][2] = 0.10;
+    in_base.composition[2][0] = 0;
+    in_base.composition[2][1] = 0.2;
+    in_base.composition[2][2] = 0.4;
+    in_base.composition[3][0] = 0;
+    in_base.composition[3][1] = 0.2;
+    in_base.composition[3][2] = 0.4;
+    in_base.composition[4][0] = 1;
+    in_base.composition[4][1] = 0;
+    in_base.composition[4][2] = 0;
+
+    in_base.temperature[0] = 293;
+    in_base.temperature[1] = 1600;
+    in_base.temperature[2] = 2000;
+    in_base.temperature[3] = 2100;
+    in_base.temperature[4] = 600;
+
+    in_base.pressure[0] = 1e9;
+    in_base.pressure[1] = 5e9;
+    in_base.pressure[2] = 2e10;
+    in_base.pressure[3] = 2e11;
+    in_base.pressure[4] = 5e8;
+
+    in_base.position[0] = Point<dim>();
+    in_base.position[1] = Point<dim>();
+    in_base.position[2] = Point<dim>();
+    in_base.position[3] = Point<dim>();
+    in_base.position[4] = Point<dim>();
+
+    /**
+     * We can't take too small strain-rates, because then the difference in the
+     * viscosity will be too small for the double accuracy which stores
+     * the viscosity solutions and the finite difference solution.
+     */
+    in_base.strain_rate[0] = SymmetricTensor<2,dim>();
+    in_base.strain_rate[0][0][0] = 1e-12;
+    in_base.strain_rate[0][0][1] = 1e-12;
+    in_base.strain_rate[0][1][1] = 1e-11;
+    in_base.strain_rate[0][2][0] = 1e-12;
+    in_base.strain_rate[0][2][1] = 1e-12;
+    in_base.strain_rate[0][2][2] = 1e-11;
+
+    in_base.strain_rate[1] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[1][0][0] = -1.71266e-13;
+    in_base.strain_rate[1][0][1] = -5.82647e-12;
+    in_base.strain_rate[1][1][1] = 4.21668e-14;
+    in_base.strain_rate[1][2][0] = -5.42647e-12;
+    in_base.strain_rate[1][2][1] = -5.22647e-12;
+    in_base.strain_rate[1][2][2] = 4.21668e-14;
+
+    in_base.strain_rate[2] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[2][1][1] = 1e-13;
+    in_base.strain_rate[2][0][1] = 1e-11;
+    in_base.strain_rate[2][0][0] = -1e-12;
+    in_base.strain_rate[2][2][0] = 1e-11;
+    in_base.strain_rate[2][2][1] = 1e-11;
+    in_base.strain_rate[2][2][2] = -1e-12;
+
+    in_base.strain_rate[3] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[3][1][1] = 4.9e-21;
+    in_base.strain_rate[3][0][1] = 4.9e-21;
+    in_base.strain_rate[3][0][0] = 4.9e-21;
+    in_base.strain_rate[3][2][0] = 4.9e-21;
+    in_base.strain_rate[3][2][1] = 4.9e-21;
+    in_base.strain_rate[3][2][2] = 4.9e-21;
+
+    in_base.strain_rate[4] = SymmetricTensor<2,dim>(in_base.strain_rate[0]);
+    in_base.strain_rate[4][1][1] = 1e-11;
+    in_base.strain_rate[4][0][1] = 1e-11;
+    in_base.strain_rate[4][0][0] = -5e-12;
+    in_base.strain_rate[4][2][0] = 1e-11;
+    in_base.strain_rate[4][2][1] = 1e-11;
+    in_base.strain_rate[4][2][2] = -5e-12;
+
+
+    // initialize some variables we will need later.
+    double finite_difference_accuracy = 1e-7;
+    double finite_difference_factor = 1+finite_difference_accuracy;
+
+
+    MaterialModelInputs<dim> in_dviscositydstrainrate(in_base);
+
+    MaterialModelOutputs<dim> out_base(5,3);
+    MaterialModelOutputs<dim> out_dviscositydpressure(5,3);
+    MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
+
+    // initialize the material we want to test.
+    aspect::ParameterHandler prm;
+
+    const aspect::MaterialModel::ViscoPlastic<dim> &const_material_model = dynamic_cast<const aspect::MaterialModel::ViscoPlastic<dim> &>(simulator_access.get_material_model());
+    aspect::MaterialModel::ViscoPlastic<dim> &material_model = const_cast<aspect::MaterialModel::ViscoPlastic<dim> &>(const_material_model);
+
+    material_model.declare_parameters(prm);
+
+    prm.enter_subsection("Material model");
     {
-      prm.set ("Viscosity averaging scheme", averaging_parameter);
-      prm.set ("Angles of internal friction", "30");
+      prm.enter_subsection ("Visco Plastic");
+      {
+        prm.set ("Viscosity averaging scheme", averaging_parameter);
+        prm.set ("Angles of internal friction", "30");
+      }
+      prm.leave_subsection();
     }
     prm.leave_subsection();
+
+    const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+
+    out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+
+    simulator_access.get_material_model().evaluate(in_base, out_base);
+
+    // set up additional output for the derivatives
+    MaterialModelDerivatives<dim> *derivatives;
+    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    double temp;
+
+    // have a bool so we know whether the test has succeed or not.
+    bool Error = false;
+
+    // test the pressure derivative.
+    MaterialModelInputs<dim> in_dviscositydpressure(in_base);
+    in_dviscositydpressure.pressure[0] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[1] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[2] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[3] *= finite_difference_factor;
+    in_dviscositydpressure.pressure[4] *= finite_difference_factor;
+
+    simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
+
+    for (unsigned int i = 0; i < 5; i++)
+      {
+        // prevent division by zero. If it is zero, the test has passed, because or
+        // the finite difference and the analytical result match perfectly, or (more
+        // likely) the material model in independent of this variable.
+        temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
+        if (in_base.pressure[i] != 0)
+          {
+            temp /= (in_base.pressure[i] * finite_difference_accuracy);
+          }
+        std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
+        if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
+          {
+            std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
+            Error = true;
+          }
+
+      }
+
+    // test the strain-rate derivative.
+    for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
+      {
+        const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
+            // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
+            // derivative
+            in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
+                                                      + std::fabs(in_base.strain_rate[i][strain_rate_indices])
+                                                      * (component > dim-1 ? 0.5 : 1 )
+                                                      * finite_difference_accuracy
+                                                      * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
+          }
+
+
+        simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
+
+        for (unsigned int i = 0; i < 5; i++)
+          {
+            // prevent division by zero. If it is zero, the test has passed, because or
+            // the finite difference and the analytical result match perfectly, or (more
+            // likely) the material model in independent of this variable.
+            temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
+            if (temp != 0)
+              {
+                temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
+              }
+            std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
+            if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
+              {
+                std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
+                Error = true;
+              }
+
+          }
+
+      }
+
+    if (Error)
+      {
+        std::cout << "Some parts of the test were not successful." << std::endl;
+      }
+    else
+      {
+        std::cout << "OK" << std::endl;
+      }
+
   }
-  prm.leave_subsection();
 
-  const_cast<aspect::MaterialModel::Interface<dim> &>(simulator_access.get_material_model()).parse_parameters(prm);
+  template <>
+  void f(const aspect::SimulatorAccess<2> &,
+         aspect::Assemblers::Manager<2> &,
+         std::string )
+  {
+    AssertThrow(false,dealii::ExcInternalError());
+  }
 
-  out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
+  template <int dim>
+  void signal_connector (aspect::SimulatorSignals<dim> &signals)
+  {
+    std::cout << "* Connecting signals" << std::endl;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "harmonic"));
 
-  simulator_access.get_material_model().evaluate(in_base, out_base);
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "geometric"));
 
-  // set up additional output for the derivatives
-  MaterialModelDerivatives<dim> *derivatives;
-  derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
-  double temp;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "arithmetic"));
 
-  // have a bool so we know whether the test has succeed or not.
-  bool Error = false;
+    signals.set_assemblers.connect (std::bind(&f<dim>,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2,
+                                              "maximum composition"));
+  }
 
-  // test the pressure derivative.
-  MaterialModelInputs<dim> in_dviscositydpressure(in_base);
-  in_dviscositydpressure.pressure[0] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[1] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[2] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[3] *= finite_difference_factor;
-  in_dviscositydpressure.pressure[4] *= finite_difference_factor;
-
-  simulator_access.get_material_model().evaluate(in_dviscositydpressure, out_dviscositydpressure);
-
-  for (unsigned int i = 0; i < 5; i++)
-    {
-      // prevent division by zero. If it is zero, the test has passed, because or
-      // the finite difference and the analytical result match perfectly, or (more
-      // likely) the material model in independent of this variable.
-      temp = (out_dviscositydpressure.viscosities[i] - out_base.viscosities[i]);
-      if (in_base.pressure[i] != 0)
-        {
-          temp /= (in_base.pressure[i] * finite_difference_accuracy);
-        }
-      std::cout << "pressure: point = " << i << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_pressure[i]  << std::endl;
-      if (std::fabs(temp - derivatives->viscosity_derivative_wrt_pressure[i]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_pressure[i])))
-        {
-          std::cout << "   Error: The derivative of the viscosity to the pressure is too different from the analytical value." << std::endl;
-          Error = true;
-        }
-
-    }
-
-  // test the strain-rate derivative.
-  for (unsigned int component = 0; component < SymmetricTensor<2,dim>::n_independent_components; ++component)
-    {
-      const TableIndices<2> strain_rate_indices = SymmetricTensor<2,dim>::unrolled_to_component_indices (component);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // components that are not on the diagonal are multiplied by 0.5, because the symmetric tensor
-          // is modified by 0.5 in both symmetric directions (xy/yx) simultaneously and we compute the combined
-          // derivative
-          in_dviscositydstrainrate.strain_rate[i] = in_base.strain_rate[i]
-                                                    + std::fabs(in_base.strain_rate[i][strain_rate_indices])
-                                                    * (component > dim-1 ? 0.5 : 1 )
-                                                    * finite_difference_accuracy
-                                                    * aspect::Utilities::nth_basis_for_symmetric_tensors<dim>(component);
-        }
-
-
-      simulator_access.get_material_model().evaluate(in_dviscositydstrainrate, out_dviscositydstrainrate);
-
-      for (unsigned int i = 0; i < 5; i++)
-        {
-          // prevent division by zero. If it is zero, the test has passed, because or
-          // the finite difference and the analytical result match perfectly, or (more
-          // likely) the material model in independent of this variable.
-          temp = out_dviscositydstrainrate.viscosities[i] - out_base.viscosities[i];
-          if (temp != 0)
-            {
-              temp /= std::fabs(in_dviscositydstrainrate.strain_rate[i][strain_rate_indices]) * finite_difference_accuracy;
-            }
-          std::cout << "strain-rate: point = " << i << ", component = " << component << ", Finite difference = " << temp << ", Analytical derivative = " << derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]  << std::endl;
-          if (std::fabs(temp - derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices]) > 1e-3 * (std::fabs(temp) + std::fabs(derivatives->viscosity_derivative_wrt_strain_rate[i][strain_rate_indices])))
-            {
-              std::cout << "   Error: The derivative of the viscosity to the strain rate is too different from the analytical value." << std::endl;
-              Error = true;
-            }
-
-        }
-
-    }
-
-  if (Error)
-    {
-      std::cout << "Some parts of the test were not successful." << std::endl;
-    }
-  else
-    {
-      std::cout << "OK" << std::endl;
-    }
-
+  ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
+                                    signal_connector<3>)
 }
-
-template <>
-void f(const aspect::SimulatorAccess<2> &,
-       aspect::Assemblers::Manager<2> &,
-       std::string )
-{
-  AssertThrow(false,dealii::ExcInternalError());
-}
-
-template <int dim>
-void signal_connector (aspect::SimulatorSignals<dim> &signals)
-{
-  std::cout << "* Connecting signals" << std::endl;
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "harmonic"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "geometric"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "arithmetic"));
-
-  signals.set_assemblers.connect (std::bind(&f<dim>,
-                                            std::placeholders::_1,
-                                            std::placeholders::_2,
-                                            "maximum composition"));
-}
-
-ASPECT_REGISTER_SIGNALS_CONNECTOR(signal_connector<2>,
-                                  signal_connector<3>)

--- a/tests/vof_err_calc.h
+++ b/tests/vof_err_calc.h
@@ -35,8 +35,6 @@ namespace aspect
 {
   namespace Postprocess
   {
-    using namespace dealii;
-
     template <int dim>
     class VolumeOfFluidSpecifiedSolutionDiff : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
     {


### PR DESCRIPTION
This is something I noticed while working on #6217: About half of our header files (and some source files) have the directive `using namespace dealii;` in their respective namespaces (or sometimes in the main `aspect` namespace). The other half doesnt, and relies on some header file including the namespace. I think it would make sense to unify this. In particular, since all of our files are expected to include `global.h` either directly or through their headers, I think it would make sense to only include the deal.II namespace in `aspect/global.h`, and make sure the `dealii` namespace is always included in the `aspect` namespace. This lowers the likelihood of name collision in all namespaces except for the global `aspect` namespace itself and hides a directive that many new users (familiar with C or python) will not understand. It also reduces the number of lines of code. 

An alternative to this PR would be to make sure every file includes the `dealii` namespace in an appropriate place.

All of the code changes are very straightforward, except:
- I had to include `using namespace dealii` also in `compat.h` (likely because `compat.h` and `global.h` have a circular include
- The change revealed a bug/unintended use of namespaces in `source/postprocess/particle_count_statistics.cc` that I fixed
- I had to add a `namespace aspect` in a number of source files of tests that previously did everything in the global namespace. This adds a lot of whitespace change in those files. Not sure this is the cleanest solution, but I think it is reasonable to except all ASPECT code to live in the `aspect` namespace.
- I left out unity tests. They all do stuff in the global namespace and use their own directives around namespaces