### PR TITLE
Convert percent to fraction in Geodynamic WorldBuilder

### DIFF
--- a/contrib/world_builder/source/world_builder/features/oceanic_plate_models/composition/tian2019_water_content.cc
+++ b/contrib/world_builder/source/world_builder/features/oceanic_plate_models/composition/tian2019_water_content.cc
@@ -178,8 +178,9 @@ namespace WorldBuilder
                   const double slab_temperature = world->properties(position_in_cartesian_coordinates.get_array(), depth, {{{1,0,0}}})[0];
                   double partition_coefficient = calculate_water_content(lithostatic_pressure,
                                                                          slab_temperature);
-
-                  partition_coefficient = std::min(max_water_content, partition_coefficient);
+                  // The partition_coefficient is output as a percentage, but geodynamic modeling software
+                  // typically deal with fractions, so we divide by 100 below
+                  partition_coefficient = std::min(max_water_content, partition_coefficient) / 100;
 
                   for (unsigned int i = 0; i < compositions.size(); ++i)
                     {

--- a/contrib/world_builder/source/world_builder/features/subducting_plate_models/composition/tian2019_water_content.cc
+++ b/contrib/world_builder/source/world_builder/features/subducting_plate_models/composition/tian2019_water_content.cc
@@ -171,8 +171,9 @@ namespace WorldBuilder
               const double slab_temperature = world->properties(position_in_cartesian_coordinates.get_array(), depth, {{{1,0,0}}})[0];
               double partition_coefficient = calculate_water_content(lithostatic_pressure,
                                                                      slab_temperature);
-
-              partition_coefficient = std::min(max_water_content, partition_coefficient);
+              // The partition_coefficient is output as a percentage, but geodynamic modeling software
+              // typically deal with fractions, so we divide by 100 below
+              partition_coefficient = std::min(max_water_content, partition_coefficient) / 100;
 
               for (unsigned int i = 0; i < compositions.size(); ++i)
                 {


### PR DESCRIPTION
This was a fix that I had made in the main branch of the world builder [here](https://github.com/GeodynamicWorldBuilder/WorldBuilder/pull/767), but it is not in the current version of worldbuilder that comes bundled with ASPECT. The world builder currently outputs the percent bound fluid using the tian 2019 composition model, but this means that in the ASPECT model, which expects mass fractions, the bound water would have a value of say 50, instead of 0.5. This PR fixes this issue.

I need this for a cookbook I'm working on in PR #6455, so I implemented the fix exactly as is done in the current main branch of the world builder. @MFraters I think we've done something like this before but just in case maybe you can take a look
