### PR TITLE
Fix thin 3d quarter shell boundary indicators

### DIFF
--- a/doc/modules/changes/20250620_gassmoeller
+++ b/doc/modules/changes/20250620_gassmoeller
@@ -1,0 +1,6 @@
+Fixed: A thin 3D spherical shell with an opening angle of 90 degrees
+(octant of a sphere) would crash, because of a bug of how boundary
+indicators were assigned. This bug is fixed in deal.II 9.7 and the
+fix was backported into ASPECT.
+<br>
+(Rene Gassmoeller, 2025/06/20)

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -429,4 +429,21 @@ namespace aspect
 
 #endif
 
+// deal.II versions up to 9.6 had a bug for very thin shell geometries.
+// This function contains a fixed version.
+#if !DEAL_II_VERSION_GTE(9,7,0)
+
+#include <deal.II/grid/grid_generator.h>
+
+namespace aspect
+{
+  template <int dim>
+  void
+  colorize_quarter_hyper_shell(Triangulation<dim>  &tria,
+                               const Point<dim>   &center,
+                               const double      inner_radius,
+                               const double      outer_radius);
+}
+#endif
+
 #endif

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -447,6 +447,17 @@ namespace aspect
                                               0,
                                               true);
 
+          // there was a bug with boundary colorization of thin shells
+          // before deal.II 9.7. Use a fixed version of that function,
+          // for deal.II versions that need it.
+#if !DEAL_II_VERSION_GTE(9,7,0)
+          if (dim == 3)
+            colorize_quarter_hyper_shell(coarse_grid,
+                                         Point<dim>(),
+                                         R0,
+                                         R1);
+#endif
+
           if (periodic)
             {
               // Tell p4est about the periodicity of the mesh.

--- a/tests/thin_quarter_shell.prm
+++ b/tests/thin_quarter_shell.prm
@@ -1,0 +1,85 @@
+# This parameter file tests that we can create a very thin spherical shell
+# with correctly assigned boundary conditions.
+
+set Dimension                              = 3
+set Use years in output instead of seconds = true
+set End time                               = 0
+set Maximum first time step                    = 1e5
+set CFL number                                 = 0.8
+set Maximum time step                          = 1e5
+
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+
+
+subsection Geometry model
+  set Model name = spherical shell
+  subsection Spherical shell
+    set Outer radius = 1560800
+    # without the fix even 1460800 as inner radius fails
+    set Inner radius = 1555800
+    set Opening angle = 90
+  end
+end
+
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Coordinate system = spherical
+    set Variable names = r, phi,theta
+    set Function expression = 0
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = top, bottom
+  set List of model names =  function
+
+  subsection Function
+    set Coordinate system = spherical
+    set Function expression = x > 1557800 ? 1 : 0
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators = top, bottom
+end
+
+
+subsection Gravity model
+  set Model name = radial constant
+
+  subsection Radial constant
+    set Magnitude = 0 #1.3
+  end
+end
+
+
+subsection Material model
+  set Model name = simpler
+  subsection Simpler model
+    set Reference density = 917
+    set Reference specific heat = 2110
+    set Reference temperature = 100
+    set Thermal conductivity = 0 #1.93
+    set Thermal expansion coefficient = 0 #1.6e-4
+    set Viscosity = 1e14
+  end
+end
+
+
+subsection Formulation
+  set Formulation = Boussinesq approximation
+end
+
+subsection Mesh refinement
+  set Initial global refinement                = 0
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+
+subsection Postprocess
+  set List of postprocessors = velocity statistics, temperature statistics
+end

--- a/tests/thin_quarter_shell/screen-output
+++ b/tests/thin_quarter_shell/screen-output
@@ -1,0 +1,16 @@
+
+Number of active cells: 3 (on 1 levels)
+Number of degrees of freedom: 242 (171+14+57)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 9 iterations.
+   Solving Stokes system (GMG)... 0+0 iterations.
+
+   Postprocessing:
+     RMS, max velocity:       0 m/year, 0 m/year
+     Temperature min/avg/max: -9.895e-17 K, 0.1672 K, 1 K
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/thin_quarter_shell/statistics
+++ b/tests/thin_quarter_shell/statistics
@@ -1,0 +1,17 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: RMS velocity (m/year)
+# 12: Max. velocity (m/year)
+# 13: Minimal temperature (K)
+# 14: Average temperature (K)
+# 15: Maximal temperature (K)
+# 16: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 3 185 57 9 0 0 0 0.00000000e+00 0.00000000e+00 -9.89525336e-17 1.67200809e-01 1.00000000e+00 4.77716598e-05 


### PR DESCRIPTION
This fixes a bug @hyunseong96 reported and that was fixed in deal.II in dealii/dealii#18568.

This is not quite ready to merge, I need to find a way to make this work without `if constexpr`, but dont have the time right now. I just wanted to open this to let @hyunseong96  and @Geoniette know about it. The test case tests a spherical shell with a radius of 1561 km and a thickness of 5 km, which now works as expected.