### PR TITLE
Avoid bare pointers.

### DIFF
--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -163,7 +163,8 @@ namespace aspect
       // prescribe the density field to the current value of the density. The actual projection
       // only happens inside Simulator<dim>::interpolate_material_output_into_compositional_field,
       // this just sets the correct term the field will be set to.
-      if (PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>())
+      if (const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+          = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>())
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
           prescribed_field_out->prescribed_field_outputs[i][density_field_index] = out.densities[i];
     }
@@ -174,7 +175,7 @@ namespace aspect
     void
     CompressibilityFormulations<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/simple_nonlinear.cc
@@ -120,7 +120,8 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       //set up additional output for the derivatives
-      MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModelDerivatives<dim>>();
+      const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+        = out.template get_additional_output_object<MaterialModelDerivatives<dim>>();
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {

--- a/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
+++ b/benchmarks/newton_solver_benchmark_set/spiegelman_et_al_2016/drucker_prager_compositions.cc
@@ -240,8 +240,8 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       //set up additional output for the derivatives
-      MaterialModelDerivatives<dim> *derivatives;
-      derivatives = out.template get_additional_output<MaterialModelDerivatives<dim>>();
+      const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+        = out.template get_additional_output_object<MaterialModelDerivatives<dim>>();
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {

--- a/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
+++ b/benchmarks/operator_splitting/advection_reaction/advection_reaction.cc
@@ -115,7 +115,8 @@ namespace aspect
           out.reaction_terms[q][c] = 0.0;
 
       // fill melt reaction rates if they exist
-      ReactionRateOutputs<dim> *reaction_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_out
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
       if (reaction_out != nullptr)
         {
@@ -194,7 +195,7 @@ namespace aspect
     void
     ExponentialDecay<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
+++ b/benchmarks/operator_splitting/exponential_decay/exponential_decay.cc
@@ -115,7 +115,8 @@ namespace aspect
           out.reaction_terms[q][c] = 0.0;
 
       // fill melt reaction rates if they exist
-      ReactionRateOutputs<dim> *reaction_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_out
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
       if (reaction_out != nullptr)
         {
@@ -193,7 +194,7 @@ namespace aspect
     void
     ExponentialDecay<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/benchmarks/shear_bands/shear_bands.cc
+++ b/benchmarks/shear_bands/shear_bands.cc
@@ -140,7 +140,8 @@ namespace aspect
             }
 
           // fill melt outputs if they exist
-          aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+          const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+            = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
           if (melt_out != nullptr)
             for (unsigned int i=0; i<in.n_evaluation_points(); ++i)

--- a/benchmarks/solitary_wave/solitary_wave.cc
+++ b/benchmarks/solitary_wave/solitary_wave.cc
@@ -441,7 +441,8 @@ namespace aspect
             }
 
           // fill melt outputs if they exist
-          aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+          const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+            = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
           if (melt_out != nullptr)
             for (unsigned int i=0; i<in.n_evaluation_points(); ++i)

--- a/benchmarks/solubility/plugin/solubility.cc
+++ b/benchmarks/solubility/plugin/solubility.cc
@@ -161,7 +161,8 @@ namespace aspect
       // Fill the melt outputs if they exist. Note that the MeltOutputs class was originally
       // designed for two-phase flow material models in ASPECT that model the flow of melt,
       // but can be reused for a geofluid of arbitrary composition.
-      MeltOutputs<dim> *fluid_out = out.template get_additional_output<MeltOutputs<dim>>();
+      std::shared_ptr<MeltOutputs<dim>> fluid_out
+        = out.template get_additional_output_object<MeltOutputs<dim>>();
 
       if (fluid_out != nullptr)
         {
@@ -183,7 +184,8 @@ namespace aspect
             }
         }
 
-      ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
       const unsigned int water_idx = this->introspection().compositional_index_for_name("water_content");
 
       // Fill reaction rate outputs if the model uses operator splitting.
@@ -395,7 +397,7 @@ namespace aspect
     Volatiles<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
+++ b/benchmarks/tosi_et_al_2015_gcubed/tosi.cc
@@ -82,8 +82,8 @@ namespace aspect
            */
 
           //set up additional output for the derivatives
-          MaterialModel::MaterialModelDerivatives<dim> *derivatives;
-          derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+          const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
+            = out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -186,8 +186,8 @@ namespace aspect
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>&> (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>&> (data_base);
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -254,7 +254,7 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
@@ -272,8 +272,8 @@ namespace aspect
       internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
       internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>&> (data_base);
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -281,8 +281,8 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
 
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+      const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -353,21 +353,21 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
-             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
+             outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == n_points, ExcInternalError());
     }
   }
@@ -407,11 +407,11 @@ namespace aspect
 
       // Some material models provide dislocation viscosities and boundary area work fractions
       // as additional material outputs. If they are attached, use them.
-      const ShearHeatingOutputs<dim> *shear_heating_out =
-        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
+      const std::shared_ptr<const ShearHeatingOutputs<dim>> shear_heating_out
+        = material_model_outputs.template get_additional_output_object<ShearHeatingOutputs<dim>>();
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity
+        = material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
@@ -459,7 +459,7 @@ namespace aspect
     {
       const unsigned int n_points = material_model_outputs.viscosities.size();
 
-      if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
@@ -550,8 +550,8 @@ namespace aspect
     AV<dim>::evaluate (const MaterialModel::MaterialModelInputs<dim> &in,
                        MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        out.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        out.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       AssertThrow((this->introspection().compositional_name_exists("gamma")),
                   ExcMessage("AV material model only works if there is a compositional field called gamma."));
@@ -778,7 +778,7 @@ namespace aspect
     void
     AV<dim>::create_additional_named_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<AnisotropicViscosity<dim>>() == nullptr)
+      if (out.template get_additional_output_object<AnisotropicViscosity<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/doc/modules/changes/20250611_bangerth
+++ b/doc/modules/changes/20250611_bangerth
@@ -1,0 +1,16 @@
+Changed: The MaterialModel::MaterialModelInputs and
+MaterialModel::MaterialModelOutputs classes had member functions
+`get_additional_input()` and `get_additional_output()` functions that
+simply returned C-style pointers. The use of such pointers leaves it
+entirely unclear who now owns the object pointed to. As a consequence,
+these functions have now been deprecated and replaced by functions
+`get_additional_input_object()` and `get_additional_output_object()`
+that return their results in the form of `std::shared_ptr` values that
+make clear that the calling place receiving the pointer now shares
+ownership of the input or output object with the place that the object
+is requested from.
+
+The old functions have been retained for backward compatibility
+purposes, but they are now deprecated.
+<br>
+(Wolfgang Bangerth, 2025/06/11)

--- a/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
+++ b/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
@@ -196,7 +196,7 @@ namespace aspect
           void fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
                                         const std::vector<double> &composite_densities,
                                         const std::vector<std::vector<double>> &volume_fractions,
-                                        SeismicAdditionalOutputs<dim> *seismic_out) const;
+                                        SeismicAdditionalOutputs<dim> &seismic_out) const;
 
           /**
            * This function uses the MaterialModelInputs &in to fill the output_values
@@ -211,7 +211,7 @@ namespace aspect
            */
           void fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                             const std::vector<std::vector<double>> &volume_fractions,
-                                            NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const;
+                                            NamedAdditionalMaterialOutputs<dim> &phase_volume_fractions_out) const;
 
           /**
            * This function uses the MaterialModelInputs &in to fill the output_values

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -445,7 +445,7 @@ namespace aspect
          * object of the specified type, then a null pointer is returned.
          */
         template <class AdditionalInputType>
-        const std::shared_ptr<AdditionalInputType>
+        std::shared_ptr<AdditionalInputType>
         get_additional_input_object();
 
         /**
@@ -453,7 +453,7 @@ namespace aspect
          * being queried is `const`.
          */
         template <class AdditionalInputType>
-        const std::shared_ptr<const AdditionalInputType>
+        std::shared_ptr<const AdditionalInputType>
         get_additional_input_object() const;
 
         /**
@@ -633,7 +633,7 @@ namespace aspect
          * If the output does not exist, a null pointer is returned.
          */
         template <class AdditionalOutputType>
-        const std::shared_ptr<AdditionalOutputType>
+        std::shared_ptr<AdditionalOutputType>
         get_additional_output_object();
 
         /**
@@ -641,7 +641,7 @@ namespace aspect
          * returning a const pointer.
          */
         template <class AdditionalOutputType>
-        const std::shared_ptr<const AdditionalOutputType>
+        std::shared_ptr<const AdditionalOutputType>
         get_additional_output_object() const;
 
         /**
@@ -1462,7 +1462,7 @@ namespace aspect
 
     template <int dim>
     template <class AdditionalInputType>
-    const std::shared_ptr<AdditionalInputType>
+    std::shared_ptr<AdditionalInputType>
     MaterialModelInputs<dim>::get_additional_input_object()
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
@@ -1475,7 +1475,7 @@ namespace aspect
 
     template <int dim>
     template <class AdditionalInputType>
-    const std::shared_ptr<const AdditionalInputType>
+    std::shared_ptr<const AdditionalInputType>
     MaterialModelInputs<dim>::get_additional_input_object() const
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
@@ -1488,7 +1488,7 @@ namespace aspect
 
     template <int dim>
     template <class AdditionalOutputType>
-    const std::shared_ptr<AdditionalOutputType>
+    std::shared_ptr<AdditionalOutputType>
     MaterialModelOutputs<dim>::get_additional_output_object()
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)
@@ -1501,7 +1501,7 @@ namespace aspect
 
     template <int dim>
     template <class AdditionalOutputType>
-    const std::shared_ptr<const AdditionalOutputType>
+    std::shared_ptr<const AdditionalOutputType>
     MaterialModelOutputs<dim>::get_additional_output_object() const
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -446,7 +446,7 @@ namespace aspect
          */
         template <class AdditionalInputType>
         const std::shared_ptr<AdditionalInputType>
-        get_additional_input();
+        get_additional_input_object();
 
         /**
          * A version of the previous function that is used when the object
@@ -454,7 +454,7 @@ namespace aspect
          */
         template <class AdditionalInputType>
         const std::shared_ptr<const AdditionalInputType>
-        get_additional_input() const;
+        get_additional_input_object() const;
 
         /**
          * Vector of shared pointers to additional material model input
@@ -634,14 +634,15 @@ namespace aspect
          */
         template <class AdditionalOutputType>
         const std::shared_ptr<AdditionalOutputType>
-        get_additional_output();
+        get_additional_output_object();
 
         /**
-         * Constant version of get_additional_output() returning a const pointer.
+         * Constant version of get_additional_output_object()
+         * returning a const pointer.
          */
         template <class AdditionalOutputType>
         const std::shared_ptr<const AdditionalOutputType>
-        get_additional_output() const;
+        get_additional_output_object() const;
 
         /**
          * Steal the additional outputs from @p other. The destination (@p
@@ -1462,7 +1463,7 @@ namespace aspect
     template <int dim>
     template <class AdditionalInputType>
     const std::shared_ptr<AdditionalInputType>
-    MaterialModelInputs<dim>::get_additional_input()
+    MaterialModelInputs<dim>::get_additional_input_object()
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
         if (dynamic_cast<AdditionalInputType *> (additional_inputs[i].get()))
@@ -1475,7 +1476,7 @@ namespace aspect
     template <int dim>
     template <class AdditionalInputType>
     const std::shared_ptr<const AdditionalInputType>
-    MaterialModelInputs<dim>::get_additional_input() const
+    MaterialModelInputs<dim>::get_additional_input_object() const
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
         if (dynamic_cast<AdditionalInputType *> (additional_inputs[i].get()))
@@ -1488,7 +1489,7 @@ namespace aspect
     template <int dim>
     template <class AdditionalOutputType>
     const std::shared_ptr<AdditionalOutputType>
-    MaterialModelOutputs<dim>::get_additional_output()
+    MaterialModelOutputs<dim>::get_additional_output_object()
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)
         if (dynamic_cast<AdditionalOutputType *> (additional_outputs[i].get()))
@@ -1501,7 +1502,7 @@ namespace aspect
     template <int dim>
     template <class AdditionalOutputType>
     const std::shared_ptr<const AdditionalOutputType>
-    MaterialModelOutputs<dim>::get_additional_output() const
+    MaterialModelOutputs<dim>::get_additional_output_object() const
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)
         if (dynamic_cast<const AdditionalOutputType *> (additional_outputs[i].get()))

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -457,6 +457,26 @@ namespace aspect
         get_additional_input_object() const;
 
         /**
+         * @deprecated This is a version of the functions above that returns a bare pointer,
+         * rather than a managed pointer object. This function is deprecated,
+         * use the functions above.
+         */
+        template <class AdditionalInputType>
+        DEAL_II_DEPRECATED
+        AdditionalInputType *
+        get_additional_input();
+
+        /**
+         * @deprecated This is a version of the functions above that returns a bare pointer,
+         * rather than a managed pointer object. This function is deprecated,
+         * use the functions above.
+         */
+        template <class AdditionalInputType>
+        DEAL_II_DEPRECATED
+        const AdditionalInputType *
+        get_additional_input() const;
+
+        /**
          * Vector of shared pointers to additional material model input
          * objects that can be added to MaterialModelInputs. By default,
          * no inputs are added.
@@ -643,6 +663,26 @@ namespace aspect
         template <class AdditionalOutputType>
         std::shared_ptr<const AdditionalOutputType>
         get_additional_output_object() const;
+
+        /**
+         * @deprecated This is a version of the functions above that returns a bare pointer,
+         * rather than a managed pointer object. This function is deprecated,
+         * use the functions above.
+         */
+        template <class AdditionalOutputType>
+        DEAL_II_DEPRECATED
+        AdditionalOutputType *
+        get_additional_output();
+
+        /**
+         * @deprecated This is a version of the functions above that returns a bare pointer,
+         * rather than a managed pointer object. This function is deprecated,
+         * use the functions above.
+         */
+        template <class AdditionalOutputType>
+        DEAL_II_DEPRECATED
+        const AdditionalOutputType *
+        get_additional_output() const;
 
         /**
          * Steal the additional outputs from @p other. The destination (@p
@@ -1509,6 +1549,43 @@ namespace aspect
           return std::dynamic_pointer_cast<const AdditionalOutputType>(additional_outputs[i]);
 
       return nullptr;
+    }
+
+
+    // The following four functions are deprecated:
+    template <int dim>
+    template <class AdditionalInputType>
+    AdditionalInputType *
+    MaterialModelInputs<dim>::get_additional_input()
+    {
+      return get_additional_input_object<AdditionalInputType>().get();
+    }
+
+
+    template <int dim>
+    template <class AdditionalInputType>
+    const AdditionalInputType *
+    MaterialModelInputs<dim>::get_additional_input() const
+    {
+      return get_additional_input_object<AdditionalInputType>().get();
+    }
+
+
+    template <int dim>
+    template <class AdditionalOutputType>
+    AdditionalOutputType *
+    MaterialModelOutputs<dim>::get_additional_output()
+    {
+      return get_additional_output_object<AdditionalOutputType>().get();
+    }
+
+
+    template <int dim>
+    template <class AdditionalOutputType>
+    const AdditionalOutputType *
+    MaterialModelOutputs<dim>::get_additional_output() const
+    {
+      return get_additional_output_object<AdditionalOutputType>().get();
     }
 
 

--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -445,21 +445,23 @@ namespace aspect
          * object of the specified type, then a null pointer is returned.
          */
         template <class AdditionalInputType>
