### PR TITLE
Add fastscape-fortran checkpointing

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -87,6 +87,23 @@ namespace aspect
          */
         void parse_parameters (ParameterHandler &prm) override;
 
+        /**
+         * Serialize the contents of this class as far as they are not read
+         * from input parameter files.
+         */
+        template <class Archive>
+        void serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Save the state of this object.
+         */
+        void save (std::map<std::string, std::string> &status_strings) const override;
+
+        /**
+         * Restore the state of the object.
+         */
+        void load (const std::map<std::string, std::string> &status_strings) override;
+
       private:
         /**
          * Function used to set the FastScape ghost nodes. FastScape boundaries are
@@ -132,9 +149,8 @@ namespace aspect
          */
         void initialize_fastscape(std::vector<double> &elevation,
                                   std::vector<double> &basement,
-                                  std::vector<double> &bedrock_transport_coefficient_array,
-                                  std::vector<double> &bedrock_river_incision_rate_array,
-                                  std::vector<double> &silt_fraction) const;
+                                  std::vector<double> &silt_fraction,
+                                  bool restart) const;
 
         /**
          * Execute FastScape
@@ -164,20 +180,6 @@ namespace aspect
                                           const unsigned int &fastscape_ny) const;
 
         /**
-         * Read data from file for restarting.
-         */
-        void read_restart_files(std::vector<double> &elevation,
-                                std::vector<double> &basement,
-                                std::vector<double> &silt_fraction) const;
-
-        /**
-         * Save data to file for restarting.
-         */
-        void save_restart_files(const std::vector<double> &elevation,
-                                std::vector<double> &basement,
-                                std::vector<double> &silt_fraction) const;
-
-        /**
          * Suggestion for the number of FastScape steps to run for every ASPECT timestep,
          * where the FastScape timestep is determined by ASPECT_timestep_length divided by
          * this parameter.
@@ -189,16 +191,6 @@ namespace aspect
          * limit it is repeatedly divided by 2 until the final timestep is smaller than this parameter.
          */
         double maximum_fastscape_timestep;
-
-        /**
-         * Check whether FastScape needs to be restarted. This is used as
-         * a mutable bool because we determine whether the model is being resumed in
-         * initialize(), and then after reinitializing FastScape we change it to false
-         * so it does not initialize FastScape again in future timesteps.
-         * TODO: There is probably a better way to do this, and restarts should be rolled into
-         * the general ASPECT restart.
-         */
-        mutable bool restart;
 
         /**
          * FastScape cell size in X.

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -52,6 +52,8 @@ namespace aspect
       free_surface_theta(stabilization_theta)
     {}
 
+
+
     template <int dim>
     void
     ApplyStabilization<dim>::
@@ -171,6 +173,20 @@ namespace aspect
     {
       return false;
     }
+
+
+
+    template <int dim>
+    void
+    Interface<dim>::save (std::map<std::string,std::string> &) const
+    {}
+
+
+
+    template <int dim>
+    void
+    Interface<dim>::load (const std::map<std::string,std::string> &)
+    {}
 
 
 

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -593,9 +593,12 @@ namespace aspect
     ar &last_pressure_normalization_adjustment;
     ar &total_walltime_until_last_snapshot;
 
+    ar &statistics;
+
     ar &postprocess_manager;
 
-    ar &statistics;
+    if (parameters.mesh_deformation_enabled)
+      ar &(*mesh_deformation);
 
     // We do not serialize the statistics_last_write_size and
     // statistics_last_hash variables on purpose. This way, upon


### PR DESCRIPTION

Hi @gassmoeller @bangerth,
here is the initial commit for rolling the fastscape-fortran restart into the checkpointing system. Thanks @gassmoeller for the help on getting this working through the mesh deformation handler! I've tested this on the cookbook, and it is working with restarts, but it ended up being a bit trickier than I expected so I'm not sure if this is the cleanest way to do it.

One issue was that these variables are all set within the const compute_velocity_constraints function, so I've set them to mutable within the header file. The second is that we save 3 potentially large vectors. At the moment I've set it so we fill these only when creating the checkpoint and keep them clear otherwise. Does this sound like the right way to approach this?