### PR TITLE
Implement direct Stokes solver class

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -84,6 +84,12 @@ namespace aspect
   template <int dim>
   class StokesMatrixFreeHandler;
 
+  namespace StokesSolver
+  {
+    template <int dim>
+    class Direct;
+  }
+
   template <int dim, int velocity_degree>
   class StokesMatrixFreeHandlerImplementation;
 
@@ -1489,17 +1495,18 @@ namespace aspect
 
       /**
        * Eliminate the nullspace of the velocity in the given vector. Both
-       * vectors are expected to contain the up to date data.
+       * vectors are expected to contain the current solution.
        *
-       * @param relevant_dst locally relevant vector for the whole FE, will be
-       * filled at the end.
-       * @param tmp_distributed_stokes only contains velocity and pressure.
+       * @param solution The locally relevant vector for the whole
+       * finite element, this vector will be filled at the end.
+       * @param distributed_stokes_solution only contains velocity and pressure and
+       * only locally owned elements.
        *
        * This function is implemented in
        * <code>source/simulator/nullspace.cc</code>.
        */
-      void remove_nullspace(LinearAlgebra::BlockVector &relevant_dst,
-                            LinearAlgebra::BlockVector &tmp_distributed_stokes) const;
+      void remove_nullspace(LinearAlgebra::BlockVector &solution,
+                            LinearAlgebra::BlockVector &distributed_stokes_solution) const;
 
       /**
        * Compute the angular momentum and other rotation properties
@@ -2171,6 +2178,12 @@ namespace aspect
        * Unique pointer for the matrix-free Stokes solver
        */
       std::unique_ptr<StokesMatrixFreeHandler<dim>> stokes_matrix_free;
+
+      /**
+       * Unique pointer for the direct Stokes solver
+       */
+      std::unique_ptr<StokesSolver::Direct<dim>> stokes_direct;
+
 
       friend class boost::serialization::access;
       friend class SimulatorAccess<dim>;

--- a/include/aspect/simulator/solver/stokes_direct.h
+++ b/include/aspect/simulator/solver/stokes_direct.h
@@ -18,11 +18,11 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _aspect_simulator_solver_interface_h
-#define _aspect_simulator_solver_interface_h
+#ifndef _aspect_simulator_solver_stokes_direct_h
+#define _aspect_simulator_solver_stokes_direct_h
 
 #include <aspect/global.h>
-#include <aspect/simulator_access.h>
+#include <aspect/simulator/solver/interface.h>
 
 
 namespace aspect
@@ -30,38 +30,11 @@ namespace aspect
   namespace StokesSolver
   {
     /**
-     * A struct that contains the return values provided by the different
-     * stokes solvers.
-     */
-    struct SolverOutputs
-    {
-      SolverOutputs()
-        :
-        initial_nonlinear_residual(numbers::signaling_nan<double>()),
-        final_linear_residual(numbers::signaling_nan<double>()),
-        pressure_normalization_adjustment(numbers::signaling_nan<double>())
-      {}
-
-      /**
-       * The initial residual of the nonlinear solver (before solving)
-       * and the final residual of the linear solver (after solving).
-       */
-      double initial_nonlinear_residual;
-      double final_linear_residual;
-
-      /**
-       * The amount by which the pressure was adjusted to satisfy the
-       * chosen pressure normalization. This information is
-       * necessary to undo the normalization before the next solve.
-       */
-      double pressure_normalization_adjustment;
-    };
-
-    /**
-     * Base class for ASPECT solvers.
+     * A direct solver for the Stokes equations using the Trilinos Amesos package.
+     * The solver used is Amesos_Klu.
      */
     template <int dim>
-    class Interface: public SimulatorAccess<dim>, public Plugins::InterfaceBase
+    class Direct: public Interface<dim>
     {
       public:
         /**
@@ -75,9 +48,6 @@ namespace aspect
          * solved is the normal linear system or the Newton system. If the Newton
          * system is solved, some operations have to change, e.g. the residual
          * is computed differently.
-         * @param last_pressure_normalization_adjustment The amount by which the
-         * pressure was adjusted to satisfy the chosen pressure normalization. This
-         * information is used to undo the normalization before the solve.
          * @param solution_vector The existing solution vector that will be
          * updated with the new solution. This vector is expected to have the
          * block structure of the full solution vector, and the blocks that
@@ -86,18 +56,16 @@ namespace aspect
          * @return A structure that contains information about the solver, like
          * the initial and final residual.
          */
-        virtual
         SolverOutputs solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
                             const LinearAlgebra::BlockVector &system_rhs,
                             const bool solve_newton_system,
                             const double last_pressure_normalization_adjustment,
-                            LinearAlgebra::BlockVector &solution_vector) = 0;
+                            LinearAlgebra::BlockVector &solution_vector) override;
 
         /**
          * Return the name of the solver for screen output.
          */
