### PR TITLE
More error checks for multicomponent material model and equation of state

### DIFF
--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -37,8 +37,6 @@ namespace aspect
                const unsigned int input_index,
                MaterialModel::EquationOfStateOutputs<dim> &eos_outputs) const
       {
-
-
         // If adiabatic heating is used, the reference temperature used to calculate density should be the adiabatic
         // temperature at the current position. This definition is consistent with the Extended Boussinesq Approximation.
         const double reference_temperature = (this->include_adiabatic_heating()
@@ -125,9 +123,20 @@ namespace aspect
             // if they are to be used for all phases associated with a given key.
             options.check_values_per_key = true;
           }
+        else
+          {
+            // If the material model does not tell us how many phases per composition to expect,
+            // at least check that the parameters parsed below have the same number of values.
+            options.store_values_per_key = true;
+          }
 
         // Parse multicomponent properties
         densities = Utilities::MapParsing::parse_map_to_double_array(prm.get("Densities"), options);
+
+        // Now that we know we have stored the number of phases per composition, we can check them for subsequent properties.
+        options.store_values_per_key = false;
+        options.check_values_per_key = true;
+
         options.property_name = "Thermal expansivities";
         thermal_expansivities = Utilities::MapParsing::parse_map_to_double_array(prm.get("Thermal expansivities"), options);
         options.property_name = "Heat capacities";


### PR DESCRIPTION
Add some additional checks for the lists of material properties in models using the incompressible multicomponent equation of state. The equation of state can be used with phase transitions; if the material model calling it does not provide the number of phase transitions, it can still check internally that all lists it reads in have the same number of values. The multicomponent material model uses the incompressible multicomponent equation of state, but no phase transitions. We should therefore add this information to the options used for reading the map (because before this change, one could just provide anything in the list of values without an error being thrown and simply only the first n values would be used). 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