-        AdditionalInputType *get_additional_input();
+        const std::shared_ptr<AdditionalInputType>
+        get_additional_input();
 
         /**
          * A version of the previous function that is used when the object
          * being queried is `const`.
          */
         template <class AdditionalInputType>
-        const AdditionalInputType *get_additional_input() const;
+        const std::shared_ptr<const AdditionalInputType>
+        get_additional_input() const;
 
         /**
          * Vector of shared pointers to additional material model input
          * objects that can be added to MaterialModelInputs. By default,
          * no inputs are added.
          */
-        std::vector<std::unique_ptr<AdditionalMaterialInputs<dim>>> additional_inputs;
+        std::vector<std::shared_ptr<AdditionalMaterialInputs<dim>>> additional_inputs;
     };
 
 
@@ -618,7 +620,7 @@ namespace aspect
          * objects that can then be added to MaterialModelOutputs. By default,
          * no outputs are added.
          */
-        std::vector<std::unique_ptr<AdditionalMaterialOutputs<dim>>> additional_outputs;
+        std::vector<std::shared_ptr<AdditionalMaterialOutputs<dim>>> additional_outputs;
 
         /**
          * Given an additional material model output class as explicitly specified
@@ -631,13 +633,15 @@ namespace aspect
          * If the output does not exist, a null pointer is returned.
          */
         template <class AdditionalOutputType>
-        AdditionalOutputType *get_additional_output();
+        const std::shared_ptr<AdditionalOutputType>
+        get_additional_output();
 
         /**
          * Constant version of get_additional_output() returning a const pointer.
          */
         template <class AdditionalOutputType>
-        const AdditionalOutputType *get_additional_output() const;
+        const std::shared_ptr<const AdditionalOutputType>
+        get_additional_output() const;
 
         /**
          * Steal the additional outputs from @p other. The destination (@p
@@ -1457,56 +1461,52 @@ namespace aspect
 
     template <int dim>
     template <class AdditionalInputType>
-    AdditionalInputType *MaterialModelInputs<dim>::get_additional_input()
+    const std::shared_ptr<AdditionalInputType>
+    MaterialModelInputs<dim>::get_additional_input()
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
-        {
-          AdditionalInputType *result = dynamic_cast<AdditionalInputType *> (additional_inputs[i].get());
-          if (result)
-            return result;
-        }
+        if (dynamic_cast<AdditionalInputType *> (additional_inputs[i].get()))
+          return std::dynamic_pointer_cast<AdditionalInputType>(additional_inputs[i]);
+
       return nullptr;
     }
 
 
     template <int dim>
     template <class AdditionalInputType>
-    const AdditionalInputType *MaterialModelInputs<dim>::get_additional_input() const
+    const std::shared_ptr<const AdditionalInputType>
+    MaterialModelInputs<dim>::get_additional_input() const
     {
       for (unsigned int i=0; i<additional_inputs.size(); ++i)
-        {
-          const AdditionalInputType *result = dynamic_cast<const AdditionalInputType *> (additional_inputs[i].get());
-          if (result)
-            return result;
-        }
+        if (dynamic_cast<AdditionalInputType *> (additional_inputs[i].get()))
+          return std::dynamic_pointer_cast<const AdditionalInputType>(additional_inputs[i]);
+
       return nullptr;
     }
 
 
     template <int dim>
     template <class AdditionalOutputType>
-    AdditionalOutputType *MaterialModelOutputs<dim>::get_additional_output()
+    const std::shared_ptr<AdditionalOutputType>
+    MaterialModelOutputs<dim>::get_additional_output()
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)
-        {
-          AdditionalOutputType *result = dynamic_cast<AdditionalOutputType *> (additional_outputs[i].get());
-          if (result)
-            return result;
-        }
+        if (dynamic_cast<AdditionalOutputType *> (additional_outputs[i].get()))
+          return std::dynamic_pointer_cast<AdditionalOutputType>(additional_outputs[i]);
+
       return nullptr;
     }
 
 
     template <int dim>
     template <class AdditionalOutputType>
-    const AdditionalOutputType *MaterialModelOutputs<dim>::get_additional_output() const
+    const std::shared_ptr<const AdditionalOutputType>
+    MaterialModelOutputs<dim>::get_additional_output() const
     {
       for (unsigned int i=0; i<additional_outputs.size(); ++i)
-        {
-          const AdditionalOutputType *result = dynamic_cast<const AdditionalOutputType *> (additional_outputs[i].get());
-          if (result)
-            return result;
-        }
+        if (dynamic_cast<const AdditionalOutputType *> (additional_outputs[i].get()))
+          return std::dynamic_pointer_cast<const AdditionalOutputType>(additional_outputs[i]);
+
       return nullptr;
     }
 

--- a/include/aspect/material_model/reaction_model/grain_size_evolution.h
+++ b/include/aspect/material_model/reaction_model/grain_size_evolution.h
@@ -108,7 +108,7 @@ namespace aspect
                                    const typename MaterialModel::MaterialModelOutputs<dim> &out,
                                    const std::vector<unsigned int> &phase_indices,
                                    const std::vector<double> &dislocation_viscosities,
-                                   std::vector<std::unique_ptr<MaterialModel::AdditionalMaterialOutputs<dim>>> &additional_outputs) const;
+                                   std::vector<std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim>>> &additional_outputs) const;
 
           /**
            * Declare the parameters this function takes through input files.

--- a/include/aspect/simulator/assemblers/interface.h
+++ b/include/aspect/simulator/assemblers/interface.h
@@ -560,7 +560,8 @@ namespace aspect
          * and allows the assembler to attach AdditionalOutputs. The
          * function might be called more than once for a
          * MaterialModelOutput, so it is recommended to check if
-         * get_additional_output() returns an instance before adding a new
+         * MaterialModelOutputs<dim>::get_additional_output_object()
+         * returns an instance before adding a new
          * one to the additional_outputs vector. By default this function does
          * not create additional outputs.
          *

--- a/source/adiabatic_conditions/compute_entropy_profile.cc
+++ b/source/adiabatic_conditions/compute_entropy_profile.cc
@@ -54,7 +54,7 @@ namespace aspect
       MaterialModel::MaterialModelOutputs<dim> out(1, this->n_compositional_fields());
       this->get_material_model().create_additional_named_outputs (out);
 
-      MaterialModel::PrescribedTemperatureOutputs<dim> *prescribed_temperature_out
+      const std::shared_ptr<MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
         = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>();
 
       // check if the material model computes prescribed temperature outputs

--- a/source/adiabatic_conditions/compute_entropy_profile.cc
+++ b/source/adiabatic_conditions/compute_entropy_profile.cc
@@ -55,7 +55,7 @@ namespace aspect
       this->get_material_model().create_additional_named_outputs (out);
 
       const std::shared_ptr<MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
-        = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>();
+        = out.template get_additional_output_object<MaterialModel::PrescribedTemperatureOutputs<dim>>();
 
       // check if the material model computes prescribed temperature outputs
       AssertThrow(prescribed_temperature_out != nullptr,

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -41,7 +41,7 @@ namespace aspect
                              std::vector<double> &fluid_pressure_gradient_outputs) const
     {
       const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-        = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       Assert(melt_outputs != nullptr, ExcMessage("Error, MeltOutputs are missing in fluid_pressure_gradient()"));
       for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
         {

--- a/source/boundary_fluid_pressure/density.cc
+++ b/source/boundary_fluid_pressure/density.cc
@@ -34,16 +34,15 @@ namespace aspect
     template <int dim>
     void
     Density<dim>::
-    fluid_pressure_gradient (
-      const types::boundary_id /*boundary_indicator*/,
-      const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
-      const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
-      const std::vector<Tensor<1,dim>> &normal_vectors,
-      std::vector<double> &fluid_pressure_gradient_outputs
-    ) const
+    fluid_pressure_gradient (const types::boundary_id /*boundary_indicator*/,
+                             const MaterialModel::MaterialModelInputs<dim> &material_model_inputs,
+                             const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
+                             const std::vector<Tensor<1,dim>> &normal_vectors,
+                             std::vector<double> &fluid_pressure_gradient_outputs) const
     {
-      const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
-      Assert(melt_outputs!=nullptr, ExcMessage("Error, MeltOutputs are missing in fluid_pressure_gradient()"));
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+        = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      Assert(melt_outputs != nullptr, ExcMessage("Error, MeltOutputs are missing in fluid_pressure_gradient()"));
       for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
         {
           const Tensor<1,dim> gravity = this->get_gravity_model().gravity_vector(material_model_inputs.position[q]);

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -42,7 +42,8 @@ namespace aspect
                   ExcMessage ("Heating model Adiabatic heating with melt only works if melt transport is enabled."));
 
       // get the melt velocity
-      const MaterialModel::MeltInputs<dim> *melt_in = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
+      const std::shared_ptr<const MaterialModel::MeltInputs<dim>> melt_in
+        = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
       AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for adiabatic heating with melt!"));
 
@@ -57,7 +58,8 @@ namespace aspect
                                                             * material_model_inputs.temperature[q];
           else
             {
-              const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+              const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+                = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
               Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for adiabatic heating with melt."));
 
               heating_model_outputs.heating_source_terms[q] = (-porosity * material_model_inputs.velocity[q]

--- a/source/heating_model/adiabatic_heating_of_melt.cc
+++ b/source/heating_model/adiabatic_heating_of_melt.cc
@@ -43,7 +43,7 @@ namespace aspect
 
       // get the melt velocity
       const std::shared_ptr<const MaterialModel::MeltInputs<dim>> melt_in
-        = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
+        = material_model_inputs.template get_additional_input_object<MaterialModel::MeltInputs<dim>>();
       AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for adiabatic heating with melt!"));
 
@@ -59,7 +59,7 @@ namespace aspect
           else
             {
               const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-                = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+                = material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
               Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for adiabatic heating with melt."));
 
               heating_model_outputs.heating_source_terms[q] = (-porosity * material_model_inputs.velocity[q]
@@ -146,7 +146,7 @@ namespace aspect
     create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const
     {
       // we need the melt inputs for this adiabatic heating of melt
-      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>() == nullptr)
+      if (inputs.template get_additional_input_object<MaterialModel::MeltInputs<dim>>() == nullptr)
         inputs.additional_inputs.emplace_back(
           std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.n_evaluation_points()));
     }

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -160,9 +160,6 @@ namespace aspect
       HeatingModel::HeatingModelOutputs individual_heating_outputs(material_model_inputs.n_evaluation_points(),
                                                                    this->n_compositional_fields());
 
-      const MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
-        = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
-
       for (const auto &heating_model : this->plugin_objects)
         {
           heating_model->evaluate(material_model_inputs, material_model_outputs, individual_heating_outputs);
@@ -183,6 +180,9 @@ namespace aspect
       // If the heating model does not get the reaction rate outputs, it can not correctly compute
       // the rates of temperature change. To make sure these (incorrect) values are never used anywhere,
       // overwrite them with signaling_NaNs.
+      const std::shared_ptr<const MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
+        = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+
       if (reaction_rate_outputs == nullptr)
         for (double &q : heating_model_outputs.rates_of_temperature_change)
           q = numbers::signaling_nan<double>();

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -181,7 +181,7 @@ namespace aspect
       // the rates of temperature change. To make sure these (incorrect) values are never used anywhere,
       // overwrite them with signaling_NaNs.
       const std::shared_ptr<const MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
-        = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
 
       if (reaction_rate_outputs == nullptr)
         for (double &q : heating_model_outputs.rates_of_temperature_change)

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -40,10 +40,10 @@ namespace aspect
       const bool use_operator_split = (this->get_parameters().use_operator_splitting);
 
       const std::shared_ptr<const MaterialModel::ReactionRateOutputs<dim>> reaction_rate_out
-        = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
 
       const std::shared_ptr<const MaterialModel::EnthalpyOutputs<dim>> enthalpy_out
-        = material_model_outputs.template get_additional_output<MaterialModel::EnthalpyOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<MaterialModel::EnthalpyOutputs<dim>>();
 
       double enthalpy_change;
 
@@ -181,7 +181,7 @@ namespace aspect
     LatentHeatMelt<dim>::create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
       if (this->include_melt_transport() && retrieve_entropy_change_from_material_model
-          && outputs.template get_additional_output<MaterialModel::EnthalpyOutputs<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::EnthalpyOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::EnthalpyOutputs<dim>> (outputs.n_evaluation_points()));

--- a/source/heating_model/latent_heat_melt.cc
+++ b/source/heating_model/latent_heat_melt.cc
@@ -39,10 +39,10 @@ namespace aspect
 
       const bool use_operator_split = (this->get_parameters().use_operator_splitting);
 
-      const MaterialModel::ReactionRateOutputs<dim> *reaction_rate_out
+      const std::shared_ptr<const MaterialModel::ReactionRateOutputs<dim>> reaction_rate_out
         = material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
 
-      const MaterialModel::EnthalpyOutputs<dim> *enthalpy_out
+      const std::shared_ptr<const MaterialModel::EnthalpyOutputs<dim>> enthalpy_out
         = material_model_outputs.template get_additional_output<MaterialModel::EnthalpyOutputs<dim>>();
 
       double enthalpy_change;

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -37,11 +37,11 @@ namespace aspect
              ExcMessage ("Heating outputs need to have the same number of entries as the material model inputs."));
 
       // Check if the material model has additional outputs relevant for the shear heating.
-      const ShearHeatingOutputs<dim> *shear_heating_out =
-        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
+      const std::shared_ptr<const ShearHeatingOutputs<dim>> shear_heating_out
+        = material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
 
-      const PrescribedShearHeatingOutputs<dim> *prescribed_shear_heating_out =
-        material_model_outputs.template get_additional_output<PrescribedShearHeatingOutputs<dim>>();
+      const std::shared_ptr<const PrescribedShearHeatingOutputs<dim>> prescribed_shear_heating_out
+        = material_model_outputs.template get_additional_output<PrescribedShearHeatingOutputs<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -38,10 +38,10 @@ namespace aspect
 
       // Check if the material model has additional outputs relevant for the shear heating.
       const std::shared_ptr<const ShearHeatingOutputs<dim>> shear_heating_out
-        = material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<ShearHeatingOutputs<dim>>();
 
       const std::shared_ptr<const PrescribedShearHeatingOutputs<dim>> prescribed_shear_heating_out
-        = material_model_outputs.template get_additional_output<PrescribedShearHeatingOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<PrescribedShearHeatingOutputs<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -44,7 +44,8 @@ namespace aspect
                         "is a compositional field called porosity."));
 
       // get the melt velocity
-      const MaterialModel::MeltInputs<dim> *melt_in = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
+      const std::shared_ptr<const MaterialModel::MeltInputs<dim>> melt_in
+        = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
       AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for shear heating with melt!"));
 
@@ -52,7 +53,8 @@ namespace aspect
       if (material_model_inputs.current_cell.state() == IteratorState::valid)
         is_melt_cell = this->get_melt_handler().is_melt_cell(material_model_inputs.current_cell);
 
-      const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+        = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
       Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)

--- a/source/heating_model/shear_heating_with_melt.cc
+++ b/source/heating_model/shear_heating_with_melt.cc
@@ -45,7 +45,7 @@ namespace aspect
 
       // get the melt velocity
       const std::shared_ptr<const MaterialModel::MeltInputs<dim>> melt_in
