### PR TITLE
Add Particle histogram postprocessor

### DIFF
--- a/doc/modules/changes/20250613_bakerdunn
+++ b/doc/modules/changes/20250613_bakerdunn
@@ -1,0 +1,4 @@
+Added: ParticleDistributionScore postprocessor which scores how clustered
+particles are within cells on a scale from 0-1, with 1 being most clustered.
+<br>
+(Jarett Baker-Dunn, 2025/06/13)

--- a/include/aspect/postprocess/particle_distribution_score.h
+++ b/include/aspect/postprocess/particle_distribution_score.h
@@ -1,0 +1,93 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_postprocess_particle_distribution_score_h
+#define _aspect_postprocess_particle_distribution_score_h
+
+#include <aspect/postprocess/interface.h>
+#include <aspect/simulator_access.h>
+#include <deal.II/base/table.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+
+    /**
+     * A postprocessor that computes a score from 0 to 1 measuring
+     * how clustered particles are within cells. Scores closer to 0 have more
+     * even density distributions, while scores closer to 1 indicate that particles
+     * are most clustered within cells.
+     * @ingroup Postprocessing
+     */
+    template <int dim>
+    class ParticleDistributionScore : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Evaluate the solution for particle clustering.
+         */
+        std::pair<std::string,std::string>
+        execute (TableHandler &statistics) override;
+
+        /**
+         * Let the postprocessor manager know about the other postprocessors
+         * this one depends on. Specifically, the particles postprocessor.
+         */
+        std::list<std::string>
+        required_other_postprocessors() const override;
+
+        /**
+         * Declare the parameters this class takes through input files.
+         */
+        static
+        void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters this class declares from the parameter file.
+         */
+        void
+        parse_parameters (ParameterHandler &prm) override;
+
+      private:
+        /**
+         * The `granularity` variable determines how many buckets are used in the histogram which computes the density distribution score.
+         * For example, a value of 2 means $2\times 2=4$ buckets in 2D.
+        */
+        unsigned int granularity;
+
+        /**
+         * Sorts all of the particles within the cell into a deal.II table based on their position.
+         * @param cell The cell for which to compute the particle distribution.
+         * @param bucket_width The size (relative to the size of the cell) of each bucket in the table.
+         * @param buckets The table to fill with the particle information.
+        */
+        void sort_particles_into_buckets(const typename Triangulation<dim>::active_cell_iterator &cell,
+                                         const double bucket_width,Table<dim,
+                                         unsigned int> &buckets) const;
+
+    };
+  }
+}
+
+
+#endif

