### PR TITLE
Introduce solver interface class

### DIFF
--- a/include/aspect/simulator/solver/interface.h
+++ b/include/aspect/simulator/solver/interface.h
@@ -39,13 +39,21 @@ namespace aspect
         /**
          * Solves the linear system.
          *
+         * @param system_matrix The system matrix. Note that even if the matrix
+         * is not assembled (e.g. for matrix free solvers), a reference to the
+         * system matrix will be provided to the solver.
+         * @param system_rhs The right hand side vector of the system.
          * @param solution_vector The existing solution vector that will be
          * updated with the new solution. This vector is expected to have the
          * block structure of the full solution vector, and the blocks that
          * are to be solved in this solver will be overwritten.
+         *
+         * @return A pair of the initial and final residual of the linear solver.
          */
         virtual
-        std::pair<double,double> solve(LinearAlgebra::BlockVector &solution_vector) = 0;
+        std::pair<double,double> solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
+                                       const LinearAlgebra::BlockVector &system_rhs,
+                                       LinearAlgebra::BlockVector &solution_vector) = 0;
 
         /**
          * Return the name of the solver for screen output.

--- a/include/aspect/simulator/solver/interface.h
+++ b/include/aspect/simulator/solver/interface.h
@@ -1,0 +1,59 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_simulator_solver_interface_h
+#define _aspect_simulator_solver_interface_h
+
+#include <aspect/global.h>
+#include <aspect/simulator_access.h>
+
+
+namespace aspect
+{
+  namespace Solver
+  {
+    /**
+     * Base class for ASPECT solvers.
+     */
+    template <int dim>
+    class Interface: public SimulatorAccess<dim>, public Plugins::InterfaceBase
+    {
+      public:
+        /**
+         * Solves the linear system.
+         *
+         * @param solution_vector The existing solution vector that will be
+         * updated with the new solution. This vector is expected to have the
+         * block structure of the full solution vector, and the blocks that
+         * are to be solved in this solver will be overwritten.
+         */
+        virtual
+        std::pair<double,double> solve(LinearAlgebra::BlockVector &solution_vector) = 0;
+
+        /**
+         * Return the name of the solver for screen output.
+         */
+        virtual
+        std::string name() const = 0;
+    };
+  }
+}
+
+#endif

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -23,10 +23,9 @@
 #define _aspect_stokes_matrix_free_h
 
 #include <aspect/global.h>
-#include <aspect/plugins.h>
+#include <aspect/simulator/solver/interface.h>
 
 #include <aspect/simulator.h>
-#include <aspect/simulator_access.h>
 
 #include <deal.II/matrix_free/matrix_free.h>
 #include <deal.II/matrix_free/operators.h>
@@ -402,20 +401,9 @@ namespace aspect
    * actual implementation is found inside StokesMatrixFreeHandlerImplementation below.
    */
   template <int dim>
