### PR TITLE
Do not store duplicate information. Also, don't mis-use it.

### DIFF
--- a/include/aspect/postprocess/crystal_preferred_orientation.h
+++ b/include/aspect/postprocess/crystal_preferred_orientation.h
@@ -108,13 +108,6 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
-
-        /**
-         * Stores the simulation end time, so that it always produces output
-         * at the last timestep.
-         */
-        double end_time;
-
         /**
          * Enums specifying what information to write:
          *

--- a/source/postprocess/crystal_preferred_orientation.cc
+++ b/source/postprocess/crystal_preferred_orientation.cc
@@ -206,7 +206,7 @@ namespace aspect
 
       // If it's not time to generate an output file or we do not write output
       // return early.
-      if (this->get_time() < last_output_time + output_interval && this->get_time() != end_time)
+      if (this->get_time() < last_output_time + output_interval && this->get_time() != this->get_end_time())
         return std::make_pair("","");
 
       if (output_file_number == numbers::invalid_unsigned_int)
@@ -742,10 +742,6 @@ namespace aspect
     void
     CrystalPreferredOrientation<dim>::parse_parameters (ParameterHandler &prm)
     {
-      end_time = prm.get_double ("End time");
-      if (this->convert_output_to_years())
-        end_time *= year_in_seconds;
-
       unsigned int n_minerals;
 
       prm.enter_subsection("Particles");


### PR DESCRIPTION
The CPO postprocessor plugin stores a copy of the end time. That's bad in itself, since it duplicates information stored elsewhere. But then it also gets it wrong: It compares the duplicated end time against `this->get_time()`, but `this->get_time()` always returns the time in seconds, whereas the plugin converted it into years when years were selected. That can't work.

This patch fixes this by simply not storing the duplicated information.

@MFraters FYI.