### PR TITLE
Add header and override to update.

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -26,6 +26,7 @@
 #ifdef ASPECT_WITH_FASTSCAPE
 
 #include <aspect/mesh_deformation/interface.h>
+#include <deal.II/base/parsed_function.h>
 
 namespace aspect
 {
@@ -51,7 +52,7 @@ namespace aspect
         /**
          * Update input variables for FastScape.
          */
-        void update();
+        void update() override;
 
         /**
          * Destructor for FastScape.


### PR DESCRIPTION
This is a fix to add the parsed function header to fastscape.h which was causing compile issues, and to add override to the update () function to get rid of a warning message. I checked with the sea level function test to make sure the function still worked as expected. @gassmoeller @bangerth 
