### PR TITLE
Clarify the Reference To EOS Outputs

### DIFF
--- a/include/aspect/material_model/equation_of_state/linearized_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/linearized_incompressible.h
@@ -45,7 +45,7 @@ namespace aspect
       {
         public:
           /**
-           * A function that computes the output of the equation of state @p out
+           * A function that computes the output of the equation of state @p eos_outputs
            * for all compositions, given the inputs in @p in and an index @p q.
            * More specifically, the inputs structure MaterialModelInputs contains
            * a number of vectors, one for each input property, containing the
@@ -61,7 +61,7 @@ namespace aspect
            */
           void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                         const unsigned int q,
-                        MaterialModel::EquationOfStateOutputs<dim> &out) const;
+                        MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const;
 
           /**
            * Return whether the model is compressible or not. Incompressibility

--- a/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
@@ -62,13 +62,13 @@ namespace aspect
       {
         public:
           /**
-           * A function that computes the output of the equation of state @p out
+           * A function that computes the output of the equation of state @p eos_outputs
            * for all compositions, given the inputs in @p in and an index q that
            * determines which entry of the vector of inputs is used.
            */
           void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                         const unsigned int q,
-                        MaterialModel::EquationOfStateOutputs<dim> &out) const;
+                        MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const;
 
           /**
            * Return whether the model is compressible or not. Incompressibility

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -53,13 +53,13 @@ namespace aspect
       {
         public:
           /**
-           * A function that computes the output of the equation of state @p out
+           * A function that computes the output of the equation of state @p eos_outputs
            * for all compositions and phases, given the inputs in @p in and an
            * index input_index that determines which entry of the vector of inputs is used.
            */
           void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                         const unsigned int input_index,
