### PR TITLE
Move the declaration of a macro to the file where we have all the other macros.

### DIFF
--- a/include/aspect/config.h.in
+++ b/include/aspect/config.h.in
@@ -35,4 +35,16 @@
 #cmakedefine ASPECT_HAVE_FASTSCAPE_NAMED_VTK
 
 #define ASPECT_MAX_NUM_PARTICLE_SYSTEMS @ASPECT_MAX_NUM_PARTICLE_SYSTEMS@
+
+
+/**
+ * A macro that is used in instantiating the ASPECT classes and functions for
+ * both 2d and 3d. Call this macro with the name of another macro that when
+ * called with a single integer argument instantiates the respective classes
+ * in the given space dimension.
+ */
+#define ASPECT_INSTANTIATE(INSTANTIATIONS) \
+  INSTANTIATIONS(2) \
+  INSTANTIATIONS(3)
+
 #endif

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -328,14 +328,4 @@ namespace aspect
 template <class Stream>
 void print_aspect_header(Stream &stream);
 
-/**
- * A macro that is used in instantiating the ASPECT classes and functions for
- * both 2d and 3d. Call this macro with the name of another macro that when
- * called with a single integer argument instantiates the respective classes
- * in the given space dimension.
- */
-#define ASPECT_INSTANTIATE(INSTANTIATIONS) \
-  INSTANTIATIONS(2) \
-  INSTANTIATIONS(3)
-
 #endif


### PR DESCRIPTION
Part of #6558 and https://github.com/dealii/dealii/issues/18071.