### PR TITLE
Avoid the use of deal_ii_setup_target in favor of direct commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -803,14 +803,28 @@ if(${ASPECT_BUILD_DEBUG} STREQUAL "ON")
   add_executable(${TARGET_EXE_DEBUG} ${TARGET_SRC})
   set_property(TARGET ${TARGET_EXE_DEBUG}
                PROPERTY OUTPUT_NAME aspect-debug)
-  deal_ii_setup_target(${TARGET_EXE_DEBUG} DEBUG)
+
+  target_compile_flags(${TARGET_EXE_DEBUG} PRIVATE "$<COMPILE_LANGUAGE:CXX>"
+    "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_DEBUG}"
+    )
+  target_link_flags(${TARGET_EXE_DEBUG} PRIVATE
+    "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_DEBUG}"
+    )
+  target_link_libraries(${TARGET_EXE_DEBUG} dealii::dealii_debug)
 endif()
 
 if(${ASPECT_BUILD_RELEASE} STREQUAL "ON")
   add_executable(${TARGET_EXE_RELEASE} ${TARGET_SRC})
   set_property(TARGET ${TARGET_EXE_RELEASE}
                PROPERTY OUTPUT_NAME aspect-release)
-  deal_ii_setup_target(${TARGET_EXE_RELEASE} RELEASE)
+
+  target_compile_flags(${TARGET_EXE_RELEASE} PRIVATE "$<COMPILE_LANGUAGE:CXX>"
+    "${DEAL_II_WARNING_FLAGS} ${DEAL_II_CXX_FLAGS} ${DEAL_II_CXX_FLAGS_RELEASE}"
+    )
+  target_link_flags(${TARGET_EXE_RELEASE} PRIVATE
+    "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_RELEASE}"
+    )
+  target_link_libraries(${TARGET_EXE_RELEASE} dealii::dealii_release)
 endif()
 
 # Make sure that we have an executable 'aspect' that


### PR DESCRIPTION
This fixes #5632, and supersedes #5712.

This seems to correctly set up compile flags for me. For example, these are the flags I get for one of the files of ASPECT:
```
/usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SERIALIZATION_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DDEBUG -DKOKKOS_DEPENDENCE -D_GLIBCXX_ASSERTIONS -I/home/bangerth/p/deal.II/1/projects/aspect/include -I/home/bangerth/p/deal.II/1/projects/build/include -I/home/bangerth/p/deal.II/1/projects/aspect/contrib/world_builder/include -I/home/bangerth/p/deal.II/1/projects/build/world_builder/include -I/home/bangerth/p/deal.II/1/projects/aspect/contrib/catch -isystem /home/bangerth/p/deal.II/1/install/include -isystem /home/bangerth/p/deal.II/1/install/include/deal.II/bundled -isystem /usr/lib/x86_64-linux-gnu/openmpi/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -isystem /usr/include/petsc -isystem /home/bangerth/bin/trilinos-16.1.0/include/kokkos -isystem /home/bangerth/bin/trilinos-16.1.0/include -isystem /usr/include/suitesparse -isystem /usr/include/hdf5/openmpi -isystem /usr/include/opencascade -isystem /usr/include/slepc -isystem /usr/include/vtk-9.1 -Werror -pedantic -Wall -Wextra -Wmissing-braces -Woverloaded-virtual -Wpointer-arith -Wsign-compare -Wsuggest-override -Wswitch -Wsynth -Wwrite-strings -Wno-placement-new -Wno-literal-suffix -Wno-psabi -Wno-unused-local-typedefs -fopenmp-simd -O0 -ggdb -Wa,--compress-debug-sections -fdiagnostics-color=always -Winvalid-pch -include /home/bangerth/p/deal.II/1/projects/build/CMakeFiles/aspect.exe.debug.dir/cmake_pch.hxx -MD -MT CMakeFiles/aspect.exe.debug.dir/source/boundary_velocity/ascii_data.cc.o -MF CMakeFiles/aspect.exe.debug.dir/source/boundary_velocity/ascii_data.cc.o.d -o CMakeFiles/aspect.exe.debug.dir/source/boundary_velocity/ascii_data.cc.o -c /home/bangerth/p/deal.II/1/projects/aspect/source/boundary_velocity/ascii_data.cc
```
In particular, this includes all of the correct warning flags we inherit from deal.II.