### PR TITLE
[WIP] [Request of initial comments] Add direction dilation.

### DIFF
--- a/include/aspect/material_model/interface.h
+++ b/include/aspect/material_model/interface.h
@@ -1232,7 +1232,7 @@ namespace aspect
          * A scalar value per evaluation point that specifies the prescribed dilation
          * in that point.
          */
-        std::vector<double> dilation;
+        std::vector<std::vector<double>> dilation;
     };
 
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -1000,8 +1000,8 @@ namespace aspect
 
     template <int dim>
     PrescribedPlasticDilation<dim>::PrescribedPlasticDilation (const unsigned int n_points)
-      : NamedAdditionalMaterialOutputs<dim>(std::vector<std::string>(1, "prescribed_dilation")),
-        dilation(n_points, numbers::signaling_nan<double>())
+      : NamedAdditionalMaterialOutputs<dim>(std::vector<std::string>(3, "prescribed_dilation")),
+        dilation(dim, std::vector<double>(n_points, numbers::signaling_nan<double>()))
     {}
 
 
@@ -1010,8 +1010,17 @@ namespace aspect
     std::vector<double> PrescribedPlasticDilation<dim>::get_nth_output(const unsigned int idx) const
     {
       (void)idx;
-      Assert(idx==0, ExcInternalError());
-      return dilation;
+      Assert(idx<3, ExcInternalError());
+      switch (idx)
+        {
+          case 0:
+            return dilation[0];
+          case 1:
+            return dilation[1];
+          case 2:
+            return dilation[2];
+        }
+      return std::vector<double>();
     }
 
 

--- a/source/simulator/assemblers/newton_stokes.cc
+++ b/source/simulator/assemblers/newton_stokes.cc
@@ -437,22 +437,32 @@ namespace aspect
                                      * JxW;
 
               if (enable_prescribed_dilation)
-                data.local_rhs(i) += (
-                                       // RHS of - (div u,q) = - (R,q)
-                                       - pressure_scaling
-                                       * prescribed_dilation->dilation[q]
-                                       * scratch.phi_p[i]
-                                     ) * JxW;
+                {
+                  const unsigned int index_direction=fe.system_to_component_index(i).first;
+                  // Only want the velocity components and not the pressure one (which is the last one), so add 1
+                  if (introspection.is_stokes_component(index_direction+1))
+                    data.local_rhs(i) += (
+                                           // RHS of - (div u,q) = - (R,q)
+                                           - pressure_scaling
+                                           * prescribed_dilation->dilation[index_direction][q]
+                                           * scratch.phi_p[i]
+                                         ) * JxW;
+                }
 
               // Only assemble this term if we are running incompressible, otherwise this term
               // is already included on the LHS of the equation.
               if (enable_prescribed_dilation && !material_model_is_compressible)
-                data.local_rhs(i) += (
-                                       // RHS of momentum eqn: - \int 2/3 eta R, div v
-                                       - 2.0 / 3.0 * eta
-                                       * prescribed_dilation->dilation[q]
-                                       * scratch.div_phi_u[i]
-                                     ) * JxW;
+                {
+                  const unsigned int index_direction=fe.system_to_component_index(i).first;
+                  // Only want the velocity components and not the pressure one (which is the last one), so add 1
+                  if (introspection.is_stokes_component(index_direction+1))
+                    data.local_rhs(i) += (
+                                           // RHS of momentum eqn: - \int 2/3 eta R, div v
+                                           - 2.0 / 3.0 * eta
+                                           * prescribed_dilation->dilation[index_direction][q]
+                                           * scratch.div_phi_u[i]
+                                         ) * JxW;
+                }
             }
 
           // and then the matrix, if necessary
@@ -623,7 +633,7 @@ namespace aspect
 
       Assert(!this->get_parameters().enable_prescribed_dilation
              ||
-             outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation.size()
+             outputs.template get_additional_output_object<MaterialModel::PrescribedPlasticDilation<dim>>()->dilation[0].size()
              == n_points, ExcInternalError());
 
       if (this->get_newton_handler().parameters.newton_derivative_scaling_factor != 0)

--- a/tests/prescribed_dilation.cc
+++ b/tests/prescribed_dilation.cc
@@ -208,7 +208,12 @@ namespace aspect
                 }
               if (prescribed_dilation)
                 {
-                  prescribed_dilation->dilation[i] = x;
+                  prescribed_dilation->dilation[0][i] = x;
+                  prescribed_dilation->dilation[1][i] = x;
+                  if (dim == 3)
+                    {
+                      prescribed_dilation->dilation[2][i] = x;
+                    }
                 }
 
             }


### PR DESCRIPTION
For a diking algorithm, I would like to be able to only add dilation in a certain direction. I personally think it is best to be general with this and let the material model decide exactly how much dilation needs to go in each direction.

I originally thought that I should just add a new direction dilation additional output, but after trying that out I think just making the dilation a dim vector might be cleaner. So that is what is implemented here. 

I am happy to get comments on this approach now and be convinced that a different approach might be better. 
