### PR TITLE
Fix grain size reset at minimum grain size

### DIFF
--- a/doc/modules/changes/20250417_gassmoeller
+++ b/doc/modules/changes/20250417_gassmoeller
@@ -1,0 +1,7 @@
+Fixed: The grain size material model would locally compute a
+wrong grain size growth term if the grain size was reset by
+a phase transition, and was reduced below the minimum grain
+size (by the phase reset or otherwise) in the same time step.
+This is fixed now.
+<br>
+(Rene Gassmoeller, 2025/04/17)

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -309,17 +309,18 @@ namespace aspect
               }
 
             // TODO: recrystallize at correct time while doing grain size evolution instead of afterwards
-            double phase_grain_size_reduction = 0.0;
             if (this->get_timestep_number() > 0)
               {
                 // check if material has crossed any phase transition, if yes, reset grain size
                 if (crossed_transition != -1)
                   if (recrystallized_grain_size[crossed_transition] > 0.0)
-                    phase_grain_size_reduction = grain_sizes[i] - recrystallized_grain_size[crossed_transition];
+                    grain_sizes[i] = recrystallized_grain_size[crossed_transition];
               }
 
+            // Make sure new grain size respects minimum grain size
             grain_sizes[i] = std::max(grain_sizes[i], minimum_grain_size);
-            const double grain_size_change = grain_sizes[i] - in.composition[i][grain_size_index] - phase_grain_size_reduction;
+
+            const double grain_size_change = grain_sizes[i] - in.composition[i][grain_size_index];
 
             // this reaction model is only responsible for the grain size field
             reaction_terms[i][grain_size_index] = grain_size_change;

--- a/tests/grain_size_crossed_transition_minimum.prm
+++ b/tests/grain_size_crossed_transition_minimum.prm
@@ -1,0 +1,16 @@
+# A test for the grain size material model to see if the grain
+# size is reset correctly after crossing a phase transition.
+# This test is a variation of the test grain_size_crossed_transition
+# with an additional minimum grain size.
+
+include $ASPECT_SOURCE_DIR/tests/grain_size_crossed_transition.prm
+
+subsection Material model
+  set Model name = grain size
+  set Material averaging = none
+
+  subsection Grain size model
+    set Recrystallized grain size            = 1e-3
+    set Minimum grain size                   = 1.5e-3
+  end
+end

--- a/tests/grain_size_crossed_transition_minimum/screen-output
+++ b/tests/grain_size_crossed_transition_minimum/screen-output
@@ -1,0 +1,71 @@
+
+Number of active cells: 192 (on 4 levels)
+Number of degrees of freedom: 3,557 (1,666+225+833+833)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 10+0 iterations.
+
+Number of active cells: 264 (on 5 levels)
+Number of degrees of freedom: 5,285 (2,482+321+1,241+1,241)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 31+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition_minimum/solution/solution-00000
+     Compositions min/max/mass: 0.002/0.002/6e+07
+     Writing particle output:   output-grain_size_crossed_transition_minimum/particles/particles-00000
+
+*** Timestep 1:  t=3221.89 years, dt=3221.89 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 23+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition_minimum/solution/solution-00001
+     Compositions min/max/mass: 0.001675/0.002/5.971e+07
+     Writing particle output:   output-grain_size_crossed_transition_minimum/particles/particles-00001
+
+*** Timestep 2:  t=6442.25 years, dt=3220.36 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 22+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition_minimum/solution/solution-00002
+     Compositions min/max/mass: 0.0015/0.002/5.939e+07
+     Writing particle output:   output-grain_size_crossed_transition_minimum/particles/particles-00002
+
+*** Timestep 3:  t=9661.42 years, dt=3219.17 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 23+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition_minimum/solution/solution-00003
+     Compositions min/max/mass: 0.0015/0.002/5.91e+07
+     Writing particle output:   output-grain_size_crossed_transition_minimum/particles/particles-00003
+
+*** Timestep 4:  t=10000 years, dt=338.578 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 19+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-grain_size_crossed_transition_minimum/solution/solution-00004
+     Compositions min/max/mass: 0.0015/0.002/5.907e+07
+     Writing particle output:   output-grain_size_crossed_transition_minimum/particles/particles-00004
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/grain_size_crossed_transition_minimum/statistics
+++ b/tests/grain_size_crossed_transition_minimum/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Number of advected particles
+# 17: Particle file name
+0 0.000000000000e+00 0.000000000000e+00 264 2803 1241 1241 0 31 32 160 output-grain_size_crossed_transition_minimum/solution/solution-00000 2.00000000e-03 2.00000000e-03 6.00000000e+07 10000 output-grain_size_crossed_transition_minimum/particles/particles-00000 
+1 3.221888105682e+03 3.221888105682e+03 264 2803 1241 1241 0 23 24 120 output-grain_size_crossed_transition_minimum/solution/solution-00001 1.67500000e-03 2.00000000e-03 5.97110625e+07  9877 output-grain_size_crossed_transition_minimum/particles/particles-00001 
+2 6.442250061082e+03 3.220361955401e+03 264 2803 1241 1241 0 22 23 115 output-grain_size_crossed_transition_minimum/solution/solution-00002 1.50000000e-03 2.00000000e-03 5.93904318e+07  9750 output-grain_size_crossed_transition_minimum/particles/particles-00002 
+3 9.661422185829e+03 3.219172124747e+03 264 2803 1241 1241 0 23 24 120 output-grain_size_crossed_transition_minimum/solution/solution-00003 1.50000000e-03 2.00000000e-03 5.90970100e+07  9603 output-grain_size_crossed_transition_minimum/particles/particles-00003 
+4 1.000000000000e+04 3.385778141710e+02 264 2803 1241 1241 0 19 20 100 output-grain_size_crossed_transition_minimum/solution/solution-00004 1.50000000e-03 2.00000000e-03 5.90662908e+07  9593 output-grain_size_crossed_transition_minimum/particles/particles-00004 


### PR DESCRIPTION
As described in the changelog and discussed with @jdannberg. There was a bug leading to wrong grain sizes if a phase transition would reset the grain size to something close to the minimum grain size (or if the grain size otherwise violated the minimum, while also being reset by the phase transition). The test makes this obvious by resetting to a smaller value than the minimum value, but the bug also occurred if resetting to exactly the minimum grain size. With the fix the grain size reset at phase transitions happens correctly, unless it would violate the minimum grain size, in which case it is reset to the minimum grain size.

I also think the new code is easier to understand.