### PR TITLE
Change pressure scaling factor for Weighted BFBT.

### DIFF
--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -165,6 +165,7 @@ namespace aspect
                       if (scratch.dof_component_indices[i] == pressure_component_index && scratch.dof_component_indices[j] == pressure_component_index)
                         data.local_matrix(i, j) += (
                                                      1.0/sqrt_eta * pressure_scaling
+                                                     * pressure_scaling
                                                      * (scratch.grad_phi_p[i]
                                                         * scratch.grad_phi_p[j] + 1e-6*scratch.phi_p[i]*scratch.phi_p[j] ))
                                                    * JxW;

--- a/tests/burstedde_bfbt/screen-output
+++ b/tests/burstedde_bfbt/screen-output
@@ -6,18 +6,18 @@ Number of degrees of freedom: 3,041 (2,187+125+729)
 
 *** Timestep 0:  t=0 seconds, dt=0 seconds
    Rebuilding Stokes preconditioner...
-   Solving Stokes system (AMG-BFBT)... 159+0 iterations.
+   Solving Stokes system (AMG-BFBT)... 26+0 iterations.
       Relative nonlinear residual (Stokes system) after nonlinear iteration 1: 1
 
    Rebuilding Stokes preconditioner...
    Solving Stokes system (AMG-BFBT)... 0+0 iterations.
-      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.87564e-07
+      Relative nonlinear residual (Stokes system) after nonlinear iteration 2: 8.85018e-07
 
 
    Postprocessing:
      Writing graphical output:      output-burstedde_bfbt/solution/solution-00000
      RMS, max velocity:             4.3 m/s, 13.2 m/s
-     Errors u_L1, p_L1, u_L2, p_L2: 6.030147e-01, 1.447579e-03, 1.059175e+00, 3.017047e-03
+     Errors u_L1, p_L1, u_L2, p_L2: 6.029961e-01, 1.448014e-03, 1.059162e+00, 3.024046e-03
 
 Termination requested by criterion: end time
 

--- a/tests/burstedde_bfbt/statistics
+++ b/tests/burstedde_bfbt/statistics
@@ -11,4 +11,4 @@
 # 11: Visualization file name
 # 12: RMS velocity (m/s)
 # 13: Max. velocity (m/s)
-0 0.000000000000e+00 0.000000000000e+00 64 2312 729 2 159 161 1700 output-burstedde_bfbt/solution/solution-00000 4.29880893e+00 1.31764111e+01 
+0 0.000000000000e+00 0.000000000000e+00 64 2312 729 2 26 27 324 output-burstedde_bfbt/solution/solution-00000 4.29880326e+00 1.31764135e+01 


### PR DESCRIPTION
This pull request is part of #6280, where we change the pressure scaling factor and Mp_preconditioner in the case that the Weighted BFBT method is used to approximate the Schur Complement. I am opening this separate pull request which only changes the pressure scaling factor in order to test how changing this alone impacts the existing test results.

The Schur Complement is S=BA^{-1}B^T, which has a squared pressure scaling factor from the B and B^T blocks.

S^{-1}_{w-BFBT}=(BC^{-1]B^T)^{-1}(BC^{-1}AD^{-1}B^T)(BD^{-1}B^T)^{-1}.

Then when assembling the BC^{-1}B^T as a pressure Laplace problem with a squared pressure
scaling factor gives us an S^{-1}_{w-BFBT} with a pressure scaling to the power of -2,
which is consistent with S having a pressure scaling to the power of +2.

@tjhei 