### PR TITLE
Introduce a SimulatorAccess function that returns the start time.

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -396,6 +396,14 @@ namespace aspect
       n_compositional_fields () const;
 
       /**
+       * Return the simulation start time in seconds. For most simulations,
+       * this will be zero -- but it may be set to something different in
+       * input files.
+       */
+      double
+      get_start_time () const;
+
+      /**
        * Return the simulation end time in seconds.
        */
       double

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -212,6 +212,14 @@ namespace aspect
 
   template <int dim>
   double
+  SimulatorAccess<dim>::get_start_time () const
+  {
+    return simulator->parameters.start_time;
+  }
+
+
+  template <int dim>
+  double
   SimulatorAccess<dim>::get_end_time () const
   {
     return simulator->parameters.end_time;


### PR DESCRIPTION
Necessary to ultimately address #6531.