### PR TITLE
Fix the comment description.

### DIFF
--- a/tests/box_initial_topography_ascii_data.prm
+++ b/tests/box_initial_topography_ascii_data.prm
@@ -86,7 +86,7 @@ subsection Boundary velocity model
   set Zero velocity boundary indicators       = 0,1,2,3,4,5
 end
 
-# The maximum topography in the ascii file is 350 km and the minimum is 20 km.
+# The maximum topography in the ascii file is 55 km and the minimum is 20 km.
 # The topography statistics should not exceed these bounds.
 subsection Postprocess
   set List of postprocessors = visualization, velocity statistics, topography


### PR DESCRIPTION
While working on PR #6549, I noticed a typo in the comments of a test file, `box_initial_topography_ascii_data.prm`. Here is the data file for reference:

```
# Test data for ascii data initial topography
# Only next line is parsed in format: [nx] [ny] because of keyword "POINTS:"
# POINTS: 3 3
# Columns: x z Topography[m]
0.      0.       50000.
330000. 0.       40000.
660000. 0.       40000.
0.      330000.  55000.
330000. 330000.  55000.
660000. 330000.  55000.
0.      660000.  20000.
330000. 660000.  20000.
660000. 660000.  20000.   
```