### PR TITLE
add get_required_properties function to heating plugins

### DIFF
--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -71,6 +71,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -74,7 +74,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -66,7 +66,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -63,6 +63,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -50,6 +50,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -53,7 +53,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -50,7 +50,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -47,6 +47,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -67,7 +67,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -64,6 +64,14 @@ namespace aspect
         update () override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -157,6 +157,14 @@ namespace aspect
         virtual
         void
         create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const;
+
+        /**
+        * Let the heating model specify which material model outputs it
+        * requires for computing the heating terms.
+        */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties() const;
     };
 
 
@@ -264,7 +272,7 @@ namespace aspect
          * Return a list of pointers to all heating models currently used in the
          * computation, as specified in the input file.
          *
-         * @deprecated Use Plugins::ManagerBase::get_active_plugin_names()
+         * @deprecated Use Plugins::ManagerBase::get_active_plugins()
          *   instead.
          */
         DEAL_II_DEPRECATED

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -69,7 +69,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
     };

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -64,6 +64,14 @@ namespace aspect
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
+
+        /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
     };
   }
 }

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -56,7 +56,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -53,6 +53,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -56,6 +56,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -59,7 +59,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -61,6 +61,14 @@ namespace aspect
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -64,7 +64,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -58,6 +58,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Allow the heating model to attach additional material model outputs.
          */
         void

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -61,7 +61,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/source/heating_model/adiabatic_heating.cc
+++ b/source/heating_model/adiabatic_heating.cc
@@ -61,6 +61,19 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    AdiabaticHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::thermal_expansion_coefficient |
+             MaterialModel::MaterialProperties::density;
+    }
+
+
+
     template <int dim>
     void
     AdiabaticHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -77,6 +77,19 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    AdiabaticHeatingMelt<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::density |
+             MaterialModel::MaterialProperties::thermal_expansion_coefficient |
+             MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     AdiabaticHeatingMelt<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -53,6 +53,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    CompositionalHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::thermal_expansion_coefficient;
+    }
+
+
+
     template <int dim>
     void
     CompositionalHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/constant_heating.cc
+++ b/source/heating_model/constant_heating.cc
@@ -45,6 +45,16 @@ namespace aspect
 
 
     template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ConstantHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::none;
+    }
+
+
+
+    template <int dim>
     void
     ConstantHeating<dim>::declare_parameters (ParameterHandler &prm)
     {

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -34,6 +34,7 @@ namespace aspect
     {}
 
 
+
     template <int dim>
     void
     Function<dim>::
@@ -56,6 +57,7 @@ namespace aspect
     }
 
 
+
     template <int dim>
     void
     Function<dim>::update ()
@@ -68,6 +70,16 @@ namespace aspect
       else
         heating_model_function.set_time (time);
     }
+
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    Function<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::none;
+    }
+
 
 
     template <int dim>
@@ -95,6 +107,7 @@ namespace aspect
       }
       prm.leave_subsection();
     }
+
 
 
     template <int dim>

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -51,6 +51,16 @@ namespace aspect
     {}
 
 
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    Interface<dim>::
+    get_required_properties() const
+    {
+      return MaterialModel::MaterialProperties::all_properties;
+    }
+
+
+
     // ------------------------------ Manager -----------------------------
 
 

--- a/source/heating_model/latent_heat.cc
+++ b/source/heating_model/latent_heat.cc
@@ -48,6 +48,18 @@ namespace aspect
                                                            * material_model_outputs.entropy_derivative_temperature[q];
         }
     }
+
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    LatentHeat<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::entropy_derivative_pressure |
+             MaterialModel::MaterialProperties::entropy_derivative_temperature |
+             MaterialModel::MaterialProperties::density;
+    }
   }
 }
 

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -109,6 +109,27 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    LatentHeatMelt<dim>::
+    get_required_properties () const
+    {
+      MaterialModel::MaterialProperties::Property required_properties = MaterialModel::MaterialProperties::additional_outputs;
+      if (this->get_parameters().use_operator_splitting)
+        required_properties = required_properties |
+                              MaterialModel::MaterialProperties::specific_heat |
+                              MaterialModel::MaterialProperties::reaction_rates;
+      else
+        required_properties = required_properties |
+                              MaterialModel::MaterialProperties::reaction_terms |
+                              MaterialModel::MaterialProperties::density;
+      return required_properties;
+    }
+
+
+
     template <int dim>
     void
     LatentHeatMelt<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -33,6 +33,7 @@ namespace aspect
       = default;
 
 
+
     template <int dim>
     void
     RadioactiveDecay<dim>::
@@ -83,6 +84,16 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    RadioactiveDecay<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::density;
+    }
+
+
+
     template <int dim>
     void
     RadioactiveDecay<dim>::declare_parameters (ParameterHandler &prm)
@@ -122,6 +133,7 @@ namespace aspect
       }
       prm.leave_subsection();
     }
