### PR TITLE
Avoid unnecessary long variable names

### DIFF
--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -173,27 +173,27 @@ namespace aspect
           /**
            * List of diffusion creep prefactors A.
            */
-          std::vector<double> prefactors_diffusion;
+          std::vector<double> prefactors;
 
           /**
            * List of diffusion creep stress exponents n (usually = 1).
            */
-          std::vector<double> stress_exponents_diffusion;
+          std::vector<double> stress_exponents;
 
           /**
            * List of diffusion creep grain size exponents m.
            */
-          std::vector<double> grain_size_exponents_diffusion;
+          std::vector<double> grain_size_exponents;
 
           /**
            * List of diffusion creep activation energies E.
            */
-          std::vector<double> activation_energies_diffusion;
+          std::vector<double> activation_energies;
 
           /**
            * List of diffusion creep activation volumes V.
            */
-          std::vector<double> activation_volumes_diffusion;
+          std::vector<double> activation_volumes;
 
           /**
            * Diffusion creep grain size d.  This is read from the

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -129,22 +129,22 @@ namespace aspect
           /**
            * List of dislocation creep prefactors A.
            */
-          std::vector<double> prefactors_dislocation;
+          std::vector<double> prefactors;
 
           /**
            * List of dislocation creep stress exponents n.
            */
-          std::vector<double> stress_exponents_dislocation;
+          std::vector<double> stress_exponents;
 
           /**
            * List of dislocation creep activation energies E.
            */
-          std::vector<double> activation_energies_dislocation;
+          std::vector<double> activation_energies;
 
           /**
            * List of dislocation creep activation volumes V.
            */
-          std::vector<double> activation_volumes_dislocation;
+          std::vector<double> activation_volumes;
 
       };
     }


### PR DESCRIPTION
I saw this while reviewing #6509. There is no need to add the qualifiers to these variable names, since they are member variables of the DiffusionCreep and DislocationCreep classes.