### PR TITLE
Mark some functions in the test suite with 'override'.

### DIFF
--- a/tests/additional_outputs_02.cc
+++ b/tests/additional_outputs_02.cc
@@ -53,7 +53,7 @@ namespace aspect
       public:
 
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+                              MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           MaterialModel::Simple<dim>::evaluate(in, out);
 
@@ -90,7 +90,7 @@ namespace aspect
   {
     public:
 
-      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const
+      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const override
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 

--- a/tests/additional_outputs_03.cc
+++ b/tests/additional_outputs_03.cc
@@ -63,7 +63,7 @@ namespace aspect
       public:
 
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const
+                              MaterialModel::MaterialModelOutputs<dim> &out) const override
         {
           MaterialModel::Simple<dim>::evaluate(in, out);
 
@@ -104,7 +104,7 @@ namespace aspect
   {
     public:
 
-      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const
+      virtual void create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &out) const override
       {
         std::cout << "* create_additional_material_model_outputs() called" << std::endl;
 

--- a/tests/heat_advection_by_melt.cc
+++ b/tests/heat_advection_by_melt.cc
@@ -40,7 +40,7 @@ namespace aspect
         const MaterialModel::MaterialModelOutputs<dim> &material_model_outputs,
         const std::vector<Tensor<1,dim>> &normal_vectors,
         std::vector<double> &fluid_pressure_gradient_outputs
-      ) const
+      ) const override
       {
         const MaterialModel::MeltOutputs<dim> *melt_outputs = material_model_outputs.template get_additional_output<MaterialModel::MeltOutputs<dim>>();
         Assert(melt_outputs != nullptr, ExcMessage("Need MeltOutputs from the material model for shear heating with melt."));
@@ -66,7 +66,7 @@ namespace aspect
       public:
 
         virtual void evaluate(const MaterialModel::MaterialModelInputs<dim> &in,
-                              MaterialModel::MaterialModelOutputs<dim> &out) const;
+                              MaterialModel::MaterialModelOutputs<dim> &out) const override;
     };
 
 


### PR DESCRIPTION
When a test fails to compile, the CI infrastructure shows you both the compilation error but also the warnings generated in compiling this file. Many of the ones I frequently see are that certain functions can be marked with `override`. This patch addresses three files with some of these places.