--- a/source/postprocess/particle_distribution_score.cc
+++ b/source/postprocess/particle_distribution_score.cc
@@ -1,0 +1,282 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/postprocess/particle_distribution_score.h>
+#include <aspect/particle/manager.h>
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    template <int dim>
+    std::pair<std::string,std::string>
+    ParticleDistributionScore<dim>::execute (TableHandler &statistics)
+    {
+      double local_min_score = std::numeric_limits<double>::max();
+      double local_max_score = 0;
+      double global_score = 0;
+      unsigned int cells_with_particles = 0;
+
+      for (const auto &cell : this->get_dof_handler().active_cell_iterators())
+        {
+          if (cell->is_locally_owned())
+            {
+              /*
+                These are the steps taken to compute the density score:
+                Create a table with perfect distribution containing an even number of particles in each bucket.
+                Create a table with the "worst case" distribution in which all particles are in one bucket.
+                Take the distance squared between the "perfect" table and the worst case table, treating both tables as vectors with granularity^dim elements.
+                Create a table with the actual distribution.
+                Take distance between "perfect" table and the actual table.
+                Return the ratio between the observed distance and the worst case distance.
+                A value of 1 represents the worst possible distribution, a value of 0 represents a completely even distribution.
+              */
+              unsigned int particles_in_cell = 0;
+              for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
+                {
+                  particles_in_cell += this->get_particle_manager(particle_manager_index).get_particle_handler().n_particles_in_cell(cell);
+                }
+              if (particles_in_cell > 0)
+                {
+                  ++cells_with_particles;
+                  const double particles_in_cell_double = static_cast<double>(particles_in_cell);
+                  const double granularity_double = static_cast<double>(granularity);
+                  const double ideal_n_particles_per_bucket = particles_in_cell_double/(Utilities::fixed_power<dim>(granularity_double));
+
+                  /*
+                  The "buckets_ideal" table contains doubles because the ideal
+                  number of particles per bucket will not always be an integer.
+                  */
+                  Table<dim,double> buckets_ideal;
+                  TableIndices<dim> bucket_sizes;
+                  for (unsigned int i=0; i<dim; ++i)
+                    bucket_sizes[i] = granularity;
+
+                  buckets_ideal.reinit(bucket_sizes);
+                  const double bucket_width = 1.0/granularity_double;
+                  buckets_ideal.fill(ideal_n_particles_per_bucket);
+
+                  Table<dim,unsigned int> buckets_actual;
+                  buckets_actual.reinit(bucket_sizes);
+                  sort_particles_into_buckets(cell,bucket_width,buckets_actual);
+
+                  /*
+                  In the worst case, all particles are in one bucket.
+                  (granularity^dim)-1 is equal to the number of buckets
+                  in the table minus 1 (the bucket all the particles are in).
+                  */
+                  const double worst_case_empty_buckets = static_cast<double>(Utilities::fixed_power<dim>(granularity_double))-1.0;
+                  const double worst_case_error_squared =
+                    ((particles_in_cell_double-ideal_n_particles_per_bucket)*(particles_in_cell_double-ideal_n_particles_per_bucket))+
+                    ((ideal_n_particles_per_bucket*ideal_n_particles_per_bucket)*(worst_case_empty_buckets));
+
+                  double actual_error_squared = 0;
+                  for (unsigned int x=0; x<granularity; ++x)
+                    {
+                      for (unsigned int y=0; y<granularity; ++y)
+                        {
+                          TableIndices<dim> entry_index;
+                          entry_index[0] = x;
+                          entry_index[1] = y;
+                          // do another loop if in 3d
+                          if (dim == 3)
+                            {
+                              for (unsigned int z=0; z<granularity; ++z)
+                                {
+                                  entry_index[2] = z;
+                                  const double value_ideal = buckets_ideal(entry_index);
+                                  const double value_actual = static_cast<double>(buckets_actual(entry_index));
+                                  actual_error_squared += (value_ideal - value_actual)*(value_ideal - value_actual);
+                                }
+                            }
+                          else
+                            {
+                              const double value_ideal = buckets_ideal(entry_index);
+                              const double value_actual = static_cast<double>(buckets_actual(entry_index));
+                              actual_error_squared += (value_ideal - value_actual)*(value_ideal - value_actual);
+                            }
+                        }
+                    }
+
+                  // Take the ratio between the actual error and the worst case
+                  // error, resulting in a score from 0 to 1 for the cell.
+                  const double distribution_score_current_cell = actual_error_squared/worst_case_error_squared;
+
+                  // summing to take average later
+                  global_score += distribution_score_current_cell;
+
+                  local_max_score = std::max(local_max_score, distribution_score_current_cell);
+                  local_min_score = std::min(local_min_score, distribution_score_current_cell);
+                }
+            }
+        }
+
+      // get final values from all processors
+      const double global_max_score = Utilities::MPI::max (local_max_score, this->get_mpi_communicator());
+      const double global_min_score = Utilities::MPI::min (local_min_score, this->get_mpi_communicator());
+      const double summed_score = Utilities::MPI::sum (global_score, this->get_mpi_communicator());
+      const double global_cells_with_particles = Utilities::MPI::sum (cells_with_particles, this->get_mpi_communicator());
+      const double average_score = summed_score / global_cells_with_particles;
+
+      // write to statistics file
+      statistics.add_value ("Minimal particle distribution score: ", global_min_score);
+      statistics.add_value ("Average particle distribution score: ", average_score);
+      statistics.add_value ("Maximal particle distribution score: ", global_max_score);
+
+      std::ostringstream output;
+      output << global_min_score << '/' <<average_score << '/' << global_max_score;
+
+      return std::pair<std::string, std::string> ("Particle distribution score min/avg/max:",
+                                                  output.str());
+    }
+
+
+
+    template <int dim>
+    std::list<std::string>
+    ParticleDistributionScore<dim>::required_other_postprocessors() const
+    {
+      return {"particles"};
+    }
+
+
+
+    template <int dim>
+    void ParticleDistributionScore<dim>::sort_particles_into_buckets(
+      const typename Triangulation<dim>::active_cell_iterator &cell,
+      const double bucket_width,
+      Table<dim,unsigned int> &buckets) const
+    {
+      for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
+        {
+          // sort the particles within the current cell
+          const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range =
+            this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);
+
+          for (const auto &particle: particle_range)
+            {
+              const double particle_x = particle.get_reference_location()[0];
+              const double particle_y = particle.get_reference_location()[1];
+
+              const double x_ratio = (particle_x) / (bucket_width);
+              const double y_ratio = (particle_y) / (bucket_width);
+
+              unsigned int x_index = static_cast<unsigned int>(std::floor(x_ratio));
+              unsigned int y_index = static_cast<unsigned int>(std::floor(y_ratio));
+
+              /*
+              If a particle is exactly on the boundary of two cells its
+              reference location will equal 1, and if this is the case,
+              the "x/y/z_index" will be outside of the range of the table without
+              these checks. The table has a number of entries equal to "granularity" in each dimension,
+              and the table is indexed at 0, so if the "x/y/z_indez" equals "granularity" it
+              will be out of range.
+              */
+              if (x_index == granularity)
+                x_index = granularity-1;
+              if (y_index == granularity)
+                y_index = granularity-1;
+
+              TableIndices<dim> entry_index;
+              entry_index[0] = x_index;
+              entry_index[1] = y_index;
+              if (dim == 3)
+                {
+                  const double particle_z = particle.get_reference_location()[2];
+                  const double z_ratio = (particle_z) / (bucket_width);
+                  unsigned int z_index = static_cast<unsigned int>(std::floor(z_ratio));
+                  if (z_index == granularity)
+                    z_index = granularity-1;
+                  entry_index[2] = z_index;
+                }
+
+              ++buckets(entry_index);
+            }
+        }
+    }
+
+
+
+    template <int dim>
+    void
+    ParticleDistributionScore<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Particle distribution score");
+        {
+          prm.declare_entry("Granularity","2",
+                            Patterns::Integer (2),
+                            "This parameter determines how many bins this postprocessor sorts particles "
+                            "into. The ideal value for granularity depends on the maximum number of particles "
+                            "in the cell. Generally higher values lead to more accuracy."
+                           );
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+    }
+
+
+
+    template <int dim>
+    void
+    ParticleDistributionScore<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Particle distribution score");
+        {
+          granularity = prm.get_integer ("Granularity");
+        }
+        prm.leave_subsection ();
+      }
+      prm.leave_subsection ();
+    }
+  }
+}
+
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    ASPECT_REGISTER_POSTPROCESSOR(ParticleDistributionScore,
+                                  "Particle Distribution Score",
+                                  "This postprocessor is intended to help evaluate how much the density of particles "
+                                  "varies within cells, with the goal of supporting the development of algorithms "
+                                  "to select particles for deletion and addition during load balancing. "
+                                  "Because particle deletion can happen in various ways when load balancing, "
+                                  "there are times when unintended gradients of particle density can form, especially "
+                                  "when particles are moving from more refined cells into coarser cells. "
+                                  "The postprocessor calculates a value from 0 to 1 for every "
+                                  "cell, with values closer to zero representing cells with a density which is more "
+                                  "uniform across the cell's area and values closer to 1 representing a cell in which the particles are "
+                                  "highly concentrated in one part of the cell. Essentially, the postprocessor is "
+                                  "trying to describe numerically how much particle density varies within cells. "
+                                  "It does this by sorting every particle in each cell into a bucket based on "
+                                  "the particle's location, and comparing the resulting data structure to ideal "
+                                  "and worst case versions.")
+  }
+}

