### PR TITLE
Simplify MatrixFree base class wrt memory consumption

### DIFF
--- a/include/aspect/simulator/solver/stokes_matrix_free.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free.h
@@ -76,53 +76,19 @@ namespace aspect
       void declare_parameters (ParameterHandler &prm);
 
       /**
-       * Return a reference to the DoFHandler that is used for velocity in
-       * the block GMG solver.
+       * Return memory consumption in bytes for all DoFHandler objects.
        */
-      virtual const DoFHandler<dim> &
-      get_dof_handler_v () const = 0;
+      virtual std::size_t get_dof_handler_memory_consumption() const = 0;
 
       /**
-       * Return a reference to the DoFHandler that is used for pressure in
-       * the block GMG solver.
+       * Return memory consumption in bytes for all transfer objects.
        */
-      virtual const DoFHandler<dim> &
-      get_dof_handler_p () const = 0;
+      virtual std::size_t get_mg_transfer_memory_consumption() const = 0;
 
       /**
-       * Return a reference to the DoFHandler that is used for the coefficient
-       * projection in the block GMG solver.
+       * Return memory consumption in bytes for all transfer objects.
        */
-      virtual const DoFHandler<dim> &
-      get_dof_handler_projection () const = 0;
-
-      /**
-       * Return a pointer to the object that describes the velocity DoF
-       * constraints for the block GMG Stokes solver.
-       */
-      virtual const AffineConstraints<double> &
-      get_constraints_v () const = 0;
-
-      /**
-       * Return a pointer to the object that describes the pressure DoF
-       * constraints for the block GMG Stokes solver.
-       */
-      virtual const AffineConstraints<double> &
-      get_constraints_p () const = 0;
-
-      /**
-       * Return a pointer to the MGTransfer object used for the A block
-       * of the block GMG Stokes solver.
-       */
-      virtual const MGTransferMF<dim,GMGNumberType> &
-      get_mg_transfer_A () const = 0;
-
-      /**
-       * Return a pointer to the MGTransfer object used for the Schur
-       * complement block of the block GMG Stokes solver.
-       */
-      virtual const MGTransferMF<dim,GMGNumberType> &
-      get_mg_transfer_S () const = 0;
+      virtual std::size_t get_constraint_memory_consumption() const = 0;
 
       /**
        * Return the memory consumption in bytes that are used to store

--- a/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_local_smoothing.h
@@ -139,54 +139,19 @@ namespace aspect
       void parse_parameters (ParameterHandler &prm) override;
 
       /**
-       * Return a reference to the DoFHandler that is used for velocity in
-       * the block GMG solver.
+       * Return memory consumption in bytes for all DoFHandler objects.
        */
-      const DoFHandler<dim> &
-      get_dof_handler_v () const override;
+      std::size_t get_dof_handler_memory_consumption() const override;
 
       /**
-       * Return a reference to the DoFHandler that is used for pressure in
-       * the block GMG solver.
+       * Return memory consumption in bytes for all transfer objects.
        */
-      const DoFHandler<dim> &
-      get_dof_handler_p () const override;
+      std::size_t get_mg_transfer_memory_consumption() const override;
 
       /**
-       * Return a reference to the DoFHandler that is used for the coefficient
-       * projection in the block GMG solver.
+       * Return memory consumption in bytes for all transfer objects.
        */
