### PR TITLE
Add documentation on installing and linking fastscape-fortran to ASPECT

### DIFF
--- a/doc/sphinx/user/install/local-installation/fastscape.md
+++ b/doc/sphinx/user/install/local-installation/fastscape.md
@@ -1,0 +1,21 @@
+(sec:install:local-installation:fastscape)=
+# Installing FastScape-fortran
+
+To install FastScape-fortran, the first step is to add the following export to
+the `.bashrc` file on linux or `.zprofile` on mac:
+
+      export GFORTRAN_CONVERT_UNIT='big_endian'
+
+This command tells FastScape how to write the VTK files. Without it the models will
+run correctly, however FastScape visualizations will not show up in paraview. After this is
+exported, next is to clone the code using the following command:
+
+      git clone https://github.com/Djneu/fastscapelib-fortran
+
+This branch includes modifications to the VTK writing for FastScape that is necessary for outputting within the ASPECT folders. You can download from the original repository as well `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case. Next, create a fastscape build directory, and within the directory run cmake with the option to build a shared library:
+
+      cmake -DBUILD_FASTSCAPELIB_SHARED=ON /path/to/fastscape_source
+
+After, compile the code using:
+
+      make

--- a/doc/sphinx/user/install/local-installation/fastscape.md
+++ b/doc/sphinx/user/install/local-installation/fastscape.md
@@ -14,22 +14,23 @@ exported, next is to clone the code using the following command:
 
 This branch includes modifications to the VTK writing for FastScape that are necessary for outputting within the ASPECT folders. You can download from the original repository as well, `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case.
 
-Next, create a fastscape build directory, and within the directory run cmake with the option to build a shared library:
+Next, run cmake with the option to build a shared library and that path to install fastscape to:
 
-      cmake -DBUILD_FASTSCAPELIB_SHARED=ON /path/to/fastscape_source
+      cmake -DBUILD_FASTSCAPELIB_SHARED=ON \
+             /path/to/fastscape_source
 
 After this, compile the code using:
 
       make
 
-Alternatively, from within the FastScape source directory you can pass a prefix using the command:
+Alternatively, you can pass a prefix using the command:
 
-    cmake -DASPECT_WITH_FASTSCAPE=ON \
-                 -DCMAKE_INSTALL_PREFIX=/path/to/install/fastscape .
+    cmake -DBUILD_FASTSCAPELIB_SHARED=ON \
+                 -DCMAKE_INSTALL_PREFIX=/path/to/install/fastscape \
+                 /path/to/fastscape_source
 
 Then compile the code using:
 
       make install
 
-This will install the required FastScape libraries inside `/path/to/install/fastscape/lib`, and the
-FastScape source files are no longer needed.
+This will create the cmake files in the current directory and install the required FastScape libraries inside `/path/to/install/fastscape/lib`.

--- a/doc/sphinx/user/install/local-installation/fastscape.md
+++ b/doc/sphinx/user/install/local-installation/fastscape.md
@@ -12,10 +12,12 @@ exported, next is to clone the code using the following command:
 
       git clone https://github.com/Djneu/fastscapelib-fortran
 
-This branch includes modifications to the VTK writing for FastScape that is necessary for outputting within the ASPECT folders. You can download from the original repository as well `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case. Next, create a fastscape build directory, and within the directory run cmake with the option to build a shared library:
+This branch includes modifications to the VTK writing for FastScape that are necessary for outputting within the ASPECT folders. You can download from the original repository as well, `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case. 
+
+Next, create a fastscape build directory, and within the directory run cmake with the option to build a shared library:
 
       cmake -DBUILD_FASTSCAPELIB_SHARED=ON /path/to/fastscape_source
 
-After, compile the code using:
+After this, compile the code using:
 
       make

--- a/doc/sphinx/user/install/local-installation/fastscape.md
+++ b/doc/sphinx/user/install/local-installation/fastscape.md
@@ -12,7 +12,7 @@ exported, next is to clone the code using the following command:
 
       git clone https://github.com/Djneu/fastscapelib-fortran
 
-This branch includes modifications to the VTK writing for FastScape that are necessary for outputting within the ASPECT folders. You can download from the original repository as well, `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case. 
+This branch includes modifications to the VTK writing for FastScape that are necessary for outputting within the ASPECT folders. You can download from the original repository as well, `https://github.com/fastscape-lem/fastscapelib-fortran`, however FastScape visualizations will be disabled in this case.
 
 Next, create a fastscape build directory, and within the directory run cmake with the option to build a shared library:
 
@@ -21,3 +21,15 @@ Next, create a fastscape build directory, and within the directory run cmake wit
 After this, compile the code using:
 
       make
+
+Alternatively, from within the FastScape source directory you can pass a prefix using the command:
+
+    cmake -DASPECT_WITH_FASTSCAPE=ON \
+                 -DCMAKE_INSTALL_PREFIX=/path/to/install/fastscape .
+
+Then compile the code using:
+
+      make install
+
+This will install the required FastScape libraries inside `/path/to/install/fastscape/lib`, and the
+FastScape source files are no longer needed.

--- a/doc/sphinx/user/install/local-installation/index.md
+++ b/doc/sphinx/user/install/local-installation/index.md
@@ -25,6 +25,7 @@ questions on the forum (<https://community.geodynamics.org/c/aspect>).
 :::{toctree}
 system-prereqs.md
 using-candi.md
+fastscape.md
 obtaining.md
 compiling.md
 documentation.md

--- a/doc/sphinx/user/install/local-installation/obtaining.md
+++ b/doc/sphinx/user/install/local-installation/obtaining.md
@@ -30,8 +30,7 @@ you must link the ASPECT to the FastScape install. This is done by typing:
 
 
     cmake -DASPECT_WITH_FASTSCAPE=ON \
-
-    -DFASTSCAPE_DIR=/path/to/fastscape/build ..
+                 -DFASTSCAPE_DIR=/path/to/fastscape/build ..
 
 During cmake, a few outputs may be seen that notify if the link with FastScape is successful. First,
 if the library is found the following will be seen:

--- a/doc/sphinx/user/install/local-installation/obtaining.md
+++ b/doc/sphinx/user/install/local-installation/obtaining.md
@@ -22,3 +22,22 @@ This will create an "out-of-source" build, where the build
 directory is different from the source directory, which is the
 only supported option. (We do not support in-source builds where the source
 and build directory are identical).
+
+# Initial configuration with FastScape-fortran
+
+If you have downloaded and installed FastScape-fortran, to use the coupling
+you must link the ASPECT to the FastScape install. This is done by typing:
+
+
+    cmake -DASPECT_WITH_FASTSCAPE=ON \
+
+    -DFASTSCAPE_DIR=/path/to/fastscape/build ..
+
+During cmake, a few outputs may be seen that notify if the link with FastScape is successful. First,
+if the library is found the following will be seen:
+
+     FastScape library found at /path/to/fastscape/build
+
+If the FastScape version that allows visualizations with ASPECT is used, the following will be output:
+
+     Found fastscape_named_vtk -- enabling its use


### PR DESCRIPTION
Here is the documentation for installing fastscape-fortran and linking it to ASPECT. I wasn't sure how to check how this would look in the manual so hopefully the formatting is okay! @gassmoeller 
