### PR TITLE
Add functions to reactive fluid transport

### DIFF
--- a/include/aspect/material_model/reactive_fluid_transport.h
+++ b/include/aspect/material_model/reactive_fluid_transport.h
@@ -60,13 +60,30 @@ namespace aspect
          * @}
          */
 
+        /**
+         * Compute the bulk density of the material based on the volume of free water in the
+         * solid.
+         *
+         * @param porosity The volume fraction of the free fluid in the solid.
+         * @param solid_density The density of the solid material.
+         * @param fluid_density The density of the fluid material.
+         **/
         double compute_bulk_density (const double porosity,
                                      const double solid_density,
                                      const double fluid_density) const;
 
-        double compute_mass_fraction (const double porosity,
-                                      const double solid_density,
-                                      const double fluid_density) const;
+        /**
+         * Compute the mass fraction on the volume fraction of a given material in relation to
+         * the bulk density.
+         *
+         * @param volume_fraction The volume fraction of the material.
+         * @param material_density The density of the material (corresponding to the volume fraction).
+         * @param bulk_density The density of the bulk composition.
+         **/
+        double compute_mass_fraction (const double volume_fraction,
+                                      const double material_density,
+                                      const double bulk_density) const;
+
         /**
          * Compute the free fluid fraction that can be present in the material based on the
          * fluid content of the material and the fluid solubility for the given input conditions.

--- a/include/aspect/material_model/reactive_fluid_transport.h
+++ b/include/aspect/material_model/reactive_fluid_transport.h
@@ -60,6 +60,13 @@ namespace aspect
          * @}
          */
 
+        double compute_bulk_density (const double porosity,
+                                     const double solid_density,
+                                     const double fluid_density) const;
+
+        double compute_mass_fraction (const double porosity,
+                                      const double solid_density,
+                                      const double fluid_density) const;
         /**
          * Compute the free fluid fraction that can be present in the material based on the
          * fluid content of the material and the fluid solubility for the given input conditions.

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -53,6 +53,8 @@ namespace aspect
         }
     }
 
+
+
     template <int dim>
     double
     ReactiveFluidTransport<dim>::
@@ -63,6 +65,8 @@ namespace aspect
       return (1 - porosity) * solid_density + porosity * fluid_density;
     }
 
+
+
     template <int dim>
     double
     ReactiveFluidTransport<dim>::
@@ -72,6 +76,8 @@ namespace aspect
     {
       return volume_frac * material_density / bulk_density;
     }
+
+
 
     template <int dim>
     void


### PR DESCRIPTION
Computations of the bulk density, and also computations for converting the volume fraction to the mass fraction, are done several times in the Reactive fluid transport model. This PR adds 2 simple functions that do these computations. This improves readability, but it will also be very helpful for me reducing the number of lines of code that I will need to add in a follow up PR which tracks how water is partitioning from each lithology in the Tian approximation reaction model.

This should not break any tests.