### PR TITLE
Modify the depths in merged chunks to account for initial topo.

### DIFF
--- a/source/geometry_model/initial_topography_model/ascii_data.cc
+++ b/source/geometry_model/initial_topography_model/ascii_data.cc
@@ -26,6 +26,7 @@
 #include <aspect/geometry_model/sphere.h>
 #include <aspect/geometry_model/spherical_shell.h>
 #include <aspect/geometry_model/chunk.h>
+#include <aspect/geometry_model/two_merged_chunks.h>
 
 #include <deal.II/base/parameter_handler.h>
 #include <array>
@@ -78,7 +79,8 @@ namespace aspect
         }
       else if (Plugins::plugin_type_matches<const GeometryModel::Sphere<dim>> (this->get_geometry_model()) ||
                Plugins::plugin_type_matches<const GeometryModel::SphericalShell<dim>> (this->get_geometry_model()) ||
-               Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()))
+               Plugins::plugin_type_matches<const GeometryModel::Chunk<dim>> (this->get_geometry_model()) ||
+               Plugins::plugin_type_matches<const GeometryModel::TwoMergedChunks<dim>> (this->get_geometry_model()))
         {
           // AsciiDataBoundary always expects to get the input
           // parameters for its functions in Cartesian


### PR DESCRIPTION
Currently, the depths in the `merged_chunk` geometry model does not account for the initial_topography. This PR modifies the implementation similar to PR #6374. 
Here is a visualization from a test :
![image](https://github.com/user-attachments/assets/1a092637-77d3-4311-8bee-d942d623f341)

There are no tests using merged chunks with topography, I am not sure if we need one.