### PR TITLE
Add WorldBuilder macro definition

### DIFF
--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -148,9 +148,6 @@ namespace aspect
         // The rotation matrix is a direction cosine matrix, representing the orientation of the grain in the domain.
         // The fabric is determined later in the computations, so initialize it to -1.
 
-#ifndef ASPECT_WITH_WORLD_BUILDER
-        (void)position;
-#endif
         std::vector<double> deformation_type(n_minerals, -1.0);
         std::vector<std::vector<double >>volume_fractions_grains(n_minerals);
         std::vector<std::vector<Tensor<2,3>>> rotation_matrices_grains(n_minerals);
@@ -191,6 +188,8 @@ namespace aspect
                 AssertThrow(false,
                             ExcMessage("The world builder was requested but not provided. Make sure that aspect is "
                                        "compiled with the World Builder and that you provide a world builder file in the input."));
+                // this is to avoid a warning about unused variables
+                (void)position;
 #endif
               }
             else

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -22,8 +22,10 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/utilities.h>
 
+#ifdef ASPECT_WITH_WORLD_BUILDER
 #include <world_builder/grains.h>
 #include <world_builder/world.h>
+#endif
 
 namespace aspect
 {
@@ -145,6 +147,10 @@ namespace aspect
         //
         // The rotation matrix is a direction cosine matrix, representing the orientation of the grain in the domain.
         // The fabric is determined later in the computations, so initialize it to -1.
+
+#ifndef ASPECT_WITH_WORLD_BUILDER
+        (void)position;
+#endif
         std::vector<double> deformation_type(n_minerals, -1.0);
         std::vector<std::vector<double >>volume_fractions_grains(n_minerals);
         std::vector<std::vector<Tensor<2,3>>> rotation_matrices_grains(n_minerals);
@@ -440,7 +446,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-      CrystalPreferredOrientation<dim>::get_property_information() const
+                                                     CrystalPreferredOrientation<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information;
         property_information.reserve(n_minerals * n_grains * (1+Tensor<2,3>::n_independent_components));

--- a/source/particle/property/crystal_preferred_orientation.cc
+++ b/source/particle/property/crystal_preferred_orientation.cc
@@ -446,7 +446,7 @@ namespace aspect
 
       template <int dim>
       std::vector<std::pair<std::string, unsigned int>>
-                                                     CrystalPreferredOrientation<dim>::get_property_information() const
+      CrystalPreferredOrientation<dim>::get_property_information() const
       {
         std::vector<std::pair<std::string,unsigned int>> property_information;
         property_information.reserve(n_minerals * n_grains * (1+Tensor<2,3>::n_independent_components));


### PR DESCRIPTION
When building ASPECT on the cluster using Intel MPI, I encountered errors related to the World Builder construction. The build works fine with OpenMPI, so I chose to disable the World Builder by setting `ASPECT_WITH_WORLD_BUILDER=OFF`. 

This fix only addresses the errors that arise when `ASPECT_WITH_WORLD_BUILDER` is disabled. It resolves issues caused by missing macro definitions in the code when the World Builder feature is turned off. Other parts of the code or functionality are not affected by this change.