### PR TITLE
fill reaction terms in material model, not reaction model

### DIFF
--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -132,6 +132,13 @@ namespace aspect
 
         }
 
+      // Set the reaction terms to zero.
+      // Melting and freezing reactions are set with the reaction rates,
+      // which are filled by the Katz 2003 reaction model.
+      for (unsigned int q=0; q<out.n_evaluation_points(); ++q)
+        for (unsigned int c=0; c<in.composition[q].size(); ++c)
+          out.reaction_terms[q][c] = 0.0;
+
       katz2003_model.calculate_reaction_rate_outputs(in, out);
       katz2003_model.calculate_fluid_outputs(in, out, reference_T);
     }

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -264,7 +264,6 @@ namespace aspect
                         else
                           reaction_rate_out->reaction_rates[i][c] = 0.0;
                       }
-                    out.reaction_terms[i][c] = 0.0;
                   }
 
                 out.entropy_derivative_pressure[i]    = entropy_change (in.temperature[i], this->get_adiabatic_conditions().pressure(in.position[i]), maximum_melt_fraction, NonlinearDependence::pressure);
@@ -277,12 +276,8 @@ namespace aspect
 
                 // no melting/freezing is used in the model --> set all reactions to zero
                 for (unsigned int c=0; c<in.composition[i].size(); ++c)
-                  {
-                    out.reaction_terms[i][c] = 0.0;
-
-                    if (reaction_rate_out != nullptr)
-                      reaction_rate_out->reaction_rates[i][c] = 0.0;
-                  }
+                  if (reaction_rate_out != nullptr)
+                    reaction_rate_out->reaction_rates[i][c] = 0.0;
               }
           }
 


### PR DESCRIPTION
@naliboff I think this should fix the problem from the [forum discussion](https://community.geodynamics.org/t/plastic-strain-in-reactive-fluid-transport-rheology/3996). 

The problem was that the katz 2003 reaction model set the reaction terms to zero for all fields, but it should be the responsibility of the material model to make sure these fields are filled, not the reaction model. Technically, the katz 2003 reaction model does not do anything with the `reaction_terms` at all, it is only concerned with `reaction_rates`. @gassmoeller suggested to simply move this code into the material model. This way, the katz 2003 reaction model will no longer overwrite the eraction terms set by the base model of the reactive fluid transport material model. 
