### PR TITLE
fix issues with area divided by being zero

### DIFF
--- a/source/postprocess/composition_velocity_statistics.cc
+++ b/source/postprocess/composition_velocity_statistics.cc
@@ -86,8 +86,9 @@ namespace aspect
       double velocity_square_integral_selected_fields = 0., area_integral_selected_fields = 0.;
       for (unsigned int c = 0; c < this->n_compositional_fields(); ++c)
         {
-          vrms_per_composition[c] = std::sqrt(global_velocity_square_integral[c]) /
-                                    std::sqrt(global_area_integral[c]);
+          if (global_area_integral[c] > 0)
+            vrms_per_composition[c] = std::sqrt(global_velocity_square_integral[c]) /
+                                      std::sqrt(global_area_integral[c]);
 
           const std::vector<std::string>::iterator selected_field_it = std::find(selected_fields.begin(), selected_fields.end(), this->introspection().name_for_compositional_index(c));
           if (selected_field_it != selected_fields.end())
@@ -97,7 +98,9 @@ namespace aspect
             }
         }
 
-      const double vrms_selected_fields = std::sqrt(velocity_square_integral_selected_fields) / std::sqrt(area_integral_selected_fields);
+      double vrms_selected_fields = 0.;
+      if (area_integral_selected_fields > 0)
+        vrms_selected_fields = std::sqrt(velocity_square_integral_selected_fields) / std::sqrt(area_integral_selected_fields);
 
       const std::string unit = (this->convert_output_to_years()) ? "m/year" : "m/s";
       const double time_scaling = (this->convert_output_to_years()) ? year_in_seconds : 1.0;
@@ -122,13 +125,16 @@ namespace aspect
         }
 
       // Also output the selected fields vrms
-      statistics.add_value("RMS velocity (" + unit + ") for the selected field ",
-                           time_scaling * vrms_selected_fields);
+      if (selected_fields.size() > 0)
+        {
+          statistics.add_value("RMS velocity (" + unit + ") for the selected field(s)",
+                               time_scaling * vrms_selected_fields);
 
-      const std::string column = {"RMS velocity (" + unit + ") for the selected field "};
+          const std::string column = {"RMS velocity (" + unit + ") for the selected field(s)"};
 
-      statistics.set_precision(column, 8);
-      statistics.set_scientific(column, true);
+          statistics.set_precision(column, 8);
+          statistics.set_scientific(column, true);
+        }
 
       std::ostringstream output;
       output.precision(4);
@@ -137,9 +143,11 @@ namespace aspect
         {
           output << time_scaling *vrms_per_composition[c]
                  << " " << unit;
-          output << " // ";
+          if (c < this->n_compositional_fields()-1)
+            output << " // ";
         }
-      output << time_scaling *vrms_selected_fields;
+      if (selected_fields.size() > 0)
+        output << " // " << time_scaling *vrms_selected_fields << " " << unit;
 
       return std::pair<std::string, std::string>("RMS velocity for compositions and combined selected fields:",
                                                  output.str());
@@ -177,11 +185,25 @@ namespace aspect
         {
           selected_fields = Utilities::split_string_list(prm.get("Names of selected compositional fields"));
 
-          AssertThrow((selected_fields.size() > 0) &&
-                      (selected_fields.size() <= this->n_compositional_fields()),
-                      ExcMessage("The length of the list of names for the compositional "
-                                 "fields for which the RMS velocity is to be summed must be larger than zero "
-                                 "and smaller or equal to the number of compositional fields."));
+          // Check that the names given as selected_fields are actually fields.
+          for (const std::string &field_name: selected_fields)
+            {
+              std::vector<std::string> field_names = this->get_parameters().names_of_compositional_fields;
+              AssertThrow(std::find(field_names.begin(),
+                                    field_names.end(),
+                                    field_name)
+                          != field_names.end(),
+                          ExcMessage("The entry '" + field_name + "' in the parameter "
+                                     "<Names of selected compositional fields> in the composition velocity "
+                                     "statistics postprocessor is not a valid name of a compositional field "
+                                     "as specified in the <Compositional fields/Names of fields> parameter."));
+            }
+
+          AssertThrow(Utilities::has_unique_entries(selected_fields),
+                      ExcMessage("The list of compositional fields for the parameter "
+                                 "<Names of selected compositional fields> in the composition velocity "
+                                 "statistics postprocessor contains entries more than once. "
+                                 "This is not allowed. Please check your parameter file."));
         }
         prm.leave_subsection();
       }

