### PR TITLE
Fix a DOI in references.bib

### DIFF
--- a/doc/sphinx/references.bib
+++ b/doc/sphinx/references.bib
@@ -12115,7 +12115,7 @@ DOI = {10.5194/se-10-1785-2019}
 author={C. Thieulot and W. Bangerth},
 title={On the choice of finite element for applications in geodynamics},
 journal={Solid Earth},
-doi={10.5194/se-13-1-2022},
+doi={10.5194/se-13-229-2022},
 volume={13},
 year={2022}}
 


### PR DESCRIPTION
I was trying to access the paper:

"On the choice of finite element for applications in geodynamics"

 but when I clicked on the DOI that is linked in the manual it takes you to an article titled:

 "Virtual field trip to the Esla Nappe (Cantabrian Zone, NW Spain): delivering traditional geological mapping skills remotely using real data"

This fixes the DOI in the manual so that it links to the correct publication.