### PR TITLE
Use AMG for Weighted BFBT

### DIFF
--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -473,7 +473,7 @@ namespace aspect
     // When we solve with melt migration, the pressure block contains
     // both pressures and contains an elliptic operator, so it makes
     // sense to use AMG instead of ILU:
-    if (parameters.include_melt_transport)
+    if (parameters.include_melt_transport || parameters.use_bfbt)
       Mp_preconditioner = std::make_unique<LinearAlgebra::PreconditionAMG>();
     else
       Mp_preconditioner = std::make_unique<LinearAlgebra::PreconditionILU>();
@@ -513,9 +513,18 @@ namespace aspect
 
     if (parameters.include_melt_transport == false)
       {
-        LinearAlgebra::PreconditionILU *Mp_preconditioner_ILU
-          = dynamic_cast<LinearAlgebra::PreconditionILU *> (Mp_preconditioner.get());
-        Mp_preconditioner_ILU->initialize (system_preconditioner_matrix.block(1,1));
+        if (parameters.use_bfbt)
+          {
+            LinearAlgebra::PreconditionAMG *Mp_preconditioner_AMG = dynamic_cast<LinearAlgebra::PreconditionAMG *> (Mp_preconditioner.get());
+            Mp_preconditioner_AMG->initialize (system_preconditioner_matrix.block(1,1));
+          }
+        else
+          {
+            LinearAlgebra::PreconditionILU *Mp_preconditioner_ILU
+              = dynamic_cast<LinearAlgebra::PreconditionILU *> (Mp_preconditioner.get());
+            Mp_preconditioner_ILU->initialize (system_preconditioner_matrix.block(1,1));
+          }
+
       }
     else
       {

--- a/tests/burstedde_bfbt/statistics
+++ b/tests/burstedde_bfbt/statistics
@@ -11,4 +11,4 @@
 # 11: Visualization file name
 # 12: RMS velocity (m/s)
 # 13: Max. velocity (m/s)
-0 0.000000000000e+00 0.000000000000e+00 64 2312 729 2 26 27 324 output-burstedde_bfbt/solution/solution-00000 4.29880326e+00 1.31764135e+01 
+0 0.000000000000e+00 0.000000000000e+00 64 2312 729 2 26 27 54 output-burstedde_bfbt/solution/solution-00000 4.29880326e+00 1.31764135e+01 

--- a/tests/nsinker_bfbt/statistics
+++ b/tests/nsinker_bfbt/statistics
@@ -9,4 +9,4 @@
 # 9: Velocity iterations in Stokes preconditioner
 # 10: Schur complement iterations in Stokes preconditioner
 # 11: Visualization file name
-0 0.000000000000e+00 0.000000000000e+00 8 402 125 1 31 32 631 output-nsinker_bfbt/solution/solution-00000 
+0 0.000000000000e+00 0.000000000000e+00 8 402 125 1 31 32 63 output-nsinker_bfbt/solution/solution-00000 


### PR DESCRIPTION
Switch the Mp_preconditioner to AMG when using Weighted BFBT to approximate the Schur Complement.
