### PR TITLE
Optimize returning a potentially large table.

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1458,7 +1458,7 @@ namespace aspect
             }
         }
 
-      return data_table;
+      return std::move(data_table);
     }
 
 


### PR DESCRIPTION
When returning a potentially large table, use move semantics to avoid the copy that may otherwise be involved.

@djneu @minerallo FYI