### PR TITLE
Add CPO serialization.

### DIFF
--- a/doc/modules/changes/20250616_mfraters
+++ b/doc/modules/changes/20250616_mfraters
@@ -1,0 +1,4 @@
+Fixed: The Crystal Preferred Orientation plugin was not serializing
+the internal state
+<br>
+(Menno Fraters, Yijun Wang, Agi Kiraly, 2025/06/16)

--- a/include/aspect/postprocess/crystal_preferred_orientation.h
+++ b/include/aspect/postprocess/crystal_preferred_orientation.h
@@ -78,6 +78,23 @@ namespace aspect
         required_other_postprocessors () const override;
 
         /**
+         * Save the state of this object.
+         */
+        void save (std::map<std::string, std::string> &status_strings) const override;
+
+        /**
+         * Restore the state of the object.
+         */
+        void load (const std::map<std::string, std::string> &status_strings) override;
+
+        /**
+         * Serialize the contents of this class as far as they are not read
+         * from input parameter files.
+         */
+        template <class Archive>
+        void serialize (Archive &ar, const unsigned int version);
+
+        /**
          * Declare the parameters this class takes through input files.
          */
         static

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -606,6 +606,54 @@ namespace aspect
 
 
     template <int dim>
+    template <class Archive>
+    void CrystalPreferredOrientation<dim>::serialize (Archive &ar, const unsigned int)
+    {
+      ar &last_output_time
+      & output_file_number
+      & times_and_pvtu_file_names
+      & output_file_names_by_timestep
+      & xdmf_entries
+      ;
+    }
+
+
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+      // Serialize into a stringstream. Put the following into a code
+      // block of its own to ensure the destruction of the 'oa'
+      // archive triggers a flush() on the stringstream so we can
+      // query the completed string below.
+      std::ostringstream os;
+      {
+        aspect::oarchive oa (os);
+
+        oa << (*this);
+      }
+
+      status_strings["Crystal Preferred Orientation"] = os.str();
+    }
+
+
+    template <int dim>
+    void
+    CrystalPreferredOrientation<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      // see if something was saved
+      if (status_strings.find("Crystal Preferred Orientation") != status_strings.end())
+        {
+          std::istringstream is (status_strings.find("Crystal Preferred Orientation")->second);
+          aspect::iarchive ia (is);
+
+          ia >> (*this);
+        }
+    }
+
+
+    template <int dim>
     void
     CrystalPreferredOrientation<dim>::declare_parameters (ParameterHandler &prm)
     {


### PR DESCRIPTION
@Wang-yijun and @KiralyAgi noticed that when restarting a model with cpo, the numbering of the files starts again from zero. This is fixed by adding the serialization code.

@Wang-yijun, I don't know if this also fixes the other restart issue you had, but I could not reproduce it. Could you give it a try and send me your input files if it doesn't work?