### PR TITLE
Reduce redundant computation in StokesOperator::local_apply()

### DIFF
--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -427,7 +427,7 @@ namespace aspect
         p_eval.reinit(cell);
         p_eval.gather_evaluate(src.block(1), EvaluationFlags::values);
 
-        // factors related with Newton derivatives
+        // Derivative terms related to the Newton solver
         VectorizedArray<number> deta_deps_times_sym_grad_u(0.);
         VectorizedArray<number> eps_times_sym_grad_u(0.);
         VectorizedArray<number> deta_dp_times_p(0.);


### PR DESCRIPTION
This PR corrects a mistake I made: in function `MatrixFreeStokesOperators::StokesOperator::local_apply()`, the loop for averaging the Newton derivatives were nested in the loop over quadrature points, which is unnecessary. The two loops are separated now.

By the way, I have a question about the Newton method with GMG solver. In the present implementation, the top-left block used in the outer loop of the linear solver is the Jacobian matrix $\boldsymbol J^{uu}$, while the matrix in the inner loop (V-cycle for the cheap solver, preconditioned CG for the expensive solver) is the original $\boldsymbol A$. I do not understand why this implementation provides a moderate convergence rate. It seems that the original author of the GMG solver planned to use the Jacobian in the inner loop, but did not do it (see the `TODO` in line 1318 of source/simulator/stokes_matrix_free.cc). I tried to add the Newton derivatives to `MatrixFreeStokesOperators::ABlockOperator::inner_cell_operation()`, but it turned out that the convergence rate was even worse in most cases. Could anyone explain why the convergence rate of the GMG solver with $\boldsymbol A$ in the inner loop is better?
