### PR TITLE
Modify the plastic dilation terms to reduce noises in effective viscosity

### DIFF
--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -429,20 +429,12 @@ namespace aspect
             // Compute the dilation terms if necessary.
             if (this->get_parameters().enable_prescribed_dilation == true)
               {
-                if (output_parameters.composition_yielding[j] == true)
-                  {
-                    output_parameters.drucker_prager_parameters[j].angle_dilation *= weakening_factors[1];
-                    const std::pair<double,double> dilation_terms = drucker_prager_plasticity.compute_dilation_terms_for_stokes_system (output_parameters.drucker_prager_parameters[j],
-                                                                    non_yielding_viscosity,
-                                                                    effective_edot_ii);
-                    output_parameters.dilation_lhs_terms[j] = dilation_terms.first;
-                    output_parameters.dilation_rhs_terms[j] = dilation_terms.second;
-                  }
-                else
-                  {
-                    output_parameters.dilation_lhs_terms[j] = 0;
-                    output_parameters.dilation_rhs_terms[j] = 0;
-                  }
+                output_parameters.drucker_prager_parameters[j].angle_dilation *= weakening_factors[1];
+                const std::pair<double,double> dilation_terms = drucker_prager_plasticity.compute_dilation_terms_for_stokes_system (output_parameters.drucker_prager_parameters[j],
+                                                                non_yielding_viscosity,
+                                                                effective_edot_ii);
+                output_parameters.dilation_lhs_terms[j] = dilation_terms.first;
+                output_parameters.dilation_rhs_terms[j] = dilation_terms.second;
               }
           }
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -287,14 +287,18 @@ namespace aspect
           if (const std::shared_ptr<PrescribedPlasticDilation<dim>> plastic_dilation =
                 out.template get_additional_output_object<PrescribedPlasticDilation<dim>>())
             {
-              plastic_dilation->dilation_lhs_term[i]
-                = MaterialUtilities::average_value(volume_fractions,
-                                                   isostrain_viscosities.dilation_lhs_terms,
-                                                   MaterialUtilities::arithmetic);
-              plastic_dilation->dilation_rhs_term[i]
-                = MaterialUtilities::average_value(volume_fractions,
-                                                   isostrain_viscosities.dilation_rhs_terms,
-                                                   MaterialUtilities::arithmetic);
+              const double dilation_lhs_term = MaterialUtilities::average_value(volume_fractions,
+                                                                                isostrain_viscosities.dilation_lhs_terms,
+                                                                                MaterialUtilities::arithmetic);
+              const double dilation_rhs_term = MaterialUtilities::average_value(volume_fractions,
+                                                                                isostrain_viscosities.dilation_rhs_terms,
+                                                                                MaterialUtilities::arithmetic);
+
+              plastic_dilation->dilation_lhs_term[i] = dilation_lhs_term;
+              if (dilation_rhs_term - dilation_lhs_term * in.pressure[i] > 0)
+                plastic_dilation->dilation_rhs_term[i] = dilation_rhs_term;
+              else
+                plastic_dilation->dilation_rhs_term[i] = dilation_lhs_term * in.pressure[i];
             }
         }
 


### PR DESCRIPTION
This PR reduces noises in the effective viscosity by modifying the plastic dilation terms. It greatly improves the results of Duretz's (2018) test:

![duretz_log_eps_new](https://github.com/user-attachments/assets/65ae9c48-8404-418c-b0e3-f12aed443ebc)

I am preparing to board the plane. I will provide a detailed explaination when I arrive at Davis.