### PR TITLE
Fix Fastscape topography for periodic boundary by setting the values of ghost nodes earlier

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1334,9 +1334,9 @@ namespace aspect
 
               // Set bottom ghost node
               velocity_x[index_bot] = velocity_x[index_top - 2*fastscape_nx];
-	      velocity_y[index_bot] = velocity_y[index_top - 2*fastscape_nx];
+              velocity_y[index_bot] = velocity_y[index_top - 2*fastscape_nx];
               velocity_z[index_bot] = velocity_z[index_top - 2*fastscape_nx] + (elevation[index_top - 2*fastscape_nx] - elevation[index_bot])/fastscape_timestep_in_years;
-             
+
               if (velocity_y[index_bot+fastscape_nx-1] > 0 && velocity_y[index_top-fastscape_nx-1] >= 0)
                 {
                   side = index_top;

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1327,6 +1327,16 @@ namespace aspect
               unsigned int op_side = index_top;
               int jj = fastscape_nx;
 
+              // Set top ghost node
+              velocity_x[index_top] = velocity_x[index_bot + 2*fastscape_nx];
+              velocity_y[index_top] = velocity_y[index_bot + 2*fastscape_nx];
+              velocity_z[index_top] = velocity_z[index_bot + 2*fastscape_nx] + (elevation[index_bot + 2*fastscape_nx] - elevation[index_top])/fastscape_timestep_in_years;
+
+              // Set bottom ghost node
+              velocity_x[index_bot] = velocity_x[index_top - 2*fastscape_nx];
+	      velocity_y[index_bot] = velocity_y[index_top - 2*fastscape_nx];
+              velocity_z[index_bot] = velocity_z[index_top - 2*fastscape_nx] + (elevation[index_top - 2*fastscape_nx] - elevation[index_bot])/fastscape_timestep_in_years;
+             
               if (velocity_y[index_bot+fastscape_nx-1] > 0 && velocity_y[index_top-fastscape_nx-1] >= 0)
                 {
                   side = index_top;
@@ -1341,16 +1351,6 @@ namespace aspect
                 }
               else
                 continue;
-
-              // Set top ghost node
-              velocity_x[index_top] = velocity_x[index_bot + 2*fastscape_nx];
-              velocity_y[index_top] = velocity_y[index_bot + 2*fastscape_nx];
-              velocity_z[index_top] = velocity_z[index_bot + 2*fastscape_nx] + (elevation[index_bot + 2*fastscape_nx] - elevation[index_top])/fastscape_timestep_in_years;
-
-              // Set bottom ghost node
-              velocity_x[index_bot] = velocity_x[index_top - 2*fastscape_nx];
-              velocity_y[index_bot] = velocity_y[index_top - 2*fastscape_nx];
-              velocity_z[index_bot] = velocity_z[index_top - 2*fastscape_nx] + (elevation[index_top - 2*fastscape_nx] - elevation[index_bot])/fastscape_timestep_in_years;
 
               // Set opposing ASPECT boundary so it's periodic.
               elevation[op_side-jj] = elevation[side+jj];


### PR DESCRIPTION
Currently, if we use Fastscape with periodic boundaries for the front and back of the Fastscape domain, the front and back topography show abnormalities. See the topography at the front and back at the top of figure 1. 
![image](https://github.com/user-attachments/assets/4cce3a52-699a-406b-a319-4c4affd962d6)

We fix this by setting the Stokes velocity on the ghost nodes that is sent to Fastscape _before_ computing the direction of the periodicity from this velocity.  This actually comes down to only moving code. See the results for the same setup in figure 2. 
![image](https://github.com/user-attachments/assets/5c552b71-4cd1-4147-94f9-2bbd6e3bb757)

We will also test the left and right with periodic boundary conditions, but we have opened this pull request to start the discussion with @Djneu (and to practise making a pull request with @anne-glerum). 


### Before your first pull request:

* [ ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
