### PR TITLE
Avoid bare pointers for initial topography model

### DIFF
--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -222,11 +222,6 @@ namespace aspect
 
       private:
         /**
-         * A pointer to the initial topography model.
-         */
-        InitialTopographyModel::Interface<dim> *topo_model;
-
-        /**
          * Extent of the box in x-, y-, and z-direction (in 3d).
          */
         Point<dim> extents;

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -55,7 +55,7 @@ namespace aspect
           /**
            * Constructor
            */
-          ChunkGeometry(const InitialTopographyModel::Interface<dim> &topography,
+          ChunkGeometry(const std::shared_ptr<const InitialTopographyModel::Interface<dim>> &topography,
                         const double min_longitude,
                         const double min_radius,
                         const double max_depth);
@@ -128,7 +128,7 @@ namespace aspect
           /**
            * A pointer to the topography model.
            */
-          const InitialTopographyModel::Interface<dim> *topo;
+          const std::shared_ptr<const InitialTopographyModel::Interface<dim>> topo;
 
           /**
            * The minimum longitude of the domain.

--- a/include/aspect/geometry_model/ellipsoidal_chunk.h
+++ b/include/aspect/geometry_model/ellipsoidal_chunk.h
@@ -44,7 +44,7 @@ namespace aspect
           /**
            * Constructor
            */
-          EllipsoidalChunkGeometry(const InitialTopographyModel::Interface<dim> &topography,
+          EllipsoidalChunkGeometry(const std::shared_ptr<const InitialTopographyModel::Interface<dim>> &topography,
                                    const double para_semi_major_axis_a,
                                    const double para_eccentricity,
                                    const double para_semi_minor_axis_b,
@@ -103,7 +103,7 @@ namespace aspect
           /**
            * A pointer to the topography model.
            */
-          const InitialTopographyModel::Interface<dim> *topography;
+          const std::shared_ptr<const InitialTopographyModel::Interface<dim>> topography;
 
         private:
           /**

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -42,7 +42,7 @@ namespace aspect
           /**
            * Constructor.
            */
-          SphericalManifoldWithTopography(const InitialTopographyModel::Interface<dim> &topography,
+          SphericalManifoldWithTopography(const std::shared_ptr<const InitialTopographyModel::Interface<dim>> topography,
                                           const double inner_radius,
                                           const double outer_radius);
 
@@ -157,7 +157,7 @@ namespace aspect
           /**
            * A pointer to the topography model.
            */
-          const InitialTopographyModel::Interface<dim> *topo;
+          const std::shared_ptr<const InitialTopographyModel::Interface<dim>> topo;
 
           /**
            * Inner and outer radii of the spherical shell.

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1805,7 +1805,7 @@ namespace aspect
        * @name Variables that describe the physical setup of the problem
        * @{
        */
-      const std::unique_ptr<InitialTopographyModel::Interface<dim>>          initial_topography_model;
+      const std::shared_ptr<InitialTopographyModel::Interface<dim>>          initial_topography_model;
       const std::unique_ptr<GeometryModel::Interface<dim>>                   geometry_model;
       const IntermediaryConstructorAction                                    post_geometry_model_creation_action;
       const std::unique_ptr<MaterialModel::Interface<dim>>                   material_model;

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -543,33 +543,41 @@ namespace aspect
       /** @{ */
 
       /**
-       * Return a pointer to the material model to access functions like
+       * Return a reference to the material model to access functions like
        * density().
        */
       const MaterialModel::Interface<dim> &
       get_material_model () const;
 
       /**
-       * Return a pointer to the gravity model description.
+       * Return a reference to the gravity model description.
        */
       const GravityModel::Interface<dim> &
       get_gravity_model () const;
 
       /**
-       * Return a pointer to the initial topography model.
+       * Return a reference to the initial topography model.
        */
       const InitialTopographyModel::Interface<dim> &
       get_initial_topography_model () const;
 
       /**
-       * Return a pointer to the geometry model.
+       * Return a shared pointer to the initial topography model.
+       * This function is useful if the calling function needs to
+       * store a pointer to the initial topography model.
+       */
+      const std::shared_ptr<const InitialTopographyModel::Interface<dim>>
+      get_initial_topography_model_pointer () const;
+
+      /**
+       * Return a reference to the geometry model.
        */
       const GeometryModel::Interface<dim> &
       get_geometry_model () const;
 
 
       /**
-       * Return a pointer to the object that describes the adiabatic
+       * Return a reference to the object that describes the adiabatic
        * conditions.
        */
       const AdiabaticConditions::Interface<dim> &

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -176,8 +176,7 @@ namespace aspect
                 surface_point[d] = spherical_representative_point[d];
 
             }
-          const InitialTopographyModel::Interface<dim> *topo_model = const_cast<InitialTopographyModel::Interface<dim>*>(&this->get_initial_topography_model());
-          topo = topo_model->value(surface_point);
+          topo = this->get_initial_topography_model().value(surface_point);
         }
 
       // The spacing of the depth profile at the location of the representative point.

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -39,14 +39,11 @@ namespace aspect
     void
     Box<dim>::initialize ()
     {
-      // Get pointer to initial topography model
-      topo_model = const_cast<InitialTopographyModel::Interface<dim>*>(&this->get_initial_topography_model());
-
       // Check that initial topography is required.
       // If so, connect the initial topography function
       // to the right signals: It should be applied after
       // the final initial adaptive refinement and after a restart.
-      if (Plugins::plugin_type_matches<InitialTopographyModel::ZeroTopography<dim>>(*topo_model) == false)
+      if (Plugins::plugin_type_matches<InitialTopographyModel::ZeroTopography<dim>>(this->get_initial_topography_model()) == false)
         {
           this->get_signals().pre_set_initial_state.connect(
             [&](typename parallel::distributed::Triangulation<dim> &tria)
@@ -118,7 +115,7 @@ namespace aspect
         surface_point[d] = x_y_z[d];
 
       // Get the surface topography at this point
-      const double topo = topo_model->value(surface_point);
+      const double topo = this->get_initial_topography_model().value(surface_point);
 
       // Compute the displacement of the z coordinate
       const double ztopo = (x_y_z[dim-1] - box_origin[dim-1]) / extents[dim-1] * topo;
@@ -262,7 +259,7 @@ namespace aspect
         surface_point[d] = position[d];
 
       // Get the surface topography at this point
-      const double topo = topo_model->value(surface_point);
+      const double topo = this->get_initial_topography_model().value(surface_point);
 
       const double d = extents[dim-1] + topo - (position(dim-1)-box_origin[dim-1]);
       return std::min (std::max (d, 0.), maximal_depth());
@@ -294,7 +291,7 @@ namespace aspect
       for (unsigned int d=0; d<dim-1; ++d)
         surface_point[d] = p[d];
 
-      const double topo = topo_model->value(surface_point);
+      const double topo = this->get_initial_topography_model().value(surface_point);
       p[dim-1] = extents[dim-1]+box_origin[dim-1]-depth+topo;
 
       return p;
@@ -305,7 +302,7 @@ namespace aspect
     double
     Box<dim>::maximal_depth() const
     {
-      return extents[dim-1] + topo_model->max_topography();
+      return extents[dim-1] + this->get_initial_topography_model().max_topography();
     }
 
     template <int dim>
@@ -354,7 +351,7 @@ namespace aspect
                 surface_point[d] = point[d];
 
               // Get the surface topography at this point
-              const double topo = topo_model->value(surface_point);
+              const double topo = this->get_initial_topography_model().value(surface_point);
               max_point[dim-1] += topo;
             }
 

--- a/source/geometry_model/ellipsoidal_chunk.cc
+++ b/source/geometry_model/ellipsoidal_chunk.cc
@@ -69,14 +69,14 @@ namespace aspect
 
       // Constructor
       template <int dim>
-      EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry(const InitialTopographyModel::Interface<dim> &topo,
+      EllipsoidalChunkGeometry<dim>::EllipsoidalChunkGeometry(const std::shared_ptr<const InitialTopographyModel::Interface<dim>> &topo,
                                                               const double para_semi_major_axis_a,
                                                               const double para_eccentricity,
                                                               const double para_semi_minor_axis_b,
                                                               const double para_bottom_depth,
                                                               const std::vector<Point<2>> &para_corners)
         :
-        topography (&topo),
+        topography (topo),
         semi_major_axis_a (para_semi_major_axis_a),
         eccentricity (para_eccentricity),
         semi_minor_axis_b (para_semi_minor_axis_b),
@@ -219,7 +219,7 @@ namespace aspect
                   Plugins::plugin_type_matches<const InitialTopographyModel::PrmPolygon<dim>>(this->get_initial_topography_model()),
                   ExcMessage("At the moment, only the Zero or Prm polygon initial topography model can be used with the Ellipsoidal Chunk geometry model."));
 
-      manifold = std::make_unique<internal::EllipsoidalChunkGeometry<dim>>(this->get_initial_topography_model(),
+      manifold = std::make_unique<internal::EllipsoidalChunkGeometry<dim>>(this->get_initial_topography_model_pointer(),
                                                                             semi_major_axis_a,
                                                                             eccentricity,
                                                                             semi_minor_axis_b,

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -54,12 +54,12 @@ namespace aspect
     {
       template <int dim>
       SphericalManifoldWithTopography<dim>::
-      SphericalManifoldWithTopography(const InitialTopographyModel::Interface<dim> &topography,
+      SphericalManifoldWithTopography(const std::shared_ptr<const InitialTopographyModel::Interface<dim>> topography,
                                       const double inner_radius,
                                       const double outer_radius)
         :
         SphericalManifold<dim>(Point<dim>()),
-        topo (&topography),
+        topo (topography),
         R0 (inner_radius),
         R1 (outer_radius)
       {}
@@ -79,7 +79,7 @@ namespace aspect
       SphericalManifoldWithTopography<dim>::
       topography_for_point(const Point<dim> &x_y_z) const
       {
-        if (dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(topo) != nullptr)
+        if (dynamic_cast<const InitialTopographyModel::ZeroTopography<dim>*>(topo.get()) != nullptr)
           return 0;
         else
           {
@@ -284,7 +284,7 @@ namespace aspect
     void
     SphericalShell<dim>::initialize ()
     {
-      manifold = std::make_unique<internal::SphericalManifoldWithTopography<dim>>(this->get_initial_topography_model(),
+      manifold = std::make_unique<internal::SphericalManifoldWithTopography<dim>>(this->get_initial_topography_model_pointer(),
                                                                                    R0, R1);
     }
 

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -43,7 +43,7 @@ namespace aspect
                   Plugins::plugin_type_matches<const InitialTopographyModel::AsciiData<dim>>(this->get_initial_topography_model()),
                   ExcMessage("At the moment, only the Zero or AsciiData initial topography model can be used with the TwoMergedChunks geometry model."));
 
-      manifold = std::make_unique<internal::ChunkGeometry<dim>>(this->get_initial_topography_model(),
+      manifold = std::make_unique<internal::ChunkGeometry<dim>>(this->get_initial_topography_model_pointer(),
                                                                  point1[1],
                                                                  point1[0],
                                                                  point2[0]-point1[0]);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -544,6 +544,7 @@ namespace aspect
   }
 
 
+
   template <int dim>
   const InitialTopographyModel::Interface<dim> &
   SimulatorAccess<dim>::get_initial_topography_model () const
@@ -552,6 +553,18 @@ namespace aspect
             ExcMessage("You can not call this function if no such model is actually available."));
     return *simulator->initial_topography_model.get();
   }
+
+
+
+  template <int dim>
+  const std::shared_ptr<const InitialTopographyModel::Interface<dim>>
+  SimulatorAccess<dim>::get_initial_topography_model_pointer () const
+  {
+    Assert (simulator->initial_topography_model.get() != nullptr,
+            ExcMessage("You can not call this function if no such model is actually available."));
+    return simulator->initial_topography_model;
+  }
+
 
 
   template <int dim>

--- a/tests/ellipsoidal_chunk_geometry.cc
+++ b/tests/ellipsoidal_chunk_geometry.cc
@@ -66,7 +66,7 @@ int f()
   test_points.push_back(Point<3> (25000.0,25000.0,50000.0));
 
 
-  InitialTopographyModel::ZeroTopography<dim> topography;
+  std::shared_ptr<InitialTopographyModel::ZeroTopography<dim>> topography = std::make_shared<InitialTopographyModel::ZeroTopography<dim>>();
   {
     std::cout << "Simple sphere test" << std::endl;
     GeometryModel::internal::EllipsoidalChunkGeometry<dim> ellipsoidal_manifold(topography,


### PR DESCRIPTION
Seen while reviewing #6549 and an extension of #5668. We still use bare pointers in several geometry models to store access to the initial topography model. In some places these pointers can be replaced by simple references (like the box geometry model), in others we can use shared pointers like for the initial temperature manager and initial composition manager.

This PR removes the remaining use of bare pointers in all geometry models.