### PR TITLE
Remove the unused function, get_radius()

### DIFF
--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -114,15 +114,6 @@ namespace aspect
             const Point<dim> &p) const override;
 
           /**
-           * This function computes the outer radius of the domain
-           * at the longitude (and latitude) of the given point
-           * (given in cartesian coordinates), i.e. the unperturbed
-           * outer radius + the topography.
-           */
-          double
-          get_radius(const Point<dim> &space_point) const;
-
-          /**
            * Return a copy of this manifold.
            */
           std::unique_ptr<Manifold<dim,dim>>

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -257,12 +257,6 @@ namespace aspect
         parse_parameters(ParameterHandler &prm) override;
 
         /**
-         * Calculate radius at current position.
-         */
-        double
-        get_radius(const Point<dim> &position) const;
-
-        /**
          * Retrieve the semi minor axis b value.
          */
         double

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -433,26 +433,6 @@ namespace aspect
 
         return r_phi_theta;
       }
-
-
-
-      template <int dim>
-      double
-      ChunkGeometry<dim>::
-      get_radius(const Point<dim> &x_y_z) const
-      {
-        const Point<dim> r_phi_theta = pull_back(x_y_z);
-        Point<dim-1> surface_point;
-        for (unsigned int d=0; d<dim-1; ++d)
-          surface_point[d] = r_phi_theta[d+1];
-        // Convert latitude to colatitude
-        if (dim == 3)
-          surface_point[1] = 0.5*numbers::PI - surface_point[1];
-        const double topography = topo->value(surface_point);
-
-        // return the outer radius at this phi, theta point including topography
-        return topography + inner_radius + max_depth;
-      }
     }
 
 

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -632,14 +632,6 @@ namespace aspect
 
     template <int dim>
     double
-    EllipsoidalChunk<dim>::get_radius(const Point<dim> &position) const
-    {
-      const Point<dim> long_lat_depth = manifold->pull_back(position);
-      return semi_major_axis_a / (std::sqrt(1 - eccentricity * eccentricity * std::sin(long_lat_depth[1]) * std::sin(long_lat_depth[1])));
-    }
-
-    template <int dim>
-    double
     EllipsoidalChunk<dim>::get_eccentricity() const
     {
       return eccentricity;


### PR DESCRIPTION
It doesn't seem like we are calling the `get_radius()`  function defined in the chunk and ellipsoidal chunk geometry models. This PR removes them. (I did not actually run the tests but only checked using `grep`).