### PR TITLE
Fix file paths in documentation

### DIFF
--- a/doc/sphinx/user/extending/compatibility.md
+++ b/doc/sphinx/user/extending/compatibility.md
@@ -7,7 +7,7 @@ ASPECT further. This is in particular true for new
 major versions. In order to allow running old plugins with newer
 ASPECT versions, we provide scripts that can
 automatically update existing plugins to the new syntax. Executing
-`doc/update_source_files.sh` with one or more plugin files as arguments will
+`contrib/utilities/update_source_files.sh` with one or more plugin files as arguments will
 create a backup of the old file (named `old_filename.bak`), and replace the
 existing file with a version that should work with the current
 ASPECT version. Using this script would look like

--- a/doc/sphinx/user/run-aspect/parameters-overview/compatibility.md
+++ b/doc/sphinx/user/run-aspect/parameters-overview/compatibility.md
@@ -6,7 +6,7 @@ from parameter files to improve ASPECT further.
 This is especially true for new major versions. In order to allow running old
 parameter files with newer ASPECT versions we
 provide scripts that can automatically update existing parameter files to the
-new syntax. Executing `doc/update_prm_files.sh` with one or more parameter
+new syntax. Executing `contrib/utilities/update_prm_files.sh` with one or more parameter
 files as arguments will create a backup of the old parameter file (named
 `old_filename.bak`), and replace the existing file with a version that should
 work with the current ASPECT version. Using


### PR DESCRIPTION
Just two file paths that are outdated (they are already correct in another place of those two files).