### PR TITLE
remove some unnecessary lines

### DIFF
--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -190,24 +190,13 @@ namespace aspect
                     if (in.composition[q][porosity_idx] + porosity_change < 0)
                       porosity_change = -in.composition[q][porosity_idx];
 
-                    if (fluid_solid_reaction_scheme != katz2003)
-                      {
-                        const unsigned int bound_fluid_idx = this->introspection().compositional_index_for_name("bound_fluid");
-                        if (c == bound_fluid_idx && this->get_timestep_number() > 0)
-                          reaction_rate_out->reaction_rates[q][c] = - porosity_change / fluid_reaction_time_scale;
-                        else if (c == porosity_idx && this->get_timestep_number() > 0)
-                          reaction_rate_out->reaction_rates[q][c] = porosity_change / fluid_reaction_time_scale;
-                        else
-                          reaction_rate_out->reaction_rates[q][c] = 0.0;
-                      }
+                    const unsigned int bound_fluid_idx = this->introspection().compositional_index_for_name("bound_fluid");
+                    if (c == bound_fluid_idx && this->get_timestep_number() > 0)
+                      reaction_rate_out->reaction_rates[q][c] = - porosity_change / fluid_reaction_time_scale;
+                    else if (c == porosity_idx && this->get_timestep_number() > 0)
+                      reaction_rate_out->reaction_rates[q][c] = porosity_change / fluid_reaction_time_scale;
                     else
-                      {
-                        if (c == porosity_idx && this->get_timestep_number() > 0)
-                          reaction_rate_out->reaction_rates[q][c] = porosity_change / fluid_reaction_time_scale;
-                        else
-                          reaction_rate_out->reaction_rates[q][c] = 0.0;
-                      }
-
+                      reaction_rate_out->reaction_rates[q][c] = 0.0;
                   }
             }
         }


### PR DESCRIPTION
I noticed this while replying to a forum post. It looks like during restructuring of this model, some extra lines were left in?
Going up to line 132 shows that all the code below to line 202 is already within an if-statement that checks that we do not use the  katz2003 fluid_solid_reaction_scheme. So the lines I removed will never be executed. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).