-        virtual
-        std::string name() const = 0;
+        std::string name() const override;
     };
   }
 }

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -978,6 +978,45 @@ namespace aspect
                                    const LinearAlgebra::BlockVector &solution,
                                    const bool limit_to_top_faces = false) const;
 
+      /**
+      * Eliminate the nullspace of the velocity in the given vector. Both
+      * vectors are expected to contain the current solution.
+      *
+      * @param solution The locally relevant vector for the whole
+      * finite element, this vector will be filled at the end.
+      * @param distributed_stokes_solution only contains velocity and pressure and
+      * only locally owned elements.
+      */
+      void remove_nullspace(LinearAlgebra::BlockVector &solution,
+                            LinearAlgebra::BlockVector &distributed_stokes_solution) const;
+
+      /**
+       * Adjust the pressure variable (which is only determined up to
+       * a constant by the equations) by adding a constant to it in
+       * such a way that the pressure on the surface or within the
+       * entire volume has a known average value. See the documentation
+       * of the normalize_pressure() function in the Simulator class
+       * for more information.
+       *
+       * @return This function returns the pressure adjustment by value.
+       * This is so that its negative can later be used again in
+       * denormalize_pressure().
+       */
+      double normalize_pressure(LinearAlgebra::BlockVector &vector) const;
+
+      /**
+       * Invert the action of the normalize_pressure() function above. This
+       * means that we move from a pressure that satisfies the pressure
+       * normalization (e.g., has a zero average pressure, or a zero average
+       * surface pressure) to one that does not actually satisfy this
+       * normalization. See the function denormalize_pressure() in the
+       * Simulator class for more information.
+       *
+       * This function modifies @p vector in-place.
+       */
+      void denormalize_pressure(const double                      pressure_adjustment,
+                                LinearAlgebra::BlockVector       &vector) const;
+
       /** @} */
 
     private:

--- a/include/aspect/stokes_matrix_free.h
+++ b/include/aspect/stokes_matrix_free.h
@@ -401,7 +401,7 @@ namespace aspect
    * actual implementation is found inside StokesMatrixFreeHandlerImplementation below.
    */
   template <int dim>
