### PR TITLE
Declare the existence of explicit specializations.

### DIFF
--- a/include/aspect/volume_of_fluid/handler.h
+++ b/include/aspect/volume_of_fluid/handler.h
@@ -219,6 +219,23 @@ namespace aspect
       friend class Simulator<dim>;
   };
 
+
+  // Declare the existence of explicit specializations
+  template <>
+  void VolumeOfFluidHandler<2>::update_volume_of_fluid_normals (const VolumeOfFluidField<2> &field,
+                                                                LinearAlgebra::BlockVector &solution);
+  template <>
+  void VolumeOfFluidHandler<3>::update_volume_of_fluid_normals (const VolumeOfFluidField<3> &/*field*/,
+                                                                LinearAlgebra::BlockVector &/*solution*/);
+  template <>
+  void VolumeOfFluidHandler<2>::update_volume_of_fluid_composition (const typename Simulator<2>::AdvectionField &composition_field,
+                                                                    const VolumeOfFluidField<2> &volume_of_fluid_field,
+                                                                    LinearAlgebra::BlockVector &solution);
+  template <>
+  void VolumeOfFluidHandler<3>::update_volume_of_fluid_composition (const Simulator<3>::AdvectionField &/*composition_field*/,
+                                                                    const VolumeOfFluidField<3> &/*volume_of_fluid_field*/,
+                                                                    LinearAlgebra::BlockVector &/*solution*/);
+
 }
 
 #endif


### PR DESCRIPTION
The error messages in #6416 are about the fact that we have explicit specializations of some VoF member functions, but that their existence is not declared before we explicitly instantiate the whole class. If we use separate file compilation, these functions are not visible and so the explicit instantiation just doesn't see them and does nothing about these functions. But if we use the unity build, everything may end up in one file and the compiler complains that you can explicitly specialize a function it has already tried to implicitly instantiate.

The solution is to *declare* the existence of these specializations.