### PR TITLE
Use lower-case spelling in CMakeLists.txt.

### DIFF
--- a/doc/plugin-CMakeLists.txt
+++ b/doc/plugin-CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2011 - 2016 by the authors of the ASPECT code.
+# Copyright (C) 2011 - 2025 by the authors of the ASPECT code.
 #
 # This file is part of ASPECT.
 #
@@ -27,24 +27,24 @@
 # below.
 # -----------------------------------------------------------------
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.13.4)
 
-FIND_PACKAGE(Aspect 2.4.0 QUIET HINTS ${Aspect_DIR} ../ ../../ $ENV{ASPECT_DIR})
+find_package(Aspect 2.4.0 QUIET HINTS ${Aspect_DIR} ../ ../../ $ENV{ASPECT_DIR})
 
-IF (NOT Aspect_FOUND)
-  MESSAGE(FATAL_ERROR "\n"
+if (NOT Aspect_FOUND)
+  message(FATAL_ERROR "\n"
 	"Could not find a valid ASPECT build/installation directory. "
 	"Please specify the directory where you are building ASPECT by passing\n"
 	"   -D Aspect_DIR=<path to ASPECT>\n"
 	"to cmake or by setting the environment variable ASPECT_DIR in your shell "
 	"before calling cmake. See the section 'How to write a plugin' in the "
         "manual for more information.")
-ENDIF ()
+endif ()
 
 DEAL_II_INITIALIZE_CACHED_VARIABLES()
 
-SET(TARGET "my_plugin")
-PROJECT(${TARGET})
+set(TARGET "my_plugin")
+project(${TARGET})
 
-ADD_LIBRARY(${TARGET} SHARED source_1.cc source_2.cc)
+add_library(${TARGET} SHARED source_1.cc source_2.cc)
 ASPECT_SETUP_PLUGIN(${TARGET})


### PR DESCRIPTION
@magmaxt missed one file in #6473, but that is easily fixed. This fixes #6437.