### PR TITLE
Undo the previous change of moving a private member in class.

### DIFF
--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -153,12 +153,11 @@ namespace aspect
            */
           double topography_for_point (const Point<dim> &x_y_z) const;
 
+        private:
           /**
            * A pointer to the topography model.
            */
           const InitialTopographyModel::Interface<dim> *topo;
-
-        private:
 
           /**
            * Inner and outer radii of the spherical shell.

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -713,7 +713,7 @@ namespace aspect
     double
     SphericalShell<dim>::maximal_depth() const
     {
-      return R1 + manifold->topo->max_topography() - R0;
+      return R1 + this->get_initial_topography_model().max_topography() - R0;
     }
 
 


### PR DESCRIPTION
Following PR #6332, this PR addresses the previous change I did, i.e., move a private member to public, which was not required.