### PR TITLE
Fix phases for background material and plasticity in the grain size material model.

### DIFF
--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -288,9 +288,13 @@ namespace aspect
 
 
         /**
-         * Number of phase transitions for the one chemical composition used in this model.
+         * Number of phase transitions for the chemical compositions used in this model.
+         *
+         * Currently this material model only supports phase transitions for the background
+         * composition, but some functions expect it to be stored in a vector.
+         * This vector will therefore contain exactly one entry.
          */
-        unsigned int n_phase_transitions;
+        std::vector<unsigned int> n_phase_transitions;
 
         /**
          * Object that handles phase transitions.

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -112,7 +112,7 @@ namespace aspect
       // Since phase transition depth increases monotonically, we only need
       // to check for the first phase that has not yet undergone the transition
       // (phase function value lower than 0.5).
-      for (unsigned int j=0; j<n_phase_transitions; ++j)
+      for (unsigned int j=0; j<n_phase_transitions[0]; ++j)
         {
           MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(in.temperature,
                                                                    in.pressure,
@@ -124,7 +124,7 @@ namespace aspect
             return j;
         }
 
-      return n_phase_transitions;
+      return n_phase_transitions[0];
     }
 
 
@@ -571,10 +571,9 @@ namespace aspect
                   const double non_yielding_stress = 2. * effective_viscosity * second_strain_rate_invariant;
 
                   // The following handles phases
-                  std::vector<unsigned int> n_phases = {n_phase_transitions+1};
-                  std::vector<double> phase_function_values(n_phase_transitions, 0.0);
+                  std::vector<double> phase_function_values(n_phase_transitions[0]+1, 0.0);
 
-                  for (unsigned int k=0; k<n_phase_transitions; ++k)
+                  for (unsigned int k=0; k<n_phase_transitions[0]; ++k)
                     {
                       phase_inputs.phase_transition_index = k;
                       phase_function_values[k] = phase_function->compute_value(phase_inputs);
@@ -584,7 +583,7 @@ namespace aspect
                   // so we set the compositional index for the Drucker-Prager parameters to 0.
                   const Rheology::DruckerPragerParameters drucker_prager_parameters = drucker_prager_plasticity.compute_drucker_prager_parameters(0,
                                                                                       phase_function_values,
-                                                                                      n_phases);
+                                                                                      n_phase_transitions);
                   const double pressure_for_yielding = use_adiabatic_pressure_for_yielding
                                                        ?
                                                        adiabatic_pressures[i]
@@ -979,10 +978,11 @@ namespace aspect
           phase_function->initialize_simulator (this->get_simulator());
           phase_function->parse_parameters (prm);
 
-          std::vector<unsigned int> n_phases_for_each_composition = phase_function->n_phases_for_each_composition();
-          n_phase_transitions = n_phases_for_each_composition[0] - 1;
+          // Phase transitions are only supported for the background composition.
+          n_phase_transitions.resize(1);
+          n_phase_transitions[0] = phase_function->n_phases_for_each_composition()[0] - 1;
 
-          for (unsigned int i=1; i<n_phase_transitions; ++i)
+          for (unsigned int i=1; i<n_phase_transitions[0]; ++i)
             AssertThrow(phase_function->get_transition_depth(i-1)<phase_function->get_transition_depth(i),
                         ExcMessage("Error: Phase transition depths have to be sorted in ascending order!"));
 
@@ -1074,7 +1074,7 @@ namespace aspect
           use_adiabatic_pressure_for_yielding = prm.get_bool ("Use adiabatic pressure for yield stress");
           drucker_prager_plasticity.initialize_simulator (this->get_simulator());
 
-          std::vector<unsigned int> n_phases = {n_phase_transitions+1};
+          std::vector<unsigned int> n_phases = {n_phase_transitions[0]+1};
           drucker_prager_plasticity.parse_parameters(prm, std::make_unique<std::vector<unsigned int>> (n_phases));
 
           // Parse grain size evolution parameters

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -978,7 +978,8 @@ namespace aspect
           phase_function->initialize_simulator (this->get_simulator());
           phase_function->parse_parameters (prm);
 
-          // Phase transitions are only supported for the background composition.
+          // The phase function is only used for the rheology, which is identical for all
+          // compositions. Therefore there is just one number of phase transitions.
           n_phase_transitions.resize(1);
           n_phase_transitions[0] = phase_function->n_phases_for_each_composition()[0] - 1;
 

--- a/tests/grain_size_yield_phases.prm
+++ b/tests/grain_size_yield_phases.prm
@@ -1,0 +1,159 @@
+# This test is like grain_size_phase_function.prm, but
+# it additionally enables plastic yielding in the material model.
+
+set Dimension                              = 2
+set End time                               = 10000
+set Use years in output instead of seconds = true
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1600
+set Output directory                       = grain_size_yield_phases
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 100000
+    set Y extent = 100000
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top,bottom
+  set List of model names = initial temperature
+
+  subsection Initial temperature
+    set Minimal temperature = 1600
+  end
+end
+
+# Velocity on boundaries characterized by functions
+subsection Boundary velocity model
+  set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  = m=0.0005, year=1
+    set Function expression = if (x<50e3 , -1*m/year, 1*m/year); if (y<50e3 , 1*m/year, -1*m/year);
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10.0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 1400 + 0.004 * x
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,z
+    set Function constants  =
+    set Function expression = 1e-3
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Names of fields   = grain_size
+  set Compositional field methods = particles
+  set Types of fields = grain size
+  set Mapped particle properties = grain_size:grain_size
+end
+
+subsection Material model
+  set Model name = grain size
+
+  subsection Grain size model
+    set Reference density                    = 1000
+    set Thermal conductivity                 = 0
+    set Thermal expansion coefficient        = 0
+    set Reference compressibility            = 0
+    set Viscosity                            = 1e19
+    set Minimum viscosity                    = 1e16
+    set Reference temperature                = 1600
+    set Grain growth activation energy       = 0, 0, 0, 0
+    set Grain growth activation volume       = 0, 0, 0, 0
+    set Grain growth rate constant           = 0, 1e-20, 0, 5e-21
+    set Grain growth exponent                = 3, 3, 3, 3
+    set Average specific grain boundary energy = 1, 1, 1, 1
+    set Work fraction for boundary area change = 0.1, 0.1, 0.1, 0.1
+    set Geometric constant                   = 3, 3, 3, 3
+    set Grain size evolution formulation     = paleowattmeter
+    set Reciprocal required strain           = 10
+    set Phase transition depths              = background:20000|50000|65000
+    set Phase transition Clapeyron slopes    = background:1e6|-5e5|2.5e5
+    set Phase transition temperatures        = background:1600|1600|1600
+    set Phase transition widths              = background:0|0|0
+    set Recrystallized grain size            = 1e-3, 1e-3, 1e-3
+
+    # Faul and Jackson 2007
+    # Diffusion creep
+    # new scaled prefactors to match vertical viscosity profile
+    set Diffusion creep prefactor            = 3.0e-016, 3.0e-015, 3.0e-017, 3.0e-016
+    set Diffusion creep exponent             = 1, 1, 1, 1
+    set Diffusion creep grain size exponent  = 3, 3, 3, 3
+    set Diffusion activation energy          = 3.75e5, 3.75e5, 3.75e5, 3.75e5
+    set Diffusion activation volume          = 0, 0, 0, 0
+    set Dislocation viscosity iteration threshold = 1e-3
+
+    # No dislocation creep
+    set Dislocation creep prefactor          = 1e-200, 1e-200, 1e-200, 1e-200
+    set Dislocation creep exponent           = 1, 1, 1, 1
+    set Dislocation activation energy        = 0, 0, 0, 0
+    set Dislocation activation volume        = 0, 0, 0, 0
+
+    set Use Drucker-Prager rheology          = true
+    set Cohesions                            = 10000
+    set Angles of internal friction          = 1e-3
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 4
+  set Time steps between mesh refinement = 0
+end
+
+subsection Particles
+  set List of particle properties = grain size
+
+  subsection Generator
+    subsection Random uniform
+      set Number of particles = 10000
+    end
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, composition statistics, particles, material statistics, ODE statistics
+
+  subsection Visualization
+    set List of output variables  = material properties, named additional outputs, stress second invariant
+    set Time between graphical output = 0
+  end
+
+  subsection Particles
+    set Time between data output = 0
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set GMRES solver restart length = 200
+  end
+end

--- a/tests/grain_size_yield_phases.prm
+++ b/tests/grain_size_yield_phases.prm
@@ -1,34 +1,12 @@
 # This test is like grain_size_phase_function.prm, but
 # it additionally enables plastic yielding in the material model.
 
-set Dimension                              = 2
-set End time                               = 10000
-set Use years in output instead of seconds = true
-set Surface pressure                       = 0
-set Adiabatic surface temperature          = 1600
-set Output directory                       = grain_size_yield_phases
+include $ASPECT_SOURCE_DIR/tests/grain_size_phase_function.prm
 
-subsection Geometry model
-  set Model name = box
-
-  subsection Box
-    set X extent = 100000
-    set Y extent = 100000
-  end
-end
-
-subsection Boundary temperature model
-  set Fixed temperature boundary indicators   = top,bottom
-  set List of model names = initial temperature
-
-  subsection Initial temperature
-    set Minimal temperature = 1600
-  end
-end
-
-# Velocity on boundaries characterized by functions
+# Velocity on boundaries to create yielding
 subsection Boundary velocity model
   set Prescribed velocity boundary indicators = bottom y: function, top y: function, left x: function, right x: function
+  set Tangential velocity boundary indicators =
 
   subsection Function
     set Variable names      = x,y
@@ -37,105 +15,13 @@ subsection Boundary velocity model
   end
 end
 
-subsection Boundary composition model
-  set List of model names = initial composition
-end
-
-subsection Gravity model
-  set Model name = vertical
-
-  subsection Vertical
-    set Magnitude = 10.0
-  end
-end
-
-subsection Initial temperature model
-  set Model name = function
-
-  subsection Function
-    set Function expression = 1400 + 0.004 * x
-  end
-end
-
-subsection Initial composition model
-  set Model name = function
-
-  subsection Function
-    set Variable names      = x,z
-    set Function constants  =
-    set Function expression = 1e-3
-  end
-end
-
-subsection Compositional fields
-  set Number of fields = 1
-  set Names of fields   = grain_size
-  set Compositional field methods = particles
-  set Types of fields = grain size
-  set Mapped particle properties = grain_size:grain_size
-end
-
 subsection Material model
   set Model name = grain size
 
   subsection Grain size model
-    set Reference density                    = 1000
-    set Thermal conductivity                 = 0
-    set Thermal expansion coefficient        = 0
-    set Reference compressibility            = 0
-    set Viscosity                            = 1e19
-    set Minimum viscosity                    = 1e16
-    set Reference temperature                = 1600
-    set Grain growth activation energy       = 0, 0, 0, 0
-    set Grain growth activation volume       = 0, 0, 0, 0
-    set Grain growth rate constant           = 0, 1e-20, 0, 5e-21
-    set Grain growth exponent                = 3, 3, 3, 3
-    set Average specific grain boundary energy = 1, 1, 1, 1
-    set Work fraction for boundary area change = 0.1, 0.1, 0.1, 0.1
-    set Geometric constant                   = 3, 3, 3, 3
-    set Grain size evolution formulation     = paleowattmeter
-    set Reciprocal required strain           = 10
-    set Phase transition depths              = background:20000|50000|65000
-    set Phase transition Clapeyron slopes    = background:1e6|-5e5|2.5e5
-    set Phase transition temperatures        = background:1600|1600|1600
-    set Phase transition widths              = background:0|0|0
-    set Recrystallized grain size            = 1e-3, 1e-3, 1e-3
-
-    # Faul and Jackson 2007
-    # Diffusion creep
-    # new scaled prefactors to match vertical viscosity profile
-    set Diffusion creep prefactor            = 3.0e-016, 3.0e-015, 3.0e-017, 3.0e-016
-    set Diffusion creep exponent             = 1, 1, 1, 1
-    set Diffusion creep grain size exponent  = 3, 3, 3, 3
-    set Diffusion activation energy          = 3.75e5, 3.75e5, 3.75e5, 3.75e5
-    set Diffusion activation volume          = 0, 0, 0, 0
-    set Dislocation viscosity iteration threshold = 1e-3
-
-    # No dislocation creep
-    set Dislocation creep prefactor          = 1e-200, 1e-200, 1e-200, 1e-200
-    set Dislocation creep exponent           = 1, 1, 1, 1
-    set Dislocation activation energy        = 0, 0, 0, 0
-    set Dislocation activation volume        = 0, 0, 0, 0
-
     set Use Drucker-Prager rheology          = true
     set Cohesions                            = 10000
     set Angles of internal friction          = 1e-3
-  end
-end
-
-subsection Mesh refinement
-  set Initial adaptive refinement        = 0
-  set Initial global refinement          = 4
-  set Time steps between mesh refinement = 0
-end
-
-subsection Particles
-  set List of particle properties = grain size
-
-  subsection Generator
-    subsection Random uniform
-      set Number of particles = 10000
-    end
   end
 end
 
@@ -145,15 +31,5 @@ subsection Postprocess
   subsection Visualization
     set List of output variables  = material properties, named additional outputs, stress second invariant
     set Time between graphical output = 0
-  end
-
-  subsection Particles
-    set Time between data output = 0
-  end
-end
-
-subsection Solver parameters
-  subsection Stokes solver parameters
-    set GMRES solver restart length = 200
   end
 end

--- a/tests/grain_size_yield_phases/screen-output
+++ b/tests/grain_size_yield_phases/screen-output
@@ -1,0 +1,30 @@
+
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (GMG)... 126+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:                          output-grain_size_yield_phases/solution/solution-00000
+     Compositions min/max/mass:                         0.001/0.001/1e+07
+     Writing particle output:                           output-grain_size_yield_phases/particles/particles-00000
+     Average density / Average viscosity / Total mass:  1000 kg/m^3, 2.175e+19 Pa s, 1e+13 kg
+
+*** Timestep 1:  t=10000 years, dt=10000 years
+   Solving temperature system... 7 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (GMG)... 93+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:                          output-grain_size_yield_phases/solution/solution-00001
+     Compositions min/max/mass:                         0.001/0.001608/1.304e+07
+     Writing particle output:                           output-grain_size_yield_phases/particles/particles-00001
+     Average density / Average viscosity / Total mass:  1000 kg/m^3, 3.49e+19 Pa s, 1e+13 kg
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/grain_size_yield_phases/statistics
+++ b/tests/grain_size_yield_phases/statistics
@@ -1,0 +1,23 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Number of advected particles
+# 17: Particle file name
+# 18: Average density (kg/m^3)
+# 19: Average viscosity (Pa s)
+# 20: Total mass (kg)
+# 21: Average iterations for ODE solver
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0 126 127 127 output-grain_size_yield_phases/solution/solution-00000 1.00000000e-03 1.00000000e-03 1.00000000e+07 10000 output-grain_size_yield_phases/particles/particles-00000 1.00000000e+03 2.17474584e+19 1.00000000e+13 nan 
+1 1.000000000000e+04 1.000000000000e+04 256 2467 1089 1089 7  93  94  94 output-grain_size_yield_phases/solution/solution-00001 1.00000000e-03 1.60801892e-03 1.30378518e+07  9994 output-grain_size_yield_phases/particles/particles-00001 1.00000000e+03 3.49013367e+19 1.00000000e+13 nan 


### PR DESCRIPTION
The implementation of plasticity in the grain size material model currently has minor issues that arise when one tries to use it together with multiple phase transitions and multiple compositions, because the function `drucker_prager_plasticity.compute_drucker_prager_parameters` is called with the number of phases instead of the number of phase transitions that it expects (off by one). This leads to triggered asserts no matter how one sets the input parameters.

I added a test that fails on the main branch and works with this change.

@jdannberg can you take a look?