### PR TITLE
Only ask for required outputs in more places

### DIFF
--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.cc
@@ -898,7 +898,8 @@ namespace aspect
         initial_temperature_manager->template get_matching_active_plugin<InitialTemperature::AdiabaticBoundary<dim>>();
 
       // This function will fill the outputs for grain size, viscosity, and dislocation viscosity
-      if (in.requests_property(MaterialProperties::viscosity))
+      if (in.requests_property(MaterialProperties::viscosity)
+          || in.requests_property(MaterialProperties::additional_outputs))
         compute_equilibrium_grain_size(in, out);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -532,7 +532,8 @@ namespace aspect
           MaterialUtilities::PhaseFunctionInputs<dim> phase_inputs(in.temperature[i], adiabatic_pressures[i], depth, rho_g, numbers::invalid_unsigned_int);
           phase_indices[i] = get_phase_index(phase_inputs);
 
-          if (in.requests_property(MaterialProperties::viscosity))
+          if (in.requests_property(MaterialProperties::viscosity)
+              || in.requests_property(MaterialProperties::additional_outputs))
             {
               double effective_viscosity;
               double disl_viscosity = std::numeric_limits<double>::max();

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -644,10 +644,8 @@ namespace aspect
                         const double f = boundary_area_change_work_fraction[phase_indices[i]];
 
                         // We can only compute the fraction of work done to reduce grain size if we have the viscosity.
-                        // However, in some cases, we can get into this function without the viscosity being computed.
-                        // In that case we can only return a number that will trigger an exception if it were to be used.
-                        // We do not want to trigger the exception here, because we might not need the shear heating work
-                        // fraction at all, and only get into this function because other additional material outputs are needed.
+                        // Therefore, we need to make sure that the viscosity outputs have been filled by the material
+                        // model.
                         if (!std::isnan(out.viscosities[0]))
                           shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / dislocation_viscosities[i];
                         else

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -648,7 +648,7 @@ namespace aspect
                         // In that case we can only return a number that will trigger an exception if it were to be used.
                         // We do not want to trigger the exception here, because we might not need the shear heating work
                         // fraction at all, and only get into this function because other additional material outputs are needed.
-                        if (in.requests_property(MaterialProperties::viscosity))
+                        if (!std::isnan(out.viscosities[0]))
                           shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / dislocation_viscosities[i];
                         else
                           shear_heating_out->shear_heating_work_fractions[i] = numbers::signaling_nan<double>();

--- a/source/postprocess/visualization/material_properties.cc
+++ b/source/postprocess/visualization/material_properties.cc
@@ -117,6 +117,48 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        in.requested_properties
+          = MaterialModel::MaterialProperties::uninitialized;
+
+        for (unsigned int i=0; i<property_names.size(); ++i)
+          {
+            if (property_names[i] == "viscosity")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::viscosity;
+
+            else if (property_names[i] == "density")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::density;
+
+            else if (property_names[i] == "thermal expansivity")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::thermal_expansion_coefficient;
+
+            else if (property_names[i] == "specific heat")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::specific_heat;
+
+            else if (property_names[i] == "thermal conductivity")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::thermal_conductivity;
+
+            else if (property_names[i] == "thermal diffusivity")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::density
+                                        | MaterialModel::MaterialProperties::specific_heat
+                                        | MaterialModel::MaterialProperties::thermal_conductivity;
+
+            else if (property_names[i] == "compressibility")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::compressibility;
+
+            else if (property_names[i] == "entropy derivative pressure")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::entropy_derivative_pressure;
+
+            else if (property_names[i] == "entropy derivative temperature")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::entropy_derivative_temperature;
+
+            else if (property_names[i] == "reaction terms")
+              in.requested_properties = in.requested_properties | MaterialModel::MaterialProperties::reaction_terms;
+
+            // We don't know what a material model needs to compute the melt fraction.
+            else if (property_names[i] == "melt fraction")
+              in.requested_properties = MaterialModel::MaterialProperties::all_properties;
+          }
+
         this->get_material_model().evaluate(in, out);
 
         // We want to output material properties as they are used in the

--- a/source/postprocess/visualization/named_additional_outputs.cc
+++ b/source/postprocess/visualization/named_additional_outputs.cc
@@ -128,6 +128,8 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(n_quadrature_points,
                                                      this->n_compositional_fields());
 
+        in.requested_properties = MaterialModel::MaterialProperties::additional_outputs;
+
         this->get_material_model().create_additional_named_outputs(out);
         this->get_material_model().evaluate(in, out);
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -319,6 +319,15 @@ namespace aspect
     for (unsigned int i=0; i<assemblers->stokes_preconditioner.size(); ++i)
       assemblers->stokes_preconditioner[i]->create_additional_material_model_outputs(scratch.material_model_outputs);
 
+    scratch.material_model_inputs.requested_properties
+      = MaterialModel::MaterialProperties::equation_of_state_properties |
+        MaterialModel::MaterialProperties::viscosity |
+        (parameters.include_melt_transport || assemble_newton_stokes_system
+         ?
+         MaterialModel::MaterialProperties::additional_outputs
+         :
+         MaterialModel::MaterialProperties::uninitialized);
+
     material_model->evaluate(scratch.material_model_inputs,
                              scratch.material_model_outputs);
     MaterialModel::MaterialAveraging::average (parameters.material_averaging,

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -48,7 +48,7 @@ namespace aspect
       public:
         PlasticAdditionalOutputs2(const unsigned int n_points);
 
-        virtual std::vector<double> get_nth_output(const unsigned int idx) const;
+        virtual std::vector<double> get_nth_output(const unsigned int idx) const override;
 
         /**
          * Cohesions at the evaluation points passed to
@@ -112,7 +112,7 @@ namespace aspect
                       typename Interface<dim>::MaterialModelOutputs &out) const override;
 
         virtual void melt_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
-                                     std::vector<double> &melt_fractions) const;
+                                     std::vector<double> &melt_fractions) const override;
 
         /**
          * @}
@@ -134,7 +134,7 @@ namespace aspect
          */
         virtual
         void
-        parse_parameters (ParameterHandler &prm);
+        parse_parameters (ParameterHandler &prm) override;
         /**
          * @}
          */
@@ -486,7 +486,7 @@ namespace aspect
             }
         }
 
-      if (in.requests_property(MaterialProperties::viscosity) )
+      if (in.requests_property(MaterialProperties::viscosity) || in.requests_property(MaterialProperties::additional_outputs))
         {
           // 5) Compute plastic weakening of the viscosity
           for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
@@ -585,7 +585,7 @@ namespace aspect
       // fill melt outputs if they exist
       MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
 
-      if (melt_out != nullptr)
+      if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
         {
           for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
             {


### PR DESCRIPTION
This builds on #6267 and #6271 (only the last commit is new) and specifies the required material model outputs in more places, for example in the graphical output where we really ask for all properties separately. 
Breaking tests will tell us which material models do take into account correctly when to compute which properties (i.e. if some properties depend on others which are not computed).  

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
