### PR TITLE
Only compute additional outputs when needed

### DIFF
--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -71,6 +71,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -74,7 +74,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -66,7 +66,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -63,6 +63,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -50,6 +50,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -53,7 +53,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -50,7 +50,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -47,6 +47,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -67,7 +67,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -64,6 +64,14 @@ namespace aspect
         update () override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/interface.h
+++ b/include/aspect/heating_model/interface.h
@@ -157,6 +157,14 @@ namespace aspect
         virtual
         void
         create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const;
+
+        /**
+        * Let the heating model specify which material model outputs it
+        * requires for computing the heating terms.
+        */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties() const;
     };
 
 
@@ -264,7 +272,7 @@ namespace aspect
          * Return a list of pointers to all heating models currently used in the
          * computation, as specified in the input file.
          *
-         * @deprecated Use Plugins::ManagerBase::get_active_plugin_names()
+         * @deprecated Use Plugins::ManagerBase::get_active_plugins()
          *   instead.
          */
         DEAL_II_DEPRECATED

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -69,7 +69,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
     };

--- a/include/aspect/heating_model/latent_heat.h
+++ b/include/aspect/heating_model/latent_heat.h
@@ -64,6 +64,14 @@ namespace aspect
         evaluate (const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
                   const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
+
+        /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
     };
   }
 }

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -56,7 +56,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -53,6 +53,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * @name Functions used in dealing with run-time parameters
          * @{
          */

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -56,6 +56,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -59,7 +59,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -61,6 +61,14 @@ namespace aspect
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -64,7 +64,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -58,6 +58,14 @@ namespace aspect
                   HeatingModel::HeatingModelOutputs &heating_model_outputs) const override;
 
         /**
+         * Specify which material model outputs the heating model requires
+         * for computing the heating terms.
+         */
+        virtual
+        MaterialModel::MaterialProperties::Property
+        get_required_properties () const override;
+
+        /**
          * Allow the heating model to attach additional material model outputs.
          */
         void

--- a/include/aspect/heating_model/shear_heating_with_melt.h
+++ b/include/aspect/heating_model/shear_heating_with_melt.h
@@ -61,7 +61,6 @@ namespace aspect
          * Specify which material model outputs the heating model requires
          * for computing the heating terms.
          */
-        virtual
         MaterialModel::MaterialProperties::Property
         get_required_properties () const override;
 

--- a/source/heating_model/adiabatic_heating.cc
+++ b/source/heating_model/adiabatic_heating.cc
@@ -61,6 +61,19 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    AdiabaticHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::thermal_expansion_coefficient |
+             MaterialModel::MaterialProperties::density;
+    }
+
+
+
     template <int dim>
     void
     AdiabaticHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -77,6 +77,19 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    AdiabaticHeatingMelt<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::density |
+             MaterialModel::MaterialProperties::thermal_expansion_coefficient |
+             MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     AdiabaticHeatingMelt<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -53,6 +53,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    CompositionalHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::thermal_expansion_coefficient;
+    }
+
+
+
     template <int dim>
     void
     CompositionalHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/constant_heating.cc
+++ b/source/heating_model/constant_heating.cc
@@ -45,6 +45,16 @@ namespace aspect
 
 
     template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ConstantHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::none;
+    }
+
+
+
+    template <int dim>
     void
     ConstantHeating<dim>::declare_parameters (ParameterHandler &prm)
     {

--- a/source/heating_model/function.cc
+++ b/source/heating_model/function.cc
@@ -34,6 +34,7 @@ namespace aspect
     {}
 
 
+
     template <int dim>
     void
     Function<dim>::
@@ -56,6 +57,7 @@ namespace aspect
     }
 
 
+
     template <int dim>
     void
     Function<dim>::update ()
@@ -68,6 +70,16 @@ namespace aspect
       else
         heating_model_function.set_time (time);
     }
+
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    Function<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::none;
+    }
+
 
 
     template <int dim>
@@ -95,6 +107,7 @@ namespace aspect
       }
       prm.leave_subsection();
     }
