### PR TITLE
Improve wording and formatting of a message.

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1947,35 +1947,47 @@ namespace aspect
       }
     catch (ExcNonlinearSolverNoConvergence &)
       {
-        pcout << "\nWARNING: The nonlinear solver in the current timestep failed to converge." << std::endl
-              << "Acting according to the parameter 'Nonlinear solver failure strategy'..." << std::endl;
+        pcout << "\n"
+              "   WARNING: The nonlinear solver in the current timestep failed to converge.\n"
+              "   Acting according to the parameter 'Nonlinear solver failure strategy':"
+              << std::endl;
         ++nonlinear_solver_failures;
 
         switch (parameters.nonlinear_solver_failure_strategy)
           {
             case Parameters<dim>::NonlinearSolverFailureStrategy::continue_with_next_timestep:
             {
-              pcout << "Continuing to the next timestep even though solution is not fully converged." << std::endl;
-              // do nothing and continue
+              pcout << "   Continuing to the next timestep even though solution is not fully converged."
+                    << std::endl
+                    << std::endl;
+              // swallow the exception and continue
               break;
             }
             case Parameters<dim>::NonlinearSolverFailureStrategy::cut_timestep_size:
             {
               if (timestep_number == 0)
                 {
-                  pcout << "Error: We can not cut the timestep in step 0, so we are aborting."
+                  pcout << "   Error: Can not cut the timestep in step 0. Aborting."
                         << std::endl;
+                  // Rethrow the current exception
                   throw;
                 }
-              time_stepping_manager.template get_matching_active_plugin<TimeStepping::RepeatOnNonlinearFail<dim>>().nonlinear_solver_has_failed();
+              else
+                pcout << "   Trying to cut the current time step.\n"
+                      << std::endl;
+
+              time_stepping_manager.template get_matching_active_plugin<TimeStepping::RepeatOnNonlinearFail<dim>>()
+              .nonlinear_solver_has_failed();
               break;
             }
+
             case Parameters<dim>::NonlinearSolverFailureStrategy::abort_program:
             {
-              pcout << "Aborting simulation as requested." << std::endl;
-              // rethrow the current exception
+              pcout << "   Aborting simulation as requested." << std::endl;
+              // Rethrow the current exception
               throw;
             }
+
             default:
               AssertThrow(false, ExcNotImplemented());
           }

--- a/tests/anisotropic_viscosity/screen-output
+++ b/tests/anisotropic_viscosity/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.00018
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Heating rate (average/total):  5.225 W/kg, 8.978 W
      RMS, max velocity:             1.08 m/s, 1.65 m/s

--- a/tests/box_simple_surface_strain_rate_residual/screen-output
+++ b/tests/box_simple_surface_strain_rate_residual/screen-output
@@ -10,9 +10,10 @@ Number of mesh deformation degrees of freedom: 2,187
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Max, min, and RMS residual strain rate invariant along boundary parts: 4.78651e-06 1/s, 1.30885e-06 1/s, 1.991e-06 1/s
      Writing graphical output:                                              output-box_simple_surface_strain_rate_residual/solution/solution-00000

--- a/tests/compressibility/screen-output
+++ b/tests/compressibility/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.00023
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Top/bottom flux:          1/2.718
      Writing graphical output: output-compressibility/solution/solution-00000

--- a/tests/continental_extension/screen-output
+++ b/tests/continental_extension/screen-output
@@ -20,9 +20,10 @@ Number of mesh deformation degrees of freedom: 462
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Temperature min/avg/max: 273 K, 1052 K, 1613 K
 
@@ -43,9 +44,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000259297
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Temperature min/avg/max: 273 K, 1052 K, 1613 K
 

--- a/tests/continental_extension_mixed_compositions_particles/screen-output
+++ b/tests/continental_extension_mixed_compositions_particles/screen-output
@@ -52,9 +52,10 @@ Number of mesh deformation degrees of freedom: 462
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00189298
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:          0/1.472/6.041e+09 // 0/0/0 // 0/1/4e+09 // 0/1/4e+09 // 0/1/1.1e+10
      Heat flux densities for boundaries: 0.19 W/m, 0.19 W/m, -0.344 W/m, 0.05501 W/m
@@ -115,9 +116,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.00366469
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:          0/1.472/6.043e+09 // 0/0.0008647/1.867e+06 // 0/1/4e+09 // -0.001458/1.001/3.999e+09 // -1.29e-07/1/1.1e+10
      Heat flux densities for boundaries: 0.19 W/m, 0.19 W/m, -0.345 W/m, 0.05501 W/m
@@ -178,9 +180,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000440009
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:          0/1.472/6.044e+09 // 0/0.001942/3.746e+06 // 0/1/4e+09 // -0.002998/1.002/3.998e+09 // -4.899e-07/1/1.1e+10
      Heat flux densities for boundaries: 0.19 W/m, 0.19 W/m, -0.3448 W/m, 0.05502 W/m
@@ -241,9 +244,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 5: 0.000186489
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:          0/1.473/6.046e+09 // 0/0.003107/5.626e+06 // 0/1/4e+09 // -0.004627/1.002/3.997e+09 // -1.281e-06/1/1.101e+10
      Heat flux densities for boundaries: 0.1899 W/m, 0.19 W/m, -0.3445 W/m, 0.05503 W/m

--- a/tests/darcy_convection_step/screen-output
+++ b/tests/darcy_convection_step/screen-output
@@ -16,9 +16,10 @@ Number of degrees of freedom: 134 (50+9+25+25+25)
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1.00007
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output: output-darcy_convection_step/solution/solution-00000
 

--- a/tests/drucker_prager_compression/screen-output
+++ b/tests/drucker_prager_compression/screen-output
@@ -35,9 +35,10 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.015363
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  1.8e-11 m/s, 2e-11 m/s
      Mass fluxes through boundary parts: -0.00054 kg/s, -0.00054 kg/s, 0 kg/s, 0.00108 kg/s

--- a/tests/drucker_prager_extension/screen-output
+++ b/tests/drucker_prager_extension/screen-output
@@ -35,9 +35,10 @@ Number of degrees of freedom: 2,804 (2,210+297+297)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0972081
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  1.96e-11 m/s, 2.32e-11 m/s
      Mass fluxes through boundary parts: 0.00054 kg/s, 0.00054 kg/s, 0 kg/s, -0.00108 kg/s

--- a/tests/dynamic_friction/screen-output
+++ b/tests/dynamic_friction/screen-output
@@ -12,9 +12,10 @@ Number of mesh deformation degrees of freedom: 594
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.999994
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity: 0.00687 m/year, 0.01 m/year
 
@@ -31,9 +32,10 @@ Number of mesh deformation degrees of freedom: 2,090
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.999999
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity: 0.00687 m/year, 0.01 m/year
 

--- a/tests/entropy_conduction/screen-output
+++ b/tests/entropy_conduction/screen-output
@@ -111,9 +111,10 @@ Number of degrees of freedom: 6,417 (2,406+402+1,203+1,203+1,203)
       Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0441691
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  1.64e-07 m/year, 8.46e-07 m/year
      Temperature min/avg/max:            1600 K, 1833 K, 1993 K

--- a/tests/global_melt/screen-output
+++ b/tests/global_melt/screen-output
@@ -40,9 +40,10 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-global_melt/solution/solution-00000
      Compositions min/max/mass: 0/0/0 // 0/0/0
@@ -88,9 +89,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000257626
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-global_melt/solution/solution-00001
      Compositions min/max/mass: 0/0/0 // 0/0/0

--- a/tests/global_melt_parallel/screen-output
+++ b/tests/global_melt_parallel/screen-output
@@ -40,9 +40,10 @@ Number of degrees of freedom: 5,641 (1,666+801+1,666+225+833+225+225)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0272016
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-global_melt_parallel/solution/solution-00000
      Compositions min/max/mass: 0/0/0 // 0/0/0
@@ -88,9 +89,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.000257626
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-global_melt_parallel/solution/solution-00001
      Compositions min/max/mass: 0/0/0 // 0/0/0

--- a/tests/grain_size_yield/screen-output
+++ b/tests/grain_size_yield/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts:                1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/gs_drucker_prager_extension/screen-output
+++ b/tests/gs_drucker_prager_extension/screen-output
@@ -36,9 +36,10 @@ Number of degrees of freedom: 3,909 (2,210+297+297+1,105)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 2.40487e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 2.05e-11 m/s, 2.51e-11 m/s
      Mass fluxes through boundary parts:                0.00054 kg/s, 0.00054 kg/s, 0 kg/s, -0.00108 kg/s

--- a/tests/gs_drucker_prager_extension_adiabatic/screen-output
+++ b/tests/gs_drucker_prager_extension_adiabatic/screen-output
@@ -36,9 +36,10 @@ Number of degrees of freedom: 3,909 (2,210+297+297+1,105)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 1.96723e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 1.88e-11 m/s, 2.05e-11 m/s
      Mass fluxes through boundary parts:                0.00054 kg/s, 0.00054 kg/s, 0 kg/s, -0.00108 kg/s

--- a/tests/hk04_olivine_composite_hydration_prefactor_with_melt/screen-output
+++ b/tests/hk04_olivine_composite_hydration_prefactor_with_melt/screen-output
@@ -12,9 +12,10 @@ Number of degrees of freedom: 3,629 (882+421+882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Average density / Average viscosity / Total mass:  3198 kg/m^3, 2.628e+20 Pa s, 3.198e+13 kg
      Writing graphical output:                          output-hk04_olivine_composite_hydration_prefactor_with_melt/solution/solution-00000

--- a/tests/inclusion_2/screen-output
+++ b/tests/inclusion_2/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 268 (162+25+81)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_2/solution/solution-00000
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 187; 1.013775e+00, 1.350377e+01, 4.460692e-01, 8.286918e+00

--- a/tests/inclusion_4/screen-output
+++ b/tests/inclusion_4/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_4/solution/solution-00000
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 2467; 2.564925e-01, 2.917000e+00, 1.276561e-01, 2.772892e+00

--- a/tests/inclusion_adaptive/screen-output
+++ b/tests/inclusion_adaptive/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 948 (578+81+289)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00000
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 659; 2.874664e-01, 2.688132e+00, 1.425676e-01, 1.852245e+00
@@ -24,9 +25,10 @@ Number of degrees of freedom: 1,520 (930+125+465)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00001
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 1055; 2.587684e-01, 2.904484e+00, 1.286212e-01, 2.779361e+00
@@ -39,9 +41,10 @@ Number of degrees of freedom: 2,716 (1,666+217+833)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00002
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 1883; 9.203223e-02, 9.273608e-01, 4.802945e-02, 9.029288e-01
@@ -54,9 +57,10 @@ Number of degrees of freedom: 4,484 (2,754+353+1,377)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00003
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 3107; 5.571668e-02, 5.986879e-01, 2.970837e-02, 8.262387e-01
@@ -69,9 +73,10 @@ Number of degrees of freedom: 5,524 (3,394+433+1,697)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00004
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 3827; 3.573939e-02, 3.728804e-01, 1.913570e-02, 4.757713e-01
@@ -84,9 +89,10 @@ Number of degrees of freedom: 7,344 (4,514+573+2,257)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-inclusion_adaptive/solution/solution-00005
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 5087; 2.676587e-02, 2.984005e-01, 1.447695e-02, 4.244469e-01

--- a/tests/material_model_dependencies_tangurnis/screen-output
+++ b/tests/material_model_dependencies_tangurnis/screen-output
@@ -36,9 +36,10 @@ Number of degrees of freedom: 268 (162+25+81)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0801765
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
 viscosity depends on
 density depends on

--- a/tests/melt_property_visualization/screen-output
+++ b/tests/melt_property_visualization/screen-output
@@ -13,9 +13,10 @@ Number of degrees of freedom: 30,600 (12,611+8,450+1,089+4,225+4,225)
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output: output-melt_property_visualization/solution/solution-00000
 

--- a/tests/melt_transport_compressible_iterative/screen-output
+++ b/tests/melt_transport_compressible_iterative/screen-output
@@ -46,9 +46,10 @@ Number of degrees of freedom: 30,600 (8,450+4,161+8,450+1,089+4,225+4,225)
       Relative nonlinear residual (total system) after nonlinear iteration 5: 5.6863e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                                  0.223 m/s, 0.339 m/s
      Pressure min/avg/max:                                               0.5079 Pa, 1.575 Pa, 2.962 Pa

--- a/tests/mesh_deformation_gmg_2d_spherical_shell/screen-output
+++ b/tests/mesh_deformation_gmg_2d_spherical_shell/screen-output
@@ -15,9 +15,10 @@ Number of mesh deformation degrees of freedom: 480
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output: output-mesh_deformation_gmg_2d_spherical_shell/solution/solution-00000
      RMS, max velocity:        3.43 m/year, 12.3 m/year

--- a/tests/newton_postprocess_nonlinear/screen-output
+++ b/tests/newton_postprocess_nonlinear/screen-output
@@ -66,9 +66,10 @@ Number of degrees of freedom: 35,978 (8,450+1,089+1,089+4,225+4,225+4,225+4,225+
      Writing graphical output:  output-newton_postprocess_nonlinear/solution/solution-00000.0004
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
 
 
 

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_GMG/screen-output
@@ -57,9 +57,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.00130892
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.55e-08 m/s, 3.02e-08 m/s
      Pressure min/avg/max:               -296.2 Pa, 5e+08 Pa, 1e+09 Pa

--- a/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_line_search/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_Newton_Stokes_no_line_search/screen-output
@@ -366,9 +366,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 45: 2.51449
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.58e-08 m/s, 5.1e-08 m/s
      Pressure min/avg/max:               -4.212e+08 Pa, 5.013e+08 Pa, 1.268e+09 Pa
@@ -737,9 +738,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 45: 8.27618
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  3.96e-08 m/s, 8.67e-08 m/s
      Pressure min/avg/max:               -7.186e+08 Pa, 4.934e+08 Pa, 1.521e+09 Pa
@@ -1107,9 +1109,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 45: 2.66797
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  4.34e-08 m/s, 1.16e-07 m/s
      Pressure min/avg/max:               -6.14e+08 Pa, 4.964e+08 Pa, 1.581e+09 Pa
@@ -1478,9 +1481,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 45: 2.38434
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  3.82e-08 m/s, 9.4e-08 m/s
      Pressure min/avg/max:               -4.383e+08 Pa, 5.385e+08 Pa, 1.824e+09 Pa
@@ -1848,9 +1852,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 45: 2.68018
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  3.95e-08 m/s, 1.01e-07 m/s
      Pressure min/avg/max:               -6.855e+08 Pa, 4.308e+08 Pa, 1.296e+09 Pa

--- a/tests/nonlinear_channel_flow_tractions_benchmark/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_benchmark/screen-output
@@ -1452,9 +1452,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 150: 2.04612e-11
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.57e-08 m/s, 3.05e-08 m/s
      Pressure min/avg/max:               -0.0002411 Pa, 5e+08 Pa, 1e+09 Pa

--- a/tests/nonlinear_channel_flow_tractions_dc_picard_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_dc_picard_Stokes_GMG/screen-output
@@ -49,9 +49,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 0.0156303
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  1.96e-08 m/s, 2.33e-08 m/s
      Pressure min/avg/max:               -2.15 Pa, 5e+08 Pa, 1e+09 Pa

--- a/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_tractions_iterated_IMPES/screen-output
@@ -506,9 +506,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.378105
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.56e-08 m/s, 3.03e-08 m/s
      Pressure min/avg/max:               -2.196e+07 Pa, 4.989e+08 Pa, 1.023e+09 Pa
@@ -1017,9 +1018,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.392493
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.56e-08 m/s, 3.03e-08 m/s
      Pressure min/avg/max:               -2.076e+07 Pa, 5.008e+08 Pa, 1.025e+09 Pa
@@ -1527,9 +1529,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.340534
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.56e-08 m/s, 3.03e-08 m/s
      Pressure min/avg/max:               -7.343e+06 Pa, 5.002e+08 Pa, 1.046e+09 Pa

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_GMG/screen-output
@@ -188,9 +188,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 30: 4.05757e-11
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.57e-08 m/s, 3.05e-08 m/s
      Pressure min/avg/max:               -1.628e+08 Pa, 5.154e+08 Pa, 1.193e+09 Pa

--- a/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_line_search/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_Newton_Stokes_no_line_search/screen-output
@@ -246,9 +246,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000131891
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.91e-08 m/s, 7.87e-08 m/s
      Pressure min/avg/max:               -5.13e+08 Pa, 5.476e+08 Pa, 1.536e+09 Pa
@@ -497,9 +498,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000186898
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.84e-08 m/s, 6.97e-08 m/s
      Pressure min/avg/max:               -6.981e+08 Pa, 5.424e+08 Pa, 1.472e+09 Pa
@@ -747,9 +749,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000180837
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.82e-08 m/s, 7.68e-08 m/s
      Pressure min/avg/max:               -5.128e+08 Pa, 4.986e+08 Pa, 1.415e+09 Pa
@@ -998,9 +1001,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000193262
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.94e-08 m/s, 9.47e-08 m/s
      Pressure min/avg/max:               -6.693e+08 Pa, 5.353e+08 Pa, 1.393e+09 Pa
@@ -1248,9 +1252,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000182747
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.78e-08 m/s, 6.33e-08 m/s
      Pressure min/avg/max:               -5.653e+08 Pa, 5.169e+08 Pa, 1.543e+09 Pa

--- a/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
+++ b/tests/nonlinear_channel_flow_velocities_iterated_IMPES/screen-output
@@ -506,9 +506,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 100: 5.41172e-07
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.57e-08 m/s, 3.05e-08 m/s
      Pressure min/avg/max:               -1.001e+08 Pa, 5.034e+08 Pa, 1.136e+09 Pa
@@ -1017,9 +1018,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.000450363
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.57e-08 m/s, 3.05e-08 m/s
      Pressure min/avg/max:               -1.046e+08 Pa, 5.042e+08 Pa, 1.103e+09 Pa
@@ -1527,9 +1529,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 100: 0.000373286
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.57e-08 m/s, 3.05e-08 m/s
      Pressure min/avg/max:               -1.276e+08 Pa, 5.044e+08 Pa, 1.124e+09 Pa

--- a/tests/nonlinear_failure_strategy_abort/screen-output
+++ b/tests/nonlinear_failure_strategy_abort/screen-output
@@ -46,8 +46,8 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 2.52488e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
 Aborting simulation as requested.
 TimerOutput objects finalize timed values printed to the
 screen by communicating over MPI in their destructors.

--- a/tests/nonlinear_failure_strategy_cut/screen-output
+++ b/tests/nonlinear_failure_strategy_cut/screen-output
@@ -46,8 +46,10 @@ Number of degrees of freedom: 9,141 (4,290+561+2,145+2,145)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 2.52488e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Trying to cut the current time step.
+
 Repeating the current time step based on the time stepping manager ...
 
 *** Timestep 1:  t=6625.49 years, dt=6625.49 years

--- a/tests/nonlinear_failure_strategy_cut_refinement/screen-output
+++ b/tests/nonlinear_failure_strategy_cut_refinement/screen-output
@@ -52,8 +52,10 @@ Number of degrees of freedom: 2,397 (1,122+153+561+561)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 6.76851e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Trying to cut the current time step.
+
 Repeating the current time step based on the time stepping manager ...
 
 *** Timestep 1:  t=6625.49 years, dt=6625.49 years
@@ -113,8 +115,10 @@ Number of degrees of freedom: 657 (306+45+153+153)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 8.80853e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Trying to cut the current time step.
+
 Repeating the current time step based on the time stepping manager ...
 
 *** Timestep 2:  t=10312.7 years, dt=3687.25 years
@@ -143,8 +147,10 @@ Repeating the current time step based on the time stepping manager ...
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.51871e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Trying to cut the current time step.
+
 Repeating the current time step based on the time stepping manager ...
 
 *** Timestep 2:  t=8469.12 years, dt=1843.63 years
@@ -203,8 +209,10 @@ Skipping mesh refinement, because the mesh did not change.
       Relative nonlinear residual (total system) after nonlinear iteration 4: 1.33341e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Trying to cut the current time step.
+
 Repeating the current time step based on the time stepping manager ...
 
 *** Timestep 3:  t=10229.8 years, dt=1760.66 years

--- a/tests/particle_property_integrated_strain_invariant/screen-output
+++ b/tests/particle_property_integrated_strain_invariant/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.439224
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing particle output: output-particle_property_integrated_strain_invariant/particles/particles-00000
 

--- a/tests/periodic_compressible/screen-output
+++ b/tests/periodic_compressible/screen-output
@@ -20,9 +20,10 @@ Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0147308
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:           output-periodic_compressible/solution/solution-00000
      RMS, max velocity:                  0.00413 m/year, 0.00624 m/year

--- a/tests/pressure_scaling_signal/screen-output
+++ b/tests/pressure_scaling_signal/screen-output
@@ -11,9 +11,10 @@ pressure_scaling = 69.1186 reference_viscosity = 1.38237 length_scale = 0.02
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:            output-pressure_scaling_signal/solution/solution-00000
      DoFs; Errors u_L1, p_L1, u_L2, p_L2: 2467; 2.564925e-01, 2.917011e+00, 1.276561e-01, 2.772922e+00

--- a/tests/reactive_fluid_transport_no_reaction/screen-output
+++ b/tests/reactive_fluid_transport_no_reaction/screen-output
@@ -13,9 +13,10 @@ Number of degrees of freedom: 74 (18+7+18+4+9+9+9)
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:   0/0/0 // 0.01/0.01/4e+04
      Melt fraction min/total/max: 0, 0, 0
@@ -32,9 +33,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.99966
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:   0/0/0 // 0.01/0.01/4e+04
      Melt fraction min/total/max: 0, 0, 0

--- a/tests/reactive_fluid_transport_zero_solubility/screen-output
+++ b/tests/reactive_fluid_transport_zero_solubility/screen-output
@@ -13,9 +13,10 @@ Number of degrees of freedom: 74 (18+7+18+4+9+9+9)
       Relative nonlinear residual (total system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:   0/0/0 // 0.01/0.01/4e+04
      Melt fraction min/total/max: 0.01, 4e+04, 0.01

--- a/tests/shear_bands/screen-output
+++ b/tests/shear_bands/screen-output
@@ -38,9 +38,10 @@ Number of degrees of freedom: 30,824 (8,514+4,177+8,514+1,105+4,257+4,257)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0132089
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-shear_bands/solution/solution-00000
      Compositions min/max/mass: 0.04952/0.05046/2e-07
@@ -80,9 +81,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.00014165
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:  output-shear_bands/solution/solution-00001
      Compositions min/max/mass: 0.04944/0.05051/2e-07

--- a/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
+++ b/tests/sol_cx_4_normalized_pressure_low_solver_tolerance/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Errors u_L1, p_L1, u_L2, p_L2: 1.126521e-06, 2.999985e-03, 1.670114e-06, 9.780679e-03
 

--- a/tests/spiegelman_fail_test/screen-output
+++ b/tests/spiegelman_fail_test/screen-output
@@ -43,9 +43,10 @@ Number of degrees of freedom: 18,133 (8,514+1,105+4,257+4,257)
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0732243
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.14e-08 m/s, 2.44e-07 m/s
      Pressure min/avg/max:               -7.28e+10 Pa, 1.519e+09 Pa, 2.899e+11 Pa
@@ -91,9 +92,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (total system) after nonlinear iteration 4: 0.0122851
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  2.94e-09 m/s, 1.54e-08 m/s
      Pressure min/avg/max:               -2.771e+10 Pa, 3.617e+08 Pa, 6.167e+10 Pa

--- a/tests/statistics_output/screen-output
+++ b/tests/statistics_output/screen-output
@@ -46,9 +46,10 @@ Number of degrees of freedom: 2,757 (810+363+810+123+405+123+123)
       Relative nonlinear residual (total system) after nonlinear iteration 2: 0.150507
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Temperature min/avg/max:       1723 K, 1755 K, 1788 K
      Heating rate (average/total):  -3.478e-11 W/kg, -193.3 W

--- a/tests/tomography_based_plate_motions_cookbook/screen-output
+++ b/tests/tomography_based_plate_motions_cookbook/screen-output
@@ -26,9 +26,10 @@ Number of degrees of freedom: 8,016 (1,728+240+864+864+864+864+864+864+864)
       Relative nonlinear residual (total system) after nonlinear iteration 1: 0.012107
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Max, min, and RMS residual velocity along boundary parts: 1.123 m/year, 0.0004104 m/year, 0.4248 m/year
      Max, min, and rms velocity along boundary parts:          0.8438 m/year, 0.000775 m/year, 0.3246 m/year, 1.123 m/year, 0.0004104 m/year, 0.4248 m/year

--- a/tests/tosi_benchmark/screen-output
+++ b/tests/tosi_benchmark/screen-output
@@ -97,9 +97,10 @@ Number of degrees of freedom: 268 (162+25+81)
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.457179
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               122 m/s, 516 m/s
      Temperature min/avg/max:                         0 K, 0.5042 K, 1 K

--- a/tests/tosi_benchmark_gmg_dc_picard_solver/screen-output
+++ b/tests/tosi_benchmark_gmg_dc_picard_solver/screen-output
@@ -174,9 +174,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 30: 4.00633e-07
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               6.95 m/s, 34.2 m/s
      Temperature min/avg/max:                         0 K, 0.5 K, 1 K
@@ -308,9 +309,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 30: 3.24223e-07
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               7.9 m/s, 39.1 m/s
      Temperature min/avg/max:                         0 K, 0.5 K, 1 K

--- a/tests/tosi_benchmark_gmg_newton_solver/screen-output
+++ b/tests/tosi_benchmark_gmg_newton_solver/screen-output
@@ -271,9 +271,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 30: 0.000517299
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               105 m/s, 417 m/s
      Temperature min/avg/max:                         0 K, 0.506 K, 1 K

--- a/tests/tosi_benchmark_newton_solver/screen-output
+++ b/tests/tosi_benchmark_newton_solver/screen-output
@@ -166,9 +166,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.219472
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               106 m/s, 448 m/s
      Temperature min/avg/max:                         0 K, 0.5058 K, 1 K

--- a/tests/tosi_benchmark_newton_solver_full_A/screen-output
+++ b/tests/tosi_benchmark_newton_solver_full_A/screen-output
@@ -166,9 +166,10 @@ Number of degrees of freedom: 3,556 (2,178+289+1,089)
       Relative nonlinear residual (total system) after nonlinear iteration 15: 0.219472
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                               106 m/s, 448 m/s
      Temperature min/avg/max:                         0 K, 0.5058 K, 1 K

--- a/tests/traction_ascii_data/screen-output
+++ b/tests/traction_ascii_data/screen-output
@@ -33,9 +33,10 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.0233251
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  66.5 m/year, 175 m/year
      Mass fluxes through boundary parts: 3.559e+06 kg/yr, 0 kg/yr, 0 kg/yr, 0 kg/yr

--- a/tests/traction_multiple_model/screen-output
+++ b/tests/traction_multiple_model/screen-output
@@ -30,9 +30,10 @@ Number of degrees of freedom: 61,140 (37,570+4,785+18,785)
       Relative nonlinear residual (total system) after nonlinear iteration 3: 0.133364
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  41.8 m/year, 121 m/year
      Mass fluxes through boundary parts: 3.376e+06 kg/yr, 0 kg/yr, 0 kg/yr, 0 kg/yr

--- a/tests/visco_plastic/screen-output
+++ b/tests/visco_plastic/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.439224
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_additional_plastic_outputs/screen-output
+++ b/tests/visco_plastic_additional_plastic_outputs/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.439224
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_adiabat_temperature/screen-output
+++ b/tests/visco_plastic_adiabat_temperature/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.057698
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_adiabatic_pressure_in_viscous_creep/screen-output
+++ b/tests/visco_plastic_adiabatic_pressure_in_viscous_creep/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0576586
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_complex/screen-output
+++ b/tests/visco_plastic_complex/screen-output
@@ -10,9 +10,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.179628
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.57e+05 kg/yr, 1.57e+05 kg/yr, -1.65e+05 kg/yr, -1.4e+05 kg/yr

--- a/tests/visco_plastic_composite/screen-output
+++ b/tests/visco_plastic_composite/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_diffusion/screen-output
+++ b/tests/visco_plastic_diffusion/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_diffusion_dislocation_composite/screen-output
+++ b/tests/visco_plastic_diffusion_dislocation_composite/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_dislocation/screen-output
+++ b/tests/visco_plastic_dislocation/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_frank_kamenetskii/screen-output
+++ b/tests/visco_plastic_frank_kamenetskii/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0521283
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_frank_kamenetskii_pressure/screen-output
+++ b/tests/visco_plastic_frank_kamenetskii_pressure/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.164417
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_frank_kamenetskii_pressure_user_refs/screen-output
+++ b/tests/visco_plastic_frank_kamenetskii_pressure_user_refs/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00222334
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_friction_function/screen-output
+++ b/tests/visco_plastic_friction_function/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00954832
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  8.8e-16 m/year, 1.92e-15 m/year
      Mass fluxes through boundary parts: 0 kg/yr, 0 kg/yr, 0 kg/yr, 0 kg/yr

--- a/tests/visco_plastic_gerya_2019_vp/screen-output
+++ b/tests/visco_plastic_gerya_2019_vp/screen-output
@@ -20,9 +20,10 @@ Number of degrees of freedom: 6,023 (2,178+289+289+1,089+1,089+1,089)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 0.0943178
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:                         0/1/4.579e+09 // 0/1/5.208e+09 // 0/1/2.127e+08
      Average density / Average viscosity / Total mass:  2700 kg/m^3, 1.098e+21 Pa s, 2.7e+13 kg

--- a/tests/visco_plastic_phases/screen-output
+++ b/tests/visco_plastic_phases/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.433991
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts:                1.676e+05 kg/yr, 1.676e+05 kg/yr, -1.701e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_phases_plasticity/screen-output
+++ b/tests/visco_plastic_phases_plasticity/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.433991
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts:                1.676e+05 kg/yr, 1.676e+05 kg/yr, -1.701e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_phases_viscosity/screen-output
+++ b/tests/visco_plastic_phases_viscosity/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.112457
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 6.97 m/year, 50.5 m/year
      Mass fluxes through boundary parts:                1.688e+05 kg/yr, 1.838e+05 kg/yr, -1.823e+05 kg/yr, -1.723e+05 kg/yr

--- a/tests/visco_plastic_phases_viscosity_max_min/screen-output
+++ b/tests/visco_plastic_phases_viscosity_max_min/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.0548563
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 1.66 m/year, 8.9 m/year
      Mass fluxes through boundary parts:                1.688e+05 kg/yr, 1.838e+05 kg/yr, -1.823e+05 kg/yr, -1.723e+05 kg/yr

--- a/tests/visco_plastic_reference_density_profile/screen-output
+++ b/tests/visco_plastic_reference_density_profile/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.439224
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_thermal_conductivity/screen-output
+++ b/tests/visco_plastic_thermal_conductivity/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.576e+05 kg/yr, 1.576e+05 kg/yr, -1.576e+05 kg/yr, -1.576e+05 kg/yr

--- a/tests/visco_plastic_total_strain_healing_temperature_dependent/screen-output
+++ b/tests/visco_plastic_total_strain_healing_temperature_dependent/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 520 (242+36+121+121)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.00069951
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:                         0.2/0.2/2e+09
      Average density / Average viscosity / Total mass:  3302 kg/m^3, 5e+21 Pa s, 3.302e+13 kg

--- a/tests/visco_plastic_track_noninitial_plastic_strain/screen-output
+++ b/tests/visco_plastic_track_noninitial_plastic_strain/screen-output
@@ -10,9 +10,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.236841
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -29,9 +30,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000132201
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_vep_brick_extension/screen-output
+++ b/tests/visco_plastic_vep_brick_extension/screen-output
@@ -169,9 +169,10 @@ Number of mesh deformation degrees of freedom: 252
       Relative nonlinear residual (Stokes system) after nonlinear iteration 4: 0.000137637
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:           0.000866 m/year, 0.00135 m/year
      Number of advected particles 400

--- a/tests/visco_plastic_viscous_strain_weakening/screen-output
+++ b/tests/visco_plastic_viscous_strain_weakening/screen-output
@@ -36,9 +36,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 10: 1.0141e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield/screen-output
+++ b/tests/visco_plastic_yield/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                                 0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts:                1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_max/screen-output
+++ b/tests/visco_plastic_yield_max/screen-output
@@ -8,9 +8,10 @@ Number of degrees of freedom: 1,444 (882+121+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.121665
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Writing graphical output:           output-visco_plastic_yield_max/solution/solution-00000
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year

--- a/tests/visco_plastic_yield_plastic_damper/screen-output
+++ b/tests/visco_plastic_yield_plastic_damper/screen-output
@@ -15,9 +15,10 @@ Number of degrees of freedom: 1,607 (578+81+81+289+289+289)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      Compositions min/max/mass:                         0/1/4.149e+09 // 0/1/5.417e+09 // 0/1/4.34e+08
      Average density / Average viscosity / Total mass:  2700 kg/m^3, 1.442e+22 Pa s, 2.7e+13 kg

--- a/tests/visco_plastic_yield_plastic_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_plastic_strain_weakening/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.237215
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_plastic_strain_weakening_particles/screen-output
+++ b/tests/visco_plastic_yield_plastic_strain_weakening_particles/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_plastic_viscous_strain_healing/screen-output
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_healing/screen-output
@@ -10,9 +10,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.237034
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -29,9 +30,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000121775
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -47,9 +49,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000108342
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -65,9 +68,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.5092e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -83,9 +87,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.18718e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -101,9 +106,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.05226e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_plastic_viscous_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_weakening/screen-output
@@ -10,9 +10,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.237215
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles/screen-output
+++ b/tests/visco_plastic_yield_plastic_viscous_strain_weakening_particles/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.237215
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -27,9 +28,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 9.93527e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening_compositions/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_compositions/screen-output
@@ -10,9 +10,10 @@ Number of degrees of freedom: 2,326 (882+121+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.507e+05 kg/yr, 1.507e+05 kg/yr, -1.651e+05 kg/yr, -1.351e+05 kg/yr
@@ -29,9 +30,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.061128
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.507e+05 kg/yr, 1.507e+05 kg/yr, -1.651e+05 kg/yr, -1.351e+05 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_defect_corr_stokes/screen-output
@@ -12,9 +12,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -33,9 +34,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 9.70804e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor/screen-output
@@ -12,9 +12,10 @@ Number of degrees of freedom: 3,208 (882+121+441+441+441+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.230577
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening_full_strain_tensor_3d/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_full_strain_tensor_3d/screen-output
@@ -17,9 +17,10 @@ Number of degrees of freedom: 17,441 (3,969+242+1,323+1,323+1,323+1,323+1,323+1,
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.247945
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+09 kg/yr, 1.651e+09 kg/yr, 0 kg/yr, 0 kg/yr, -1.651e+09 kg/yr, -1.651e+09 kg/yr

--- a/tests/visco_plastic_yield_strain_weakening_iterated_advection/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_iterated_advection/screen-output
@@ -54,9 +54,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
      RMS, max velocity:         0.000408 m/year, 0.000691 m/year
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
 
 
 
@@ -112,9 +113,10 @@ Continuing to the next timestep even though solution is not fully converged.
      RMS, max velocity:         0.000408 m/year, 0.000691 m/year
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
 
 
 
@@ -170,9 +172,10 @@ Continuing to the next timestep even though solution is not fully converged.
      RMS, max velocity:         0.000408 m/year, 0.000691 m/year
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
 
 
 

--- a/tests/visco_plastic_yield_strain_weakening_particles/screen-output
+++ b/tests/visco_plastic_yield_strain_weakening_particles/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -28,9 +29,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 5.54406e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_temperature_activated_viscous_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_temperature_activated_viscous_strain_weakening/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.246453
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.609e+05 kg/yr, 1.609e+05 kg/yr, -1.598e+05 kg/yr, -1.621e+05 kg/yr

--- a/tests/visco_plastic_yield_total_strain_healing/screen-output
+++ b/tests/visco_plastic_yield_total_strain_healing/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.237034
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -27,9 +28,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000121775
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -44,9 +46,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.000108342
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -61,9 +64,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.5092e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -78,9 +82,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.18718e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr
@@ -95,9 +100,10 @@ Continuing to the next timestep even though solution is not fully converged.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1.05226e-05
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_viscous_strain_weakening/screen-output
+++ b/tests/visco_plastic_yield_viscous_strain_weakening/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr

--- a/tests/visco_plastic_yield_viscous_strain_weakening_particles/screen-output
+++ b/tests/visco_plastic_yield_viscous_strain_weakening_particles/screen-output
@@ -9,9 +9,10 @@ Number of degrees of freedom: 1,885 (882+121+441+441)
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 0.23759
 
 
-WARNING: The nonlinear solver in the current timestep failed to converge.
-Acting according to the parameter 'Nonlinear solver failure strategy'...
-Continuing to the next timestep even though solution is not fully converged.
+   WARNING: The nonlinear solver in the current timestep failed to converge.
+   Acting according to the parameter 'Nonlinear solver failure strategy':
+   Continuing to the next timestep even though solution is not fully converged.
+
    Postprocessing:
      RMS, max velocity:                  0.000408 m/year, 0.000691 m/year
      Mass fluxes through boundary parts: 1.651e+05 kg/yr, 1.651e+05 kg/yr, -1.651e+05 kg/yr, -1.651e+05 kg/yr


### PR DESCRIPTION
The message shown at https://community.geodynamics.org/t/mpi-error-and-particles-lost-rapidly/3965/3 is poorly formatted in the flow of the other output. While there, also updating some of the wording.