--- a/tests/particle_distribution_score.prm
+++ b/tests/particle_distribution_score.prm
@@ -1,0 +1,150 @@
+# Adapted from the drop-supg.prm benchmark
+
+set Dimension                              = 2
+set Use years in output instead of seconds = false
+set End time                               = 0.18
+set Nonlinear solver scheme                = single Advection, no Stokes
+set Resume computation                     = false
+set Maximum time step                      = 0.03
+
+
+subsection Prescribed Stokes solution
+  set Model name = function
+
+  subsection Velocity function
+    set Variable names      = x,y
+    set Function constants  = velSlow=-0.1
+    set Function expression = 0; velSlow
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 0.5
+    set Y extent = 5
+    set Y repetitions = 10
+    set Box origin X coordinate = 0
+    set Box origin Y coordinate = 0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function constants  =
+    set Function expression = 1
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y
+    set Function expression = 1
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = box
+  set Fixed temperature boundary indicators   = top, bottom, left, right
+
+  subsection Box
+    set Bottom temperature = 0
+    set Left temperature   = 0
+    set Right temperature  = 0
+    set Top temperature    = 0
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = box
+  set Fixed composition boundary indicators   = top, bottom, left, right
+
+  subsection Box
+    set Bottom composition = 0
+    set Left composition   = 0
+    set Right composition  = 0
+    set Top composition    = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1e-5
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 0
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Compositional field methods = field
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement              = 2
+  set Initial global refinement                = 1
+  set Time steps between mesh refinement       = 0
+
+  set Strategy = minimum refinement function
+
+  subsection Minimum refinement function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y
+    set Function expression = if ( y<=4, 2, 4)
+  end
+  
+end
+
+subsection Particles
+  set Particle generator name =  reference cell
+  set Maximum particles per cell = 32
+  set Load balancing strategy = remove and add particles
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
+    end
+  end
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Score
+
+  subsection Visualization
+    set Time between graphical output = .001
+    set List of output variables = artificial viscosity
+  end
+
+  subsection Particles
+    set Time between data output = 0.001
+    set Data output format       = vtu
+  end
+
+  subsection Particle distribution score
+    set Granularity = 2
+  end
+
+end
+
+subsection Solver parameters
+  set Temperature solver tolerance = 1e-10
+end