-  class StokesMatrixFreeHandler: public SimulatorAccess<dim>, public Plugins::InterfaceBase
+  class StokesMatrixFreeHandler: public Solver::Interface<dim>
   {
     public:
-      /**
-       * Solves the Stokes linear system using the matrix-free
-       * solver.
-       *
-       * @param solution_vector The existing solution vector that will be
-       * updated with the new solution. This vector is expected to have the
-       * block structure of the full solution vector, and its velocity and
-       * pressure blocks will be updated with the new solution.
-       */
-      virtual std::pair<double,double> solve(LinearAlgebra::BlockVector &solution_vector) = 0;
-
       /**
        * Allocates and sets up the members of the StokesMatrixFreeHandler. This
        * is called by Simulator<dim>::setup_dofs()
@@ -531,6 +519,11 @@ namespace aspect
        * Initialize the matrix-free solver.
        */
       void initialize() override;
+
+      /**
+       * Return the name of the solver for screen output.
+       */
+      std::string name() const override;
 
       /**
        * Solves the Stokes linear system using the matrix-free

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -529,12 +529,17 @@ namespace aspect
        * Solves the Stokes linear system using the matrix-free
        * solver.
        *
-       * @param solution_vector The existing solution vector that will be
+       * @param system_matrix The system matrix. Note that we do not actually
+       * use this matrix for this matrix free solver.
+       * @param system_rhs The right hand side vector of the system.
+       * @param solution_vector The solution vector that will be
        * updated with the new solution. This vector is expected to have the
        * block structure of the full solution vector, and its velocity and
        * pressure blocks will be updated with the new solution.
        */
-      std::pair<double,double> solve(LinearAlgebra::BlockVector &solution_vector) override;
+      std::pair<double,double> solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
+                                     const LinearAlgebra::BlockVector &system_rhs,
+                                     LinearAlgebra::BlockVector &solution_vector) override;
 
       /**
        * Allocates and sets up the members of the StokesMatrixFreeHandler. This

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -780,7 +780,7 @@ namespace aspect
 
     if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
       {
-        return stokes_matrix_free->solve(solution_vector);
+        return stokes_matrix_free->solve(system_matrix, system_rhs, solution_vector);
       }
 
     // In the following, we will operate on a vector that contains only

--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -768,7 +768,7 @@ namespace aspect
     const std::string name = [&]() -> std::string
     {
       if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::block_gmg)
-        return "GMG";
+        return stokes_matrix_free->name();
       if (parameters.use_direct_stokes_solver)
         return "direct";
       if (parameters.use_bfbt)

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1033,6 +1033,12 @@ namespace aspect
                   ExcNotImplemented());
   }
 
+  template <int dim, int velocity_degree>
+  std::string
+  StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::name () const
+  {
+    return "GMG";
+  }
 
 
   template <int dim, int velocity_degree>

--- a/source/simulator/stokes_matrix_free.cc
+++ b/source/simulator/stokes_matrix_free.cc
@@ -1033,12 +1033,15 @@ namespace aspect
                   ExcNotImplemented());
   }
 
+
+
   template <int dim, int velocity_degree>
   std::string
   StokesMatrixFreeHandlerImplementation<dim, velocity_degree>::name () const
   {
     return "GMG";
   }
+
 
 
   template <int dim, int velocity_degree>
@@ -1699,7 +1702,10 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  std::pair<double,double> StokesMatrixFreeHandlerImplementation<dim,velocity_degree>::solve(LinearAlgebra::BlockVector &solution_vector)
+  std::pair<double,double>
+  StokesMatrixFreeHandlerImplementation<dim,velocity_degree>::solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
+                                                                    const LinearAlgebra::BlockVector &system_rhs,
+                                                                    LinearAlgebra::BlockVector &solution_vector)
   {
     double initial_nonlinear_residual = numbers::signaling_nan<double>();
     double final_linear_residual      = numbers::signaling_nan<double>();
@@ -1867,8 +1873,8 @@ namespace aspect
     LinearAlgebra::BlockVector distributed_stokes_rhs(this->introspection().index_sets.stokes_partitioning,
                                                       this->get_mpi_communicator());
 
-    distributed_stokes_rhs.block(block_vel) = sim.system_rhs.block(block_vel);
-    distributed_stokes_rhs.block(block_p) = sim.system_rhs.block(block_p);
+    distributed_stokes_rhs.block(block_vel) = system_rhs.block(block_vel);
+    distributed_stokes_rhs.block(block_p) = system_rhs.block(block_p);
 
     Assert(block_vel == 0, ExcNotImplemented());
     Assert(block_p == 1, ExcNotImplemented());
@@ -2338,9 +2344,15 @@ namespace aspect
     // convert melt pressures
     // TODO: We assert in the StokesMatrixFreeHandler constructor that we
     //       are not including melt transport.
-    if (this->get_parameters().include_melt_transport)
-      this->get_melt_handler().compute_melt_variables(sim.system_matrix,solution_vector,sim.system_rhs);
+    // TODO: We have to const_cast, because the compute_melt_variables
+    //       function assembles and solves an equation. To avoid this we either
+    //       have to hand over non-const references to the current function, or
+    //       call the compute_melt_variables function after finishing the current function.
 
+    if (this->get_parameters().include_melt_transport)
+      this->get_melt_handler().compute_melt_variables(const_cast<LinearAlgebra::BlockSparseMatrix &>(system_matrix),
+                                                      solution_vector,
+                                                      const_cast<LinearAlgebra::BlockVector &>(system_rhs));
 
     return std::pair<double,double>(initial_nonlinear_residual,
                                     final_linear_residual);


### PR DESCRIPTION
A follow-up to #6247 that could be used as a basis to also move the direct solver and the AMG solver into their own classes and reduce the bloat of the simulator class a bit.
The final design of the interface class is up for modification and discussion, since none of this is really exposed to the user we should be able to modify the interface class for a while without issues.