+
 
 
     template <int dim>

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -84,6 +84,18 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ShearHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::viscosity |
+             MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     ShearHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -79,6 +79,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ShearHeatingMelt<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     ShearHeatingMelt<dim>::

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -811,7 +811,7 @@ namespace aspect
 
         if (plastic_out != nullptr)
           {
-            AssertThrow(in.requests_property(MaterialProperties::viscosity),
+            AssertThrow(!std::isnan(out.viscosities[0]),
                         ExcMessage("The PlasticAdditionalOutputs cannot be filled when the viscosity has not been computed."));
 
             plastic_out->cohesions[i] = 0;

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -274,7 +274,8 @@ namespace aspect
           // has been called.
           // TODO do we even need a separate function? We could compute the PlasticAdditionalOutputs here like
           // the ElasticAdditionalOutputs.
-          rheology->fill_plastic_outputs(i, volume_fractions, plastic_yielding, in, out, isostrain_viscosities);
+          if (in.requests_property(MaterialProperties::additional_outputs))
+            rheology->fill_plastic_outputs(i, volume_fractions, plastic_yielding, in, out, isostrain_viscosities);
 
           if (this->get_parameters().enable_elasticity)
             {

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -943,6 +943,19 @@ namespace aspect
                                                           scratch.finite_element_values,
                                                           introspection);
 
+    if (advection_field.is_temperature())
+      scratch.material_model_inputs.requested_properties
+        =
+          MaterialModel::MaterialProperties::equation_of_state_properties |
+          MaterialModel::MaterialProperties::additional_outputs |
+          MaterialModel::MaterialProperties::viscosity |
+          MaterialModel::MaterialProperties::thermal_conductivity;
+
+    for (const auto &heating_model : heating_model_manager.get_active_plugins())
+      scratch.material_model_inputs.requested_properties
+        = scratch.material_model_inputs.requested_properties |
+          heating_model->get_required_properties();
+
     material_model->evaluate(scratch.material_model_inputs,
                              scratch.material_model_outputs);
     if (parameters.formulation_temperature_equation ==

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -945,10 +945,7 @@ namespace aspect
 
     if (advection_field.is_temperature())
       scratch.material_model_inputs.requested_properties
-        =
-          MaterialModel::MaterialProperties::equation_of_state_properties |
-          MaterialModel::MaterialProperties::additional_outputs |
-          MaterialModel::MaterialProperties::viscosity |
+        = MaterialModel::MaterialProperties::equation_of_state_properties |
           MaterialModel::MaterialProperties::thermal_conductivity;
 
     for (const auto &heating_model : heating_model_manager.get_active_plugins())
@@ -1072,6 +1069,21 @@ namespace aspect
                                                                       current_linearization_point,
                                                                       *scratch.face_finite_element_values,
                                                                       introspection);
+
+                if (advection_field.is_temperature())
+                  scratch.face_material_model_inputs.requested_properties
+                    = MaterialModel::MaterialProperties::equation_of_state_properties |
+                      MaterialModel::MaterialProperties::thermal_conductivity;
+
+                if (parameters.include_melt_transport)
+                  scratch.face_material_model_inputs.requested_properties
+                    = scratch.face_material_model_inputs.requested_properties |
+                      MaterialModel::MaterialProperties::additional_outputs;
+
+                for (const auto &heating_model : heating_model_manager.get_active_plugins())
+                  scratch.face_material_model_inputs.requested_properties
+                    = scratch.face_material_model_inputs.requested_properties |
+                      heating_model->get_required_properties();
 
                 material_model->evaluate(scratch.face_material_model_inputs,
                                          scratch.face_material_model_outputs);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -948,6 +948,11 @@ namespace aspect
         = MaterialModel::MaterialProperties::equation_of_state_properties |
           MaterialModel::MaterialProperties::thermal_conductivity;
 
+    if (parameters.include_melt_transport)
+      scratch.material_model_inputs.requested_properties
+        = scratch.material_model_inputs.requested_properties |
+          MaterialModel::MaterialProperties::additional_outputs;
+
     for (const auto &heating_model : heating_model_manager.get_active_plugins())
       scratch.material_model_inputs.requested_properties
         = scratch.material_model_inputs.requested_properties |
@@ -1074,11 +1079,6 @@ namespace aspect
                   scratch.face_material_model_inputs.requested_properties
                     = MaterialModel::MaterialProperties::equation_of_state_properties |
                       MaterialModel::MaterialProperties::thermal_conductivity;
-
-                if (parameters.include_melt_transport)
-                  scratch.face_material_model_inputs.requested_properties
-                    = scratch.face_material_model_inputs.requested_properties |
-                      MaterialModel::MaterialProperties::additional_outputs;
 
                 for (const auto &heating_model : heating_model_manager.get_active_plugins())
                   scratch.face_material_model_inputs.requested_properties

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -561,6 +561,17 @@ namespace aspect
                                                               solution,
                                                               scratch.finite_element_values,
                                                               introspection);
+
+        if (advection_field.is_temperature())
+          scratch.material_model_inputs.requested_properties
+            = MaterialModel::MaterialProperties::equation_of_state_properties |
+              MaterialModel::MaterialProperties::thermal_conductivity;
+
+        for (const auto &heating_model : heating_model_manager.get_active_plugins())
+          scratch.material_model_inputs.requested_properties
+            = scratch.material_model_inputs.requested_properties |
+              heating_model->get_required_properties();
+
         material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);
         heating_model_manager.evaluate(scratch.material_model_inputs,scratch.material_model_outputs,scratch.heating_model_outputs);
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -699,7 +699,7 @@ namespace aspect
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
-      Assert(melt_outputs->compaction_viscosities[0] > 0.0,
+      Assert(melt_outputs->fluid_densities[0] > 0.0,
              ExcMessage ("MeltOutputs have to be filled for models with melt transport. "
                          "At the moment, these outputs are not filled, or they do not have "
                          "reasonable values."));


### PR DESCRIPTION
Some properties in the material model (in this case for me, it was the grain size change) can be expensive to compute. This PR allows the heating models to specify which material model outputs they need, and if the outputs are not required then they won't be filled in the temperature assembly. 
To make this work with user-written plugins, the default implementation is that all material model outputs are required. 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