--- a/source/postprocess/composition_velocity_statistics.cc
+++ b/source/postprocess/composition_velocity_statistics.cc
@@ -188,11 +188,7 @@ namespace aspect
           // Check that the names given as selected_fields are actually fields.
           for (const std::string &field_name: selected_fields)
             {
-              std::vector<std::string> field_names = this->get_parameters().names_of_compositional_fields;
-              AssertThrow(std::find(field_names.begin(),
-                                    field_names.end(),
-                                    field_name)
-                          != field_names.end(),
+              AssertThrow(this->introspection().compositional_name_exists(field_name),
                           ExcMessage("The entry '" + field_name + "' in the parameter "
                                      "<Names of selected compositional fields> in the composition velocity "
                                      "statistics postprocessor is not a valid name of a compositional field "

--- a/tests/composition_velocity_zero.prm
+++ b/tests/composition_velocity_zero.prm
@@ -20,6 +20,10 @@ subsection Postprocess
   set List of postprocessors = visualization, temperature statistics, composition statistics, composition velocity statistics
 
   subsection Composition velocity statistics
+    # The postprocessor always calculates the RMS velocity of all individual compositional fields.
+    # This parameter allows it to additionally compute a combined RMS velocity for specific fields.
+    # Leaving this parameter blank only means that we do not want to do this combined calculation,
+    # but the RMS velocity of all individual fields will still be computed.
     set Names of selected compositional fields =
   end
 end

--- a/tests/composition_velocity_zero.prm
+++ b/tests/composition_velocity_zero.prm
@@ -1,0 +1,25 @@
+# This is a test for the composition velocity statistics
+# postprocessor, specifically, if it also works when a
+# field is zero.
+
+include $ASPECT_SOURCE_DIR/tests/composition_active.prm
+
+set End time = 0.2
+
+subsection Compositional fields
+  set Number of fields = 3
+end
+
+subsection Initial composition model
+  subsection Function
+    set Function expression = if(y<0.2, 1, 0) ; if(y>0.8, 1, 0); 0.0
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, temperature statistics, composition statistics, composition velocity statistics
+
+  subsection Composition velocity statistics
+    set Names of selected compositional fields =
+  end
+end

--- a/tests/composition_velocity_zero/screen-output
+++ b/tests/composition_velocity_zero/screen-output
@@ -1,0 +1,81 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 1,815 (578+81+289+289+289+289)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+   Solving C_2 system ... 0 iterations.
+   Skipping C_3 composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 11+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:                                   output-composition_velocity_zero/solution/solution-00000
+     Temperature min/avg/max:                                    0 K, 0.5 K, 1 K
+     Compositions min/max/mass:                                  0/1/0.4583 // 0/1/0.4583 // 0/0/0
+     RMS velocity for compositions and combined selected fields: 0.1856 m/s // 0.5652 m/s // 0 m/s
+
+*** Timestep 1:  t=0.0625 seconds, dt=0.0625 seconds
+   Solving temperature system... 9 iterations.
+   Solving C_1 system ... 9 iterations.
+   Solving C_2 system ... 10 iterations.
+   Skipping C_3 composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 9+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:                                    0 K, 0.5013 K, 1 K
+     Compositions min/max/mass:                                  -0.006514/1.046/0.4591 // -0.01597/1.028/0.4583 // 0/0/0
+     RMS velocity for compositions and combined selected fields: 0.1513 m/s // 0.5546 m/s // 0 m/s
+
+*** Timestep 2:  t=0.125 seconds, dt=0.0625 seconds
+   Solving temperature system... 10 iterations.
+   Solving C_1 system ... 12 iterations.
+   Solving C_2 system ... 11 iterations.
+   Skipping C_3 composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 12+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:                                   output-composition_velocity_zero/solution/solution-00001
+     Temperature min/avg/max:                                    0 K, 0.5026 K, 1 K
+     Compositions min/max/mass:                                  -0.008045/1.061/0.4596 // -0.02111/1.031/0.4583 // 0/0/0
+     RMS velocity for compositions and combined selected fields: 0.1549 m/s // 0.5509 m/s // 0 m/s
+
+*** Timestep 3:  t=0.1875 seconds, dt=0.0625 seconds
+   Solving temperature system... 10 iterations.
+   Solving C_1 system ... 12 iterations.
+   Solving C_2 system ... 12 iterations.
+   Skipping C_3 composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 12+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max:                                    0 K, 0.504 K, 1 K
+     Compositions min/max/mass:                                  -0.006562/1.059/0.46 // -0.01251/1.028/0.4582 // 0/0/0
+     RMS velocity for compositions and combined selected fields: 0.1608 m/s // 0.5471 m/s // 0 m/s
+
+*** Timestep 4:  t=0.2 seconds, dt=0.0125 seconds
+   Solving temperature system... 8 iterations.
+   Solving C_1 system ... 9 iterations.
+   Solving C_2 system ... 10 iterations.
+   Skipping C_3 composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 10+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:                                   output-composition_velocity_zero/solution/solution-00002
+     Temperature min/avg/max:                                    0 K, 0.5042 K, 1 K
+     Compositions min/max/mass:                                  -0.005787/1.057/0.46 // -0.01031/1.026/0.4582 // 0/0/0
+     RMS velocity for compositions and combined selected fields: 0.1576 m/s // 0.5454 m/s // 0 m/s
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/composition_velocity_zero/statistics
+++ b/tests/composition_velocity_zero/statistics
@@ -1,0 +1,36 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for composition solver 2
+# 11: Iterations for composition solver 3
+# 12: Iterations for Stokes solver
+# 13: Velocity iterations in Stokes preconditioner
+# 14: Schur complement iterations in Stokes preconditioner
+# 15: Visualization file name
+# 16: Minimal temperature (K)
+# 17: Average temperature (K)
+# 18: Maximal temperature (K)
+# 19: Average nondimensional temperature (K)
+# 20: Minimal value for composition C_1
+# 21: Maximal value for composition C_1
+# 22: Global mass for composition C_1
+# 23: Minimal value for composition C_2
+# 24: Maximal value for composition C_2
+# 25: Global mass for composition C_2
+# 26: Minimal value for composition C_3
+# 27: Maximal value for composition C_3
+# 28: Global mass for composition C_3
+# 29: RMS velocity (m/s) for composition C_1
+# 30: RMS velocity (m/s) for composition C_2
+# 31: RMS velocity (m/s) for composition C_3
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 867  0  0  0 0 11 12 12 output-composition_velocity_zero/solution/solution-00000 0.00000000e+00 5.00000000e-01 1.00000000e+00 5.00000000e-01  0.00000000e+00 1.00000000e+00 4.58333333e-01  0.00000000e+00 1.00000000e+00 4.58333333e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.85598478e-01 5.65186390e-01 0.00000000e+00 
+1 6.250000000000e-02 6.250000000000e-02 64 659 289 867  9  9 10 0  9 10 10                                                       "" 0.00000000e+00 5.01307080e-01 1.00000000e+00 5.01307080e-01 -6.51418521e-03 1.04574786e+00 4.59121531e-01 -1.59732147e-02 1.02778909e+00 4.58311436e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.51343782e-01 5.54553975e-01 0.00000000e+00 
+2 1.250000000000e-01 6.250000000000e-02 64 659 289 867 10 12 11 0 12 13 13 output-composition_velocity_zero/solution/solution-00001 0.00000000e+00 5.02607651e-01 1.00000000e+00 5.02607651e-01 -8.04466110e-03 1.06122236e+00 4.59646475e-01 -2.11129170e-02 1.03069943e+00 4.58272164e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.54902185e-01 5.50876862e-01 0.00000000e+00 
+3 1.875000000000e-01 6.250000000000e-02 64 659 289 867 10 12 12 0 12 13 13                                                       "" 0.00000000e+00 5.03960928e-01 1.00000000e+00 5.03960928e-01 -6.56171110e-03 1.05857321e+00 4.59987096e-01 -1.25102409e-02 1.02796339e+00 4.58199926e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.60765139e-01 5.47060039e-01 0.00000000e+00 
+4 2.000000000000e-01 1.250000000000e-02 64 659 289 867  8  9 10 0 10 11 11 output-composition_velocity_zero/solution/solution-00002 0.00000000e+00 5.04151035e-01 1.00000000e+00 5.04151035e-01 -5.78749351e-03 1.05724360e+00 4.60039447e-01 -1.03114165e-02 1.02602294e+00 4.58209086e-01 0.00000000e+00 0.00000000e+00 0.00000000e+00 1.57563454e-01 5.45393415e-01 0.00000000e+00 

--- a/tests/kinematically_driven_subduction_2d_case1/screen-output
+++ b/tests/kinematically_driven_subduction_2d_case1/screen-output
@@ -17,7 +17,7 @@ Number of degrees of freedom: 47,115 (15,058+1,941+7,529+7,529+7,529+7,529)
      RMS, max velocity:                                          0.0197 m/year, 0.0501 m/year
      Heating rate (average/total):                               0 W/kg, 0 W
      Compositions max depth [m]:                                 7.328e+04 // 1.07e+05 // 7.328e+04
-     RMS velocity for compositions and combined selected fields: 0.0142 m/year // 0.03851 m/year // 0.03684 m/year // 0.03841
+     RMS velocity for compositions and combined selected fields: 0.0142 m/year // 0.03851 m/year // 0.03684 m/year // 0.03841 m/year
      Viscous dissipation per field and for whole domain (W/m):   6727 // 9668 // 3.565 // 1.82e+04
 
 *** Timestep 1:  t=100000 years, dt=100000 years
@@ -31,7 +31,7 @@ Number of degrees of freedom: 47,115 (15,058+1,941+7,529+7,529+7,529+7,529)
      RMS, max velocity:                                          0.0197 m/year, 0.0501 m/year
      Heating rate (average/total):                               0 W/kg, 0 W
      Compositions max depth [m]:                                 7.328e+04 // 1.07e+05 // 7.328e+04
-     RMS velocity for compositions and combined selected fields: 0.01422 m/year // 0.03849 m/year // 0.03669 m/year // 0.03838
+     RMS velocity for compositions and combined selected fields: 0.01422 m/year // 0.03849 m/year // 0.03669 m/year // 0.03838 m/year
      Viscous dissipation per field and for whole domain (W/m):   6771 // 9688 // 46.3 // 1.827e+04
 
 Termination requested by criterion: end time

--- a/tests/kinematically_driven_subduction_2d_case1/statistics
+++ b/tests/kinematically_driven_subduction_2d_case1/statistics
@@ -21,7 +21,7 @@
 # 21: RMS velocity (m/year) for composition OP
 # 22: RMS velocity (m/year) for composition ML_SP
 # 23: RMS velocity (m/year) for composition crust_SP
-# 24: RMS velocity (m/year) for the selected field 
+# 24: RMS velocity (m/year) for the selected field(s)
 # 25: Viscous dissipation (W/m) for composition OP
 # 26: Viscous dissipation (W/m) for composition ML_SP
 # 27: Viscous dissipation (W/m) for composition crust_SP

--- a/tests/kinematically_driven_subduction_2d_case2a/screen-output
+++ b/tests/kinematically_driven_subduction_2d_case2a/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 77,231 (15,058+1,941+7,529+7,529+7,529+7,529+7,529
      RMS, max velocity:                                                           0.0197 m/year, 0.0501 m/year
      Heating rate (average/total):                                                0 W/kg, 0 W
      Compositions max depth [m]:                                                  2360 // 2360 // 3.141e+04 // 3.141e+04 // 7.328e+04 // 1.07e+05 // 8.139e+04
-     RMS velocity for compositions and combined selected fields:                  0.01466 m/year // 0.03894 m/year // 0.01446 m/year // 0.03875 m/year // 0.01389 m/year // 0.03843 m/year // 0.02546 m/year // 0.03854
+     RMS velocity for compositions and combined selected fields:                  0.01466 m/year // 0.03894 m/year // 0.01446 m/year // 0.03875 m/year // 0.01389 m/year // 0.03843 m/year // 0.02546 m/year // 0.03854 m/year
      Viscous dissipation per field and for whole domain (W/m):                    511.2 // 0.4366 // 2730 // 2241 // 3472 // 7423 // 80.49 // 1.819e+04
      Temperature min/avg/max:                                                     273.1 K, 1554 K, 1720 K
      Trench location [m]:                                                         1.465e+06 m
@@ -45,7 +45,7 @@ Number of degrees of freedom: 77,231 (15,058+1,941+7,529+7,529+7,529+7,529+7,529
      RMS, max velocity:                                                           0.0198 m/year, 0.0501 m/year
      Heating rate (average/total):                                                0 W/kg, 0 W
      Compositions max depth [m]:                                                  2360 // 2360 // 3.141e+04 // 3.141e+04 // 7.328e+04 // 1.07e+05 // 8.139e+04
-     RMS velocity for compositions and combined selected fields:                  0.01441 m/year // 0.03911 m/year // 0.01418 m/year // 0.0389 m/year // 0.01364 m/year // 0.0386 m/year // 0.02561 m/year // 0.03871
+     RMS velocity for compositions and combined selected fields:                  0.01441 m/year // 0.03911 m/year // 0.01418 m/year // 0.0389 m/year // 0.01364 m/year // 0.0386 m/year // 0.02561 m/year // 0.03871 m/year
      Viscous dissipation per field and for whole domain (W/m):                    495.1 // 0.4273 // 2614 // 2198 // 3363 // 7300 // 51.5 // 1.779e+04
      Temperature min/avg/max:                                                     273.1 K, 1553 K, 1720 K
      Trench location [m]:                                                         1.465e+06 m

--- a/tests/kinematically_driven_subduction_2d_case2a/statistics
+++ b/tests/kinematically_driven_subduction_2d_case2a/statistics
@@ -33,7 +33,7 @@
 # 33: RMS velocity (m/year) for composition thermal_OP
 # 34: RMS velocity (m/year) for composition thermal_SP
 # 35: RMS velocity (m/year) for composition WZ
-# 36: RMS velocity (m/year) for the selected field 
+# 36: RMS velocity (m/year) for the selected field(s)
 # 37: Viscous dissipation (W/m) for composition BOC_OP
 # 38: Viscous dissipation (W/m) for composition BOC_SP
 # 39: Viscous dissipation (W/m) for composition SHB_OP

--- a/tests/kinematically_driven_subduction_2d_case2b/screen-output
+++ b/tests/kinematically_driven_subduction_2d_case2b/screen-output
@@ -23,7 +23,7 @@ Number of degrees of freedom: 77,231 (15,058+1,941+7,529+7,529+7,529+7,529+7,529
      RMS, max velocity:                                                           0.0193 m/year, 0.0501 m/year
      Heating rate (average/total):                                                0 W/kg, 0 W
      Compositions max depth [m]:                                                  2360 // 2360 // 3.141e+04 // 3.141e+04 // 7.328e+04 // 1.07e+05 // 8.139e+04
-     RMS velocity for compositions and combined selected fields:                  0.01479 m/year // 0.03895 m/year // 0.01458 m/year // 0.03876 m/year // 0.01402 m/year // 0.03844 m/year // 0.02555 m/year // 0.03855
+     RMS velocity for compositions and combined selected fields:                  0.01479 m/year // 0.03895 m/year // 0.01458 m/year // 0.03876 m/year // 0.01402 m/year // 0.03844 m/year // 0.02555 m/year // 0.03855 m/year
      Viscous dissipation per field and for whole domain (W/m):                    516.2 // 0.4375 // 2740 // 2240 // 3525 // 7391 // 72.41 // 1.827e+04
      Temperature min/avg/max:                                                     273.1 K, 1554 K, 1720 K
      Trench location [m]:                                                         1.465e+06 m
@@ -45,7 +45,7 @@ Number of degrees of freedom: 77,231 (15,058+1,941+7,529+7,529+7,529+7,529+7,529
      RMS, max velocity:                                                           0.0194 m/year, 0.0501 m/year
      Heating rate (average/total):                                                0 W/kg, 0 W
      Compositions max depth [m]:                                                  2360 // 2360 // 3.141e+04 // 3.141e+04 // 7.328e+04 // 1.07e+05 // 8.139e+04
-     RMS velocity for compositions and combined selected fields:                  0.01455 m/year // 0.03911 m/year // 0.01432 m/year // 0.0389 m/year // 0.01378 m/year // 0.0386 m/year // 0.02569 m/year // 0.0387
+     RMS velocity for compositions and combined selected fields:                  0.01455 m/year // 0.03911 m/year // 0.01432 m/year // 0.0389 m/year // 0.01378 m/year // 0.0386 m/year // 0.02569 m/year // 0.0387 m/year
      Viscous dissipation per field and for whole domain (W/m):                    499.6 // 0.4271 // 2633 // 2195 // 3418 // 7272 // 48.77 // 1.789e+04
      Temperature min/avg/max:                                                     273.1 K, 1553 K, 1720 K
      Trench location [m]:                                                         1.465e+06 m

--- a/tests/kinematically_driven_subduction_2d_case2b/statistics
+++ b/tests/kinematically_driven_subduction_2d_case2b/statistics
@@ -33,7 +33,7 @@
 # 33: RMS velocity (m/year) for composition thermal_OP
 # 34: RMS velocity (m/year) for composition thermal_SP
 # 35: RMS velocity (m/year) for composition WZ
-# 36: RMS velocity (m/year) for the selected field 
+# 36: RMS velocity (m/year) for the selected field(s)
 # 37: Viscous dissipation (W/m) for composition BOC_OP
 # 38: Viscous dissipation (W/m) for composition BOC_SP
 # 39: Viscous dissipation (W/m) for composition SHB_OP


### PR DESCRIPTION
The composition velocity statistics postprocessor had a few issues where it was possible to provide wrong input in the parameter file without an error message being triggered, resulting in either wrong output or a divide-by-zero. This PR improves this in several places and additionally allows for the input parameter being an empty list (if all the user wants is the average velocity of each compositional field, separately, rather than any combination). 

If a compositional field is zero throughout the model domain, the output for its velocity is now zero rather than NaN (which was what triggered the floating point exception before). 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