-        = material_model_inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>();
+        = material_model_inputs.template get_additional_input_object<MaterialModel::MeltInputs<dim>>();
       AssertThrow(melt_in != nullptr,
                   ExcMessage ("Need MeltInputs from the material model for shear heating with melt!"));
 
@@ -54,7 +54,7 @@ namespace aspect
         is_melt_cell = this->get_melt_handler().is_melt_cell(material_model_inputs.current_cell);
 
       const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-        = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
@@ -108,7 +108,7 @@ namespace aspect
     create_additional_material_model_inputs(MaterialModel::MaterialModelInputs<dim> &inputs) const
     {
       // we need the melt inputs for this shear heating of melt
-      if (inputs.template get_additional_input<MaterialModel::MeltInputs<dim>>() == nullptr)
+      if (inputs.template get_additional_input_object<MaterialModel::MeltInputs<dim>>() == nullptr)
         inputs.additional_inputs.emplace_back(
           std::make_unique<MaterialModel::MeltInputs<dim>> (inputs.n_evaluation_points()));
     }

--- a/source/initial_temperature/prescribed_temperature.cc
+++ b/source/initial_temperature/prescribed_temperature.cc
@@ -67,7 +67,7 @@ namespace aspect
       // set up variable to interpolate prescribed field outputs onto temperature field
       double temperature = in.temperature[0];
       if (const std::shared_ptr<const MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
-          = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>())
+          = out.template get_additional_output_object<MaterialModel::PrescribedTemperatureOutputs<dim>>())
         {
           temperature = prescribed_temperature_out->prescribed_temperature_outputs[0];
         }

--- a/source/initial_temperature/prescribed_temperature.cc
+++ b/source/initial_temperature/prescribed_temperature.cc
@@ -66,7 +66,7 @@ namespace aspect
 
       // set up variable to interpolate prescribed field outputs onto temperature field
       double temperature = in.temperature[0];
-      if (MaterialModel::PrescribedTemperatureOutputs<dim> *prescribed_temperature_out
+      if (const std::shared_ptr<const MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
           = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>())
         {
           temperature = prescribed_temperature_out->prescribed_temperature_outputs[0];

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -106,7 +106,7 @@ namespace aspect
 
           // fill seismic velocities outputs if they exist
           if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
-              = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+              = out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>())
             if (in.requests_property(MaterialProperties::additional_outputs))
               {
                 if (seismic_vp_index != numbers::invalid_unsigned_int)
@@ -227,7 +227,7 @@ namespace aspect
     void
     AsciiReferenceProfile<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr
+      if (out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>() == nullptr
           && seismic_vp_index != numbers::invalid_unsigned_int
           && seismic_vs_index != numbers::invalid_unsigned_int)
         {

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -105,7 +105,8 @@ namespace aspect
             out.reaction_terms[i][c] = 0.0;
 
           // fill seismic velocities outputs if they exist
-          if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+          if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
+              = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
             if (in.requests_property(MaterialProperties::additional_outputs))
               {
                 if (seismic_vp_index != numbers::invalid_unsigned_int)

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -35,7 +35,8 @@ namespace aspect
     evaluate(const MaterialModelInputs<dim> &in,
              MaterialModelOutputs<dim> &out) const
     {
-      ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+        = out.template get_additional_output<ReactionRateOutputs<dim>>();
 
       // The Composition reaction model has up to two compositional fields (plus one background field)
       // that can influence the density

--- a/source/material_model/composition_reaction.cc
+++ b/source/material_model/composition_reaction.cc
@@ -36,7 +36,7 @@ namespace aspect
              MaterialModelOutputs<dim> &out) const
     {
       const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
-        = out.template get_additional_output<ReactionRateOutputs<dim>>();
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
       // The Composition reaction model has up to two compositional fields (plus one background field)
       // that can influence the density
@@ -224,7 +224,7 @@ namespace aspect
     CompositionReaction<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -37,7 +37,7 @@ namespace aspect
     {
       // set up additional output for the derivatives
       const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
-        = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+        = out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
       EquationOfStateOutputs<dim> eos_outputs (1);
 

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -36,8 +36,8 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       // set up additional output for the derivatives
-      MaterialModel::MaterialModelDerivatives<dim> *derivatives;
-      derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+      const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
+        = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
       EquationOfStateOutputs<dim> eos_outputs (1);
 

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -192,14 +192,14 @@ namespace aspect
 
           // set up variable to interpolate prescribed field outputs onto compositional fields
           if (const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
-              = out.template get_additional_output<PrescribedFieldOutputs<dim>>())
+              = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>())
             {
               prescribed_field_out->prescribed_field_outputs[i][projected_density_index] = out.densities[i];
             }
 
           // set up variable to interpolate prescribed field outputs onto temperature field
           if (const std::shared_ptr<PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
-              = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>())
+              = out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>())
             {
               prescribed_temperature_out->prescribed_temperature_outputs[i] = adjusted_inputs.temperature[i];
             }
@@ -237,7 +237,7 @@ namespace aspect
                   const double pressure = this->get_adiabatic_conditions().pressure(in.position[i]);
 
                   const std::shared_ptr<PlasticAdditionalOutputs<dim>>
-                  plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+                  plastic_out = out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>();
                   if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
                       plastic_out->cohesions[i] = cohesion;
@@ -271,7 +271,7 @@ namespace aspect
 
           // fill seismic velocities outputs if they exist
           if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
-              = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+              = out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>())
             if (in.requests_property(MaterialProperties::additional_outputs))
               {
 
@@ -436,14 +436,14 @@ namespace aspect
     void
     EntropyModel<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
 
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
@@ -451,7 +451,7 @@ namespace aspect
             (n_points, this->n_compositional_fields()));
         }
 
-      if (out.template get_additional_output<PrescribedTemperatureOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
@@ -459,7 +459,7 @@ namespace aspect
             (n_points));
         }
 
-      if (out.template get_additional_output<PlasticAdditionalOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -191,13 +191,15 @@ namespace aspect
             out.reaction_terms[i][c]            = 0.;
 
           // set up variable to interpolate prescribed field outputs onto compositional fields
-          if (PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>())
+          if (const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+              = out.template get_additional_output<PrescribedFieldOutputs<dim>>())
             {
               prescribed_field_out->prescribed_field_outputs[i][projected_density_index] = out.densities[i];
             }
 
           // set up variable to interpolate prescribed field outputs onto temperature field
-          if (PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>())
+          if (const std::shared_ptr<PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
+              = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>())
             {
               prescribed_temperature_out->prescribed_temperature_outputs[i] = adjusted_inputs.temperature[i];
             }
@@ -234,7 +236,8 @@ namespace aspect
 
                   const double pressure = this->get_adiabatic_conditions().pressure(in.position[i]);
 
-                  PlasticAdditionalOutputs<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+                  const std::shared_ptr<PlasticAdditionalOutputs<dim>>
+                  plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
                   if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
                       plastic_out->cohesions[i] = cohesion;
@@ -267,7 +270,8 @@ namespace aspect
             }
 
           // fill seismic velocities outputs if they exist
-          if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+          if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
+              = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
             if (in.requests_property(MaterialProperties::additional_outputs))
               {
 

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -422,16 +422,16 @@ namespace aspect
       {
         // fill seismic velocity outputs if they exist
         if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
-            = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+            = out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>())
           fill_seismic_velocities(in, out.densities, volume_fractions, *seismic_out);
 
         // fill phase volume outputs if they exist
         if (const std::shared_ptr<NamedAdditionalMaterialOutputs<dim>> phase_volume_fractions_out
-            = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim>>())
+            = out.template get_additional_output_object<NamedAdditionalMaterialOutputs<dim>>())
           fill_phase_volume_fractions(in, volume_fractions, *phase_volume_fractions_out);
 
         if (const std::shared_ptr<PhaseOutputs<dim>> dominant_phases_out
-            = out.template get_additional_output<PhaseOutputs<dim>>())
+            = out.template get_additional_output_object<PhaseOutputs<dim>>())
           fill_dominant_phases(in, volume_fractions, *dominant_phases_out);
       }
 
@@ -528,21 +528,21 @@ namespace aspect
       void
       ThermodynamicTableLookup<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
       {
-        if (out.template get_additional_output<NamedAdditionalMaterialOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<NamedAdditionalMaterialOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
               std::make_unique<MaterialModel::NamedAdditionalMaterialOutputs<dim>> (unique_phase_names, n_points));
           }
 
-        if (out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
               std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
           }
 
-        if (out.template get_additional_output<PhaseOutputs<dim>>() == nullptr
+        if (out.template get_additional_output_object<PhaseOutputs<dim>>() == nullptr
             && material_lookup[0]->has_dominant_phase())
           {
             const unsigned int n_points = out.n_evaluation_points();

--- a/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
+++ b/source/material_model/equation_of_state/thermodynamic_table_lookup.cc
@@ -171,7 +171,7 @@ namespace aspect
       fill_seismic_velocities (const MaterialModel::MaterialModelInputs<dim> &in,
                                const std::vector<double> &composite_densities,
                                const std::vector<std::vector<double>> &volume_fractions,
-                               SeismicAdditionalOutputs<dim> *seismic_out) const
+                               SeismicAdditionalOutputs<dim> &seismic_out) const
       {
         // This function returns the Voigt-Reuss-Hill averages of the
         // seismic velocities of the different materials.
@@ -184,8 +184,8 @@ namespace aspect
           {
             if (material_lookup.size() == 1)
               {
-                seismic_out->vs[i] = material_lookup[0]->seismic_Vs(in.temperature[i],in.pressure[i]);
-                seismic_out->vp[i] = material_lookup[0]->seismic_Vp(in.temperature[i],in.pressure[i]);
+                seismic_out.vs[i] = material_lookup[0]->seismic_Vs(in.temperature[i],in.pressure[i]);
+                seismic_out.vp[i] = material_lookup[0]->seismic_Vp(in.temperature[i],in.pressure[i]);
               }
             else
               {
@@ -207,8 +207,8 @@ namespace aspect
 
                 const double k_VRH = (k_voigt + 1./invk_reuss)/2.;
                 const double mu_VRH = (mu_voigt + 1./invmu_reuss)/2.;
-                seismic_out->vp[i] = std::sqrt((k_VRH + 4./3.*mu_VRH)/composite_densities[i]);
-                seismic_out->vs[i] = std::sqrt(mu_VRH/composite_densities[i]);
+                seismic_out.vp[i] = std::sqrt((k_VRH + 4./3.*mu_VRH)/composite_densities[i]);
+                seismic_out.vs[i] = std::sqrt(mu_VRH/composite_densities[i]);
               }
           }
       }
@@ -220,7 +220,7 @@ namespace aspect
       ThermodynamicTableLookup<dim>::
       fill_phase_volume_fractions (const MaterialModel::MaterialModelInputs<dim> &in,
                                    const std::vector<std::vector<double>> &volume_fractions,
-                                   NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out) const
+                                   NamedAdditionalMaterialOutputs<dim> &phase_volume_fractions_out) const
       {
         // Each call to material_lookup[j]->phase_volume_fraction(k,temperature,pressure)
         // returns the volume fraction of the kth phase which is present in that material lookup
@@ -238,7 +238,7 @@ namespace aspect
             for (unsigned int k = 0; k < unique_phase_indices[j].size(); ++k)
               phase_volume_fractions[unique_phase_indices[j][k]][i] += volume_fractions[i][j] * material_lookup[j]->phase_volume_fraction(k,in.temperature[i],in.pressure[i]);
 
-        phase_volume_fractions_out->output_values = phase_volume_fractions;
+        phase_volume_fractions_out.output_values = phase_volume_fractions;
       }
 
 
@@ -421,14 +421,17 @@ namespace aspect
                                                               MaterialModel::MaterialModelOutputs<dim> &out) const
       {
         // fill seismic velocity outputs if they exist
-        if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
-          fill_seismic_velocities(in, out.densities, volume_fractions, seismic_out);
+        if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
+            = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+          fill_seismic_velocities(in, out.densities, volume_fractions, *seismic_out);
 
         // fill phase volume outputs if they exist
-        if (NamedAdditionalMaterialOutputs<dim> *phase_volume_fractions_out = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim>>())
-          fill_phase_volume_fractions(in, volume_fractions, phase_volume_fractions_out);
+        if (const std::shared_ptr<NamedAdditionalMaterialOutputs<dim>> phase_volume_fractions_out
+            = out.template get_additional_output<NamedAdditionalMaterialOutputs<dim>>())
+          fill_phase_volume_fractions(in, volume_fractions, *phase_volume_fractions_out);
 
-        if (PhaseOutputs<dim> *dominant_phases_out = out.template get_additional_output<PhaseOutputs<dim>>())
+        if (const std::shared_ptr<PhaseOutputs<dim>> dominant_phases_out
+            = out.template get_additional_output<PhaseOutputs<dim>>())
           fill_dominant_phases(in, volume_fractions, *dominant_phases_out);
       }
 

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -610,7 +610,7 @@ namespace aspect
                     }
 
                   const std::shared_ptr<PlasticAdditionalOutputs<dim>> plastic_out
-                    = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+                    = out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>();
 
                   if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
@@ -624,7 +624,7 @@ namespace aspect
               out.viscosities[i] = std::min(std::max(min_eta,effective_viscosity),max_eta);
 
               if (const std::shared_ptr<DislocationViscosityOutputs<dim>> disl_viscosities_out
-                  = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
+                  = out.template get_additional_output_object<DislocationViscosityOutputs<dim>>())
                 if (in.requests_property(MaterialProperties::additional_outputs))
                   {
                     disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
@@ -636,7 +636,7 @@ namespace aspect
           // fill seismic velocities outputs if they exist
           if (use_table_properties)
             if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
-                = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+                = out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>())
               if (in.requests_property(MaterialProperties::additional_outputs))
                 {
                   seismic_out->vp[i] = seismic_Vp(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
@@ -645,7 +645,7 @@ namespace aspect
         }
 
       const std::shared_ptr<DislocationViscosityOutputs<dim>> disl_viscosities_out
-        = out.template get_additional_output<DislocationViscosityOutputs<dim>>();
+        = out.template get_additional_output_object<DislocationViscosityOutputs<dim>>();
       if (in.requests_property(MaterialProperties::additional_outputs))
         grain_size_evolution->fill_additional_outputs(in,out,phase_indices,
                                                       disl_viscosities_out->dislocation_viscosities,out.additional_outputs);
@@ -1144,7 +1144,7 @@ namespace aspect
     GrainSize<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       // These properties are useful as output.
-      if (out.template get_additional_output<DislocationViscosityOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<DislocationViscosityOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
@@ -1155,14 +1155,14 @@ namespace aspect
       grain_size_evolution->create_additional_named_outputs(out);
 
       // These properties are only output properties.
-      if (use_table_properties && out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr)
+      if (use_table_properties && out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_points));
         }
 
-      if (enable_drucker_prager_rheology && out.template get_additional_output<PlasticAdditionalOutputs<dim>>() == nullptr)
+      if (enable_drucker_prager_rheology && out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -609,7 +609,8 @@ namespace aspect
                                                                                         effective_viscosity);
                     }
 
