### PR TITLE
Add arkode grain size parameters

### DIFF
--- a/include/aspect/material_model/reaction_model/grain_size_evolution.h
+++ b/include/aspect/material_model/reaction_model/grain_size_evolution.h
@@ -257,6 +257,16 @@ namespace aspect
            * Cache the total number of phase transitions defined in phase_function.
            */
           unsigned int n_phase_transitions;
+
+          /**
+           * The initial step size taken by the ARKode solver.
+           */
+          double arkode_initial_step_size;
+
+          /**
+           * The minimum step size taken by the ARKode solver.
+           */
+          double arkode_minimum_step_size;
       };
     }
 

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -173,10 +173,9 @@ namespace aspect
         data.initial_time = 0.0;
         data.final_time = this->get_timestep();
 
-        // TODO: make this an input parameter.
-        data.initial_step_size = 0.001 * this->get_timestep();
+        data.initial_step_size = arkode_initial_step_size * this->get_timestep();
         data.output_period = this->get_timestep();
-        data.minimum_step_size = 1.e-6*this->get_timestep();
+        data.minimum_step_size = arkode_minimum_step_size * this->get_timestep();
         data.maximum_order = 3;
         data.maximum_non_linear_iterations = 30;
 
@@ -417,6 +416,18 @@ namespace aspect
         prm.declare_entry ("Advect logarithm of grain size", "false",
                            Patterns::Bool (),
                            "This option does not exist any more.");
+        prm.declare_entry ("ARKode initial step size", "1e-3",
+                           Patterns::Double (1e-12, 1.0),
+                           "The initial step size that the ODE solver uses when solving the grain "
+                           "size evolution equation. The step size is relative to the ASPECT time step, i.e. "
+                           "the default value of 1e-3 means the initial step size will be 1e-3 times the "
+                           "current ASPECT time step.");
+        prm.declare_entry ("ARKode minimum step size", "1e-6",
+                           Patterns::Double (1e-12, 1.0),
+                           "The minimum step size that the ODE solver uses when solving the grain "
+                           "size evolution equation. The step size is relative to the ASPECT time step, i.e. "
+                           "the default value of 1e-6 means the step size will never be smaller than 1e-6 "
+                           "times the current ASPECT time step.");
 
         prm.enter_subsection("Grain damage partitioning");
         {
@@ -553,6 +564,9 @@ namespace aspect
                                "has been removed. Please remove it from your input file. For models "
                                "with large spatial variations in grain size, please advect your "
                                "grain size on particles."));