+
 
 
     template <int dim>

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -203,7 +203,8 @@ namespace aspect
 
       for (const auto &heating_model : this->plugin_objects)
         {
-          heating_model->create_additional_material_model_outputs(material_model_outputs);
+          if ((heating_model->get_required_properties() & MaterialModel::MaterialProperties::additional_outputs) != 0)
+            heating_model->create_additional_material_model_outputs(material_model_outputs);
         }
     }
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -51,6 +51,16 @@ namespace aspect
     {}
 
 
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    Interface<dim>::
+    get_required_properties() const
+    {
+      return MaterialModel::MaterialProperties::all_properties;
+    }
+
+
+
     // ------------------------------ Manager -----------------------------
 
 

--- a/source/heating_model/latent_heat.cc
+++ b/source/heating_model/latent_heat.cc
@@ -48,6 +48,18 @@ namespace aspect
                                                            * material_model_outputs.entropy_derivative_temperature[q];
         }
     }
+
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    LatentHeat<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::entropy_derivative_pressure |
+             MaterialModel::MaterialProperties::entropy_derivative_temperature |
+             MaterialModel::MaterialProperties::density;
+    }
   }
 }
 

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -109,6 +109,27 @@ namespace aspect
         }
     }
 
+
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    LatentHeatMelt<dim>::
+    get_required_properties () const
+    {
+      MaterialModel::MaterialProperties::Property required_properties = MaterialModel::MaterialProperties::additional_outputs;
+      if (this->get_parameters().use_operator_splitting)
+        required_properties = required_properties |
+                              MaterialModel::MaterialProperties::specific_heat |
+                              MaterialModel::MaterialProperties::reaction_rates;
+      else
+        required_properties = required_properties |
+                              MaterialModel::MaterialProperties::reaction_terms |
+                              MaterialModel::MaterialProperties::density;
+      return required_properties;
+    }
+
+
+
     template <int dim>
     void
     LatentHeatMelt<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -33,6 +33,7 @@ namespace aspect
       = default;
 
 
+
     template <int dim>
     void
     RadioactiveDecay<dim>::
@@ -83,6 +84,16 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    RadioactiveDecay<dim>::get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::density;
+    }
+
+
+
     template <int dim>
     void
     RadioactiveDecay<dim>::declare_parameters (ParameterHandler &prm)
@@ -122,6 +133,7 @@ namespace aspect
       }
       prm.leave_subsection();
     }
+
 
 
     template <int dim>

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -84,6 +84,18 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ShearHeating<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::viscosity |
+             MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     ShearHeating<dim>::declare_parameters (ParameterHandler &prm)

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -79,6 +79,17 @@ namespace aspect
     }
 
 
+
+    template <int dim>
+    MaterialModel::MaterialProperties::Property
+    ShearHeatingMelt<dim>::
+    get_required_properties () const
+    {
+      return MaterialModel::MaterialProperties::additional_outputs;
+    }
+
+
+
     template <int dim>
     void
     ShearHeatingMelt<dim>::

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -106,18 +106,19 @@ namespace aspect
 
           // fill seismic velocities outputs if they exist
           if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
-            {
-              if (seismic_vp_index != numbers::invalid_unsigned_int)
-                seismic_out->vp[i] = profile.get_data_component(profile_position,seismic_vp_index);
-              if (seismic_vs_index != numbers::invalid_unsigned_int)
-                seismic_out->vs[i] = profile.get_data_component(profile_position,seismic_vs_index);
-              if (seismic_dvp_dT_index != numbers::invalid_unsigned_int)
-                seismic_out->vp[i] += profile.get_data_component(profile_position,seismic_dvp_dT_index)
-                                      * temperature_deviation;
-              if (seismic_dvs_dT_index != numbers::invalid_unsigned_int)
-                seismic_out->vs[i] += profile.get_data_component(profile_position,seismic_dvs_dT_index)
-                                      * temperature_deviation;
-            }
+            if (in.requests_property(MaterialProperties::additional_outputs))
+              {
+                if (seismic_vp_index != numbers::invalid_unsigned_int)
+                  seismic_out->vp[i] = profile.get_data_component(profile_position,seismic_vp_index);
+                if (seismic_vs_index != numbers::invalid_unsigned_int)
+                  seismic_out->vs[i] = profile.get_data_component(profile_position,seismic_vs_index);
+                if (seismic_dvp_dT_index != numbers::invalid_unsigned_int)
+                  seismic_out->vp[i] += profile.get_data_component(profile_position,seismic_dvp_dT_index)
+                                        * temperature_deviation;
+                if (seismic_dvs_dT_index != numbers::invalid_unsigned_int)
+                  seismic_out->vs[i] += profile.get_data_component(profile_position,seismic_dvs_dT_index)
+                                        * temperature_deviation;
+              }
         }
     }
 

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -127,7 +127,7 @@ namespace aspect
                   Assert(dealii::numbers::is_finite(out.viscosities[i]),
                          ExcMessage ("Error: Averaged viscosity is not finite."));
 