-                  PlasticAdditionalOutputs<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+                  const std::shared_ptr<PlasticAdditionalOutputs<dim>> plastic_out
+                    = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
 
                   if (plastic_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
                     {
@@ -622,7 +623,8 @@ namespace aspect
 
               out.viscosities[i] = std::min(std::max(min_eta,effective_viscosity),max_eta);
 
-              if (DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
+              if (const std::shared_ptr<DislocationViscosityOutputs<dim>> disl_viscosities_out
+                  = out.template get_additional_output<DislocationViscosityOutputs<dim>>())
                 if (in.requests_property(MaterialProperties::additional_outputs))
                   {
                     disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
@@ -633,7 +635,8 @@ namespace aspect
 
           // fill seismic velocities outputs if they exist
           if (use_table_properties)
-            if (SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
+            if (const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
+                = out.template get_additional_output<SeismicAdditionalOutputs<dim>>())
               if (in.requests_property(MaterialProperties::additional_outputs))
                 {
                   seismic_out->vp[i] = seismic_Vp(in.temperature[i], in.pressure[i], in.composition[i], in.position[i]);
@@ -641,9 +644,11 @@ namespace aspect
                 }
         }
 
-      DislocationViscosityOutputs<dim> *disl_viscosities_out = out.template get_additional_output<DislocationViscosityOutputs<dim>>();
+      const std::shared_ptr<DislocationViscosityOutputs<dim>> disl_viscosities_out
+        = out.template get_additional_output<DislocationViscosityOutputs<dim>>();
       if (in.requests_property(MaterialProperties::additional_outputs))
-        grain_size_evolution->fill_additional_outputs(in,out,phase_indices,disl_viscosities_out->dislocation_viscosities,out.additional_outputs);
+        grain_size_evolution->fill_additional_outputs(in,out,phase_indices,
+                                                      disl_viscosities_out->dislocation_viscosities,out.additional_outputs);
 
       if (in.requests_property(MaterialProperties::reaction_terms))
         {

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -851,7 +851,7 @@ namespace aspect
         // store the original viscosities if we need to compute the
         // system jacobian later on
         const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives =
-          values_out.template get_additional_output<MaterialModelDerivatives<dim>>();
+          values_out.template get_additional_output_object<MaterialModelDerivatives<dim>>();
 
         std::vector<double> viscosity_before_averaging;
         if (derivatives != nullptr)

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -850,7 +850,7 @@ namespace aspect
 
         // store the original viscosities if we need to compute the
         // system jacobian later on
-        MaterialModelDerivatives<dim> *derivatives =
+        const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives =
           values_out.template get_additional_output<MaterialModelDerivatives<dim>>();
 
         std::vector<double> viscosity_before_averaging;

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -579,10 +579,10 @@ namespace aspect
     MeltBoukare<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
-      const std::shared_ptr<MeltOutputs<dim>> melt_out = out.template get_additional_output<MeltOutputs<dim>>();
-      const std::shared_ptr<BoukareOutputs<dim>> boukare_out = out.template get_additional_output<BoukareOutputs<dim>>();
-      const std::shared_ptr<EnthalpyOutputs<dim>> enthalpy_out = out.template get_additional_output<EnthalpyOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out = out.template get_additional_output_object<MeltOutputs<dim>>();
+      const std::shared_ptr<BoukareOutputs<dim>> boukare_out = out.template get_additional_output_object<BoukareOutputs<dim>>();
+      const std::shared_ptr<EnthalpyOutputs<dim>> enthalpy_out = out.template get_additional_output_object<EnthalpyOutputs<dim>>();
 
       const unsigned int Fe_solid_idx = this->introspection().compositional_index_for_name("molar_Fe_in_solid");
       unsigned int Fe_melt_idx = numbers::invalid_unsigned_int;
@@ -1249,13 +1249,13 @@ namespace aspect
     MeltBoukare<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (out.n_evaluation_points(), this->n_compositional_fields()));
         }
 
-      if (out.template get_additional_output<BoukareOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<BoukareOutputs<dim>>() == nullptr)
         {
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::BoukareOutputs<dim>> (out.n_evaluation_points()));

--- a/source/material_model/melt_boukare.cc
+++ b/source/material_model/melt_boukare.cc
@@ -579,10 +579,10 @@ namespace aspect
     MeltBoukare<dim>::
     evaluate(const typename Interface<dim>::MaterialModelInputs &in, typename Interface<dim>::MaterialModelOutputs &out) const
     {
-      ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
-      MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
-      BoukareOutputs<dim> *boukare_out = out.template get_additional_output<BoukareOutputs<dim>>();
-      EnthalpyOutputs<dim> *enthalpy_out = out.template get_additional_output<EnthalpyOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+      const std::shared_ptr<BoukareOutputs<dim>> boukare_out = out.template get_additional_output<BoukareOutputs<dim>>();
+      const std::shared_ptr<EnthalpyOutputs<dim>> enthalpy_out = out.template get_additional_output<EnthalpyOutputs<dim>>();
 
       const unsigned int Fe_solid_idx = this->introspection().compositional_index_for_name("molar_Fe_in_solid");
       unsigned int Fe_melt_idx = numbers::invalid_unsigned_int;

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -104,7 +104,7 @@ namespace aspect
       std::vector<double> old_porosity(in.n_evaluation_points());
 
       const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
-        = out.template get_additional_output<ReactionRateOutputs<dim>>();
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
       // we want to get the porosity field from the old solution here,
       // because we need a field that is not updated in the nonlinear iterations
@@ -255,7 +255,7 @@ namespace aspect
 
       // fill melt outputs if they exist
       const std::shared_ptr<MeltOutputs<dim>> melt_out
-        = out.template get_additional_output<MeltOutputs<dim>>();
+        = out.template get_additional_output_object<MeltOutputs<dim>>();
 
       if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
         {
@@ -529,7 +529,7 @@ namespace aspect
     MeltGlobal<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -103,7 +103,8 @@ namespace aspect
     {
       std::vector<double> old_porosity(in.n_evaluation_points());
 
-      ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+        = out.template get_additional_output<ReactionRateOutputs<dim>>();
 
       // we want to get the porosity field from the old solution here,
       // because we need a field that is not updated in the nonlinear iterations
@@ -253,7 +254,8 @@ namespace aspect
         }
 
       // fill melt outputs if they exist
-      MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out
+        = out.template get_additional_output<MeltOutputs<dim>>();
 
       if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
         {

--- a/source/material_model/melt_simple.cc
+++ b/source/material_model/melt_simple.cc
@@ -252,7 +252,7 @@ namespace aspect
     void
     MeltSimple<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (this->get_parameters().use_operator_splitting && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+      if (this->get_parameters().use_operator_splitting && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -610,7 +610,7 @@ namespace aspect
                                                         const typename MaterialModel::MaterialModelOutputs<dim> &out,
                                                         const std::vector<unsigned int> &phase_indices,
                                                         const std::vector<double> &dislocation_viscosities,
-                                                        std::vector<std::unique_ptr<MaterialModel::AdditionalMaterialOutputs<dim>>> &additional_outputs) const
+                                                        std::vector<std::shared_ptr<MaterialModel::AdditionalMaterialOutputs<dim>>> &additional_outputs) const
       {
         for (auto &additional_output: additional_outputs)
           if (HeatingModel::ShearHeatingOutputs<dim> *shear_heating_out = dynamic_cast<HeatingModel::ShearHeatingOutputs<dim> *>(additional_output.get()))

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -594,7 +594,7 @@ namespace aspect
       {
         // These properties will be used by the heating model to reduce
         // shear heating by the amount of work done to reduce grain size.
-        if (out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<HeatingModel::ShearHeatingOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -177,7 +177,7 @@ namespace aspect
                                       typename Interface<dim>::MaterialModelOutputs &out) const
       {
         const std::shared_ptr<ReactionRateOutputs<dim>>
-        reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+        reaction_rate_out = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
         for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
@@ -294,7 +294,7 @@ namespace aspect
                               const double reference_T) const
       {
         const std::shared_ptr<MeltOutputs<dim>> melt_out
-          = out.template get_additional_output<MeltOutputs<dim>>();
+          = out.template get_additional_output_object<MeltOutputs<dim>>();
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
         if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -176,7 +176,8 @@ namespace aspect
       calculate_reaction_rate_outputs(const typename Interface<dim>::MaterialModelInputs &in,
                                       typename Interface<dim>::MaterialModelOutputs &out) const
       {
-        ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+        const std::shared_ptr<ReactionRateOutputs<dim>>
+        reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
 
         for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
@@ -292,7 +293,8 @@ namespace aspect
                               typename Interface<dim>::MaterialModelOutputs &out,
                               const double reference_T) const
       {
-        MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+        const std::shared_ptr<MeltOutputs<dim>> melt_out
+          = out.template get_additional_output<MeltOutputs<dim>>();
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
         if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -148,7 +148,7 @@ namespace aspect
           // designed for two-phase flow material models in ASPECT that model the flow of melt,
           // but can be reused for a geofluid of arbitrary composition.
           const std::shared_ptr<MeltOutputs<dim>> fluid_out
-            = out.template get_additional_output<MeltOutputs<dim>>();
+            = out.template get_additional_output_object<MeltOutputs<dim>>();
 
           if (fluid_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
             {
@@ -174,7 +174,7 @@ namespace aspect
             }
 
           const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
-            = out.template get_additional_output<ReactionRateOutputs<dim>>();
+            = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
           // Fill reaction rate outputs if the model uses operator splitting.
           // Specifically, change the porosity (representing the amount of free fluid)
@@ -445,7 +445,7 @@ namespace aspect
     ReactiveFluidTransport<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       if (this->get_parameters().use_operator_splitting
-          && out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr)
         {
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::ReactionRateOutputs<dim>> (out.n_evaluation_points(), this->n_compositional_fields()));

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -147,7 +147,8 @@ namespace aspect
           // Fill the melt outputs if they exist. Note that the MeltOutputs class was originally
           // designed for two-phase flow material models in ASPECT that model the flow of melt,
           // but can be reused for a geofluid of arbitrary composition.
-          MeltOutputs<dim> *fluid_out = out.template get_additional_output<MeltOutputs<dim>>();
+          const std::shared_ptr<MeltOutputs<dim>> fluid_out
+            = out.template get_additional_output<MeltOutputs<dim>>();
 
           if (fluid_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
             {
@@ -172,7 +173,8 @@ namespace aspect
                 }
             }
 
-          ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+          const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+            = out.template get_additional_output<ReactionRateOutputs<dim>>();
 
           // Fill reaction rate outputs if the model uses operator splitting.
           // Specifically, change the porosity (representing the amount of free fluid)

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -323,7 +323,7 @@ namespace aspect
       {
         // Create the ElasticAdditionalOutputs that include the average shear modulus, elastic
         // viscosity, timestep ratio and total deviatoric stress of the current timestep.
-        if (out.template get_additional_output<ElasticAdditionalOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<ElasticAdditionalOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
@@ -331,7 +331,7 @@ namespace aspect
           }
 
         // We need to modify the shear heating outputs to correctly account for elastic stresses.
-        if (out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<HeatingModel::PrescribedShearHeatingOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
@@ -342,7 +342,7 @@ namespace aspect
         // step (either on the fields or directly on the particles)
         // that sets both sets of stresses to the total stress of the
         // previous timestep.
-        if (out.template get_additional_output<ReactionRateOutputs<dim>>() == nullptr &&
+        if (out.template get_additional_output_object<ReactionRateOutputs<dim>>() == nullptr &&
             (this->get_parameters().use_operator_splitting || (this->get_parameters().mapped_particle_properties).count(this->introspection().compositional_index_for_name("ve_stress_xx"))))
           {
             const unsigned int n_points = out.n_evaluation_points();
@@ -362,12 +362,12 @@ namespace aspect
         // Create a reference to the structure for the elastic outputs.
         // The structure is created during the Stokes assembly.
         const std::shared_ptr<MaterialModel::ElasticOutputs<dim>>
-        elastic_out = out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+        elastic_out = out.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>();
 
         // Create a reference to the structure for the prescribed shear heating outputs.
         // The structure is created during the advection assembly.
         const std::shared_ptr<HeatingModel::PrescribedShearHeatingOutputs<dim>>
-        heating_out = out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>();
+        heating_out = out.template get_additional_output_object<HeatingModel::PrescribedShearHeatingOutputs<dim>>();
 
         if (elastic_out == nullptr && heating_out == nullptr)
           return;
@@ -485,7 +485,7 @@ namespace aspect
       {
         // Create a reference to the structure for the elastic additional outputs
         const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>>
-        elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+        elastic_additional_out = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
         if (elastic_additional_out == nullptr || !in.requests_property(MaterialProperties::additional_outputs))
           return;
@@ -600,7 +600,7 @@ namespace aspect
                                             MaterialModel::MaterialModelOutputs<dim> &out) const
       {
         const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
-          = out.template get_additional_output<ReactionRateOutputs<dim>>();
+          = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
         if (reaction_rate_out == nullptr)
           return;

--- a/source/material_model/rheology/elasticity.cc
+++ b/source/material_model/rheology/elasticity.cc
@@ -361,13 +361,13 @@ namespace aspect
       {
         // Create a reference to the structure for the elastic outputs.
         // The structure is created during the Stokes assembly.
-        MaterialModel::ElasticOutputs<dim>
-        *elastic_out = out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+        const std::shared_ptr<MaterialModel::ElasticOutputs<dim>>
+        elastic_out = out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
 
         // Create a reference to the structure for the prescribed shear heating outputs.
         // The structure is created during the advection assembly.
-        HeatingModel::PrescribedShearHeatingOutputs<dim>
-        *heating_out = out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>();
+        const std::shared_ptr<HeatingModel::PrescribedShearHeatingOutputs<dim>>
+        heating_out = out.template get_additional_output<HeatingModel::PrescribedShearHeatingOutputs<dim>>();
 
         if (elastic_out == nullptr && heating_out == nullptr)
           return;
@@ -484,8 +484,8 @@ namespace aspect
                                                         MaterialModel::MaterialModelOutputs<dim> &out) const
       {
         // Create a reference to the structure for the elastic additional outputs
-        MaterialModel::ElasticAdditionalOutputs<dim>
-        *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+        const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>>
+        elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
         if (elastic_additional_out == nullptr || !in.requests_property(MaterialProperties::additional_outputs))
           return;
@@ -599,7 +599,8 @@ namespace aspect
                                             const std::vector<double> &average_elastic_shear_moduli,
                                             MaterialModel::MaterialModelOutputs<dim> &out) const
       {
-        ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+        const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+          = out.template get_additional_output<ReactionRateOutputs<dim>>();
 
         if (reaction_rate_out == nullptr)
           return;

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -435,7 +435,7 @@ namespace aspect
                                     const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
         const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
-          = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+          = out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
         if (derivatives != nullptr)
           {
@@ -831,7 +831,7 @@ namespace aspect
       void
       ViscoPlastic<dim>::create_plastic_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
       {
-        if (out.template get_additional_output<PlasticAdditionalOutputs<dim>>() == nullptr)
+        if (out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>() == nullptr)
           {
             const unsigned int n_points = out.n_evaluation_points();
             out.additional_outputs.push_back(
@@ -850,7 +850,7 @@ namespace aspect
                            const IsostrainViscosities &isostrain_viscosities) const
       {
         const std::shared_ptr<PlasticAdditionalOutputs<dim>> plastic_out
-          = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+          = out.template get_additional_output_object<PlasticAdditionalOutputs<dim>>();
 
         if (plastic_out != nullptr)
           {

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -434,8 +434,8 @@ namespace aspect
                                     const std::vector<double> &phase_function_values,
                                     const std::vector<unsigned int> &n_phase_transitions_per_composition) const
       {
-        MaterialModel::MaterialModelDerivatives<dim> *derivatives =
-          out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+        const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
+          = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
         if (derivatives != nullptr)
           {
@@ -849,7 +849,8 @@ namespace aspect
                            MaterialModel::MaterialModelOutputs<dim> &out,
                            const IsostrainViscosities &isostrain_viscosities) const
       {
-        PlasticAdditionalOutputs<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
+        const std::shared_ptr<PlasticAdditionalOutputs<dim>> plastic_out
+          = out.template get_additional_output<PlasticAdditionalOutputs<dim>>();
 
         if (plastic_out != nullptr)
           {

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -287,7 +287,7 @@ namespace aspect
     {
       // set up variable to interpolate prescribed field outputs onto compositional field
       const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
-        = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
           && prescribed_field_out != nullptr
@@ -487,7 +487,7 @@ namespace aspect
       equation_of_state.create_additional_named_outputs(out);
 
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
-          && out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+          && out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/source/material_model/steinberger.cc
+++ b/source/material_model/steinberger.cc
@@ -286,7 +286,8 @@ namespace aspect
                             MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       // set up variable to interpolate prescribed field outputs onto compositional field
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
 
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::density)
           && prescribed_field_out != nullptr

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -237,7 +237,7 @@ namespace aspect
 
               // Compute viscosity derivatives if they are requested
               if (const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives =
-                    out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>())
+                    out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>())
 
                 rheology->compute_viscosity_derivatives(i, volume_fractions,
                                                         isostrain_viscosities.composition_viscosities,
@@ -256,7 +256,7 @@ namespace aspect
               out.viscosities[i] = numbers::signaling_nan<double>();
 
               if (const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives =
-                    out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>())
+                    out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>())
                 {
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = numbers::signaling_nan<SymmetricTensor<2,dim>>();
                   derivatives->viscosity_derivative_wrt_pressure[i] = numbers::signaling_nan<double>();

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -236,7 +236,7 @@ namespace aspect
               plastic_yielding = isostrain_viscosities.composition_yielding[std::distance(volume_fractions.begin(), max_composition)];
 
               // Compute viscosity derivatives if they are requested
-              if (MaterialModel::MaterialModelDerivatives<dim> *derivatives =
+              if (const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives =
                     out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>())
 
                 rheology->compute_viscosity_derivatives(i, volume_fractions,
@@ -255,7 +255,7 @@ namespace aspect
 
               out.viscosities[i] = numbers::signaling_nan<double>();
 
-              if (MaterialModel::MaterialModelDerivatives<dim> *derivatives =
+              if (const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives =
                     out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>())
                 {
                   derivatives->viscosity_derivative_wrt_strain_rate[i] = numbers::signaling_nan<SymmetricTensor<2,dim>>();

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -67,7 +67,8 @@ namespace aspect
             in.reinit(fe_values, cell, this->introspection(), this->get_solution());
             this->get_material_model().evaluate(in, out);
 
-            MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+            const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_out
+              = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
             AssertThrow(melt_out != nullptr,
                         ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 

--- a/source/mesh_refinement/compaction_length.cc
+++ b/source/mesh_refinement/compaction_length.cc
@@ -68,7 +68,7 @@ namespace aspect
             this->get_material_model().evaluate(in, out);
 
             const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_out
-              = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+              = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
             AssertThrow(melt_out != nullptr,
                         ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -165,7 +165,7 @@ namespace aspect
                   this->get_material_model().create_additional_named_outputs(material_outputs_cell);
 
                   const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
-                    = material_outputs_cell.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+                    = material_outputs_cell.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
 
                   // Collect the values of the old solution restricted to the current cell's DOFs
                   small_vector<double> old_solution_values(this->get_fe().dofs_per_cell);

--- a/source/particle/property/elastic_stress.cc
+++ b/source/particle/property/elastic_stress.cc
@@ -163,7 +163,8 @@ namespace aspect
                   material_outputs_cell = MaterialModel::MaterialModelOutputs<dim>(n_particles_in_cell, this->n_compositional_fields());
                   // The reaction rates are stored in additional outputs
                   this->get_material_model().create_additional_named_outputs(material_outputs_cell);
-                  MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
+
+                  const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
                     = material_outputs_cell.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
 
                   // Collect the values of the old solution restricted to the current cell's DOFs

--- a/source/postprocess/depth_average.cc
+++ b/source/postprocess/depth_average.cc
@@ -386,7 +386,7 @@ namespace aspect
               this->get_material_model().create_additional_named_outputs(out);
 
               const bool material_model_provides_seismic_output =
-                (out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
+                (out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
 
               const bool output_vs = std::find( output_variables.begin(), output_variables.end(), "Vs") != output_variables.end();
               const bool output_vp = std::find( output_variables.begin(), output_variables.end(), "Vp") != output_variables.end();

--- a/source/postprocess/visualization/darcy_velocity.cc
+++ b/source/postprocess/visualization/darcy_velocity.cc
@@ -74,7 +74,7 @@ namespace aspect
         MeltHandler<dim>::create_material_model_outputs(out);
         this->get_material_model().evaluate(in, out);
         const std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out
-          = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+          = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(std::isfinite(fluid_out->fluid_viscosities[0]),
                     ExcMessage("To compute the Darcy velocity the material model needs to provide the melt material model "
                                "outputs. At least the fluid viscosity was not computed, or is not a number."));

--- a/source/postprocess/visualization/darcy_velocity.cc
+++ b/source/postprocess/visualization/darcy_velocity.cc
@@ -73,7 +73,8 @@ namespace aspect
         MaterialModel::MaterialModelOutputs<dim> out(in.n_evaluation_points(), this->n_compositional_fields());
         MeltHandler<dim>::create_material_model_outputs(out);
         this->get_material_model().evaluate(in, out);
-        MaterialModel::MeltOutputs<dim> *fluid_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out
+          = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(std::isfinite(fluid_out->fluid_viscosities[0]),
                     ExcMessage("To compute the Darcy velocity the material model needs to provide the melt material model "
                                "outputs. At least the fluid viscosity was not computed, or is not a number."));

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -127,7 +127,7 @@ namespace aspect
 
         this->get_material_model().evaluate(in, out);
         const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-          = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+          = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(melt_outputs != nullptr,
                     ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 

--- a/source/postprocess/visualization/melt.cc
+++ b/source/postprocess/visualization/melt.cc
@@ -126,7 +126,8 @@ namespace aspect
         MeltHandler<dim>::create_material_model_outputs(out);
 
         this->get_material_model().evaluate(in, out);
-        MaterialModel::MeltOutputs<dim> *melt_outputs = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+          = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
         AssertThrow(melt_outputs != nullptr,
                     ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -137,7 +137,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/principal_stress.cc
+++ b/source/postprocess/visualization/principal_stress.cc
@@ -136,7 +136,8 @@ namespace aspect
             else
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -105,11 +105,11 @@ namespace aspect
 
 
                     const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
-                      = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vs = seismic_outputs->vs[0];
 
                     const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> adiabatic_seismic_outputs
-                      = adiabatic_out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = adiabatic_out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double adiabatic_Vs = adiabatic_seismic_outputs->vs[0];
 
                     // Compute the percentage deviation from the average
@@ -151,7 +151,7 @@ namespace aspect
                     this->get_material_model().evaluate(in, out);
 
                     const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
-                      = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vs = seismic_outputs->vs[0];
 
                     // Find the depth of the zeroth quadrature point in the cell and work out
@@ -247,11 +247,11 @@ namespace aspect
 
 
                     const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
-                      = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vp = seismic_outputs->vp[0];
 
                     const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> adiabatic_seismic_outputs
-                      = adiabatic_out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = adiabatic_out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double adiabatic_Vp = adiabatic_seismic_outputs->vp[0];
 
                     // Compute the percentage deviation from the average
@@ -315,7 +315,7 @@ namespace aspect
                     this->get_material_model().evaluate(in, out);
 
                     const std::shared_ptr<const MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
-                      = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
+                      = out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vp = seismic_outputs->vp[0];
 
                     // Find the depth of the zeroth quadrature point in the cell and work out
@@ -390,7 +390,7 @@ namespace aspect
         this->get_material_model().create_additional_named_outputs(out);
 
         const bool material_model_provides_seismic_output =
-          (out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
+          (out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
 
         AssertThrow(material_model_provides_seismic_output,
                     ExcMessage("You requested the 'Vs anomaly' postprocessor, "
@@ -469,7 +469,7 @@ namespace aspect
         this->get_material_model().create_additional_named_outputs(out);
 
         const bool material_model_provides_seismic_output =
-          (out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
+          (out.template get_additional_output_object<MaterialModel::SeismicAdditionalOutputs<dim>>() != nullptr);
 
         AssertThrow(material_model_provides_seismic_output,
                     ExcMessage("You requested the 'Vp anomaly' postprocessor, "

--- a/source/postprocess/visualization/seismic_anomalies.cc
+++ b/source/postprocess/visualization/seismic_anomalies.cc
@@ -104,11 +104,11 @@ namespace aspect
 
 
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
+                    const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
                       = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vs = seismic_outputs->vs[0];
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *adiabatic_seismic_outputs
+                    const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> adiabatic_seismic_outputs
                       = adiabatic_out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double adiabatic_Vs = adiabatic_seismic_outputs->vs[0];
 
@@ -150,7 +150,7 @@ namespace aspect
                       std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, out);
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
+                    const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
                       = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vs = seismic_outputs->vs[0];
 
@@ -246,11 +246,11 @@ namespace aspect
 
 
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
+                    const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
                       = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vp = seismic_outputs->vp[0];
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *adiabatic_seismic_outputs
+                    const std::shared_ptr<MaterialModel::SeismicAdditionalOutputs<dim>> adiabatic_seismic_outputs
                       = adiabatic_out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double adiabatic_Vp = adiabatic_seismic_outputs->vp[0];
 
@@ -314,7 +314,7 @@ namespace aspect
                       std::make_unique<MaterialModel::SeismicAdditionalOutputs<dim>> (n_q_points));
                     this->get_material_model().evaluate(in, out);
 
-                    MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
+                    const std::shared_ptr<const MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
                       = out.template get_additional_output<MaterialModel::SeismicAdditionalOutputs<dim>>();
                     const double Vp = seismic_outputs->vp[0];
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -89,7 +89,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'shear stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/shear_stress.cc
+++ b/source/postprocess/visualization/shear_stress.cc
@@ -88,7 +88,8 @@ namespace aspect
             if (this->get_parameters().enable_elasticity == true)
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'shear stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -65,7 +65,8 @@ namespace aspect
 
         this->get_material_model().evaluate(in, out);
 
-        const MaterialModel::MaterialModelDerivatives<dim> *derivatives = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+        const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
+          = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -66,7 +66,7 @@ namespace aspect
         this->get_material_model().evaluate(in, out);
 
         const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
-          = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+          = out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
         for (unsigned int q=0; q<n_quadrature_points; ++q)
           {

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -90,7 +90,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/stress.cc
+++ b/source/postprocess/visualization/stress.cc
@@ -89,7 +89,8 @@ namespace aspect
             if (this->get_parameters().enable_elasticity)
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/stress_residual.cc
+++ b/source/postprocess/visualization/stress_residual.cc
@@ -82,7 +82,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 
@@ -94,7 +94,7 @@ namespace aspect
 
             // Get the current yield_stress
             const std::shared_ptr<const MaterialModel::PlasticAdditionalOutputs<dim>> plastic_output
-              = out.template get_additional_output<MaterialModel::PlasticAdditionalOutputs<dim>>();
+              = out.template get_additional_output_object<MaterialModel::PlasticAdditionalOutputs<dim>>();
             const double yield_stress = plastic_output->yield_stresses[q];
 
             // Compute the difference between the second stress invariant and the yield stress

--- a/source/postprocess/visualization/stress_residual.cc
+++ b/source/postprocess/visualization/stress_residual.cc
@@ -81,7 +81,8 @@ namespace aspect
             if (this->get_parameters().enable_elasticity == true)
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 
@@ -92,8 +93,8 @@ namespace aspect
             const double stress_invariant = std::sqrt(std::fabs(second_invariant(deviatoric_stress)));
 
             // Get the current yield_stress
-            const MaterialModel::PlasticAdditionalOutputs<dim> *plastic_output =
-              out.template get_additional_output<MaterialModel::PlasticAdditionalOutputs<dim>>();
+            const std::shared_ptr<const MaterialModel::PlasticAdditionalOutputs<dim>> plastic_output
+              = out.template get_additional_output<MaterialModel::PlasticAdditionalOutputs<dim>>();
             const double yield_stress = plastic_output->yield_stresses[q];
 
             // Compute the difference between the second stress invariant and the yield stress

--- a/source/postprocess/visualization/stress_second_invariant.cc
+++ b/source/postprocess/visualization/stress_second_invariant.cc
@@ -85,7 +85,8 @@ namespace aspect
             if (this->get_parameters().enable_elasticity == true)
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/stress_second_invariant.cc
+++ b/source/postprocess/visualization/stress_second_invariant.cc
@@ -86,7 +86,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -82,7 +82,8 @@ namespace aspect
             if (this->get_parameters().enable_elasticity == true)
               {
                 // Get the total deviatoric stress from the material model.
-                const MaterialModel::ElasticAdditionalOutputs<dim> *elastic_additional_out = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
+                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/postprocess/visualization/surface_stress.cc
+++ b/source/postprocess/visualization/surface_stress.cc
@@ -83,7 +83,7 @@ namespace aspect
               {
                 // Get the total deviatoric stress from the material model.
                 const std::shared_ptr<const MaterialModel::ElasticAdditionalOutputs<dim>> elastic_additional_out
-                  = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+                  = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
                 Assert(elastic_additional_out != nullptr, ExcMessage("Elastic Additional Outputs are needed for the 'principal stress' postprocessor, but they have not been created."));
 

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -543,7 +543,8 @@ namespace aspect
                                                      (time_step + old_time_step)) : 1.0;
       const unsigned int solution_component = advection_field.component_index(introspection);
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
-      MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -644,7 +645,8 @@ namespace aspect
         }
 
 
-      const MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
       for (unsigned int q=0; q < n_q_points; ++q)
         {
 

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -544,7 +544,7 @@ namespace aspect
       const unsigned int solution_component = advection_field.component_index(introspection);
       const FEValuesExtractors::Scalar solution_field = advection_field.scalar_extractor(introspection);
       const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -646,7 +646,7 @@ namespace aspect
 
 
       const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       for (unsigned int q=0; q < n_q_points; ++q)
         {
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -62,7 +62,7 @@ namespace aspect
       // If elasticity is enabled, then we need ElasticOutputs to get the viscoelastic
       // strain rate.
       const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+        scratch.material_model_outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>();
       if (this->get_parameters().enable_elasticity)
         AssertThrow(elastic_out != nullptr,
                     ExcMessage("Error: The Newton method requires ElasticOutputs when elasticity is enabled."));
@@ -80,7 +80,7 @@ namespace aspect
         }
 
       const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
       std::vector<double> deta_deps_times_grads_phi_u(stokes_dofs_per_cell);
       std::vector<double> eps_times_grads_phi_u(stokes_dofs_per_cell);
@@ -282,7 +282,7 @@ namespace aspect
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const
     {
       if (this->get_parameters().enable_elasticity &&
-          outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
+          outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::ElasticOutputs<dim>> (outputs.n_evaluation_points()));
@@ -315,14 +315,14 @@ namespace aspect
 
       const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
         = enable_additional_stokes_rhs ?
-          scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()
+          scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()
           : nullptr;
 
       // If elasticity is enabled, then we need ElasticOutputs to get the viscoelastic
       // strain rate and the elastic force.
       const bool enable_elasticity = this->get_parameters().enable_elasticity;
       const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>();
       if (enable_elasticity)
         AssertThrow(elastic_out != nullptr,
                     ExcMessage("Error: The Newton method requires ElasticOutputs when elasticity is enabled."));
@@ -331,13 +331,13 @@ namespace aspect
 
       const std::shared_ptr<const MaterialModel::PrescribedPlasticDilation<dim>> prescribed_dilation
         = enable_prescribed_dilation ?
-          scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
+          scratch.material_model_outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()
           : nullptr;
 
       const bool material_model_is_compressible = (this->get_material_model().is_compressible());
 
       const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
 
 
@@ -590,7 +590,7 @@ namespace aspect
       const unsigned int n_points = outputs.n_evaluation_points();
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
@@ -598,11 +598,11 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
-             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
+             outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == n_points, ExcInternalError());
 
       if ((this->get_parameters().enable_elasticity) &&
-          outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
+          outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
@@ -610,12 +610,12 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_elasticity
              ||
-             outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>()->elastic_force.size()
+             outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>()->elastic_force.size()
              == n_points, ExcInternalError());
 
       // prescribed dilation:
       if (this->get_parameters().enable_prescribed_dilation
-          && outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
@@ -623,7 +623,7 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_prescribed_dilation
              ||
-             outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation.size()
+             outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation.size()
              == n_points, ExcInternalError());
 
       if (this->get_newton_handler().parameters.newton_derivative_scaling_factor != 0)
@@ -687,7 +687,7 @@ namespace aspect
               else
                 {
                   const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
-                    = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+                    = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
                   // This one is only available in debug mode, because normally
                   // the AssertThrow in the preconditioner should already have

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -61,7 +61,7 @@ namespace aspect
 
       // If elasticity is enabled, then we need ElasticOutputs to get the viscoelastic
       // strain rate.
-      const MaterialModel::ElasticOutputs<dim> *elastic_out =
+      const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out =
         scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
       if (this->get_parameters().enable_elasticity)
         AssertThrow(elastic_out != nullptr,
@@ -79,7 +79,7 @@ namespace aspect
           ++i;
         }
 
-      const MaterialModel::MaterialModelDerivatives<dim> *derivatives
+      const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
         = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
       std::vector<double> deta_deps_times_grads_phi_u(stokes_dofs_per_cell);
@@ -313,29 +313,30 @@ namespace aspect
 
       const bool enable_additional_stokes_rhs = this->get_parameters().enable_additional_stokes_rhs;
 
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim> *force = enable_additional_stokes_rhs ?
-                                                                            scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()
-                                                                            : nullptr;
+      const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+        = enable_additional_stokes_rhs ?
+          scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()
+          : nullptr;
 
       // If elasticity is enabled, then we need ElasticOutputs to get the viscoelastic
       // strain rate and the elastic force.
       const bool enable_elasticity = this->get_parameters().enable_elasticity;
-      const MaterialModel::ElasticOutputs<dim> *elastic_out =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
       if (enable_elasticity)
         AssertThrow(elastic_out != nullptr,
                     ExcMessage("Error: The Newton method requires ElasticOutputs when elasticity is enabled."));
 
       const bool enable_prescribed_dilation = this->get_parameters().enable_prescribed_dilation;
 
-      const MaterialModel::PrescribedPlasticDilation<dim>
-      *prescribed_dilation = enable_prescribed_dilation ?
-                             scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
-                             : nullptr;
+      const std::shared_ptr<const MaterialModel::PrescribedPlasticDilation<dim>> prescribed_dilation
+        = enable_prescribed_dilation ?
+          scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
+          : nullptr;
 
       const bool material_model_is_compressible = (this->get_material_model().is_compressible());
 
-      const MaterialModel::MaterialModelDerivatives<dim> *derivatives
+      const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
         = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
 
@@ -685,7 +686,8 @@ namespace aspect
                 }
               else
                 {
-                  const MaterialModel::MaterialModelDerivatives<dim> *derivatives = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+                  const std::shared_ptr<MaterialModel::MaterialModelDerivatives<dim>> derivatives
+                    = scratch.material_model_outputs.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
                   // This one is only available in debug mode, because normally
                   // the AssertThrow in the preconditioner should already have

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -296,17 +296,16 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
 
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+      const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
-      const MaterialModel::ElasticOutputs<dim>
-      *elastic_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
 
-      const MaterialModel::PrescribedPlasticDilation<dim>
-      *prescribed_dilation =
-        (this->get_parameters().enable_prescribed_dilation)
-        ? scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
-        : nullptr;
+      const std::shared_ptr<const MaterialModel::PrescribedPlasticDilation<dim>> prescribed_dilation
+        = (this->get_parameters().enable_prescribed_dilation)
+          ? scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
+          : nullptr;
 
       const bool material_model_is_compressible = (this->get_material_model().is_compressible());
 

--- a/source/simulator/assemblers/stokes.cc
+++ b/source/simulator/assemblers/stokes.cc
@@ -297,14 +297,14 @@ namespace aspect
       const double pressure_scaling = this->get_pressure_scaling();
 
       const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
       const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>();
 
       const std::shared_ptr<const MaterialModel::PrescribedPlasticDilation<dim>> prescribed_dilation
         = (this->get_parameters().enable_prescribed_dilation)
-          ? scratch.material_model_outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()
+          ? scratch.material_model_outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()
           : nullptr;
 
       const bool material_model_is_compressible = (this->get_material_model().is_compressible());
@@ -480,7 +480,7 @@ namespace aspect
 
       // Stokes RHS:
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
@@ -488,12 +488,12 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
-             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
+             outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == n_points, ExcInternalError());
 
       // prescribed dilation:
       if (this->get_parameters().enable_prescribed_dilation
-          && outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::PrescribedPlasticDilation<dim>> (n_points));
@@ -501,12 +501,12 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_prescribed_dilation
              ||
-             outputs.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation.size()
+             outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation.size()
              == n_points, ExcInternalError());
 
       // Elasticity:
       if ((this->get_parameters().enable_elasticity) &&
-          outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
+          outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::ElasticOutputs<dim>> (n_points));
@@ -514,7 +514,7 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_elasticity
              ||
-             outputs.template get_additional_output<MaterialModel::ElasticOutputs<dim>>()->elastic_force.size()
+             outputs.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>()->elastic_force.size()
              == n_points, ExcInternalError());
     }
 

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -996,7 +996,7 @@ namespace aspect
       {
         material_model->create_additional_named_outputs(scratch.material_model_outputs);
         const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
-          = scratch.material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+          = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
 
         Assert(reaction_rate_outputs == nullptr,
                ExcMessage("You are using a material model where the reaction rate outputs "

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -995,7 +995,7 @@ namespace aspect
         !(introspection.compositional_name_exists("ve_stress_xx") && parameters.mapped_particle_properties.count(introspection.compositional_index_for_name("ve_stress_xx"))))
       {
         material_model->create_additional_named_outputs(scratch.material_model_outputs);
-        MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
+        const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
           = scratch.material_model_outputs.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
 
         Assert(reaction_rate_outputs == nullptr,

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -317,7 +317,7 @@ namespace aspect
         material_model->create_additional_named_outputs(out);
 
         const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_outputs
-          = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+          = out.template get_additional_output_object<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
         // Throw if the elastic_outputs do not exist
         AssertThrow(elastic_outputs != nullptr,

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -316,7 +316,8 @@ namespace aspect
 
         material_model->create_additional_named_outputs(out);
 
-        MaterialModel::ElasticAdditionalOutputs<dim> *elastic_outputs = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
+        const std::shared_ptr<MaterialModel::ElasticAdditionalOutputs<dim>> elastic_outputs
+          = out.template get_additional_output<MaterialModel::ElasticAdditionalOutputs<dim>>();
 
         // Throw if the elastic_outputs do not exist
         AssertThrow(elastic_outputs != nullptr,

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1663,7 +1663,7 @@ namespace aspect
     // add reaction rate outputs
     material_model->create_additional_named_outputs(out);
 
-    MaterialModel::ReactionRateOutputs<dim> *reaction_rate_outputs
+    const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
       = out.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
 
     AssertThrow(reaction_rate_outputs != nullptr,
@@ -1723,7 +1723,7 @@ namespace aspect
       return;
     };
 
-    auto copy_rates_into_one_vector = [n_q_points,n_fields](const MaterialModel::ReactionRateOutputs<dim> *reaction_out,
+    auto copy_rates_into_one_vector = [n_q_points,n_fields](const MaterialModel::ReactionRateOutputs<dim> &reaction_out,
                                                             const HeatingModel::HeatingModelOutputs &heating_out,
                                                             VectorType &rates)
     {
@@ -1732,7 +1732,7 @@ namespace aspect
           if (f==0)
             rates[j*n_fields+f] = heating_out.rates_of_temperature_change[j];
           else
-            rates[j*n_fields+f] = reaction_out->reaction_rates[j][f-1];
+            rates[j*n_fields+f] = reaction_out.reaction_rates[j][f-1];
       return;
     };
 
@@ -1781,7 +1781,7 @@ namespace aspect
                 material_model->fill_additional_material_model_inputs(in, solution, fe_values, introspection);
                 material_model->evaluate(in, out);
                 heating_model_manager.evaluate(in, out, heating_model_outputs);
-                copy_rates_into_one_vector (reaction_rate_outputs, heating_model_outputs, ydot);
+                copy_rates_into_one_vector (*reaction_rate_outputs, heating_model_outputs, ydot);
               };
 
               // Make the reaction time steps: We have to update the values of compositional fields and the temperature.
@@ -1991,9 +1991,9 @@ namespace aspect
     // add the prescribed field outputs that will be used for interpolating
     material_model->create_additional_named_outputs(out);
 
-    MaterialModel::PrescribedFieldOutputs<dim> *prescribed_field_out
+    const std::shared_ptr<MaterialModel::PrescribedFieldOutputs<dim>> prescribed_field_out
       = out.template get_additional_output<MaterialModel::PrescribedFieldOutputs<dim>>();
-    MaterialModel::PrescribedTemperatureOutputs<dim> *prescribed_temperature_out
+    const std::shared_ptr<MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
       = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>();
 
     // Make a loop first over all cells, and then over all degrees of freedom in each element

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1664,7 +1664,7 @@ namespace aspect
     material_model->create_additional_named_outputs(out);
 
     const std::shared_ptr<MaterialModel::ReactionRateOutputs<dim>> reaction_rate_outputs
-      = out.template get_additional_output<MaterialModel::ReactionRateOutputs<dim>>();
+      = out.template get_additional_output_object<MaterialModel::ReactionRateOutputs<dim>>();
 
     AssertThrow(reaction_rate_outputs != nullptr,
                 ExcMessage("You are trying to use the operator splitting solver scheme, "
@@ -1992,9 +1992,9 @@ namespace aspect
     material_model->create_additional_named_outputs(out);
 
     const std::shared_ptr<MaterialModel::PrescribedFieldOutputs<dim>> prescribed_field_out
-      = out.template get_additional_output<MaterialModel::PrescribedFieldOutputs<dim>>();
+      = out.template get_additional_output_object<MaterialModel::PrescribedFieldOutputs<dim>>();
     const std::shared_ptr<MaterialModel::PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
-      = out.template get_additional_output<MaterialModel::PrescribedTemperatureOutputs<dim>>();
+      = out.template get_additional_output_object<MaterialModel::PrescribedTemperatureOutputs<dim>>();
 
     // Make a loop first over all cells, and then over all degrees of freedom in each element
     // to interpolate material properties onto a solution vector.

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -313,7 +313,7 @@ namespace aspect
                         std::vector<double> &output) override
         {
           const std::shared_ptr<const MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
-            = out.template get_additional_output<const MaterialModel::SeismicAdditionalOutputs<dim>>();
+            = out.template get_additional_output_object<const MaterialModel::SeismicAdditionalOutputs<dim>>();
 
           Assert(seismic_outputs != nullptr,ExcInternalError());
 

--- a/source/simulator/lateral_averaging.cc
+++ b/source/simulator/lateral_averaging.cc
@@ -312,7 +312,7 @@ namespace aspect
                         const LinearAlgebra::BlockVector &,
                         std::vector<double> &output) override
         {
-          const MaterialModel::SeismicAdditionalOutputs<dim> *seismic_outputs
+          const std::shared_ptr<const MaterialModel::SeismicAdditionalOutputs<dim>> seismic_outputs
             = out.template get_additional_output<const MaterialModel::SeismicAdditionalOutputs<dim>>();
 
           Assert(seismic_outputs != nullptr,ExcInternalError());

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -123,7 +123,7 @@ namespace aspect
         return 0.0;
 
       const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-        = outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       const double ref_K_D = this->reference_darcy_coefficient();
 
       double K_D = 0.0;
@@ -188,7 +188,7 @@ namespace aspect
       MeltHandler<dim>::create_material_model_outputs(outputs);
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>(outputs.n_evaluation_points()));
@@ -196,7 +196,7 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
-             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
+             outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == outputs.n_evaluation_points(), ExcInternalError());
     }
 
@@ -227,7 +227,7 @@ namespace aspect
                                                                        true);
 
       const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
       const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
@@ -337,7 +337,7 @@ namespace aspect
 
         const Introspection<dim> &introspection = simulator_access->introspection();
         const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_out
-          = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+          = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
         Assert(melt_out != nullptr, ExcInternalError());
 
@@ -418,9 +418,9 @@ namespace aspect
       const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
 
       const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
       const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
       const double pressure_scaling = this->get_pressure_scaling();
 
@@ -594,7 +594,7 @@ namespace aspect
       const typename DoFHandler<dim>::face_iterator face = scratch.face_material_model_inputs.current_cell->face(scratch.face_number);
 
       const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.face_material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.face_material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       std::vector<double> grad_p_f(n_face_q_points);
       this->get_melt_handler().get_boundary_fluid_pressure().fluid_pressure_gradient(
@@ -705,7 +705,7 @@ namespace aspect
       const FEValuesExtractors::Scalar solution_field = scratch.advection_field->scalar_extractor(introspection);
 
       const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
-        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
 
       Assert(melt_outputs->fluid_densities[0] > 0.0,
              ExcMessage ("MeltOutputs have to be filled for models with melt transport. "
@@ -1179,7 +1179,7 @@ namespace aspect
             const bool is_melt_cell = this->get_melt_handler().is_melt_cell(in.current_cell);
 
             const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
-              = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+              = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
             Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for computing the melt variables."));
             const FEValuesExtractors::Vector fluid_velocity_extractor = this->introspection().variable("fluid velocity").extractor_vector();
 
@@ -1855,7 +1855,7 @@ namespace aspect
   MeltHandler<dim>::
   create_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &output)
   {
-    if (output.template get_additional_output<MaterialModel::MeltOutputs<dim>>() != nullptr)
+    if (output.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>() != nullptr)
       return;
 
     const unsigned int n_comp = output.reaction_terms[0].size();

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -122,7 +122,8 @@ namespace aspect
       if (consider_is_melt_cell && !melt_handler.is_melt_cell(inputs.current_cell))
         return 0.0;
 
-      const MaterialModel::MeltOutputs<dim> *melt_outputs = outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+        = outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
       const double ref_K_D = this->reference_darcy_coefficient();
 
       double K_D = 0.0;
@@ -225,7 +226,8 @@ namespace aspect
                                                                        this->get_melt_handler(),
                                                                        true);
 
-      MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
       const FEValuesExtractors::Scalar ex_p_f = introspection.variable("fluid pressure").extractor_scalar();
       const FEValuesExtractors::Scalar ex_p_c = introspection.variable("compaction pressure").extractor_scalar();
@@ -334,7 +336,8 @@ namespace aspect
           return 0.0;
 
         const Introspection<dim> &introspection = simulator_access->introspection();
-        const MaterialModel::MeltOutputs<dim> *melt_out = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_out
+          = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
         Assert(melt_out != nullptr, ExcInternalError());
 
@@ -414,9 +417,10 @@ namespace aspect
       const unsigned int p_f_component_index = introspection.variable("fluid pressure").first_component_index;
       const unsigned int p_c_component_index = introspection.variable("compaction pressure").first_component_index;
 
-      MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
       const double pressure_scaling = this->get_pressure_scaling();
 
@@ -589,7 +593,8 @@ namespace aspect
 
       const typename DoFHandler<dim>::face_iterator face = scratch.face_material_model_inputs.current_cell->face(scratch.face_number);
 
-      MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.face_material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.face_material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
       std::vector<double> grad_p_f(n_face_q_points);
       this->get_melt_handler().get_boundary_fluid_pressure().fluid_pressure_gradient(
@@ -699,7 +704,8 @@ namespace aspect
 
       const FEValuesExtractors::Scalar solution_field = scratch.advection_field->scalar_extractor(introspection);
 
-      MaterialModel::MeltOutputs<dim> *melt_outputs = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+      const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_outputs
+        = scratch.material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
 
       Assert(melt_outputs->fluid_densities[0] > 0.0,
              ExcMessage ("MeltOutputs have to be filled for models with melt transport. "
@@ -1172,7 +1178,8 @@ namespace aspect
 
             const bool is_melt_cell = this->get_melt_handler().is_melt_cell(in.current_cell);
 
-            MaterialModel::MeltOutputs<dim> *melt_outputs = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+            const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+              = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
             Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for computing the melt variables."));
             const FEValuesExtractors::Vector fluid_velocity_extractor = this->introspection().variable("fluid velocity").extractor_vector();
 

--- a/source/simulator/newton.cc
+++ b/source/simulator/newton.cc
@@ -115,7 +115,7 @@ namespace aspect
   NewtonHandler<dim>::
   create_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &output)
   {
-    if (output.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>() != nullptr)
+    if (output.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>() != nullptr)
       return;
 
     output.additional_outputs.push_back(

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -491,14 +491,14 @@ namespace aspect
                          ExcMessage("Invalid strain_rate in the MaterialModelInputs. This is likely because it was "
                                     "not filled by the caller."));
 
-                  const MaterialModel::MaterialModelDerivatives<dim> *derivatives
+                  const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
                     = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
 
                   Assert(derivatives != nullptr,
                          ExcMessage ("Error: The Newton method requires the material to "
                                      "compute derivatives."));
 
-                  const MaterialModel::ElasticOutputs<dim> *elastic_out
+                  const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out
                     = out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
 
                   for (unsigned int q=0; q<n_q_points; ++q)

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -451,7 +451,7 @@ namespace aspect
           MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->introspection().n_compositional_fields);
           this->get_newton_handler().create_material_model_outputs(out);
           if (this->get_parameters().enable_elasticity &&
-              out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>() == nullptr)
+              out.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>() == nullptr)
             out.additional_outputs.push_back(std::make_unique<MaterialModel::ElasticOutputs<dim>>(out.n_evaluation_points()));
 
           const unsigned int n_cells = stokes_matrix.get_matrix_free()->n_cell_batches();
@@ -492,14 +492,14 @@ namespace aspect
                                     "not filled by the caller."));
 
                   const std::shared_ptr<const MaterialModel::MaterialModelDerivatives<dim>> derivatives
-                    = out.template get_additional_output<MaterialModel::MaterialModelDerivatives<dim>>();
+                    = out.template get_additional_output_object<MaterialModel::MaterialModelDerivatives<dim>>();
 
                   Assert(derivatives != nullptr,
                          ExcMessage ("Error: The Newton method requires the material to "
                                      "compute derivatives."));
 
                   const std::shared_ptr<const MaterialModel::ElasticOutputs<dim>> elastic_out
-                    = out.template get_additional_output<MaterialModel::ElasticOutputs<dim>>();
+                    = out.template get_additional_output_object<MaterialModel::ElasticOutputs<dim>>();
 
                   for (unsigned int q=0; q<n_q_points; ++q)
                     {

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -66,7 +66,7 @@ namespace aspect
       MaterialModel::MaterialModelInputs<dim> in(fe_values.n_quadrature_points, this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> out(fe_values.n_quadrature_points, this->n_compositional_fields());
       MeltHandler<dim>::create_material_model_outputs(out);
-      MaterialModel::MeltOutputs<dim> *fluid_out = nullptr;
+      std::shared_ptr<MaterialModel::MeltOutputs<dim>> fluid_out;
 
       double max_local_speed_over_meshsize = 0;
 

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -81,7 +81,7 @@ namespace aspect
               {
                 in.reinit(fe_values, cell, this->introspection(), this->get_solution());
                 this->get_material_model().evaluate(in, out);
-                fluid_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+                fluid_out = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
               }
 
             double max_local_velocity = 0;

--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -57,9 +57,8 @@ namespace aspect
         {
           MaterialModel::Simple<dim>::evaluate(in, out);
 
-          AdditionalOutputs1<dim> *additional;
-
-          additional = out.template get_additional_output<AdditionalOutputs1<dim>>();
+          const std::shared_ptr<AdditionalOutputs1<dim>> additional
+            = out.template get_additional_output_object<AdditionalOutputs1<dim>>();
           if (additional)
             ++counter_with;
           else
@@ -94,7 +93,7 @@ namespace aspect
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 
-        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim>>() != nullptr)
+        if (out.template get_additional_output_object<MaterialModel::AdditionalOutputs1<dim>>() != nullptr)
           return;
 
         std::cout << "   creating additional output!" << std::endl;
@@ -107,8 +106,8 @@ namespace aspect
       {
         internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
 
-        MaterialModel::AdditionalOutputs1<dim> *additional
-          = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalOutputs1<dim>>();
+        const std::shared_ptr<MaterialModel::AdditionalOutputs1<dim>> additional
+          = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalOutputs1<dim>>();
 
         std::cout << "* local_assemble_stokes call, have additional? " << (additional!=nullptr) << std::endl;
         if (additional!=nullptr)

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -67,9 +67,8 @@ namespace aspect
         {
           MaterialModel::Simple<dim>::evaluate(in, out);
 
-          AdditionalOutputs1<dim> *additional;
-
-          additional = out.template get_additional_output<AdditionalOutputs1<dim>>();
+          const std::shared_ptr<AdditionalOutputs1<dim>> additional
+            = out.template get_additional_output_object<AdditionalOutputs1<dim>>();
           if (additional)
             ++counter_with;
           else
@@ -108,7 +107,7 @@ namespace aspect
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 
-        if (out.template get_additional_output<MaterialModel::AdditionalOutputs1<dim>>() != nullptr)
+        if (out.template get_additional_output_object<MaterialModel::AdditionalOutputs1<dim>>() != nullptr)
           return;
 
         std::cout << "   creating additional output!" << std::endl;
@@ -121,8 +120,8 @@ namespace aspect
       {
         internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
 
-        MaterialModel::AdditionalOutputs1<dim> *additional
-          = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalOutputs1<dim>>();
+        const std::shared_ptr<MaterialModel::AdditionalOutputs1<dim>> additional
+          = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalOutputs1<dim>>();
 
         std::cout << "* local_assemble_stokes call, have additional? " << (additional!=nullptr) << std::endl;
         if (additional!=nullptr)

--- a/tests/anisotropic_viscosity.cc
+++ b/tests/anisotropic_viscosity.cc
@@ -158,8 +158,8 @@ namespace aspect
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>&> (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>&> (data_base);
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -240,7 +240,7 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
@@ -258,8 +258,8 @@ namespace aspect
       internal::Assembly::Scratch::StokesPreconditioner<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesPreconditioner<dim>&> (scratch_base);
       internal::Assembly::CopyData::StokesPreconditioner<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesPreconditioner<dim>&> (data_base);
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -330,8 +330,8 @@ namespace aspect
       internal::Assembly::Scratch::StokesSystem<dim> &scratch = dynamic_cast<internal::Assembly::Scratch::StokesSystem<dim>&> (scratch_base);
       internal::Assembly::CopyData::StokesSystem<dim> &data = dynamic_cast<internal::Assembly::CopyData::StokesSystem<dim>&> (data_base);
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -339,8 +339,8 @@ namespace aspect
       const unsigned int n_q_points    = scratch.finite_element_values.n_quadrature_points;
       const double pressure_scaling = this->get_pressure_scaling();
 
-      const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-      *force = scratch.material_model_outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+      const std::shared_ptr<const MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+        = scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
       for (unsigned int q=0; q<n_q_points; ++q)
         {
@@ -422,21 +422,21 @@ namespace aspect
     {
       const unsigned int n_points = outputs.viscosities.size();
 
-      if (outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
         }
 
       if (this->get_parameters().enable_additional_stokes_rhs
-          && outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
+          && outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>() == nullptr)
         {
           outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> (n_points));
         }
       Assert(!this->get_parameters().enable_additional_stokes_rhs
              ||
-             outputs.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
+             outputs.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>()->rhs_u.size()
              == n_points, ExcInternalError());
     }
 
@@ -454,8 +454,8 @@ namespace aspect
       if (!scratch.rebuild_stokes_matrix)
         return;
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        scratch.material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        scratch.material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       const Introspection<dim> &introspection = this->introspection();
       const FiniteElement<dim> &fe = this->get_fe();
@@ -539,11 +539,11 @@ namespace aspect
 
       // Some material models provide dislocation viscosities and boundary area work fractions
       // as additional material outputs. If they are attached, use them.
-      const ShearHeatingOutputs<dim> *shear_heating_out =
-        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
+      const std::shared_ptr<const ShearHeatingOutputs<dim>> shear_heating_out =
+        material_model_outputs.template get_additional_output_object<ShearHeatingOutputs<dim>>();
 
-      const MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<const MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
@@ -589,7 +589,7 @@ namespace aspect
     {
       const unsigned int n_points = material_model_outputs.viscosities.size();
 
-      if (material_model_outputs.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
+      if (material_model_outputs.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>() == nullptr)
         {
           material_model_outputs.additional_outputs.push_back(
             std::make_unique<MaterialModel::AnisotropicViscosity<dim>> (n_points));
@@ -673,8 +673,8 @@ namespace aspect
     evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      MaterialModel::AnisotropicViscosity<dim> *anisotropic_viscosity =
-        out.template get_additional_output<MaterialModel::AnisotropicViscosity<dim>>();
+      const std::shared_ptr<MaterialModel::AnisotropicViscosity<dim>> anisotropic_viscosity =
+        out.template get_additional_output_object<MaterialModel::AnisotropicViscosity<dim>>();
 
       Simple<dim>::evaluate(in, out);
       Point<dim> center;

--- a/tests/burstedde_stokes_rhs.cc
+++ b/tests/burstedde_stokes_rhs.cc
@@ -186,9 +186,8 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-
-          MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-          *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+          const std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+            = out.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {

--- a/tests/composition_active_with_melt.cc
+++ b/tests/composition_active_with_melt.cc
@@ -81,7 +81,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -144,8 +144,8 @@ namespace aspect
     simulator_access.get_material_model().evaluate(in_base, out_base);
 
     // set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>();
     double temp;
 
     // have a bool so we know whether the test has succeed or not.

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -159,8 +159,8 @@ namespace aspect
     simulator_access.get_material_model().evaluate(in_base, out_base);
 
     // set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>();
     double temp;
 
     // have a bool so we know whether the test has succeed or not.

--- a/tests/free_surface_blob_melt.cc
+++ b/tests/free_surface_blob_melt.cc
@@ -139,7 +139,8 @@ namespace aspect
         }
 
       // fill melt outputs if they exist
-      MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out
+        = out.template get_additional_output_object<MeltOutputs<dim>>();
 
       if (melt_out != nullptr)
         {

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -42,7 +42,8 @@ namespace aspect
         std::vector<double> &fluid_pressure_gradient_outputs
       ) const
       {
-        const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs
+          = material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
         for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)
@@ -79,7 +80,8 @@ namespace aspect
       MeltGlobal<dim>::evaluate(in, out);
 
       // fill melt outputs if they exist
-      MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out
+        = out.template get_additional_output_object<MeltOutputs<dim>>();
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
           out.densities[i] = 2.0;

--- a/tests/melt_compressible_advection.cc
+++ b/tests/melt_compressible_advection.cc
@@ -73,7 +73,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_force_vector.cc
+++ b/tests/melt_force_vector.cc
@@ -95,8 +95,8 @@ namespace aspect
                             typename MaterialModel::Interface<dim>::MaterialModelOutputs &out) const
       {
         const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-        MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-        *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+        const std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+          = out.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
         for (unsigned int i=0; i<in.n_evaluation_points(); ++i)
           {
@@ -123,7 +123,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           for (unsigned int i=0; i<in.n_evaluation_points(); ++i)

--- a/tests/melt_introspection.cc
+++ b/tests/melt_introspection.cc
@@ -89,7 +89,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_material_1.cc
+++ b/tests/melt_material_1.cc
@@ -67,7 +67,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_material_2.cc
+++ b/tests/melt_material_2.cc
@@ -67,7 +67,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_material_3.cc
+++ b/tests/melt_material_3.cc
@@ -67,7 +67,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_material_4.cc
+++ b/tests/melt_material_4.cc
@@ -69,7 +69,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_transport_adaptive.cc
+++ b/tests/melt_transport_adaptive.cc
@@ -133,7 +133,8 @@ namespace aspect
 
               this->get_material_model().evaluate(in, out);
 
-              MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+              const std::shared_ptr<MaterialModel::MeltOutputs<dim>> melt_out
+                = out.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
               AssertThrow(melt_out != nullptr,
                           ExcMessage("Need MeltOutputs from the material model for computing the melt properties."));
 
@@ -233,7 +234,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_transport_compressible.cc
+++ b/tests/melt_transport_compressible.cc
@@ -71,7 +71,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_transport_convergence_simple.cc
+++ b/tests/melt_transport_convergence_simple.cc
@@ -79,7 +79,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_transport_convergence_test.cc
+++ b/tests/melt_transport_convergence_test.cc
@@ -79,7 +79,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/melt_visco_plastic.cc
+++ b/tests/melt_visco_plastic.cc
@@ -392,7 +392,8 @@ namespace aspect
       std::vector<double> volumetric_strain_rates(in.n_evaluation_points());
       std::vector<double> volumetric_yield_strength(in.n_evaluation_points());
 
-      ReactionRateOutputs<dim> *reaction_rate_out = out.template get_additional_output<ReactionRateOutputs<dim>>();
+      const std::shared_ptr<ReactionRateOutputs<dim>> reaction_rate_out
+        = out.template get_additional_output_object<ReactionRateOutputs<dim>>();
 
       if (this->include_melt_transport() )
         {
@@ -566,7 +567,8 @@ namespace aspect
               const double cohesion = MaterialUtilities::average_value(volume_fractions, cohesions, viscosity_averaging);
               const double angle_internal_friction = MaterialUtilities::average_value(volume_fractions, angles_internal_friction, viscosity_averaging);
 
-              PlasticAdditionalOutputs2<dim> *plastic_out = out.template get_additional_output<PlasticAdditionalOutputs2<dim>>();
+              const std::shared_ptr<PlasticAdditionalOutputs2<dim>> plastic_out
+                = out.template get_additional_output_object<PlasticAdditionalOutputs2<dim>>();
               if (plastic_out != nullptr)
                 {
                   plastic_out->cohesions[i] = cohesion;
@@ -583,7 +585,8 @@ namespace aspect
         }
 
       // fill melt outputs if they exist
-      MeltOutputs<dim> *melt_out = out.template get_additional_output<MeltOutputs<dim>>();
+      const std::shared_ptr<MeltOutputs<dim>> melt_out
+        = out.template get_additional_output_object<MeltOutputs<dim>>();
 
       if (melt_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
         {
@@ -1004,7 +1007,7 @@ namespace aspect
     void
     MeltViscoPlastic<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PlasticAdditionalOutputs2<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PlasticAdditionalOutputs2<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/melting_rate.cc
+++ b/tests/melting_rate.cc
@@ -88,7 +88,8 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out
+          = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/multiple_named_additional_outputs.cc
+++ b/tests/multiple_named_additional_outputs.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (prescribed_field_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -64,7 +65,8 @@ namespace aspect
             prescribed_field_out->prescribed_field_outputs[i][1] = std::exp(-y*y/2.0);
           }
 
-      SeismicAdditionalOutputs<dim> *seismic_out = out.template get_additional_output<SeismicAdditionalOutputs<dim>>();
+      const std::shared_ptr<SeismicAdditionalOutputs<dim>> seismic_out
+        = out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>();
 
       if (seismic_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -80,14 +82,14 @@ namespace aspect
     void
     PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::PrescribedFieldOutputs<dim>> (n_points,this->n_compositional_fields()));
         }
 
-      if (out.template get_additional_output<SeismicAdditionalOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<SeismicAdditionalOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/multiple_prescribed_fields.cc
+++ b/tests/multiple_prescribed_fields.cc
@@ -56,7 +56,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (prescribed_field_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -72,7 +73,7 @@ namespace aspect
     void
     PrescribedFieldsMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/multiple_prescribed_fields_dc.cc
+++ b/tests/multiple_prescribed_fields_dc.cc
@@ -56,7 +56,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (prescribed_field_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -72,7 +73,7 @@ namespace aspect
     void
     PrescribedFieldsMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/prescribed_dilation.cc
+++ b/tests/prescribed_dilation.cc
@@ -168,11 +168,11 @@ namespace aspect
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                               MaterialModel::MaterialModelOutputs<dim> &out) const
         {
-          MaterialModel::PrescribedPlasticDilation<dim>
-          *prescribed_dilation = out.template get_additional_output<MaterialModel::PrescribedPlasticDilation<dim>>();
+          const std::shared_ptr<MaterialModel::PrescribedPlasticDilation<dim>> prescribed_dilation
+            = out.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>();
 
-          MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>
-          *force = out.template get_additional_output<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
+          const std::shared_ptr<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>> force
+            = out.template get_additional_output_object<MaterialModel::AdditionalMaterialOutputsStokesRHS<dim>>();
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {

--- a/tests/prescribed_field.cc
+++ b/tests/prescribed_field.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (prescribed_field_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -67,7 +68,7 @@ namespace aspect
     void
     PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/prescribed_field_temperature.cc
+++ b/tests/prescribed_field_temperature.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto temperature field
-      PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>();
+      const std::shared_ptr<PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
+        = out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>();
 
       if (prescribed_temperature_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -67,7 +68,7 @@ namespace aspect
     void
     PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedTemperatureOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/prescribed_field_with_diffusion.cc
+++ b/tests/prescribed_field_with_diffusion.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedFieldOutputs<dim> *prescribed_field_out = out.template get_additional_output<PrescribedFieldOutputs<dim>>();
+      const std::shared_ptr<PrescribedFieldOutputs<dim>> prescribed_field_out
+        = out.template get_additional_output_object<PrescribedFieldOutputs<dim>>();
 
       if (prescribed_field_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -70,7 +71,7 @@ namespace aspect
     void
     PrescribedFieldMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedFieldOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedFieldOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/prescribed_temperature.cc
+++ b/tests/prescribed_temperature.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>();
+      const std::shared_ptr<PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
+        = out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>();
 
       if (prescribed_temperature_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -70,7 +71,7 @@ namespace aspect
     void
     PrescribedTemperatureMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedTemperatureOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/prescribed_temperature_with_diffusion.cc
+++ b/tests/prescribed_temperature_with_diffusion.cc
@@ -55,7 +55,8 @@ namespace aspect
       Simple<dim>::evaluate(in, out);
 
       // set up variable to interpolate prescribed field outputs onto compositional fields
-      PrescribedTemperatureOutputs<dim> *prescribed_temperature_out = out.template get_additional_output<PrescribedTemperatureOutputs<dim>>();
+      const std::shared_ptr<PrescribedTemperatureOutputs<dim>> prescribed_temperature_out
+        = out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>();
 
       if (prescribed_temperature_out != nullptr)
         for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
@@ -70,7 +71,7 @@ namespace aspect
     void
     PrescribedTemperatureMaterial<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (out.template get_additional_output<PrescribedTemperatureOutputs<dim>>() == nullptr)
+      if (out.template get_additional_output_object<PrescribedTemperatureOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(

--- a/tests/rheology_scaled_profile.cc
+++ b/tests/rheology_scaled_profile.cc
@@ -64,7 +64,7 @@ namespace aspect
         create_additional_material_model_outputs (const unsigned int n_points,
                                                   MaterialModel::MaterialModelOutputs<dim> &outputs) const override
         {
-          if (outputs.template get_additional_output<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>() == nullptr)
+          if (outputs.template get_additional_output_object<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>() == nullptr)
             {
               outputs.additional_outputs.push_back(
                 std::make_unique<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>> (n_points));
@@ -77,8 +77,8 @@ namespace aspect
                         const LinearAlgebra::BlockVector &,
                         std::vector<double> &output) override
         {
-          const MaterialModel::UnscaledViscosityAdditionalOutputs<dim> *unscaled_viscosity_outputs
-            = out.template get_additional_output<const MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>();
+          const std::shared_ptr<const MaterialModel::UnscaledViscosityAdditionalOutputs<dim>> unscaled_viscosity_outputs
+            = out.template get_additional_output_object<const MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>();
 
           Assert(unscaled_viscosity_outputs != nullptr,ExcInternalError());
 
@@ -176,8 +176,8 @@ namespace aspect
         void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
                       MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
-          UnscaledViscosityAdditionalOutputs<dim> *unscaled_viscosity_out =
-            out.template get_additional_output<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>();
+          const std::shared_ptr<UnscaledViscosityAdditionalOutputs<dim>> unscaled_viscosity_out =
+            out.template get_additional_output_object<MaterialModel::UnscaledViscosityAdditionalOutputs<dim>>();
 
           for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
             {
@@ -213,7 +213,7 @@ namespace aspect
         void
         create_additional_named_outputs (MaterialModelOutputs<dim> &outputs) const override
         {
-          if (outputs.template get_additional_output<UnscaledViscosityAdditionalOutputs<dim>>() == nullptr)
+          if (outputs.template get_additional_output_object<UnscaledViscosityAdditionalOutputs<dim>>() == nullptr)
             {
               const unsigned int n_points = outputs.n_evaluation_points();
               outputs.additional_outputs.push_back(

--- a/tests/rising_melt_blob.cc
+++ b/tests/rising_melt_blob.cc
@@ -65,7 +65,7 @@ namespace aspect
           }
 
         // fill melt outputs if they exist
-        aspect::MaterialModel::MeltOutputs<dim> *melt_out = out.template get_additional_output<aspect::MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<aspect::MaterialModel::MeltOutputs<dim>> melt_out = out.template get_additional_output_object<aspect::MaterialModel::MeltOutputs<dim>>();
 
         if (melt_out != nullptr)
           {

--- a/tests/segregation_heating.cc
+++ b/tests/segregation_heating.cc
@@ -41,7 +41,8 @@ namespace aspect
         std::vector<double> &fluid_pressure_gradient_outputs
       ) const
       {
-        const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
+        const std::shared_ptr<const MaterialModel::MeltOutputs<dim>>
+        melt_outputs = material_model_outputs.template get_additional_output_object<MaterialModel::MeltOutputs<dim>>();
         Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
 
         for (unsigned int q=0; q<fluid_pressure_gradient_outputs.size(); ++q)

--- a/tests/simple_nonlinear.cc
+++ b/tests/simple_nonlinear.cc
@@ -137,7 +137,7 @@ namespace aspect
     MaterialModelOutputs<dim> out_base(5,3);
     MaterialModelOutputs<dim> out_dviscositydstrainrate(5,3);
 
-    if (out_base.template get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
+    if (out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>() != nullptr)
       throw "error";
 
     out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
@@ -169,8 +169,8 @@ namespace aspect
     mat.evaluate(in_base, out_base);
 
     // set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>();
     double temp;
 
     // have a bool so we know whether the test has succeed or not.

--- a/tests/spiegelman_fail_test.cc
+++ b/tests/spiegelman_fail_test.cc
@@ -260,8 +260,8 @@ namespace aspect
              MaterialModel::MaterialModelOutputs<dim> &out) const
     {
       //set up additional output for the derivatives
-      MaterialModelDerivatives<dim> *derivatives;
-      derivatives = out.template get_additional_output<MaterialModelDerivatives<dim>>();
+      const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+        = out.template get_additional_output_object<MaterialModelDerivatives<dim>>();
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {

--- a/tests/spiegelman_material.cc
+++ b/tests/spiegelman_material.cc
@@ -151,7 +151,7 @@ namespace aspect
     MaterialModelOutputs<dim> out_dviscositydstrainrate_oneone(5,3);
     MaterialModelOutputs<dim> out_dviscositydtemperature(5,3);
 
-    if (out_base.get_additional_output<MaterialModelDerivatives<dim>>() != nullptr)
+    if (out_base.get_additional_output_object<MaterialModelDerivatives<dim>>() != nullptr)
       throw "error";
 
     out_base.additional_outputs.push_back(std::make_unique<MaterialModelDerivatives<dim>> (5));
@@ -194,8 +194,8 @@ namespace aspect
     mat.evaluate(in_dviscositydtemperature, out_dviscositydtemperature);
 
     //set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.get_additional_output_object<MaterialModelDerivatives<dim>>();
 
     double temp;
     for (unsigned int i = 0; i < 5; i++)

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -150,8 +150,8 @@ namespace aspect
     simulator_access.get_material_model().evaluate(in_base, out_base);
 
     // set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>();
     double temp;
 
     // have a bool so we know whether the test has succeed or not.

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -165,8 +165,8 @@ namespace aspect
     simulator_access.get_material_model().evaluate(in_base, out_base);
 
     // set up additional output for the derivatives
-    MaterialModelDerivatives<dim> *derivatives;
-    derivatives = out_base.template get_additional_output<MaterialModelDerivatives<dim>>();
+    const std::shared_ptr<MaterialModelDerivatives<dim>> derivatives
+      = out_base.template get_additional_output_object<MaterialModelDerivatives<dim>>();
     double temp;
 
     // have a bool so we know whether the test has succeed or not.

--- a/unit_tests/additional_outputs.cc
+++ b/unit_tests/additional_outputs.cc
@@ -58,7 +58,7 @@ namespace
       void evaluate(const MaterialModel::MaterialModelInputs<dim> &/*in*/,
                     MaterialModel::MaterialModelOutputs<dim> &out) const override
       {
-        const auto additional = out.template get_additional_output<AdditionalOutputs1<dim>>();
+        const auto additional = out.template get_additional_output_object<AdditionalOutputs1<dim>>();
         additional->additional_material_output1[0] = 42.0;
       }
   };
@@ -75,22 +75,22 @@ TEST_CASE("AdditionalOutputs works")
   in.requested_properties = MaterialProperties::additional_outputs;
 
 
-  REQUIRE(out.get_additional_output<AdditionalOutputs1<dim>>() == nullptr);
+  REQUIRE(out.get_additional_output_object<AdditionalOutputs1<dim>>() == nullptr);
 
   out.additional_outputs.push_back(std::make_unique<AdditionalOutputs1<dim>> (1, 1));
 
-  REQUIRE(out.get_additional_output<AdditionalOutputs1<dim>>() != nullptr);
+  REQUIRE(out.get_additional_output_object<AdditionalOutputs1<dim>>() != nullptr);
 
   Material1<dim> mat;
   mat.evaluate(in, out);
 
-  REQUIRE(out.get_additional_output<AdditionalOutputs1<dim>>()->additional_material_output1[0] == 42.0);
+  REQUIRE(out.get_additional_output_object<AdditionalOutputs1<dim>>()->additional_material_output1[0] == 42.0);
 
   // test const version of get_additional_output:
   {
     const MaterialModelOutputs<dim> &const_out = out;
-    REQUIRE(const_out.get_additional_output<AdditionalOutputs1<dim>>() != nullptr);
-    const auto a = const_out.get_additional_output<AdditionalOutputs1<dim>>();
+    REQUIRE(const_out.get_additional_output_object<AdditionalOutputs1<dim>>() != nullptr);
+    const auto a = const_out.get_additional_output_object<AdditionalOutputs1<dim>>();
     REQUIRE(a != nullptr);
   }
 }

--- a/unit_tests/additional_outputs.cc
+++ b/unit_tests/additional_outputs.cc
@@ -58,9 +58,7 @@ namespace
       void evaluate(const MaterialModel::MaterialModelInputs<dim> &/*in*/,
                     MaterialModel::MaterialModelOutputs<dim> &out) const override
       {
-        AdditionalOutputs1<dim> *additional;
-
-        additional = out.template get_additional_output<AdditionalOutputs1<dim>>();
+        const auto additional = out.template get_additional_output<AdditionalOutputs1<dim>>();
         additional->additional_material_output1[0] = 42.0;
       }
   };
@@ -92,7 +90,7 @@ TEST_CASE("AdditionalOutputs works")
   {
     const MaterialModelOutputs<dim> &const_out = out;
     REQUIRE(const_out.get_additional_output<AdditionalOutputs1<dim>>() != nullptr);
-    const AdditionalOutputs1<dim> *a = const_out.get_additional_output<AdditionalOutputs1<dim>>();
+    const auto a = const_out.get_additional_output<AdditionalOutputs1<dim>>();
     REQUIRE(a != nullptr);
   }
 }


### PR DESCRIPTION
This PR fixes #5668. I had hoped that it were smaller, but it turns out that the two sets of `get_additional_input/output()` functions are used in quite a number of different places.

At its core, the objects that have these member functions store `std::unique_ptr`s to `AdditionalIntput/Output` objects. But then the two functions return *bare* pointers to these objects, and that clearly invalidates the "unique pointer" abstraction because now other places *also* have pointers to the object. This is clearly not using the right abstraction, then.

What this patch does is to let the classes store *shared* pointers instead, and return shared pointers that can then also be co-owned by the calling places. None of these places actually store these pointers for very long, but at least conceptually, shared pointers are the right approach. This patch then changes all of the places where we call these functions, unfortunately quite a few.

In the process, I'm also converting a few places where functions took these returned bare pointers as arguments. I *could* have changed these places to take *shared* pointers instead, but generally these are either input or output arguments and we usually use references to objects in these places. So that's what this patch does as well.