### PR TITLE
Allow manual workflow trigger

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -6,6 +6,7 @@ on:
      - 'main'
      - 'aspect-*'
   # pull_request: disable testing of PRs because it is too slow
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
       - 'aspect-*'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.actor }}-${{ github.ref }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.actor }}-${{ github.ref }}-typos


### PR DESCRIPTION
Github deletes workflow results 90 days after the run, which is unfortunate when reviewing old PRs. This PR adds the option to manually trigger our github actions workflows. I hope this avoids having to rebase and force push in order to rerun the workflows.