--- a/tests/particle_distribution_score/screen-output
+++ b/tests/particle_distribution_score/screen-output
@@ -1,0 +1,123 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 40 (on 2 levels)
+Number of degrees of freedom: 883 (410+63+205+205)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+
+Number of active cells: 160 (on 3 levels)
+Number of degrees of freedom: 3,121 (1,458+205+729+729)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+
+Number of active cells: 256 (on 4 levels)
+Number of degrees of freedom: 4,877 (2,282+313+1,141+1,141)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9191 K, 1.125 K
+     Heat fluxes through boundary parts:          0.001421 W, 0.001421 W, 0.02279 W, -0.02368 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00000
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00000
+     Particle distribution score min/avg/max: 0/0/0
+
+*** Timestep 1:  t=0.03 seconds, dt=0.03 seconds
+   Solving temperature system... 7 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 10 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9187 K, 1.126 K
+     Heat fluxes through boundary parts:          0.004462 W, 0.004462 W, 0.02756 W, -0.006674 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00001
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00001
+     Particle distribution score min/avg/max: 0/0/0
+
+*** Timestep 2:  t=0.06 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 10 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9184 K, 1.127 K
+     Heat fluxes through boundary parts:          0.004388 W, 0.004388 W, 0.02864 W, -0.005477 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00002
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00002
+     Particle distribution score min/avg/max: 0/0/0
+
+*** Timestep 3:  t=0.09 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.918 K, 1.128 K
+     Heat fluxes through boundary parts:          0.004316 W, 0.004316 W, 0.02969 W, -0.00443 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00003
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00003
+     Particle distribution score min/avg/max: 0/0.00173611/0.037037
+
+*** Timestep 4:  t=0.12 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9175 K, 1.13 K
+     Heat fluxes through boundary parts:          0.004247 W, 0.004247 W, 0.03069 W, -0.003485 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00004
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00004
+     Particle distribution score min/avg/max: 0/0.00173611/0.037037
+
+*** Timestep 5:  t=0.15 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9171 K, 1.132 K
+     Heat fluxes through boundary parts:          0.004181 W, 0.004181 W, 0.03164 W, -0.002761 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00005
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00005
+     Particle distribution score min/avg/max: 0/0.00173611/0.037037
+
+*** Timestep 6:  t=0.18 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 8 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                           0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                     0 K, 0.9166 K, 1.145 K
+     Heat fluxes through boundary parts:          0.004117 W, 0.004117 W, 0.03255 W, -0.002135 W
+     Writing graphical output:                    output-particle_distribution_score/solution/solution-00006
+     Writing particle output:                     output-particle_distribution_score/particles/particles-00006
+     Particle distribution score min/avg/max: 0/0.00136574/0.037037
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/particle_distribution_score/statistics
+++ b/tests/particle_distribution_score/statistics
@@ -1,0 +1,31 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: RMS velocity (m/s)
+# 11: Max. velocity (m/s)
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+# 15: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 16: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 17: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 18: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 19: Visualization file name
+# 20: Number of advected particles
+# 21: Particle file name
+# 22: Minimal particle distribution score: 
+# 23: Average particle distribution score: 
+# 24: Maximal particle distribution score: 
+0 0.000000000000e+00 0.000000000000e+00 256 2595 1141 1141 0  0 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.19097222e-01 1.12500000e+00 1.42150000e-03 1.42150000e-03 2.27923333e-02 -2.36768333e-02 output-particle_distribution_score/solution/solution-00000 4096 output-particle_distribution_score/particles/particles-00000 0.0000 0.0000 0.0000 
+1 3.000000000000e-02 3.000000000000e-02 256 2595 1141 1141 7 10 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.18734356e-01 1.12572330e+00 4.46198391e-03 4.46198391e-03 2.75576324e-02 -6.67363935e-03 output-particle_distribution_score/solution/solution-00001 4096 output-particle_distribution_score/particles/particles-00001 0.0000 0.0000 0.0000 
+2 6.000000000000e-02 3.000000000000e-02 256 2595 1141 1141 6 10 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.18354102e-01 1.12668357e+00 4.38828347e-03 4.38828347e-03 2.86418272e-02 -5.47722400e-03 output-particle_distribution_score/solution/solution-00002 4096 output-particle_distribution_score/particles/particles-00002 0.0000 0.0000 0.0000 
+3 9.000000000000e-02 3.000000000000e-02 256 2595 1141 1141 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.17952147e-01 1.12799617e+00 4.31631667e-03 4.31631667e-03 2.96865527e-02 -4.42953318e-03 output-particle_distribution_score/solution/solution-00003 4096 output-particle_distribution_score/particles/particles-00003 0.0000 0.0017 0.0370 
+4 1.200000000000e-01 3.000000000000e-02 256 2595 1141 1141 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.17528195e-01 1.12969534e+00 4.24714727e-03 4.24714727e-03 3.06876552e-02 -3.48482045e-03 output-particle_distribution_score/solution/solution-00004 4096 output-particle_distribution_score/particles/particles-00004 0.0000 0.0017 0.0370 
+5 1.500000000000e-01 3.000000000000e-02 256 2595 1141 1141 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.17084254e-01 1.13175984e+00 4.18053319e-03 4.18053319e-03 3.16431938e-02 -2.76051527e-03 output-particle_distribution_score/solution/solution-00005 4096 output-particle_distribution_score/particles/particles-00005 0.0000 0.0017 0.0370 
+6 1.800000000000e-01 3.000000000000e-02 256 2595 1141 1141 6  8 1.00000000e-01 1.00000000e-01 0.00000000e+00 9.16622132e-01 1.14542667e+00 4.11684386e-03 4.11684386e-03 3.25527670e-02 -2.13533305e-03 output-particle_distribution_score/solution/solution-00006 4080 output-particle_distribution_score/particles/particles-00006 0.0000 0.0014 0.0370 

