### PR TITLE
Derive VectorFunctionFromVelocityFunctionObject from VectorFunctionFromTensorFunctionObject.

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -1103,9 +1103,12 @@ namespace aspect
      * that matches the dealii::Function interface with a number of output
      * components equal to the number of components of the finite element
      * in use.
+     *
+     * This function is a special case of the VectorFunctionFromTensorFunctionObject
+     * class.
      */
     template <int dim>
-    class VectorFunctionFromVelocityFunctionObject : public Function<dim>
+    class VectorFunctionFromVelocityFunctionObject : public VectorFunctionFromTensorFunctionObject<dim>
     {
       public:
         /**
@@ -1114,40 +1117,11 @@ namespace aspect
          * interface.
          *
          * @param n_components total number of components of the finite element system.
-         * @param function_object The function that will form one component
+         * @param function_object The function that will form the first `dim` components
          *     of the resulting Function object.
          */
         VectorFunctionFromVelocityFunctionObject (const unsigned int n_components,
                                                   const std::function<Tensor<1,dim> (const Point<dim> &)> &function_object);
-
-        /**
-         * Return the value of the
-         * function at the given
-         * point. Returns the value the
-         * function given to the constructor
-         * produces for this point.
-         */
-        double value (const Point<dim>   &p,
-                      const unsigned int  component = 0) const override;
-
-        /**
-         * Return all components of a
-         * vector-valued function at a
-         * given point.
-         *
-         * <tt>values</tt> shall have the right
-         * size beforehand,
-         * i.e. #n_components.
-         */
-        void vector_value (const Point<dim>   &p,
-                           Vector<double>     &values) const override;
-
-      private:
-        /**
-         * The function object which we call when this class's value() or
-         * value_list() functions are called.
-         */
-        const std::function<Tensor<1,dim> (const Point<dim> &)> function_object;
     };
 
     /**

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2777,46 +2777,8 @@ namespace aspect
     (const unsigned int n_components,
      const std::function<Tensor<1,dim> (const Point<dim> &)> &function_object)
       :
-      Function<dim>(n_components),
-      function_object (function_object)
+      VectorFunctionFromTensorFunctionObject<dim>(function_object, 0, n_components)
     {
-    }
-
-
-
-    template <int dim>
-    double
-    VectorFunctionFromVelocityFunctionObject<dim>::value (const Point<dim> &p,
-                                                          const unsigned int component) const
-    {
-      Assert (component < this->n_components,
-              ExcIndexRange (component, 0, this->n_components));
-
-      if (component < dim)
-        {
-          const Tensor<1,dim> v = function_object(p);
-          return v[component];
-        }
-      else
-        return 0;
-    }
-
-
-
-    template <int dim>
-    void
-    VectorFunctionFromVelocityFunctionObject<dim>::
-    vector_value (const Point<dim>   &p,
-                  Vector<double>     &values) const
-    {
-      AssertDimension(values.size(), this->n_components);
-
-      // set everything to zero, and then the right components to their correct values
-      values = 0;
-
-      const Tensor<1,dim> v = function_object(p);
-      for (unsigned int d=0; d<dim; ++d)
-        values(d) = v[d];
     }
 
 


### PR DESCRIPTION
Fixes #6535.