### PR TITLE
Allow sea level function defined in seconds

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1629,7 +1629,10 @@ namespace aspect
     {
       if (use_sea_level_function)
         {
-          sea_level_function.set_time(this->get_time() / year_in_seconds);
+          if (this->convert_output_to_years())
+            sea_level_function.set_time(this->get_time() / year_in_seconds);
+          else
+            sea_level_function.set_time(this->get_time());
         }
     }
 


### PR DESCRIPTION
Small follow-up to #6376. We should allow the sea level function to be defined either in years or in seconds, depending on the input parameter `Use years in output instead of seconds`. We do this for other functions as well.

FYI @xlia62