--- a/tests/particle_distribution_score_3d.prm
+++ b/tests/particle_distribution_score_3d.prm
@@ -1,0 +1,152 @@
+# Adapted from the drop-supg.prm benchmark
+
+set Dimension                              = 3
+set Use years in output instead of seconds = false
+set End time                               = 0.18
+set Nonlinear solver scheme                = single Advection, no Stokes
+set Resume computation                     = false
+set Maximum time step                      = 0.03
+
+
+subsection Prescribed Stokes solution
+  set Model name = function
+
+  subsection Velocity function
+    set Variable names      = x,y,z
+    set Function constants  = velSlow=-0.1
+    set Function expression = 0; velSlow; 0
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 0.5
+    set Y extent = 5
+    set Z extent = 0.5
+    set Y repetitions = 10
+    set Box origin X coordinate = 0
+    set Box origin Y coordinate = 0
+    set Box origin Z coordinate = 0
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y,z
+    set Function constants  =
+    set Function expression = 1
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Variable names      = x,y,z
+    set Function expression = 1
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = box
+  set Fixed temperature boundary indicators   = top, bottom, left, right
+
+  subsection Box
+    set Bottom temperature = 0
+    set Left temperature   = 0
+    set Right temperature  = 0
+    set Top temperature    = 0
+  end
+end
+
+subsection Boundary composition model
+  set List of model names = box
+  set Fixed composition boundary indicators   = top, bottom, left, right
+
+  subsection Box
+    set Bottom composition = 0
+    set Left composition   = 0
+    set Right composition  = 0
+    set Top composition    = 0
+  end
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 0.0
+  end
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density             = 1
+    set Reference specific heat       = 1
+    set Reference temperature         = 0
+    set Thermal conductivity          = 1e-5
+    set Thermal expansion coefficient = 0
+    set Viscosity                     = 0
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 1
+  set Compositional field methods = field
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement              = 2
+  set Initial global refinement                = 1
+  set Time steps between mesh refinement       = 0
+
+  set Strategy = minimum refinement function
+
+  subsection Minimum refinement function
+    set Coordinate system   = cartesian
+    set Variable names      = x,y,z
+    set Function expression = if ( y<=4, 2, 4)
+  end
+  
+end
+
+subsection Particles
+  set Particle generator name =  reference cell
+  set Maximum particles per cell = 32
+  set Load balancing strategy = remove and add particles
+  subsection Generator
+    subsection Reference cell
+      set Number of particles per cell per direction = 4
+    end
+  end
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Score
+
+  subsection Visualization
+    set Time between graphical output = .001
+    set List of output variables = artificial viscosity
+  end
+
+  subsection Particles
+    set Time between data output = 0.001
+    set Data output format       = vtu
+  end
+
+  subsection Particle distribution score
+    set Granularity = 2
+  end
+
+end
+
+subsection Solver parameters
+  set Temperature solver tolerance = 1e-10
+end

