### PR TITLE
Simplify some macros

### DIFF
--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -650,14 +650,13 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace ReactionModel
+    {
 #define INSTANTIATE(dim) \
-  namespace ReactionModel \
-  { \
-    template class GrainSizeEvolution<dim>; \
-  }
+  template class GrainSizeEvolution<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
-
+      ASPECT_INSTANTIATE(INSTANTIATE)
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -626,14 +626,13 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace ReactionModel
+    {
 #define INSTANTIATE(dim) \
-  namespace ReactionModel \
-  { \
-    template class Katz2003MantleMelting<dim>; \
-  }
+  template class Katz2003MantleMelting<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
-
+      ASPECT_INSTANTIATE(INSTANTIATE)
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/reaction_model/tian2019_solubility.cc
+++ b/source/material_model/reaction_model/tian2019_solubility.cc
@@ -194,14 +194,13 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace ReactionModel
+    {
 #define INSTANTIATE(dim) \
-  namespace ReactionModel \
-  { \
-    template class Tian2019Solubility<dim>; \
-  }
+  template class Tian2019Solubility<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
-
+      ASPECT_INSTANTIATE(INSTANTIATE)
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/ascii_depth_profile.cc
+++ b/source/material_model/rheology/ascii_depth_profile.cc
@@ -86,14 +86,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class AsciiDepthProfile<dim>; \
-  }
+  template class AsciiDepthProfile<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -844,14 +844,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class CompositeViscoPlastic<dim>; \
-  }
+  template class CompositeViscoPlastic<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/compositional_viscosity_prefactors.cc
+++ b/source/material_model/rheology/compositional_viscosity_prefactors.cc
@@ -182,14 +182,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class CompositionalViscosityPrefactors<dim>; \
-  }
+  template class CompositionalViscosityPrefactors<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/constant_viscosity_prefactors.cc
+++ b/source/material_model/rheology/constant_viscosity_prefactors.cc
@@ -92,14 +92,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class ConstantViscosityPrefactors<dim>; \
-  }
+  template class ConstantViscosityPrefactors<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -336,14 +336,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class DiffusionCreep<dim>; \
-  }
+  template class DiffusionCreep<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/diffusion_dislocation.cc
+++ b/source/material_model/rheology/diffusion_dislocation.cc
@@ -373,14 +373,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class DiffusionDislocation<dim>; \
-  }
+  template class DiffusionDislocation<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -272,14 +272,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class DislocationCreep<dim>; \
-  }
+  template class DislocationCreep<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -400,14 +400,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class DruckerPrager<dim>; \
-  }
+  template class DruckerPrager<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/drucker_prager_power.cc
+++ b/source/material_model/rheology/drucker_prager_power.cc
@@ -240,14 +240,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class DruckerPragerPower<dim>; \
-  }
+  template class DruckerPragerPower<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/frank_kamenetskii.cc
+++ b/source/material_model/rheology/frank_kamenetskii.cc
@@ -176,14 +176,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class FrankKamenetskii<dim>; \
-  }
+  template class FrankKamenetskii<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/friction_models.cc
+++ b/source/material_model/rheology/friction_models.cc
@@ -299,14 +299,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class FrictionModels<dim>; \
-  }
+  template class FrictionModels<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -699,14 +699,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class PeierlsCreep<dim>; \
-  }
+  template class PeierlsCreep<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }

--- a/source/material_model/rheology/strain_dependent.cc
+++ b/source/material_model/rheology/strain_dependent.cc
@@ -905,14 +905,14 @@ namespace aspect
 {
   namespace MaterialModel
   {
+    namespace Rheology
+    {
 #define INSTANTIATE(dim) \
-  namespace Rheology \
-  { \
-    template class StrainDependent<dim>; \
-  }
+  template class StrainDependent<dim>;
 
-    ASPECT_INSTANTIATE(INSTANTIATE)
+      ASPECT_INSTANTIATE(INSTANTIATE)
 
 #undef INSTANTIATE
+    }
   }
 }


### PR DESCRIPTION
These macros really just instantiate one class, but currently include opening and closing the namespace too. I think we should keep the macros as short as possible, this makes them easier to read and reduces the number of awkward line continuations `\`