### PR TITLE
SimulatorAccess for StokesMatrixFree

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -432,15 +432,18 @@ namespace aspect
         switch (parameters.stokes_velocity_degree)
           {
             case 2:
-              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,2>>(*this, prm);
+              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,2>>(*this, parameters);
               break;
             case 3:
-              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,3>>(*this, prm);
+              stokes_matrix_free = std::make_unique<StokesMatrixFreeHandlerImplementation<dim,3>>(*this, parameters);
               break;
             default:
               AssertThrow(false, ExcMessage("The finite element degree for the Stokes system you selected is not supported yet."));
           }
 
+        stokes_matrix_free->initialize_simulator(*this);
+        stokes_matrix_free->parse_parameters(prm);
+        stokes_matrix_free->initialize();
       }
 
     postprocess_manager.initialize_simulator (*this);


### PR DESCRIPTION
Something that always bothered me about the StokesMatrixFree class was how liberally it used the pointer to simulator to access information it could have gotten from SimulatorAccess instead. This PR is a first step towards disentangling StokesMatrixFree from Simulator internals. Ultimately, I am thinking of making the solvers their independent plugin system as well. I am not sure if we fully get there, but at least with the current changes the code also looks more like a normal plugin.

This PR:
- derives `StokesMatrixFree` from `SimulatorAccess` and `Plugins::InterfaceBase`, to give it read access via SimulatorAccess and align its functions more with how all other plugins look like.
- changes the initialization of `StokesMatrixFree` to the order of functions we usually use (costructor -> initialize_simulator -> parse_parameters -> initialize).
- replaces a lot of direct accesses to the simulator (`sim. ...`) with simulator_acces (`this->get_...`)

Ideally, no functionality should change.