### PR TITLE
Modify the depth in spherical shell with initial topography

### DIFF
--- a/include/aspect/geometry_model/interface.h
+++ b/include/aspect/geometry_model/interface.h
@@ -98,9 +98,9 @@ namespace aspect
          * @note Implementations of this function in derived classes can
          * only compute the depth with regard to the <i>reference
          * configuration</i> of the geometry, i.e., the geometry initially
-         * created. If you are using a dynamic topography in your models
-         * that changes in every time step, or if you apply initial
-         * topography to your model, then the <i>actual</i> depth
+         * created with initial topography or not.
+         * If you are using a dynamic topography in your models
+         * that changes in every time step, then the <i>actual</i> depth
          * of a point with regard to this dynamic topography will not
          * match the value this function returns. This is so because
          * computing the actual depth is difficult: In parallel computations,

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -153,11 +153,12 @@ namespace aspect
            */
           double topography_for_point (const Point<dim> &x_y_z) const;
 
-        private:
           /**
            * A pointer to the topography model.
            */
           const InitialTopographyModel::Interface<dim> *topo;
+
+        private:
 
           /**
            * Inner and outer radii of the spherical shell.
@@ -302,7 +303,7 @@ namespace aspect
         /**
          * Return whether the given point lies within the domain specified
          * by the geometry. This function does not take into account
-         * initial or dynamic surface topography.
+         * dynamic surface topography.
          */
         bool
         point_is_in_domain(const Point<dim> &point) const override;

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -703,10 +703,9 @@ namespace aspect
       // Choose a point along the axes toward the north pole, at the
       // requested depth.
       Point<dim> p;
-      p[dim-1] = std::min (std::max(R1 - depth, R0), R1);
 
-      // Return this point. This ignores the surface topography,
-      // but that is as documented.
+      p[dim-1] = std::min (std::max(R1 + manifold->topography_for_point(p) - depth, R0), R1);
+
       return p;
     }
 
@@ -716,12 +715,7 @@ namespace aspect
     double
     SphericalShell<dim>::maximal_depth() const
     {
-      // The depth is defined as relative to a reference surface (without
-      // topography) and since we don't apply topography on the CMB,
-      // the maximal depth really is R1-R0 unless one applies a
-      // topography that is always strictly below zero (i.e., where the
-      // actual surface lies strictly below the reference surface).
-      return R1-R0;
+      return R1 + manifold->topo->max_topography() - R0;
     }
 
 
@@ -804,7 +798,6 @@ namespace aspect
     std::array<double,dim>
     SphericalShell<dim>::cartesian_to_natural_coordinates(const Point<dim> &position) const
     {
-      // TODO: Take into account topography
       return Utilities::Coordinates::cartesian_to_spherical_coordinates<dim>(position);
     }
 
@@ -823,7 +816,6 @@ namespace aspect
     Point<dim>
     SphericalShell<dim>::natural_to_cartesian_coordinates(const std::array<double,dim> &position) const
     {
-      // TODO: Take into account topography
       return Utilities::Coordinates::spherical_to_cartesian_coordinates<dim>(position);
     }
 


### PR DESCRIPTION
This PR modifies how the depths are computed in spherical shell in the presence of topography. Currently, the depths are calculated relative to an outer spherical shell of constant radius such that when initial topography is used, the depth is zero between the uplifted topography and the spherical shell. Therefore, when depth-dependent material properties are used, the layers corresponding to a given material property are thicker underneath high topography regions (figure below). In this PR, depths are computed from the deformed spherical shell surface as done in the `box` geometry model.  

![computed_depths](https://github.com/user-attachments/assets/49c60954-c497-4583-b81d-889b3596dd78)

I will modify the tests in the next commit if this change looks reasonable.
### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).