### PR TITLE
fix reaction rates in katz2003 reaction model

### DIFF
--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -181,10 +181,11 @@ namespace aspect
         for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
 
+            const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
+            const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
+
             if (this->include_melt_transport())
               {
-                const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-                const unsigned int peridotite_idx = this->introspection().compositional_index_for_name("peridotite");
                 const double old_porosity = in.composition[i][porosity_idx];
                 const double maximum_melt_fraction = in.composition[i][peridotite_idx];
 
@@ -275,13 +276,16 @@ namespace aspect
                 out.entropy_derivative_pressure[i]    = entropy_change (in.temperature[i], this->get_adiabatic_conditions().pressure(in.position[i]), 0, NonlinearDependence::pressure);
                 out.entropy_derivative_temperature[i] = entropy_change (in.temperature[i], this->get_adiabatic_conditions().pressure(in.position[i]), 0, NonlinearDependence::temperature);
 
-                // no melting/freezing is used in the model --> set all reactions to zero
+                // no melting/freezing is used in the model --> set reactions for peridotite and porosity fields to 0
                 for (unsigned int c=0; c<in.composition[i].size(); ++c)
                   {
-                    out.reaction_terms[i][c] = 0.0;
+                    if (c == peridotite_idx || c == porosity_idx)
+                      {
+                        out.reaction_terms[i][c] = 0.0;
 
-                    if (reaction_rate_out != nullptr)
-                      reaction_rate_out->reaction_rates[i][c] = 0.0;
+                        if (reaction_rate_out != nullptr)
+                          reaction_rate_out->reaction_rates[i][c] = 0.0;
+                      }
                   }
               }
           }


### PR DESCRIPTION
This PR follows a[ forum discussion](https://community.geodynamics.org/t/plastic-strain-in-reactive-fluid-transport-rheology/3996) and suggested fix by @jdannberg.

A fix for the reaction rates in the `katz2003` reaction model, where all reaction rates are set to 0 if melt transport is not enabled in the model. 

This led to fields such as plastic strain that evolve through reaction terms not accumulating in the `reactive fluid transport` material model, where the `visco plastic` material model was used as the base model. 

In other words, strain reaction terms correctly calculated in the `visco plastic `material were overwritten in the` reactive fluid transport` material when the `katz2003` reaction model was used.

A simple test confirmed the fix worked, and I'll add a modified version of it once the user on the forum confirms it works for them as well.

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