+
+        arkode_initial_step_size = prm.get_double ("ARKode initial step size");
+        arkode_minimum_step_size = prm.get_double ("ARKode minimum step size");
 
         if (grain_growth_activation_energy.size() != grain_growth_activation_volume.size() ||
             grain_growth_activation_energy.size() != grain_growth_rate_constant.size() ||

--- a/tests/grain_size_plunge_varied_step.prm
+++ b/tests/grain_size_plunge_varied_step.prm
@@ -1,0 +1,20 @@
+# A test for the grain size material model using the pinned state damage formulation.
+# This test is like the grain_size_plunge test, but modifies the ODE solver parameters
+# to check that they are working as intended. At the time of writing the test, the ODE
+# statistics postprocessor reports 3 steps for the default values, and 5 steps
+# for the parameters in this file. Using an initial step size of 1.0 results in 1 step.
+
+include $ASPECT_SOURCE_DIR/benchmarks/grain_size_pinned_state/grain_size_plunge.prm
+
+set End time                               = 1e2
+
+subsection Material model
+  subsection Grain size model
+    set ARKode initial step size = 1e-6
+    set ARKode minimum step size = 1e-6
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = ODE statistics
+end

--- a/tests/grain_size_plunge_varied_step/screen-output
+++ b/tests/grain_size_plunge_varied_step/screen-output
@@ -1,0 +1,490 @@
+
+Number of active cells: 1 (on 1 levels)
+Number of degrees of freedom: 40 (18+4+9+9)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 5e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 1
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 1
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.19663e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.839327
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 0.839327
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 3.52226e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.704451
+      Relative nonlinear residual (total system) after nonlinear iteration 3: 0.704451
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.78152e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.556303
+      Relative nonlinear residual (total system) after nonlinear iteration 4: 0.556303
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.09133e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.418266
+      Relative nonlinear residual (total system) after nonlinear iteration 5: 0.418266
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.51567e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.303134
+      Relative nonlinear residual (total system) after nonlinear iteration 6: 0.303134
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.06991e+12, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.213981
+      Relative nonlinear residual (total system) after nonlinear iteration 7: 0.213981
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 7.41481e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.148296
+      Relative nonlinear residual (total system) after nonlinear iteration 8: 0.148296
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 5.07421e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.101484
+      Relative nonlinear residual (total system) after nonlinear iteration 9: 0.101484
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 3.44277e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0688553
+      Relative nonlinear residual (total system) after nonlinear iteration 10: 0.0688553
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.32236e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0464471
+      Relative nonlinear residual (total system) after nonlinear iteration 11: 0.0464471
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.56048e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0312095
+      Relative nonlinear residual (total system) after nonlinear iteration 12: 0.0312095
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.04581e+11, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0209161
+      Relative nonlinear residual (total system) after nonlinear iteration 13: 0.0209161
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 6.99657e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.0139931
+      Relative nonlinear residual (total system) after nonlinear iteration 14: 0.0139931
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.67533e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00935066
+      Relative nonlinear residual (total system) after nonlinear iteration 15: 0.00935066
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 3.12176e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00624353
+      Relative nonlinear residual (total system) after nonlinear iteration 16: 0.00624353
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.08335e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00416669
+      Relative nonlinear residual (total system) after nonlinear iteration 17: 0.00416669
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.38986e+10, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00277973
+      Relative nonlinear residual (total system) after nonlinear iteration 18: 0.00277973
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 9.27006e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00185401
+      Relative nonlinear residual (total system) after nonlinear iteration 19: 0.00185401
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 6.18195e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00123639
+      Relative nonlinear residual (total system) after nonlinear iteration 20: 0.00123639
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.12215e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.00082443
+      Relative nonlinear residual (total system) after nonlinear iteration 21: 0.00082443
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.74848e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000549696
+      Relative nonlinear residual (total system) after nonlinear iteration 22: 0.000549696
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.83249e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000366497
+      Relative nonlinear residual (total system) after nonlinear iteration 23: 0.000366497
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.22173e+09, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000244347
+      Relative nonlinear residual (total system) after nonlinear iteration 24: 0.000244347
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 8.14522e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000162904
+      Relative nonlinear residual (total system) after nonlinear iteration 25: 0.000162904
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 5.43029e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 0.000108606
+      Relative nonlinear residual (total system) after nonlinear iteration 26: 0.000108606
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 3.62026e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 7.24052e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 27: 7.24052e-05
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.41354e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 4.82707e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 28: 4.82707e-05
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.60904e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 3.21807e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 29: 3.21807e-05
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.0727e+08, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 2.14539e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 30: 2.14539e-05
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 7.15134e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 1.43027e-05
+      Relative nonlinear residual (total system) after nonlinear iteration 31: 1.43027e-05
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.76757e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.10201e-16, 1.58051e-16, 9.53514e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 32: 9.53514e-06
+
+
+   Postprocessing:
+
+*** Timestep 1:  t=10 years, dt=10 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06765e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 0.00130736, 0.81353
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.81353
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.11893e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.46417e-16, 3.39288e-06, 4.23785e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.23785e-06
+
+
+   Postprocessing:
+
+*** Timestep 2:  t=20.1 years, dt=10.1 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06772e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 2.07453e-16, 2.28817e-06, 0.813544
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813544
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.47189e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.46692e-16, 2.70691e-09, 4.94377e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 4.94377e-07
+
+
+   Postprocessing:
+
+*** Timestep 3:  t=30.301 years, dt=10.201 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06775e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-17, 3.11984e-06, 0.81355
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.81355
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.17197e+07, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 0, 6.94872e-10, 2.34395e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.34395e-06
+
+
+   Postprocessing:
+
+*** Timestep 4:  t=40.604 years, dt=10.303 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06774e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-16, 3.45764e-06, 0.813549
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813549
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 9.35999e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 7.33458e-16, 1.15975e-09, 1.872e-06
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 1.872e-06
+
+
+   Postprocessing:
+
+*** Timestep 5:  t=51.0101 years, dt=10.406 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06772e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.39284e-16, 3.62082e-06, 0.813545
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813545
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 3.10074e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 9.39284e-16, 4.83175e-09, 6.20147e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 6.20147e-07
+
+
+   Postprocessing:
+
+*** Timestep 6:  t=61.5202 years, dt=10.5101 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.31205e-15, 3.71788e-06, 0.813542
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813542
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.43161e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.18266e-15, 7.50958e-09, 2.86323e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 2.86323e-07
+
+
+   Postprocessing:
+
+*** Timestep 7:  t=72.1354 years, dt=10.6152 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.28093e-15, 3.79005e-06, 0.813541
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813541
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 2.6708e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.25333e-15, 8.3844e-09, 5.3416e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 5.3416e-07
+
+
+   Postprocessing:
+
+*** Timestep 8:  t=82.8567 years, dt=10.7214 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.44474e-15, 3.85507e-06, 0.813542
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813542
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 1.74328e+06, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51028e-15, 8.06395e-09, 3.48656e-07
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.48656e-07
+
+
+   Postprocessing:
+
+*** Timestep 9:  t=93.6853 years, dt=10.8286 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.67415e-15, 3.92039e-06, 0.813543
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813543
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 358438, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.64006e-15, 7.48312e-09, 7.16875e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 7.16875e-08
+
+
+   Postprocessing:
+
+*** Timestep 10:  t=100 years, dt=6.31473 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Initial Newton Stokes residual = 5e+12, v = 5e+12, p = 0
+
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 4.06771e+12
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.51955e-15, 1.46266e-06, 0.813543
+      Relative nonlinear residual (total system) after nonlinear iteration 1: 0.813543
+
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 1 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 1+0 iterations.
+      Newton system information: Norm of the rhs: 199617, Derivative scaling factor: 0
+      Relative nonlinear residuals (temperature, compositional fields, Stokes system): 1.34038e-15, 1.6689e-09, 3.99234e-08
+      Relative nonlinear residual (total system) after nonlinear iteration 2: 3.99234e-08
+
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/grain_size_plunge_varied_step/statistics
+++ b/tests/grain_size_plunge_varied_step/statistics
@@ -1,0 +1,25 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Number of nonlinear iterations
+# 9: Iterations for temperature solver
+# 10: Iterations for composition solver 1
+# 11: Iterations for Stokes solver
+# 12: Velocity iterations in Stokes preconditioner
+# 13: Schur complement iterations in Stokes preconditioner
+# 14: Average iterations for ODE solver
+ 0 0.000000000000e+00 0.000000000000e+00 1 22 9 9 32 0 0 32 64 63 nan 
+ 1 1.000000000000e+01 1.000000000000e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 2 2.010000000000e+01 1.010000000000e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 3 3.030100000000e+01 1.020100000000e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 4 4.060401000000e+01 1.030301000000e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 5 5.101005010000e+01 1.040604010000e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 6 6.152015060100e+01 1.051010050100e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 7 7.213535210701e+01 1.061520150601e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 8 8.285670562808e+01 1.072135352107e+01 1 22 9 9  2 0 2  2  4  4 nan 
+ 9 9.368527268436e+01 1.082856705628e+01 1 22 9 9  2 0 2  2  4  4 nan 
+10 1.000000000000e+02 6.314727315639e+00 1 22 9 9  2 0 2  2  4  4 nan 


### PR DESCRIPTION
This implements one TODO for the grain size evolution model, namely to be able to specify in the input file which initial step size and minimum step size ARKode is to use. This is useful, because in models with slowly changing properties increasing the minimum step size can speed up the model. But more importantly in models with quickly changing grain size the current default parameters sometimes (rarely) do not allow for the solver to converge to the intended accuracy, which leads to warnings. Being able to reduce the minimum step size fixes this issue.

@jdannberg can you take a look?