### PR TITLE
Remove usage of deprecated name

### DIFF
--- a/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
+++ b/benchmarks/compressibility_formulations/plugins/compressibility_formulations.cc
@@ -127,7 +127,7 @@ namespace aspect
     {
       base_model->evaluate(in,out);
 
-      const unsigned int density_field_index = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
+      const unsigned int density_field_index = this->introspection().find_composition_type(CompositionalFieldDescription::density);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {

--- a/source/material_model/equation_of_state/multicomponent_compressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_compressible.cc
@@ -41,7 +41,7 @@ namespace aspect
 
         // If we are using the projected density approximation then we need to use the adiabatic pressure
         double pressure_for_density;
-        if (this->introspection().composition_type_exists(Parameters<dim>::CompositionalFieldDescription::density) &&
+        if (this->introspection().composition_type_exists(CompositionalFieldDescription::density) &&
             this->get_parameters().formulation_mass_conservation==Parameters<dim>::Formulation::MassConservation::projected_density_field)
           pressure_for_density = this->get_adiabatic_conditions().pressure(in.position[q]);
         else

--- a/source/material_model/multicomponent_compressible.cc
+++ b/source/material_model/multicomponent_compressible.cc
@@ -40,8 +40,8 @@ namespace aspect
 
       unsigned int density_field_index = numbers::invalid_unsigned_int;
 
-      if (this->introspection().composition_type_exists(Parameters<dim>::CompositionalFieldDescription::density))
-        density_field_index = this->introspection().find_composition_type(Parameters<dim>::CompositionalFieldDescription::density);
+      if (this->introspection().composition_type_exists(CompositionalFieldDescription::density))
+        density_field_index = this->introspection().find_composition_type(CompositionalFieldDescription::density);
 
       for (unsigned int i=0; i < in.n_evaluation_points(); ++i)
         {
@@ -179,7 +179,7 @@ namespace aspect
     void
     MulticomponentCompressible<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      if (this->introspection().composition_type_exists(Parameters<dim>::CompositionalFieldDescription::density))
+      if (this->introspection().composition_type_exists(CompositionalFieldDescription::density))
         {
           if (out.template has_additional_output_object<PrescribedFieldOutputs<dim>>() == false)
             {

--- a/tests/check_compositional_field_functions.cc
+++ b/tests/check_compositional_field_functions.cc
@@ -35,8 +35,8 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
 
   // Fields 0 and 4 are chemical compositions
   // These are called Field 1 and Field 5
-  const std::vector<unsigned int> indices = simulator_access.introspection().get_indices_for_fields_of_type(aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition);
-  const std::vector<std::string> names = simulator_access.introspection().get_names_for_fields_of_type(aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition);
+  const std::vector<unsigned int> indices = simulator_access.introspection().get_indices_for_fields_of_type(aspect::CompositionalFieldDescription::chemical_composition);
+  const std::vector<std::string> names = simulator_access.introspection().get_names_for_fields_of_type(aspect::CompositionalFieldDescription::chemical_composition);
 
   const std::vector<double> field_values { 0.1, 0.3, 0.3, 0.3, 0.2, 0.3, 0.3};
   const std::vector<double> compositional_field_fractions = MaterialUtilities::compute_only_composition_fractions(field_values, indices);

--- a/tests/check_compositional_field_names.cc
+++ b/tests/check_compositional_field_names.cc
@@ -33,21 +33,21 @@ void f(const aspect::SimulatorAccess<dim> &simulator_access,
   aspect::ParameterHandler prm;
 
   const std::vector<std::string> c_names = simulator_access.introspection().get_composition_names();
-  const std::vector<typename aspect::Parameters<dim>::CompositionalFieldDescription> descriptions = simulator_access.introspection().get_composition_descriptions();
+  const std::vector<typename aspect::CompositionalFieldDescription> descriptions = simulator_access.introspection().get_composition_descriptions();
 
   for (unsigned int i=0; i<simulator_access.introspection().n_compositional_fields; ++i)
     {
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::chemical_composition)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::chemical_composition)
         std::cout << c_names[i] << " is of type chemical composition" << std::endl;
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::grain_size)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::grain_size)
         std::cout << c_names[i] << " is of type grain size" << std::endl;
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::porosity)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::porosity)
         std::cout << c_names[i] << " is of type porosity" << std::endl;
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::generic)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::generic)
         std::cout << c_names[i] << " is of type generic" << std::endl;
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::stress)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::stress)
         std::cout << c_names[i] << " is of type stress" << std::endl;
-      if (descriptions[i].type == aspect::Parameters<dim>::CompositionalFieldDescription::unspecified)
+      if (descriptions[i].type == aspect::CompositionalFieldDescription::unspecified)
         std::cout << c_names[i] << " is of type unspecified" << std::endl;
     }
 


### PR DESCRIPTION
This struct has been moved to another namespace in #5083. Remove the usage of the deprecated name and instead use the new name. I am surprised our testers do not produce warnings for this.