### PR TITLE
Fix a bug in the FastScape_fortran interfaces.

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -767,7 +767,7 @@ namespace aspect
             fastscape_mesh_filled = false;
         }
 
-      Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);
+      fastscape_mesh_filled = Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);
       AssertThrow (fastscape_mesh_filled == true,
                    ExcMessage("The FastScape mesh is missing data. A likely cause for this is that the "
                               "maximum surface refinement or surface refinement difference are improperly set."));


### PR DESCRIPTION
@djneu and @minerallo: There's a bug in the (old) FastScape interfaces in that we broadcast the state of `fastscape_mesh_filled` from process zero to all of the other processes, but at the receiving side we do not actually store that value. I'm surprised to see this worked. I'm *pretty* sure that this patch is correct -- do either of you have any insight into it?