### PR TITLE
Add Links to Markdown Files

### DIFF
--- a/cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.md
+++ b/cookbooks/bunge_et_al_mantle_convection/doc/bunge_et_al_mantle_convection.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:bunke-mantle-convection)=
 # The Bunge et al. mantle convection experiments
 
 *This section was contributed by Cedric Thieulot and Bob Myhill.*

--- a/cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.md
+++ b/cookbooks/christensen_yuen_phase_function/doc/christensen_yuen_phase_function.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:christensen-yuen-phase-function)=
 # Convection in a 2d box with a phase transition
 
 *This section was contributed by Juliane Dannberg.*

--- a/cookbooks/composition-reaction/doc/composition-reaction.md
+++ b/cookbooks/composition-reaction/doc/composition-reaction.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:composition-reaction)=
 # The active case with reactions.
 
 *This section was contributed by Juliane Dannberg and Ren&eacute;

--- a/cookbooks/composition_active/doc/composition_active.md
+++ b/cookbooks/composition_active/doc/composition_active.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:composition-active)=
 # The active case.
 
 The next step, of course, is to make the flow actually depend on the

--- a/cookbooks/composition_active_particles/doc/composition_active_particles.md
+++ b/cookbooks/composition_active_particles/doc/composition_active_particles.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:composition-active-particles)=
 # Using active particles.
 
 In the examples above, particle properties passively track distinct model

--- a/cookbooks/composition_passive/doc/composition_passive.md
+++ b/cookbooks/composition_passive/doc/composition_passive.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:composition-passive)=
 # The passive case.
 
 We will consider the exact same situation as in the previous section but we

--- a/cookbooks/composition_passive_particles/doc/composition_passive_particles.md
+++ b/cookbooks/composition_passive_particles/doc/composition_passive_particles.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:composition-passive-particles)=
 # The passive case with particles
 
 In order to advect particles along with the flow field, one just needs to add

--- a/cookbooks/continental_extension/doc/continental_extension.md
+++ b/cookbooks/continental_extension/doc/continental_extension.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:continental-extension)=
 # Continental extension
 
 *This section was contributed by John Naliboff, Anne Glerum, and Valentina

--- a/cookbooks/crystal_preferred_orientation_olivine_fraters_billen_2021/doc/crystal_preferred_orientation_olivine_fraters_billen_2021.md
+++ b/cookbooks/crystal_preferred_orientation_olivine_fraters_billen_2021/doc/crystal_preferred_orientation_olivine_fraters_billen_2021.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:crystal-preferred-orientation-olivine)=
 # Olivine Fabric Developments Under Simple Shear
 
 *This section was contributed by Xiaochuan Tian, with help from Yijun Wang and Menno Fraters. It is

--- a/cookbooks/free_surface_with_crust/doc/free_surface_with_crust.md
+++ b/cookbooks/free_surface_with_crust/doc/free_surface_with_crust.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:free-surface-with-crust)=
 # Using a free surface in a model with a crust
 
 *This section was contributed by William Durkin.*

--- a/cookbooks/inclusions/doc/inclusions.md
+++ b/cookbooks/inclusions/doc/inclusions.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:inclusions)=
 # Viscous inclusions under simple and pure shear
 
 *This section was contributed by Cedric Thieulot.*

--- a/cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.md
+++ b/cookbooks/kinematically_driven_subduction_2d/doc/kinematically_driven_subduction_2d.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:kinematic-2d-oceanic-subduction)=
 # Kinematically-driven 2d oceanic subduction
 
 *This section was contributed by Anne Glerum and Yingying Li.*

--- a/cookbooks/latent-heat/doc/latent-heat.md
+++ b/cookbooks/latent-heat/doc/latent-heat.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:latent-heat)=
 # Latent heat benchmark
 
 *This section was contributed by Juliane Dannberg.*

--- a/cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.md
+++ b/cookbooks/mid_ocean_ridge/doc/mid_ocean_ridge.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:mid-ocean-ridge)=
 # Melt migration in a 2D mid-ocean ridge model
 
 *This section was contributed by Juliane Dannberg.*

--- a/cookbooks/plume_2D_chunk/doc/plume.md
+++ b/cookbooks/plume_2D_chunk/doc/plume.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:plume-2d-chunk)=
 # Plume in a 2D chunk
 
 *This section was contributed by Cedric Thieulot and Paul Bremner.*

--- a/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.md
+++ b/cookbooks/shell_3d_postprocess/doc/shell_3d_postprocess.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:shell-3d-postprocess)=
 # Postprocessing spherical 3D convection
 
 *This section was contributed by Jacqueline Austermann, Ian Rose, and Shangxin

--- a/cookbooks/stokes/doc/stokes.md
+++ b/cookbooks/stokes/doc/stokes.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:stokes-benchmark)=
 # The "Stokes' law" benchmark
 
 *This section was contributed by Juliane Dannberg.*

--- a/cookbooks/tomography_based_plate_motions/doc/tomography_based_plate_motions.md
+++ b/cookbooks/tomography_based_plate_motions/doc/tomography_based_plate_motions.md
@@ -1,4 +1,5 @@
-﻿# Mantle convection using tomography data
+﻿(sec:cookbooks:tomography-plate-motions)=
+# Mantle convection using tomography data
 
 *This section was contributed by Arushi Saxena, Juliane Dannberg and Ren&eacute; Gassm&ouml;ller.*
 

--- a/cookbooks/van-keken-vof/doc/van-keken-vof.md
+++ b/cookbooks/van-keken-vof/doc/van-keken-vof.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:vankeken-vof)=
 # Computation of the van Keken Problem with the Volume-of-Fluid Interface Tracking Method
 
 *This section is a co-production of Jonathan Robey and E. G. Puckett.*

--- a/cookbooks/vankeken_subduction/doc/vankeken_subduction.md
+++ b/cookbooks/vankeken_subduction/doc/vankeken_subduction.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:vankeken-2008-benchmark)=
 # Van Keken 2008 corner flow recreation
 
 *This section was contributed by Daniel Douglas, Cedric Thieulot, Wolfgang Bangerth, and Max Rudolph.*

--- a/cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.md
+++ b/cookbooks/visualizing_phase_diagram/doc/visualizing_phase_diagram.md
@@ -1,3 +1,4 @@
+(sec:cookbooks:visualizing-phase-diagrams)=
 # Visualizing phase diagrams
 
 *This section was contributed by Haoyuan Li and Magali Billen.*

--- a/doc/sphinx/user/cookbooks/teaching-setups.md
+++ b/doc/sphinx/user/cookbooks/teaching-setups.md
@@ -1,4 +1,4 @@
-
+(sec:cookbooks:teaching-setups)=
 # Setups for teaching
 
 Because <span class="smallcaps">ASPECT</span> is freely available, has an


### PR DESCRIPTION
Working with @PrajaktaPMohite we realized that continental_extension cookbook didn't have a link to the markdown file. I added the links to all markdown files in the cookbooks section.