-                  if (derivatives != nullptr)
+                  if (derivatives != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
                       const double averaging_factor = maximum_viscosity * maximum_viscosity
                                                       / ((eta_plastic + minimum_viscosity + maximum_viscosity) * (eta_plastic + minimum_viscosity + maximum_viscosity));

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -246,7 +246,7 @@ namespace aspect
                       effective_viscosity = 1.0 / ( ( 1.0 /  eta_plastic  ) + ( 1.0 / (vis_lateral * viscosity_profile) ) );
 
                       PlasticAdditionalOutputs<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
-                      if (plastic_out != nullptr)
+                      if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                         {
                           plastic_out->cohesions[i] = cohesion;
                           plastic_out->friction_angles[i] = angle_of_internal_friction;
@@ -259,18 +259,19 @@ namespace aspect
 
           // fill seismic velocities outputs if they exist
           if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
-            {
+            if (in.requests_property(MaterialProperties::additional_outputs))
+              {
 
-              std::vector<double> vp (material_file_names.size());
-              std::vector<double> vs (material_file_names.size());
-              for (unsigned int j=0; j<material_file_names.size(); ++j)
-                {
-                  vp[j] = entropy_reader[j]->seismic_vp(entropy,pressure);
-                  vs[j] = entropy_reader[j]->seismic_vs(entropy,pressure);
-                }
-              seismic_out->vp[i] = MaterialUtilities::average_value (volume_fractions, vp, MaterialUtilities::arithmetic);
-              seismic_out->vs[i] = MaterialUtilities::average_value (volume_fractions, vs, MaterialUtilities::arithmetic);
-            }
+                std::vector<double> vp (material_file_names.size());
+                std::vector<double> vs (material_file_names.size());
+                for (unsigned int j=0; j<material_file_names.size(); ++j)
+                  {
+                    vp[j] = entropy_reader[j]->seismic_vp(entropy,pressure);
+                    vs[j] = entropy_reader[j]->seismic_vs(entropy,pressure);
+                  }
+                seismic_out->vp[i] = MaterialUtilities::average_value (volume_fractions, vp, MaterialUtilities::arithmetic);
+                seismic_out->vs[i] = MaterialUtilities::average_value (volume_fractions, vs, MaterialUtilities::arithmetic);
+              }
         }
 
       // Evaluate thermal conductivity. This has to happen after

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -611,7 +611,7 @@ namespace aspect
 
                   PlasticAdditionalOutputs<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
 
-                  if (plastic_out != nullptr)
+                  if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
                       plastic_out->cohesions[i] = drucker_prager_parameters.cohesion;
                       plastic_out->friction_angles[i] = drucker_prager_parameters.angle_internal_friction;
@@ -623,24 +623,27 @@ namespace aspect
               out.viscosities[i] = std::min(std::max(min_eta,effective_viscosity),max_eta);
 
               if (DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
-                {
-                  disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
-                  disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
-                }
+                if (in.requests_property(MaterialProperties::additional_outputs))
+                  {
+                    disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
+                    disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
+                  }
 
             }
 
           // fill seismic velocities outputs if they exist
           if (use_table_properties)
             if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
-              {
-                seismic_out->vp[i] = seismic_Vp(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
-                seismic_out->vs[i] = seismic_Vs(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
-              }
+              if (in.requests_property(MaterialProperties::additional_outputs))
+                {
+                  seismic_out->vp[i] = seismic_Vp(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
+                  seismic_out->vs[i] = seismic_Vs(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
+                }
         }
 
       DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>();
-      grain_size_evolution->fill_additional_outputs(in,out,phase_indices,disl_viscosities_out->dislocation_viscosities,out.additional_outputs);
+      if (in.requests_property(MaterialProperties::additional_outputs))
+        grain_size_evolution->fill_additional_outputs(in,out,phase_indices,disl_viscosities_out->dislocation_viscosities,out.additional_outputs);
 
       if (in.requests_property(MaterialProperties::reaction_terms))
         {

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -255,7 +255,7 @@ namespace aspect
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
 
-      if (melt_out != nullptr)
+      if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
         {
           const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -635,32 +635,33 @@ namespace aspect
       {
         for (auto &additional_output: additional_outputs)
           if (HeatingModel::ShearHeatingOutputs<dim> *shear_heating_out = dynamic_cast<HeatingModel::ShearHeatingOutputs<dim> *>(additional_output.get()))
-            {
-              for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
-                {
-                  if (grain_size_evolution_formulation == Formulation::paleowattmeter)
-                    {
-                      const double f = boundary_area_change_work_fraction[phase_indices[i]];
+            if (in.requests_property(MaterialProperties::additional_outputs))
+              {
+                for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
+                  {
+                    if (grain_size_evolution_formulation == Formulation::paleowattmeter)
+                      {
+                        const double f = boundary_area_change_work_fraction[phase_indices[i]];
 
-                      // We can only compute the fraction of work done to reduce grain size if we have the viscosity.
-                      // However, in some cases, we can get into this function without the viscosity being computed.
-                      // In that case we can only return a number that will trigger an exception if it were to be used.
-                      // We do not want to trigger the exception here, because we might not need the shear heating work
-                      // fraction at all, and only get into this function because other additional material outputs are needed.
-                      if (in.requests_property(MaterialProperties::viscosity))
-                        shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / dislocation_viscosities[i];
-                      else
-                        shear_heating_out->shear_heating_work_fractions[i] = numbers::signaling_nan<double>();
-                    }
-                  else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
-                    {
-                      const double f = compute_partitioning_fraction(in.temperature[i]);
-                      shear_heating_out->shear_heating_work_fractions[i] = 1. - f;
-                    }
-                  else
-                    AssertThrow(false, ExcNotImplemented());
-                }
-            }
+                        // We can only compute the fraction of work done to reduce grain size if we have the viscosity.
+                        // However, in some cases, we can get into this function without the viscosity being computed.
+                        // In that case we can only return a number that will trigger an exception if it were to be used.
+                        // We do not want to trigger the exception here, because we might not need the shear heating work
+                        // fraction at all, and only get into this function because other additional material outputs are needed.
+                        if (in.requests_property(MaterialProperties::viscosity))
+                          shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / dislocation_viscosities[i];
+                        else
+                          shear_heating_out->shear_heating_work_fractions[i] = numbers::signaling_nan<double>();
+                      }
+                    else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
+                      {
+                        const double f = compute_partitioning_fraction(in.temperature[i]);
+                        shear_heating_out->shear_heating_work_fractions[i] = 1. - f;
+                      }
+                    else
+                      AssertThrow(false, ExcNotImplemented());
+                  }
+              }
       }
     }
   }

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -149,7 +149,7 @@ namespace aspect
           // but can be reused for a geofluid of arbitrary composition.
           MeltOutputs<dim> *fluid_out = out.template get_additional_output<MeltOutputs<dim>>();
 
-          if (fluid_out != nullptr)
+          if (fluid_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
             {
               for (unsigned int q=0; q<out.n_evaluation_points(); ++q)
                 {
@@ -177,7 +177,8 @@ namespace aspect
           // Fill reaction rate outputs if the model uses operator splitting.
           // Specifically, change the porosity (representing the amount of free fluid)
           // based on the water solubility and the fluid content.
-          if (this->get_parameters().use_operator_splitting && reaction_rate_out != nullptr)
+          if (this->get_parameters().use_operator_splitting && reaction_rate_out != nullptr
+              && in.requests_property(MaterialProperties::reaction_rates))
             {
               std::vector<double> eq_free_fluid_fractions(out.n_evaluation_points());
               melt_fractions(in, eq_free_fluid_fractions);

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -811,7 +811,7 @@ namespace aspect
 
         if (plastic_out != nullptr)
           {
-            AssertThrow(in.requests_property(MaterialProperties::viscosity),
+            AssertThrow(!std::isnan(out.viscosities[0]),
                         ExcMessage("The PlasticAdditionalOutputs cannot be filled when the viscosity has not been computed."));
 
             plastic_out->cohesions[i] = 0;

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -282,14 +282,15 @@ namespace aspect
     Steinberger<dim>::
     fill_prescribed_outputs(const unsigned int q,
                             const std::vector<double> &,
-                            const MaterialModel::MaterialModelInputs<dim> &,
+                            const MaterialModel::MaterialModelInputs<dim> &in,
                             MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       // set up variable to interpolate prescribed field outputs onto compositional field
       PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
 
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
-          && prescribed_field_out != nullptr)
+          && prescribed_field_out != nullptr
+          && in.requests_property(MaterialProperties::additional_outputs))
         {
           const unsigned int projected_density_index = this->introspection().find_composition_type(CompositionalFieldDescription::density);
           prescribed_field_out->prescribed_field_outputs[q][projected_density_index] = out.densities[q];

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -286,9 +286,10 @@ namespace aspect
 
               // Fill the material properties that are part of the elastic additional outputs
               if (ElasticAdditionalOutputs<dim> *elastic_out = out.template get_additional_output<ElasticAdditionalOutputs<dim>>())
-                {
-                  elastic_out->elastic_shear_moduli[i] = average_elastic_shear_moduli[i];
-                }
+                if (in.requests_property(MaterialProperties::additional_outputs))
+                  {
+                    elastic_out->elastic_shear_moduli[i] = average_elastic_shear_moduli[i];
+                  }
             }
         }
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -274,7 +274,8 @@ namespace aspect
           // has been called.
           // TODO do we even need a separate function? We could compute the PlasticAdditionalOutputs here like
           // the ElasticAdditionalOutputs.
-          rheology->fill_plastic_outputs(i, volume_fractions, plastic_yielding, in, out, isostrain_viscosities);
+          if (in.requests_property(MaterialProperties::additional_outputs))
+            rheology->fill_plastic_outputs(i, volume_fractions, plastic_yielding, in, out, isostrain_viscosities);
 
           if (this->get_parameters().enable_elasticity)
             {

--- a/source/material_model/viscoelastic.cc
+++ b/source/material_model/viscoelastic.cc
@@ -83,9 +83,10 @@ namespace aspect
 
           // Fill the material properties that are part of the elastic additional outputs
           if (ElasticAdditionalOutputs<dim> *elastic_out = out.template get_additional_output<ElasticAdditionalOutputs<dim>>())
-            {
-              elastic_out->elastic_shear_moduli[i] = average_elastic_shear_moduli[i];
-            }
+            if (in.requests_property(MaterialProperties::additional_outputs))
+              {
+                elastic_out->elastic_shear_moduli[i] = average_elastic_shear_moduli[i];
+              }
         }
 
       elastic_rheology.fill_elastic_outputs(in, average_elastic_shear_moduli, out);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -943,6 +943,19 @@ namespace aspect
                                                           scratch.finite_element_values,
                                                           introspection);
 
+    if (advection_field.is_temperature())
+      scratch.material_model_inputs.requested_properties
+        =
+          MaterialModel::MaterialProperties::equation_of_state_properties |
+          MaterialModel::MaterialProperties::additional_outputs |
+          MaterialModel::MaterialProperties::viscosity |
+          MaterialModel::MaterialProperties::thermal_conductivity;
+
+    for (const auto &heating_model : heating_model_manager.get_active_plugins())
+      scratch.material_model_inputs.requested_properties
+        = scratch.material_model_inputs.requested_properties |
+          heating_model->get_required_properties();
+
     material_model->evaluate(scratch.material_model_inputs,
                              scratch.material_model_outputs);
     if (parameters.formulation_temperature_equation ==

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -945,10 +945,7 @@ namespace aspect
 
     if (advection_field.is_temperature())
       scratch.material_model_inputs.requested_properties
-        =
-          MaterialModel::MaterialProperties::equation_of_state_properties |
-          MaterialModel::MaterialProperties::additional_outputs |
-          MaterialModel::MaterialProperties::viscosity |
+        = MaterialModel::MaterialProperties::equation_of_state_properties |
           MaterialModel::MaterialProperties::thermal_conductivity;
 
     for (const auto &heating_model : heating_model_manager.get_active_plugins())
@@ -1072,6 +1069,21 @@ namespace aspect
                                                                       current_linearization_point,
                                                                       *scratch.face_finite_element_values,
                                                                       introspection);
+
+                if (advection_field.is_temperature())
+                  scratch.face_material_model_inputs.requested_properties
+                    = MaterialModel::MaterialProperties::equation_of_state_properties |
+                      MaterialModel::MaterialProperties::thermal_conductivity;
+
+                if (parameters.include_melt_transport)
+                  scratch.face_material_model_inputs.requested_properties
+                    = scratch.face_material_model_inputs.requested_properties |
+                      MaterialModel::MaterialProperties::additional_outputs;
+
+                for (const auto &heating_model : heating_model_manager.get_active_plugins())
+                  scratch.face_material_model_inputs.requested_properties
+                    = scratch.face_material_model_inputs.requested_properties |
+                      heating_model->get_required_properties();
 
                 material_model->evaluate(scratch.face_material_model_inputs,
                                          scratch.face_material_model_outputs);

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -948,6 +948,11 @@ namespace aspect
         = MaterialModel::MaterialProperties::equation_of_state_properties |
           MaterialModel::MaterialProperties::thermal_conductivity;
 
+    if (parameters.include_melt_transport)
+      scratch.material_model_inputs.requested_properties
+        = scratch.material_model_inputs.requested_properties |
+          MaterialModel::MaterialProperties::additional_outputs;
+
     for (const auto &heating_model : heating_model_manager.get_active_plugins())
       scratch.material_model_inputs.requested_properties
         = scratch.material_model_inputs.requested_properties |
@@ -1074,11 +1079,6 @@ namespace aspect
                   scratch.face_material_model_inputs.requested_properties
                     = MaterialModel::MaterialProperties::equation_of_state_properties |
                       MaterialModel::MaterialProperties::thermal_conductivity;
-
-                if (parameters.include_melt_transport)
-                  scratch.face_material_model_inputs.requested_properties
-                    = scratch.face_material_model_inputs.requested_properties |
-                      MaterialModel::MaterialProperties::additional_outputs;
 
                 for (const auto &heating_model : heating_model_manager.get_active_plugins())
                   scratch.face_material_model_inputs.requested_properties

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -927,10 +927,10 @@ namespace aspect
           scratch.mesh_velocity_values);
 
     // compute material properties and heating terms
-    scratch.material_model_inputs.reinit  (scratch.finite_element_values,
-                                           cell,
-                                           this->introspection,
-                                           current_linearization_point);
+    scratch.material_model_inputs.reinit (scratch.finite_element_values,
+                                          cell,
+                                          this->introspection,
+                                          current_linearization_point);
 
     for (unsigned int i=0; i<1+introspection.n_compositional_fields; ++i)
       for (unsigned int j=0; j<assemblers->advection_system[i].size(); ++j)

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -561,6 +561,17 @@ namespace aspect
                                                               solution,
                                                               scratch.finite_element_values,
                                                               introspection);
+
+        if (advection_field.is_temperature())
+          scratch.material_model_inputs.requested_properties
+            = MaterialModel::MaterialProperties::equation_of_state_properties |
+              MaterialModel::MaterialProperties::thermal_conductivity;
+
+        for (const auto &heating_model : heating_model_manager.get_active_plugins())
+          scratch.material_model_inputs.requested_properties
+            = scratch.material_model_inputs.requested_properties |
+              heating_model->get_required_properties();
+
         material_model->evaluate(scratch.material_model_inputs,scratch.material_model_outputs);
         heating_model_manager.evaluate(scratch.material_model_inputs,scratch.material_model_outputs,scratch.heating_model_outputs);
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -699,7 +699,7 @@ namespace aspect
 
       MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
-      Assert(melt_outputs->compaction_viscosities[0] > 0.0,
+      Assert(melt_outputs->fluid_densities[0] > 0.0,
              ExcMessage ("MeltOutputs have to be filled for models with melt transport. "
                          "At the moment, these outputs are not filled, or they do not have "
                          "reasonable values."));


### PR DESCRIPTION
Additional material model outputs are only computed by the material model if they are requested.
This builds on #6267 and helps us see if we forgot a place where we need to request the additional outputs. 
