### PR TITLE
Move AdvectionField out of Simulator into separate file

### DIFF
--- a/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
+++ b/benchmarks/entropy_adiabat/plugins/entropy_advection.cc
@@ -40,7 +40,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
       const std::vector<CompositionalFieldDescription> &composition_descriptions = this->introspection().get_composition_descriptions();
       if (!advection_field.is_temperature()
           && composition_descriptions[advection_field.compositional_variable].type != CompositionalFieldDescription::entropy)
@@ -180,7 +180,7 @@ namespace aspect
     {
       internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>&> (scratch_base);
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
       const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
       std::vector<double> residuals(n_q_points,0.0);
 

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -22,7 +22,8 @@
 #include <aspect/postprocess/interface.h>
 #include <aspect/gravity_model/interface.h>
 #include <aspect/geometry_model/interface.h>
-#include <aspect/simulator.h>
+#include <aspect/introspection.h>
+#include <aspect/advection_field.h>
 #include <aspect/simulator_access.h>
 #include <aspect/global.h>
 
@@ -827,7 +828,7 @@ namespace aspect
       AssertThrow(this->introspection().compositional_name_exists("porosity"),
                   ExcMessage("Postprocessor Solitary Wave only works if there is a compositional field called porosity."));
       const unsigned int porosity_index = this->introspection().compositional_index_for_name("porosity");
-      const typename Simulator<dim>::AdvectionField porosity = Simulator<dim>::AdvectionField::composition(porosity_index);
+      const AdvectionField porosity = AdvectionField::composition(porosity_index);
 
       // create a quadrature formula based on the compositional element alone.
       AssertThrow (this->introspection().n_compositional_fields > 0,

--- a/include/aspect/advection_field.h
+++ b/include/aspect/advection_field.h
@@ -1,0 +1,196 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_advection_field_h
+#define _aspect_advection_field_h
+
+#include <aspect/global.h>
+#include <aspect/parameters.h>
+
+#include <deal.II/fe/fe_values_extractors.h>
+
+namespace aspect
+{
+  using namespace dealii;
+
+  /**
+   * Forward declare the Introspection() class to avoid circular dependencies.
+   */
+  template <int dim> struct Introspection;
+
+  /**
+   * A structure that is used as an argument to functions that can work on
+   * both the temperature and the compositional variables and that need to
+   * be told which one of the two, as well as on which of the
+   * compositional variables.
+   */
+  struct AdvectionField
+  {
+    /**
+     * An enum indicating whether the identified variable is the
+     * temperature or one of the compositional fields.
+     */
+    enum FieldType { temperature_field, compositional_field };
+
+    /**
+     * A variable indicating whether the identified variable is the
+     * temperature or one of the compositional fields.
+     */
+    const FieldType    field_type;
+
+    /**
+     * A variable identifying which of the compositional fields is
+     * selected. This variable is meaningless if the temperature is
+     * selected.
+     */
+    const unsigned int compositional_variable;
+
+    /**
+     * Constructor.
+     * @param field_type Determines whether this variable should select
+     * the temperature field or a compositional field.
+     * @param compositional_variable The number of the compositional field
+     * if the first argument in fact chooses a compositional variable.
+     * Meaningless if the first argument equals temperature.
+     *
+     * This function is implemented in
+     * <code>source/simulator/helper_functions.cc</code>.
+     */
+    AdvectionField (const FieldType field_type,
+                    const unsigned int compositional_variable = numbers::invalid_unsigned_int);
+
+    /**
+     * A static function that creates an object identifying the
+     * temperature.
+     *
+     * This function is implemented in
+     * <code>source/simulator/helper_functions.cc</code>.
+     */
+    static
+    AdvectionField temperature ();
+
+    /**
+     * A static function that creates an object identifying given
+     * compositional field.
+     *
+     * This function is implemented in
+     * <code>source/simulator/helper_functions.cc</code>.
+     */
+    static
+    AdvectionField composition (const unsigned int compositional_variable);
+
+    /**
+     * Return whether this object refers to the temperature field.
+     */
+    bool
+    is_temperature () const;
+
+    /**
+     * Return whether this object refers to a field discretized by
+     * discontinuous finite elements.
+     */
+    template<int dim>
+    bool
+    is_discontinuous (const Introspection<dim> &introspection) const;
+
+    /**
+     * Return the method that is used to solve the advection of this field
+     * (i.e. 'fem_field', 'particles').
+     */
+    template<int dim>
+    typename Parameters<dim>::AdvectionFieldMethod::Kind
+    advection_method (const Introspection<dim> &introspection) const;
+
+    /**
+     * Look up the component index for this temperature or compositional
+     * field. See Introspection::component_indices for more information.
+     */
+    template<int dim>
+    unsigned int
+    component_index(const Introspection<dim> &introspection) const;
+
+    /**
+     * Look up the block index for this temperature or compositional
+     * field. See Introspection::block_indices for more information.
+     */
+    template<int dim>
+    unsigned int
+    block_index(const Introspection<dim> &introspection) const;
+
+    /**
+     * Look up the block index where the sparsity pattern for this field
+     * is stored. This can be different than block_index() as several fields
+     * can use the same pattern (typically in the first compositional field
+     * if all fields are compatible). See Introspection::block_indices
+     * for more information.
+     */
+    template<int dim>
+    unsigned int
+    sparsity_pattern_block_index(const Introspection<dim> &introspection) const;
+
+    /**
+     * Returns an index that runs from 0 (temperature field) to n (nth
+     * compositional field), and uniquely identifies the current advection
+     * field among the list of all advection fields. Can be used to index
+     * vectors that contain entries for all advection fields.
+     */
+    unsigned int
+    field_index() const;
+
+    /**
+     * Look up the base element within the larger composite finite element
+     * we used for everything, for this temperature or compositional field
+     * See Introspection::base_elements for more information.
+     */
+    template<int dim>
+    unsigned int
+    base_element(const Introspection<dim> &introspection) const;
+
+    /**
+     * Return the FEValues scalar extractor for this temperature
+     * or compositional field.
+     * This function is implemented in
+     * <code>source/simulator/helper_functions.cc</code>.
+     */
+    template<int dim>
+    FEValuesExtractors::Scalar
+    scalar_extractor(const Introspection<dim> &introspection) const;
+
+    /**
+     * Look up the polynomial degree order for this temperature or compositional
+     * field. See Introspection::polynomial_degree for more information.
+     */
+    template<int dim>
+    unsigned int
+    polynomial_degree(const Introspection<dim> &introspection) const;
+
+    /**
+     * Return a string that describes the field type and the compositional
+     * variable number and name, if applicable.
+     */
+    template<int dim>
+    std::string
+    name(const Introspection<dim> &introspection) const;
+  };
+}
+
+
+#endif

--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -490,7 +490,7 @@ namespace aspect
       /**
        * Return whether this object refers to the porosity field.
        */
-      bool is_porosity (const typename Simulator<dim>::AdvectionField &advection_field) const;
+      bool is_porosity (const AdvectionField &advection_field) const;
 
       /**
        * Apply free surface stabilization to a cell of the system matrix when melt

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -65,6 +65,7 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <aspect/postprocess/interface.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/particle/manager.h>
+#include <aspect/advection_field.h>
 
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -261,145 +262,7 @@ namespace aspect
        */
       using NullspaceRemoval = typename Parameters<dim>::NullspaceRemoval;
 
-
-      /**
-       * A structure that is used as an argument to functions that can work on
-       * both the temperature and the compositional variables and that need to
-       * be told which one of the two, as well as on which of the
-       * compositional variables.
-       */
-      struct AdvectionField
-      {
-        /**
-         * An enum indicating whether the identified variable is the
-         * temperature or one of the compositional fields.
-         */
-        enum FieldType { temperature_field, compositional_field };
-
-        /**
-         * A variable indicating whether the identified variable is the
-         * temperature or one of the compositional fields.
-         */
-        const FieldType    field_type;
-
-        /**
-         * A variable identifying which of the compositional fields is
-         * selected. This variable is meaningless if the temperature is
-         * selected.
-         */
-        const unsigned int compositional_variable;
-
-        /**
-         * Constructor.
-         * @param field_type Determines whether this variable should select
-         * the temperature field or a compositional field.
-         * @param compositional_variable The number of the compositional field
-         * if the first argument in fact chooses a compositional variable.
-         * Meaningless if the first argument equals temperature.
-         *
-         * This function is implemented in
-         * <code>source/simulator/helper_functions.cc</code>.
-         */
-        AdvectionField (const FieldType field_type,
-                        const unsigned int compositional_variable = numbers::invalid_unsigned_int);
-
-        /**
-         * A static function that creates an object identifying the
-         * temperature.
-         *
-         * This function is implemented in
-         * <code>source/simulator/helper_functions.cc</code>.
-         */
-        static
-        AdvectionField temperature ();
-
-        /**
-         * A static function that creates an object identifying given
-         * compositional field.
-         *
-         * This function is implemented in
-         * <code>source/simulator/helper_functions.cc</code>.
-         */
-        static
-        AdvectionField composition (const unsigned int compositional_variable);
-
-        /**
-         * Return whether this object refers to the temperature field.
-         */
-        bool
-        is_temperature () const;
-
-        /**
-         * Return whether this object refers to a field discretized by
-         * discontinuous finite elements.
-         */
-        bool
-        is_discontinuous (const Introspection<dim> &introspection) const;
-
-        /**
-         * Return the method that is used to solve the advection of this field
-         * (i.e. 'fem_field', 'particles').
-         */
-        typename Parameters<dim>::AdvectionFieldMethod::Kind
-        advection_method (const Introspection<dim> &introspection) const;
-
-        /**
-         * Look up the component index for this temperature or compositional
-         * field. See Introspection::component_indices for more information.
-         */
-        unsigned int component_index(const Introspection<dim> &introspection) const;
-
-        /**
-         * Look up the block index for this temperature or compositional
-         * field. See Introspection::block_indices for more information.
-         */
-        unsigned int block_index(const Introspection<dim> &introspection) const;
-
-        /**
-         * Look up the block index where the sparsity pattern for this field
-         * is stored. This can be different than block_index() as several fields
-         * can use the same pattern (typically in the first compositional field
-         * if all fields are compatible). See Introspection::block_indices
-         * for more information.
-         */
-        unsigned int sparsity_pattern_block_index(const Introspection<dim> &introspection) const;
-
-        /**
-         * Returns an index that runs from 0 (temperature field) to n (nth
-         * compositional field), and uniquely identifies the current advection
-         * field among the list of all advection fields. Can be used to index
-         * vectors that contain entries for all advection fields.
-         */
-        unsigned int field_index() const;
-
-        /**
-         * Look up the base element within the larger composite finite element
-         * we used for everything, for this temperature or compositional field
-         * See Introspection::base_elements for more information.
-         */
-        unsigned int base_element(const Introspection<dim> &introspection) const;
-
-        /**
-         * Return the FEValues scalar extractor for this temperature
-         * or compositional field.
-         * This function is implemented in
-         * <code>source/simulator/helper_functions.cc</code>.
-         */
-        FEValuesExtractors::Scalar scalar_extractor(const Introspection<dim> &introspection) const;
-
-        /**
-         * Look up the polynomial degree order for this temperature or compositional
-         * field. See Introspection::polynomial_degree for more information.
-         */
-        unsigned int polynomial_degree(const Introspection<dim> &introspection) const;
-
-        /**
-         * Return a string that describes the field type and the compositional
-         * variable number and name, if applicable.
-         */
-        std::string
-        name(const Introspection<dim> &introspection) const;
-      };
+      using AdvectionField = aspect::AdvectionField;
 
     private:
 

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -223,7 +223,7 @@ namespace aspect
                            const UpdateFlags         update_flags,
                            const UpdateFlags         face_update_flags,
                            const unsigned int        n_compositional_fields,
-                           const typename Simulator<dim>::AdvectionField     &field);
+                           const AdvectionField     &field);
           AdvectionSystem (const AdvectionSystem &scratch);
 
           FEValues<dim> finite_element_values;
