### PR TITLE
Remove a member initialization from header file

### DIFF
--- a/include/aspect/boundary_traction/ascii_data.h
+++ b/include/aspect/boundary_traction/ascii_data.h
@@ -126,7 +126,7 @@ namespace aspect
         * Whether to prescribe pressure (default: true) or full traction vector (false)
         * at the boundary. If true, only 1 component will be used for the boundary condition.
         */
-        bool prescribe_pressure_instead_of_full_traction=true;
+        bool prescribe_pressure_instead_of_full_traction;
 
     };
   }


### PR DESCRIPTION
Follow-up to #6285 and #6297. @tiannh7: Like I mentioned this code is not wrong in its current form, but we do not usually default initialize variables in this way in ASPECT. Additionaly it is potentially confusing, because it splits the default value of the member variable from the default value of the input parameter (which is set in `declare_parameters`). This could lead to confusion in the future if someone only changes one but not the other.

It is our common pattern to rely on setting the variable values in the `parse_parameters` function and if for some reason we have to initialize them earlier (e.g. in the constructor) we would only set them to invalid values. Since there are no invalid values for a `bool`, I would just leave it uninitialized until the correct value is read from the parameter file, which is what this PR does.