-                        MaterialModel::EquationOfStateOutputs<dim> &out) const;
+                        MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const;
 
           /**
            * Return whether the model is compressible or not. Incompressibility

--- a/source/material_model/equation_of_state/linearized_incompressible.cc
+++ b/source/material_model/equation_of_state/linearized_incompressible.cc
@@ -33,28 +33,28 @@ namespace aspect
       LinearizedIncompressible<dim>::
       evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                const unsigned int q,
-               MaterialModel::EquationOfStateOutputs<dim> &out) const
+               MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const
       {
 
-        Assert(maximum_number_of_compositions+1 >= out.densities.size(),
+        Assert(maximum_number_of_compositions+1 >= eos_outputs.densities.size(),
                ExcMessage("Error: You are trying to evaluate the equation of state with "
-                          + Utilities::to_string(out.densities.size()-1) +
+                          + Utilities::to_string(eos_outputs.densities.size()-1) +
                           " compositional fields, which is larger than "
                           + Utilities::to_string(maximum_number_of_compositions) +
                           ", the number of fields the equation of state was set up with."));
 
 
-        for (unsigned int c=0; c < out.densities.size(); ++c)
+        for (unsigned int c=0; c < eos_outputs.densities.size(); ++c)
           {
-            out.densities[c] = reference_rho * (1 - thermal_alpha * (in.temperature[q] - reference_T));
+            eos_outputs.densities[c] = reference_rho * (1 - thermal_alpha * (in.temperature[q] - reference_T));
             if (c>0)
-              out.densities[c] += compositional_delta_rhos[c-1];
+              eos_outputs.densities[c] += compositional_delta_rhos[c-1];
 
-            out.thermal_expansion_coefficients[c] = thermal_alpha;
-            out.specific_heat_capacities[c] = reference_specific_heat;
-            out.compressibilities[c] = 0.0;
-            out.entropy_derivative_pressure[c] = 0.0;
-            out.entropy_derivative_temperature[c] = 0.0;
+            eos_outputs.thermal_expansion_coefficients[c] = thermal_alpha;
+            eos_outputs.specific_heat_capacities[c] = reference_specific_heat;
+            eos_outputs.compressibilities[c] = 0.0;
+            eos_outputs.entropy_derivative_pressure[c] = 0.0;
+            eos_outputs.entropy_derivative_temperature[c] = 0.0;
           }
       }
 

--- a/source/material_model/equation_of_state/multicomponent_compressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_compressible.cc
@@ -34,28 +34,28 @@ namespace aspect
       MulticomponentCompressible<dim>::
       evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                const unsigned int q,
-               MaterialModel::EquationOfStateOutputs<dim> &out) const
+               MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const
       {
 
         const double pressure = in.pressure[q];
         const double temperature = std::max(in.temperature[q], 1.); // temperature can't be zero for correct evaluation
 
-        for (unsigned int c=0; c < out.densities.size(); ++c)
+        for (unsigned int c=0; c < eos_outputs.densities.size(); ++c)
           {
             const double ak = reference_thermal_expansivities[c]/reference_isothermal_compressibilities[c];
             const double f = (1. + (pressure - ak*(temperature - reference_temperatures[c])) *
                               isothermal_bulk_modulus_pressure_derivatives[c] *
                               reference_isothermal_compressibilities[c]);
 
-            out.densities[c] = reference_densities[c]*std::pow(f, 1./isothermal_bulk_modulus_pressure_derivatives[c]);
-            out.thermal_expansion_coefficients[c] = reference_thermal_expansivities[c] / f;
-            out.specific_heat_capacities[c] = (isochoric_specific_heats[c] +
-                                               (temperature*reference_thermal_expansivities[c] *
-                                                ak * std::pow(f, -1.-(1./isothermal_bulk_modulus_pressure_derivatives[c]))
-                                                / reference_densities[c]));
-            out.compressibilities[c] = reference_isothermal_compressibilities[c]/f;
-            out.entropy_derivative_pressure[c] = 0.;
-            out.entropy_derivative_temperature[c] = 0.;
+            eos_outputs.densities[c] = reference_densities[c]*std::pow(f, 1./isothermal_bulk_modulus_pressure_derivatives[c]);
+            eos_outputs.thermal_expansion_coefficients[c] = reference_thermal_expansivities[c] / f;
+            eos_outputs.specific_heat_capacities[c] = (isochoric_specific_heats[c] +
+                                                       (temperature*reference_thermal_expansivities[c] *
+                                                        ak * std::pow(f, -1.-(1./isothermal_bulk_modulus_pressure_derivatives[c]))
+                                                        / reference_densities[c]));
+            eos_outputs.compressibilities[c] = reference_isothermal_compressibilities[c]/f;
+            eos_outputs.entropy_derivative_pressure[c] = 0.;
+            eos_outputs.entropy_derivative_temperature[c] = 0.;
           }
       }
 

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -35,7 +35,7 @@ namespace aspect
       MulticomponentIncompressible<dim>::
       evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                const unsigned int input_index,
-               MaterialModel::EquationOfStateOutputs<dim> &out) const
+               MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const
       {
 
 
@@ -47,14 +47,14 @@ namespace aspect
                                               :
                                               reference_T);
 
-        for (unsigned int c=0; c < out.densities.size(); ++c)
+        for (unsigned int c=0; c < eos_outputs.densities.size(); ++c)
           {
-            out.densities[c] = densities[c] * (1 - thermal_expansivities[c] * (in.temperature[input_index] - reference_temperature));
-            out.thermal_expansion_coefficients[c] = thermal_expansivities[c];
-            out.specific_heat_capacities[c] = specific_heats[c];
-            out.compressibilities[c] = 0.0;
-            out.entropy_derivative_pressure[c] = 0.0;
-            out.entropy_derivative_temperature[c] = 0.0;
+            eos_outputs.densities[c] = densities[c] * (1 - thermal_expansivities[c] * (in.temperature[input_index] - reference_temperature));
+            eos_outputs.thermal_expansion_coefficients[c] = thermal_expansivities[c];
+            eos_outputs.specific_heat_capacities[c] = specific_heats[c];
+            eos_outputs.compressibilities[c] = 0.0;
+            eos_outputs.entropy_derivative_pressure[c] = 0.0;
+            eos_outputs.entropy_derivative_temperature[c] = 0.0;
           }
       }
 


### PR DESCRIPTION
I was looking through `multicomponent_compressible.cc` with @flacombe1 and after struggling with understanding the logic behind one of the loops we realized it's because we were assuming that `out` referred to `MaterialModelOutputs`, but it actually referred to `EquationOfStateOutputs`. This is inconsistent with a bulk of the code, where `EquationOfStateOutputs` is referred to as `eos_outputs` and `MaterialModelOutputs` is referred to as `out`, so I changed the reference to `EquationOfStateOutputs` wherever I saw that it was inconsistent.