@@ -317,7 +317,7 @@ namespace aspect
            * fields. See the documentation of the AdvectionField class for
            * more details.
            */
-          const typename Simulator<dim>::AdvectionField *advection_field;
+          const AdvectionField *advection_field;
 
           /**
            * The amount of entropy viscosity that should be applied to the

--- a/include/aspect/volume_of_fluid/handler.h
+++ b/include/aspect/volume_of_fluid/handler.h
@@ -120,14 +120,14 @@ namespace aspect
        * approximation that is bilinear on the unit cell and write that field
        * to the specified AdvectionField
        */
-      void update_volume_of_fluid_composition (const typename Simulator<dim>::AdvectionField &composition_field,
+      void update_volume_of_fluid_composition (const AdvectionField &composition_field,
                                                const VolumeOfFluidField<dim> &volume_of_fluid_field,
                                                LinearAlgebra::BlockVector &solution);
 
       /**
        * Do single timestep update, includes logic for doing Strang split update
        */
-      void do_volume_of_fluid_update (const typename Simulator<dim>::AdvectionField &advection_field);
+      void do_volume_of_fluid_update (const AdvectionField &advection_field);
 
       /**
        * Assemble matrix and RHS for the specified field and dimension

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -21,7 +21,7 @@
 
 #include <aspect/mesh_refinement/compaction_length.h>
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
@@ -42,8 +42,8 @@ namespace aspect
 
       // Use a quadrature in the support points of the porosity to compute the
       // compaction length at:
-      const typename Simulator<dim>::AdvectionField porosity = Simulator<dim>::AdvectionField::composition(
-                                                                 this->introspection().compositional_index_for_name("porosity"));
+      const AdvectionField porosity = AdvectionField::composition(
+                                        this->introspection().compositional_index_for_name("porosity"));
 
       const unsigned int base_element_index = porosity.base_element(this->introspection());
       const Quadrature<dim> quadrature(this->get_fe().base_element(base_element_index).get_unit_support_points());

--- a/source/mesh_refinement/composition_gradient.cc
+++ b/source/mesh_refinement/composition_gradient.cc
@@ -19,8 +19,8 @@
 */
 
 
-#include <aspect/simulator.h>
 #include <aspect/mesh_refinement/composition_gradient.h>
+#include <aspect/advection_field.h>
 
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/fe/fe_values.h>
@@ -61,7 +61,7 @@ namespace aspect
 
                 for (const unsigned int c : this->introspection().get_compositional_field_indices_with_base_element(base_element_index))
                   {
-                    const typename Simulator<dim>::AdvectionField composition = Simulator<dim>::AdvectionField::composition(c);
+                    const AdvectionField composition = AdvectionField::composition(c);
                     fe_values[composition.scalar_extractor(this->introspection())].get_function_gradients (this->get_solution(),
                         composition_gradients);
 

--- a/source/simulator/advection_field.cc
+++ b/source/simulator/advection_field.cc
@@ -1,0 +1,213 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/advection_field.h>
+#include <aspect/introspection.h>
+#include <aspect/parameters.h>
+
+
+namespace aspect
+{
+  AdvectionField::AdvectionField (const FieldType field_type,
+                                  const unsigned int compositional_variable)
+    :
+    field_type (field_type),
+    compositional_variable (compositional_variable)
+  {
+    if (field_type == temperature_field)
+      Assert (compositional_variable == numbers::invalid_unsigned_int,
+              ExcMessage ("You can't specify a compositional variable if you "
+                          "have in fact selected the temperature."));
+  }
+
+
+
+  AdvectionField
+  AdvectionField::temperature ()
+  {
+    return AdvectionField(temperature_field);
+  }
+
+
+
+  AdvectionField
+  AdvectionField::composition (const unsigned int compositional_variable)
+  {
+    return AdvectionField(compositional_field,
+                          compositional_variable);
+  }
+
+
+
+  bool
+  AdvectionField::is_temperature() const
+  {
+    return (field_type == temperature_field);
+  }
+
+
+
+  template <int dim>
+  bool
+  AdvectionField::is_discontinuous(const Introspection<dim> &introspection) const
+  {
+    if (field_type == temperature_field)
+      return introspection.use_discontinuous_temperature_discretization;
+    else if (field_type == compositional_field)
+      return introspection.use_discontinuous_composition_discretization[compositional_variable];
+
+    Assert (false, ExcInternalError());
+    return false;
+  }
+
+
+
+  template <int dim>
+  typename Parameters<dim>::AdvectionFieldMethod::Kind
+  AdvectionField::advection_method(const Introspection<dim> &introspection) const
+  {
+    if (field_type == temperature_field)
+      return introspection.temperature_method;
+    else if (field_type == compositional_field)
+      return introspection.compositional_field_methods[compositional_variable];
+
+    Assert (false, ExcInternalError());
+    return Parameters<dim>::AdvectionFieldMethod::fem_field;
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  AdvectionField::block_index(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.block_indices.temperature;
+    else
+      return introspection.block_indices.compositional_fields[compositional_variable];
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  AdvectionField::sparsity_pattern_block_index(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.block_indices.temperature;
+    else
+      return introspection.block_indices.compositional_field_sparsity_pattern[compositional_variable];
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  AdvectionField::component_index(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.component_indices.temperature;
+    else
+      return introspection.component_indices.compositional_fields[compositional_variable];
+  }
+
+
+
+  unsigned int
+  AdvectionField::field_index() const
+  {
+    if (this->is_temperature())
+      return 0;
+    else
+      return compositional_variable + 1;
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  AdvectionField::base_element(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.base_elements.temperature;
+    else
+      return introspection.base_elements.compositional_fields[compositional_variable];
+  }
+
+
+
+  template <int dim>
+  FEValuesExtractors::Scalar
+  AdvectionField::scalar_extractor(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.extractors.temperature;
+    else
+      {
+        Assert(compositional_variable < introspection.n_compositional_fields,
+               ExcMessage("Invalid AdvectionField."));
+        return introspection.extractors.compositional_fields[compositional_variable];
+      }
+  }
+
+
+
+  template <int dim>
+  unsigned int
+  AdvectionField::polynomial_degree(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return introspection.polynomial_degree.temperature;
+    else
+      return introspection.polynomial_degree.compositional_fields[compositional_variable];
+  }
+
+
+
+  template <int dim>
+  std::string
+  AdvectionField::name(const Introspection<dim> &introspection) const
+  {
+    if (this->is_temperature())
+      return "temperature";
+    else
+      return "composition " + std::to_string(compositional_variable) + " (" + introspection.name_for_compositional_index(compositional_variable) + ")";
+  }
+}
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+#define INSTANTIATE(dim) \
+  template bool AdvectionField::is_discontinuous (const Introspection<dim> &) const; \
+  template typename Parameters<dim>::AdvectionFieldMethod::Kind AdvectionField::advection_method (const Introspection<dim> &) const; \
+  template unsigned int AdvectionField::block_index (const Introspection<dim> &) const; \
+  template unsigned int AdvectionField::sparsity_pattern_block_index (const Introspection<dim> &) const; \
+  template unsigned int AdvectionField::component_index (const Introspection<dim> &) const; \
+  template unsigned int AdvectionField::base_element(const Introspection<dim> &) const; \
+  template FEValuesExtractors::Scalar AdvectionField::scalar_extractor (const Introspection<dim> &) const; \
+  template unsigned int AdvectionField::polynomial_degree (const Introspection<dim> &) const; \
+  template std::string AdvectionField::name (const Introspection<dim> &) const;
+
+  ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
+}

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -21,8 +21,13 @@
 #include <aspect/simulator/assemblers/advection.h>
 
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 #include <aspect/utilities.h>
+#include <aspect/boundary_heat_flux/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/boundary_temperature/interface.h>
+#include <aspect/boundary_composition/interface.h>
+#include <aspect/adiabatic_conditions/interface.h>
 
 namespace aspect
 {
@@ -62,7 +67,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
       const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
       const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
 
@@ -263,7 +268,7 @@ namespace aspect
     {
       internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>&> (scratch_base);
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
       const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
       std::vector<double> residuals(n_q_points);
 
@@ -326,7 +331,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
 
       Assert(advection_field.advection_method(introspection)
              == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion,
@@ -434,7 +439,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
 
       if (!advection_field.is_temperature())
         return;
@@ -515,7 +520,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
 
       Assert(advection_field.advection_method(introspection)
              == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field,
@@ -629,7 +634,7 @@ namespace aspect
     DarcySystem<dim>::compute_residual(internal::Assembly::Scratch::ScratchBase<dim> &scratch_base) const
     {
       internal::Assembly::Scratch::AdvectionSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::AdvectionSystem<dim>& > (scratch_base);
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
       const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
       const Introspection<dim> &introspection = this->introspection();
       std::vector<double> residuals(n_q_points);
@@ -684,7 +689,7 @@ namespace aspect
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
 
       const unsigned int face_no = scratch.face_number;
       const typename DoFHandler<dim>::face_iterator face = scratch.cell->face(face_no);
@@ -902,7 +907,7 @@ namespace aspect
       const unsigned int face_no = scratch.face_number;
       const typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
 
-      const typename Simulator<dim>::AdvectionField advection_field = *scratch.advection_field;
+      const AdvectionField advection_field = *scratch.advection_field;
 
       const unsigned int n_q_points    = scratch.face_finite_element_values->n_quadrature_points;
 

--- a/source/simulator/assemblers/interface.cc
+++ b/source/simulator/assemblers/interface.cc
@@ -20,7 +20,7 @@
 
 #include <aspect/simulator/assemblers/interface.h>
 
-#include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 #include <aspect/utilities.h>
 
 #include <deal.II/base/signaling_nan.h>
@@ -194,7 +194,7 @@ namespace aspect
                          const UpdateFlags         update_flags,
                          const UpdateFlags         face_update_flags,
                          const unsigned int        n_compositional_fields,
-                         const typename Simulator<dim>::AdvectionField &field)
+                         const AdvectionField &field)
           :
           ScratchBase<dim>(),
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -23,6 +23,7 @@
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 #include <aspect/melt.h>
+#include <aspect/advection_field.h>
 #include <aspect/volume_of_fluid/handler.h>
 #include <aspect/newton.h>
 #include <aspect/stokes_matrix_free.h>
@@ -906,7 +907,7 @@ namespace aspect
     template <int dim>
     bool compositional_field_needs_matrix_block(const Introspection<dim> &introspection, const unsigned int composition_index)
     {
-      const typename Simulator<dim>::AdvectionField adv_field (Simulator<dim>::AdvectionField::composition(composition_index));
+      const AdvectionField adv_field (AdvectionField::composition(composition_index));
       switch (adv_field.advection_method(introspection))
         {
           case Parameters<dim>::AdvectionFieldMethod::fem_field:

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -20,9 +20,11 @@
 
 
 #include <aspect/melt.h>
-#include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 #include <aspect/utilities.h>
 #include <aspect/mesh_deformation/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/boundary_traction/interface.h>
 #include <aspect/simulator/assemblers/advection.h>
 #include <deal.II/base/signaling_nan.h>
 
@@ -1350,9 +1352,9 @@ namespace aspect
   template <int dim>
   bool
   MeltHandler<dim>::
-  is_porosity(const typename Simulator<dim>::AdvectionField &advection_field) const
+  is_porosity(const AdvectionField &advection_field) const
   {
-    if (advection_field.field_type != Simulator<dim>::AdvectionField::compositional_field)
+    if (advection_field.field_type != AdvectionField::compositional_field)
       return false;
     else
       return (this->introspection().name_for_compositional_index(advection_field.compositional_variable) == "porosity");

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -20,6 +20,7 @@
 
 
 #include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 #include <aspect/mesh_deformation/free_surface.h>
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/particle/manager.h>
@@ -304,7 +305,7 @@ namespace aspect
   SimulatorAccess<dim>::get_artificial_viscosity (Vector<float> &viscosity_per_cell,
                                                   const bool skip_interior_cells) const
   {
-    const typename Simulator<dim>::AdvectionField advection_field = Simulator<dim>::AdvectionField::temperature();
+    const AdvectionField advection_field = AdvectionField::temperature();
     simulator->get_artificial_viscosity(viscosity_per_cell, advection_field, skip_interior_cells);
   }
 
@@ -315,7 +316,7 @@ namespace aspect
   SimulatorAccess<dim>::get_artificial_viscosity_composition (Vector<float> &viscosity_per_cell,
                                                               const unsigned int compositional_variable) const
   {
-    const typename Simulator<dim>::AdvectionField advection_field = Simulator<dim>::AdvectionField::composition(compositional_variable);
+    const AdvectionField advection_field = AdvectionField::composition(compositional_variable);
     simulator->get_artificial_viscosity(viscosity_per_cell, advection_field);
   }
 

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -20,6 +20,7 @@
 
 #include <aspect/global.h>
 #include <aspect/parameters.h>
+#include <aspect/advection_field.h>
 #include <aspect/volume_of_fluid/handler.h>
 #include <aspect/mesh_refinement/volume_of_fluid_interface.h>
 #include <aspect/simulator/assemblers/interface.h>
@@ -495,7 +496,7 @@ namespace aspect
 
 
   template <int dim>
-  void VolumeOfFluidHandler<dim>::do_volume_of_fluid_update (const typename Simulator<dim>::AdvectionField &advection_field)
+  void VolumeOfFluidHandler<dim>::do_volume_of_fluid_update (const AdvectionField &advection_field)
   {
     const bool direction_order_descending = (this->get_timestep_number() % 2) == 1;
     const VolumeOfFluidField<dim> volume_of_fluid_field = data[volume_of_fluid_composition_map_index[advection_field.field_index()]];

--- a/source/volume_of_fluid/setup_initial_conditions.cc
+++ b/source/volume_of_fluid/setup_initial_conditions.cc
@@ -19,7 +19,7 @@
  */
 
 #include <aspect/global.h>
-#include <aspect/simulator.h>
+#include <aspect/advection_field.h>
 #include <aspect/volume_of_fluid/handler.h>
 #include <aspect/volume_of_fluid/utilities.h>
 
@@ -55,7 +55,7 @@ namespace aspect
         sim.old_old_solution.block(volume_of_fluidLS_blockidx) = sim.solution.block(volume_of_fluidLS_blockidx);
 
         // Update associated composition field
-        const typename Simulator<dim>::AdvectionField composition_field = Simulator<dim>::AdvectionField::composition(data[f].composition_index);
+        const AdvectionField composition_field = AdvectionField::composition(data[f].composition_index);
         update_volume_of_fluid_composition (composition_field, data[f], sim.solution);
         const unsigned int volume_of_fluid_C_blockidx = composition_field.block_index(this->introspection());
         sim.old_solution.block(volume_of_fluid_C_blockidx) = sim.solution.block(volume_of_fluid_C_blockidx);


### PR DESCRIPTION
It was always a bit cumbersome to use the `AdvectionField` struct, because it was a member of the `Simulator` class, even though it is frequently used outside of this class. This PR moves the struct into its own file and makes it independent of the Simulator class. This makes using it more intuitive, and also allows to remove a lot of uses of `include <aspect/simulator.h>`, which only needed the AdvectionField. All existing code should continue to work, because I left a `using ...` directive inside the Simulator class.

As a follow-up I am considering moving all the functions inside `AdvectionField` that take `Introspection<dim` as an argument into the Introspection class. It feels more natural to ask `Introspection`: What is the polynomial degree of this `AdvectionField`, than to ask AdvectionField: What is your polynomial degree? and by the way here is the introspection object that actually knows this information.

This PR allows me to use AdvectionField for PR #5482.