-      const DoFHandler<dim> &
-      get_dof_handler_projection () const override;
-
-      /**
-       * Return a pointer to the object that describes the velocity DoF
-       * constraints for the block GMG Stokes solver.
-       */
-      const AffineConstraints<double> &
-      get_constraints_v () const override;
-
-      /**
-       * Return a pointer to the object that describes the pressure DoF
-       * constraints for the block GMG Stokes solver.
-       */
-      const AffineConstraints<double> &
-      get_constraints_p () const override;
-
-      /**
-       * Return a pointer to the MGTransfer object used for the A block
-       * of the block GMG Stokes solver.
-       */
-      const MGTransferMF<dim,GMGNumberType> &
-      get_mg_transfer_A () const override;
-
-      /**
-       * Return a pointer to the MGTransfer object used for the Schur
-       * complement block of the block GMG Stokes solver.
-       */
-      const MGTransferMF<dim,GMGNumberType> &
-      get_mg_transfer_S () const override;
-
+      std::size_t get_constraint_memory_consumption() const override;
 
       /**
        * Return the memory consumption in bytes that are used to store

--- a/source/postprocess/memory_statistics.cc
+++ b/source/postprocess/memory_statistics.cc
@@ -43,13 +43,8 @@ namespace aspect
       double constraints_mem = this->get_current_constraints().memory_consumption();
       if (this->is_stokes_matrix_free())
         {
-          dof_handler_mem += this->get_stokes_matrix_free().get_dof_handler_v().memory_consumption()
-                             + this->get_stokes_matrix_free().get_dof_handler_p().memory_consumption();
-
-          dof_handler_mem  += this->get_stokes_matrix_free().get_dof_handler_projection().memory_consumption();
-
-          constraints_mem += this->get_stokes_matrix_free().get_constraints_v().memory_consumption()
-                             + this->get_stokes_matrix_free().get_constraints_p().memory_consumption();
+          dof_handler_mem += this->get_stokes_matrix_free().get_dof_handler_memory_consumption();
+          constraints_mem += this->get_stokes_matrix_free().get_constraint_memory_consumption();
         }
       statistics.add_value ("DoFHandler memory consumption (MB) ", dof_handler_mem/mb);
       statistics.add_value ("AffineConstraints<double> memory consumption (MB) ", constraints_mem/mb);
@@ -58,8 +53,7 @@ namespace aspect
 
       if (this->is_stokes_matrix_free())
         {
-          const double mg_transfer_mem = this->get_stokes_matrix_free().get_mg_transfer_A().memory_consumption()
-                                         + this->get_stokes_matrix_free().get_mg_transfer_S().memory_consumption();
+          const double mg_transfer_mem = this->get_stokes_matrix_free().get_mg_transfer_memory_consumption();
           statistics.add_value ("MGTransfer memory consumption (MB) ", mg_transfer_mem/mb);
 
           const double cell_data_mem = this->get_stokes_matrix_free().get_cell_data_memory_consumption();

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -1807,64 +1807,28 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
-  const DoFHandler<dim> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_dof_handler_v () const
+  std::size_t
+  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_dof_handler_memory_consumption() const
   {
-    return dof_handler_v;
+    return dof_handler_v.memory_consumption() + dof_handler_p.memory_consumption() + dof_handler_projection.memory_consumption();
   }
 
 
 
   template <int dim, int velocity_degree>
-  const DoFHandler<dim> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_dof_handler_p () const
+  std::size_t
+  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_mg_transfer_memory_consumption() const
   {
-    return dof_handler_p;
+    return mg_transfer_A_block.memory_consumption() + mg_transfer_Schur_complement.memory_consumption();
   }
 
 
 
   template <int dim, int velocity_degree>
-  const DoFHandler<dim> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_dof_handler_projection () const
+  std::size_t
+  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_constraint_memory_consumption() const
   {
-    return dof_handler_projection;
-  }
-
-
-
-  template <int dim, int velocity_degree>
-  const AffineConstraints<double> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_constraints_v() const
-  {
-    return constraints_v;
-  }
-
-
-
-  template <int dim, int velocity_degree>
-  const AffineConstraints<double> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_constraints_p() const
-  {
-    return constraints_p;
-  }
-
-
-
-  template <int dim, int velocity_degree>
-  const MGTransferMF<dim,GMGNumberType> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_mg_transfer_A() const
-  {
-    return mg_transfer_A_block;
-  }
-
-
-
-  template <int dim, int velocity_degree>
-  const MGTransferMF<dim,GMGNumberType> &
-  StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::get_mg_transfer_S() const
-  {
-    return mg_transfer_Schur_complement;
+    return constraints_v.memory_consumption() + constraints_p.memory_consumption();
   }
 
 


### PR DESCRIPTION
Instead of helper functions that return references to various internal objects (DoFHandler, Constraints, ...), just provide functions to report memory consumption directly.