--- a/tests/particle_distribution_score_3d/screen-output
+++ b/tests/particle_distribution_score_3d/screen-output
@@ -1,0 +1,113 @@
+
+Number of active cells: 80 (on 2 levels)
+Number of degrees of freedom: 5,314 (3,075+189+1,025+1,025)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+
+Number of active cells: 640 (on 3 levels)
+Number of degrees of freedom: 33,830 (19,683+1,025+6,561+6,561)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving C_1 system ... 0 iterations.
+
+Number of active cells: 1,536 (on 4 levels)
+Number of degrees of freedom: 76,062 (44,331+2,177+14,777+14,777)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8557 K, 1.266 K
+     Heat fluxes through boundary parts:      0.0005881 W, 0.0005881 W, 0.02101 W, -0.02296 W, 0.0005881 W, 0.0005881 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00000
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00000
+     Particle distribution score min/avg/max: 0/0.0159462/0.0535714
+
+*** Timestep 1:  t=0.03 seconds, dt=0.03 seconds
+   Solving temperature system... 8 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 10 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8557 K, 1.268 K
+     Heat fluxes through boundary parts:      0.000632 W, 0.000632 W, 0.02101 W, -0.02296 W, 0.000632 W, 0.000632 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00001
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00001
+     Particle distribution score min/avg/max: 0/0.0159462/0.0535714
+
+*** Timestep 2:  t=0.06 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8557 K, 1.27 K
+     Heat fluxes through boundary parts:      0.0006358 W, 0.0006358 W, 0.021 W, -0.02295 W, 0.0006358 W, 0.0006358 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00002
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00002
+     Particle distribution score min/avg/max: 0/0.0159462/0.0535714
+
+*** Timestep 3:  t=0.09 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8557 K, 1.273 K
+     Heat fluxes through boundary parts:      0.0006394 W, 0.0006394 W, 0.021 W, -0.02295 W, 0.0006394 W, 0.0006394 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00003
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00003
+     Particle distribution score min/avg/max: 0.00223214/0.017468/0.102715
+
+*** Timestep 4:  t=0.12 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8556 K, 1.277 K
+     Heat fluxes through boundary parts:      0.0006432 W, 0.0006432 W, 0.021 W, -0.02295 W, 0.0006432 W, 0.0006432 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00004
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00004
+     Particle distribution score min/avg/max: 0.00223214/0.017468/0.102715
+
+*** Timestep 5:  t=0.15 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8556 K, 1.281 K
+     Heat fluxes through boundary parts:      0.0006472 W, 0.0006472 W, 0.021 W, -0.02295 W, 0.0006472 W, 0.0006472 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00005
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00005
+     Particle distribution score min/avg/max: 0.00223214/0.017468/0.102715
+
+*** Timestep 6:  t=0.18 seconds, dt=0.03 seconds
+   Solving temperature system... 6 iterations.
+   Advecting particles...  done.
+   Solving C_1 system ... 9 iterations.
+
+   Postprocessing:
+     RMS, max velocity:                       0.1 m/s, 0.1 m/s
+     Temperature min/avg/max:                 0 K, 0.8556 K, 1.287 K
+     Heat fluxes through boundary parts:      0.0006514 W, 0.0006514 W, 0.021 W, -0.02294 W, 0.0006514 W, 0.0006514 W
+     Writing graphical output:                output-particle_distribution_score_3d/solution/solution-00006
+     Writing particle output:                 output-particle_distribution_score_3d/particles/particles-00006
+     Particle distribution score min/avg/max: 0.00223214/0.0180055/0.102715
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/particle_distribution_score_3d/statistics
+++ b/tests/particle_distribution_score_3d/statistics
@@ -1,0 +1,33 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: RMS velocity (m/s)
+# 11: Max. velocity (m/s)
+# 12: Minimal temperature (K)
+# 13: Average temperature (K)
+# 14: Maximal temperature (K)
+# 15: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 16: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 17: Outward heat flux through boundary with indicator 2 ("front") (W)
+# 18: Outward heat flux through boundary with indicator 3 ("back") (W)
+# 19: Outward heat flux through boundary with indicator 4 ("bottom") (W)
+# 20: Outward heat flux through boundary with indicator 5 ("top") (W)
+# 21: Visualization file name
+# 22: Number of advected particles
+# 23: Particle file name
+# 24: Minimal particle distribution score: 
+# 25: Average particle distribution score: 
+# 26: Maximal particle distribution score: 
+0 0.000000000000e+00 0.000000000000e+00 1536 46508 14777 14777 0  0 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55740017e-01 1.26562500e+00 5.88050275e-04 5.88050275e-04 2.10069444e-02 -2.29600694e-02 5.88050275e-04 5.88050275e-04 output-particle_distribution_score_3d/solution/solution-00000 49152 output-particle_distribution_score_3d/particles/particles-00000 0.0000 0.0159 0.0536 
+1 3.000000000000e-02 3.000000000000e-02 1536 46508 14777 14777 8 10 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55716261e-01 1.26750350e+00 6.32012047e-04 6.32012047e-04 2.10057206e-02 -2.29575175e-02 6.32012047e-04 6.32012047e-04 output-particle_distribution_score_3d/solution/solution-00001 49152 output-particle_distribution_score_3d/particles/particles-00001 0.0000 0.0159 0.0536 
+2 6.000000000000e-02 3.000000000000e-02 1536 46508 14777 14777 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55691635e-01 1.26988464e+00 6.35836417e-04 6.35836417e-04 2.10044962e-02 -2.29549637e-02 6.35836417e-04 6.35836417e-04 output-particle_distribution_score_3d/solution/solution-00002 49152 output-particle_distribution_score_3d/particles/particles-00002 0.0000 0.0159 0.0536 
+3 9.000000000000e-02 3.000000000000e-02 1536 46508 14777 14777 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55665883e-01 1.27294649e+00 6.39418145e-04 6.39418144e-04 2.10032719e-02 -2.29524107e-02 6.39418145e-04 6.39418144e-04 output-particle_distribution_score_3d/solution/solution-00003 47714 output-particle_distribution_score_3d/particles/particles-00003 0.0022 0.0175 0.1027 
+4 1.200000000000e-01 3.000000000000e-02 1536 46508 14777 14777 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55638931e-01 1.27674661e+00 6.43222005e-04 6.43222004e-04 2.10020478e-02 -2.29498592e-02 6.43222005e-04 6.43222004e-04 output-particle_distribution_score_3d/solution/solution-00004 47714 output-particle_distribution_score_3d/particles/particles-00004 0.0022 0.0175 0.1027 
+5 1.500000000000e-01 3.000000000000e-02 1536 46508 14777 14777 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55610779e-01 1.28128692e+00 6.47220007e-04 6.47220006e-04 2.10008239e-02 -2.29473096e-02 6.47220007e-04 6.47220006e-04 output-particle_distribution_score_3d/solution/solution-00005 47714 output-particle_distribution_score_3d/particles/particles-00005 0.0022 0.0175 0.1027 
+6 1.800000000000e-01 3.000000000000e-02 1536 46508 14777 14777 6  9 1.00000000e-01 1.00000000e-01 0.00000000e+00 8.55581452e-01 1.28653297e+00 6.51350187e-04 6.51350186e-04 2.09996003e-02 -2.29447618e-02 6.51350187e-04 6.51350186e-04 output-particle_distribution_score_3d/solution/solution-00006 47077 output-particle_distribution_score_3d/particles/particles-00006 0.0022 0.0180 0.1027 


### PR DESCRIPTION
This pull request adds a postprocessor which evaluates the density distribution of particles within each cell using a histogram method. This postprocessor aims to provide a quantitative way to evaluate the degree to which the removal of particles during load balancing leads to gradients of particle density. Evaluating density gradients in this way will make it easier to develop a new algorithm for creating and deleting particles during load balancing in order to avoid unwanted density gradients.

