### PR TITLE
Fix Sphinx warnings

### DIFF
--- a/benchmarks/advection/README.md
+++ b/benchmarks/advection/README.md
@@ -13,4 +13,4 @@ Benchmarks:
 2. Rotate Shape (rotate_shape_supg.prm, rotate_shape_ev.prm)
    Various shapes being rotated by 360 degrees by a fixed velocity
 
-See [doc/advection.md](doc/advection.md) for details.
+See [](doc/advection) for details.

--- a/benchmarks/advection/doc/advection.md
+++ b/benchmarks/advection/doc/advection.md
@@ -23,7 +23,7 @@ Both benchmarks have the identical setup in the temperature and a
 compositional field. The only difference is that the temperature equation
 contains a (small) physical diffusion term.
 
-**[Description of benchmark files](../README.md)**
+**[Description of benchmark files](../README)**
 
 ```{figure-md} fig:benchmark-drop
 <img src="drop.png" />

--- a/benchmarks/rayleigh_taylor_instability/README.md
+++ b/benchmarks/rayleigh_taylor_instability/README.md
@@ -11,4 +11,4 @@ This file can later be processed with the 'gnuplot_script'.
 There is also the standalone input file `rayleigh_taylor_instability.prm` which
 runs only one of the cases (isoviscous and lambda=256km).
 
-See [doc/rayleigh_taylor_instability.md](doc/rayleigh_taylor_instability.md) for more information.
+See [](doc/rayleigh_taylor_instability) for more information.

--- a/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.md
+++ b/benchmarks/rayleigh_taylor_instability/doc/rayleigh_taylor_instability.md
@@ -57,7 +57,7 @@ file:
     end
 
 
-**[Description of benchmark files](../README.md)**
+**[Description of benchmark files](../README)**
 
 ```{figure-md} fig:RTi_grids_a
 <img src="grid.*" style="width:44.0%" />

--- a/benchmarks/sinking_block/README.md
+++ b/benchmarks/sinking_block/README.md
@@ -8,4 +8,4 @@ In order to run the benchmark for many resolution, density and viscosity combina
 all the input files generated inside the triple loop.
 The `sinking_block.prm` input file is the standalone prm file for the sinking block benchmark.
 
-For more information see [doc/sinking_block.md](doc/sinking_block.md).
+For more information see [](doc/sinking_block).

--- a/benchmarks/sinking_block/doc/sinking_block.md
+++ b/benchmarks/sinking_block/doc/sinking_block.md
@@ -34,7 +34,7 @@ $\delta\rho=8,32,128~\text{ kg m}^{-3}$. Results are shown in
 {numref}`fig:sinking_block2` and we indeed recover the expected trend with all data
 points forming a single smooth line.
 
-**[Description of benchmark files](../README.md)**
+**[Description of benchmark files](../README)**
 
 ```{figure-md} fig:sinking_block1
 <img src="dens_vel.png" style="width:60.0%" />


### PR DESCRIPTION
It looks like readthedocs has upgraded its Sphinx version, which now produces new warnings in our documentation (e.g. in #6235 [here](https://readthedocs.org/projects/aspect-documentation/builds/27241799/)). As far as I can tell this is caused by internal links that specify markdown files with their file ending. The links work with or without file ending, but with the ending there is a warning in the build process (which is interpreted as an error by our CI because of our configuration). Removing the file ending removes the warning and the links still work (checked in both html and pdf).