-  class StokesMatrixFreeHandler: public Solver::Interface<dim>
+  class StokesMatrixFreeHandler: public StokesSolver::Interface<dim>
   {
     public:
       /**
@@ -532,14 +532,24 @@ namespace aspect
        * @param system_matrix The system matrix. Note that we do not actually
        * use this matrix for this matrix free solver.
        * @param system_rhs The right hand side vector of the system.
+       * @param solve_newton_system A flag indicating whether the system to be
+       * solved is the normal linear system or the Newton system. If the Newton
+       * system is solved, some operations have to change, e.g. the residual
+       * is computed differently.
        * @param solution_vector The solution vector that will be
        * updated with the new solution. This vector is expected to have the
        * block structure of the full solution vector, and its velocity and
        * pressure blocks will be updated with the new solution.
+       *
+       * @return A structure that contains information about the solver, like
+       * the initial and final residual.
        */
-      std::pair<double,double> solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
-                                     const LinearAlgebra::BlockVector &system_rhs,
-                                     LinearAlgebra::BlockVector &solution_vector) override;
+      StokesSolver::SolverOutputs
+      solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
+            const LinearAlgebra::BlockVector &system_rhs,
+            const bool solve_newton_system,
+            const double last_pressure_normalization_adjustment,
+            LinearAlgebra::BlockVector &solution_vector) override;
 
       /**
        * Allocates and sets up the members of the StokesMatrixFreeHandler. This

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -26,6 +26,7 @@
 #include <aspect/volume_of_fluid/handler.h>
 #include <aspect/newton.h>
 #include <aspect/stokes_matrix_free.h>
+#include <aspect/simulator/solver/stokes_direct.h>
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/postprocess/particles.h>
 
@@ -444,6 +445,14 @@ namespace aspect
         stokes_matrix_free->initialize_simulator(*this);
         stokes_matrix_free->parse_parameters(prm);
         stokes_matrix_free->initialize();
+      }
+
+    if (parameters.stokes_solver_type == Parameters<dim>::StokesSolverType::direct_solver)
+      {
+        stokes_direct = std::make_unique<StokesSolver::Direct<dim>>();
+        stokes_direct->initialize_simulator(*this);
+        stokes_direct->parse_parameters(prm);
+        stokes_direct->initialize();
       }
 
     postprocess_manager.initialize_simulator (*this);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -873,6 +873,35 @@ namespace aspect
   {
     return simulator->compute_net_angular_momentum(use_constant_density, solution, limit_to_top_faces);
   }
+
+
+
+  template <int dim>
+  double
+  SimulatorAccess<dim>::normalize_pressure(LinearAlgebra::BlockVector &vector) const
+  {
+    return simulator->normalize_pressure(vector);
+  }
+
+
+
+  template <int dim>
+  void
+  SimulatorAccess<dim>::denormalize_pressure(const double                      pressure_adjustment,
+                                             LinearAlgebra::BlockVector       &vector) const
+  {
+    simulator->denormalize_pressure(pressure_adjustment, vector);
+  }
+
+
+
+  template <int dim>
+  void
+  SimulatorAccess<dim>::remove_nullspace(LinearAlgebra::BlockVector &solution,
+                                         LinearAlgebra::BlockVector &distributed_stokes_solution) const
+  {
+    simulator->remove_nullspace(solution, distributed_stokes_solution);
+  }
 }
 
 

--- a/source/simulator/solver/stokes_direct.cc
+++ b/source/simulator/solver/stokes_direct.cc
@@ -1,0 +1,221 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/simulator/solver/stokes_direct.h>
+
+#include <deal.II/lac/trilinos_solver.h>
+
+namespace aspect
+{
+  namespace StokesSolver
+  {
+    template <int dim>
+    SolverOutputs
+    Direct<dim>::solve(const LinearAlgebra::BlockSparseMatrix &system_matrix,
+                       const LinearAlgebra::BlockVector &system_rhs,
+                       const bool solve_newton_system,
+                       const double last_pressure_normalization_adjustment,
+                       LinearAlgebra::BlockVector &solution_vector)
+    {
+
+      // In the following, we will operate on a vector that contains only
+      // the velocity and pressure DoFs, rather than on the full
+      // system. Set such a reduced vector up, without any ghost elements.
+      // (Worth noting: for direct solvers, this vector has one block,
+      // whereas for the iterative solvers, the result has two blocks.)
+      LinearAlgebra::BlockVector distributed_stokes_solution (this->introspection().index_sets.stokes_partitioning,
+                                                              this->get_mpi_communicator());
+
+      // We will need the Stokes block indices a lot below, shorten their names
+      const unsigned int velocity_block_index = this->introspection().block_indices.velocities;
+      const unsigned int pressure_block_index = (this->get_parameters().include_melt_transport) ?
+                                                this->introspection().variable("fluid pressure").block_index
+                                                : this->introspection().block_indices.pressure;
+      (void) velocity_block_index;
+      (void) pressure_block_index;
+
+
+      // Create a view of all constraints that only pertains to the
+      // Stokes subset of degrees of freedom. We can then use this later
+      // to call constraints.distribute(), constraints.set_zero(), etc.,
+      // on those block vectors that only have the Stokes components in
+      // them.
+      //
+      // For the moment, assume that the Stokes degrees are first in the
+      // overall vector, so that they form a contiguous range starting
+      // at zero. The assertion checks this, but this could easily be
+      // generalized if the Stokes block were not starting at zero.
+#if DEAL_II_VERSION_GTE(9,6,0)
+      {
+        Assert (velocity_block_index == 0, ExcNotImplemented());
+      }
+
+      IndexSet stokes_dofs (this->get_dof_handler().n_dofs());
+      stokes_dofs.add_range (0, distributed_stokes_solution.size());
+      const AffineConstraints<double> current_stokes_constraints
+        = this->get_current_constraints().get_view (stokes_dofs);
+#else
+      const AffineConstraints<double> &current_stokes_constraints = this->get_current_constraints();
+#endif
+
+      double initial_nonlinear_residual = numbers::signaling_nan<double>();
+      double final_linear_residual      = numbers::signaling_nan<double>();
+
+
+      // We hard-code the blocks down below, so make sure block 0 is indeed
+      // the block containing velocity and pressure:
+      Assert(distributed_stokes_solution.n_blocks() == 1, ExcInternalError());
+      Assert(velocity_block_index == 0, ExcNotImplemented());
+      Assert(pressure_block_index == 0
+             ||
+             (this->get_parameters().include_melt_transport
+              && this->introspection().variable("fluid pressure").block_index == 0
+              && this->introspection().variable("compaction pressure").block_index == 0),
+             ExcNotImplemented());
+
+      // Clarify that we only use one block for the direct solver
+      const unsigned int velocity_and_pressure_block = velocity_block_index;
+
+      // Start with a reasonable guess.
+      //
+      // While we don't need to set up the initial guess for the direct solver
+      // (it will be ignored by the solver anyway), we need this if we are
+      // using a nonlinear scheme, because we use this to compute the current
+      // nonlinear residual (see initial_residual below).
+      solution_vector.block(velocity_and_pressure_block) = this->get_current_linearization_point().block(velocity_and_pressure_block);
+
+      // TODO: if there was an easy way to know if the caller needs the
+      // initial residual we could skip all of this stuff.
+      distributed_stokes_solution.block(velocity_and_pressure_block) = solution_vector.block(velocity_and_pressure_block);
+      this->denormalize_pressure (last_pressure_normalization_adjustment,
+                                  distributed_stokes_solution);
+      current_stokes_constraints.set_zero (distributed_stokes_solution);
+
+      // Undo the pressure scaling:
+      const IndexSet &pressure_idxset = this->get_parameters().include_melt_transport ?
+                                        this->introspection().index_sets.locally_owned_melt_pressure_dofs
+                                        : this->introspection().index_sets.locally_owned_pressure_dofs;
+
+      for (unsigned int i=0; i< pressure_idxset.n_elements(); ++i)
+        {
+          types::global_dof_index idx = pressure_idxset.nth_index_in_set(i);
+
+          distributed_stokes_solution(idx) /= this->get_pressure_scaling();
+        }
+      distributed_stokes_solution.compress(VectorOperation::insert);
+
+      // we need a temporary vector for the residual (even if we don't care about it)
+      LinearAlgebra::Vector residual (this->introspection().index_sets.stokes_partitioning[0], this->get_mpi_communicator());
+
+      initial_nonlinear_residual = system_matrix.block(velocity_and_pressure_block,velocity_and_pressure_block).residual(
+                                     residual,
+                                     distributed_stokes_solution.block(velocity_and_pressure_block),
+                                     system_rhs.block(velocity_and_pressure_block));
+
+      SolverControl cn;
+      // TODO: can we re-use the direct solver?
+      TrilinosWrappers::SolverDirect solver(cn);
+      try
+        {
+          solver.solve(system_matrix.block(velocity_and_pressure_block,velocity_and_pressure_block),
+                       distributed_stokes_solution.block(velocity_and_pressure_block),
+                       system_rhs.block(velocity_and_pressure_block));
+
+          // if we got here, we have successfully solved the linear system
+          // with a direct solver, and the final linear residual should
+          // be approximately zero. we could compute it exactly, but
+          // this is probably not necessary
+          final_linear_residual = 0;
+        }
+      // if the solver fails, report the error from processor 0 with some additional
+      // information about its location, and throw a quiet exception on all other
+      // processors
+      catch (const std::exception &exc)
+        {
+          if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+            {
+              AssertThrow (false,
+                           ExcMessage (std::string("The direct Stokes solver "
+                                                   "did not succeed. It reported the following error:\n\n")
+                                       +
+                                       exc.what()));
+            }
+          else
+            throw QuietException();
+        }
+
+
+      current_stokes_constraints.distribute (distributed_stokes_solution);
+
+      // Now rescale the pressure back to real physical units. Note that we are
+      // working on a vector in which all velocities and pressures are in one
+      // block (that's the design for block layout in case we're using a direct
+      // solver), and so unlike in the "common" case, we can't just scale a
+      // whole vector block -- we have to do it element by element.
+      {
+        const IndexSet &pressure_idxset
+          = (this->get_parameters().include_melt_transport ?
+             this->introspection().index_sets.locally_owned_melt_pressure_dofs
+             : this->introspection().index_sets.locally_owned_pressure_dofs);
+        for (const types::global_dof_index i : pressure_idxset)
+          distributed_stokes_solution(i) *= this->get_pressure_scaling();
+
+        distributed_stokes_solution.block(velocity_and_pressure_block).compress(VectorOperation::insert);
+      }
+
+      // Then copy back the solution from the temporary (non-ghosted) vector
+      // into the ghosted one with all solution components. Note that
+      // for a direct solver, we have only one block for velocity+pressure,
+      // and so only one block needs to be copied.
+      solution_vector.block(velocity_and_pressure_block) = distributed_stokes_solution.block(velocity_and_pressure_block);
+
+      // do some cleanup now that we have the solution
+      this->remove_nullspace(solution_vector, distributed_stokes_solution);
+
+      SolverOutputs outputs;
+
+      if (solve_newton_system == false)
+        outputs.pressure_normalization_adjustment = this->normalize_pressure(solution_vector);
+
+      this->get_pcout() << "done." << std::endl;
+
+      outputs.initial_nonlinear_residual = initial_nonlinear_residual;
+      outputs.final_linear_residual = final_linear_residual;
+
+      return outputs;
+    }
+
+    template <int dim>
+    std::string
+    Direct<dim>::name () const
+    {
+      return "direct";
+    }
+
+
+    // explicit instantiation of the functions we implement in this file
+#define INSTANTIATE(dim) \
+  template class Direct<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+  }
+}


### PR DESCRIPTION
The next step after #6251 towards making our solvers more modular and reducing the size of the Simulator class. This PR moves the code for the direct solver out of the simulator class and into a new class derived from `Solver::Interface`. To get this to work without making it a friend of Simulator I had to expose a few simulator functions through `SimulatorAccess` which also further reduced the use of simulator in StokesMatrixFree.

This is not ready for review yet! I want to see the test results first and want to do some further refactoring.