### PR TITLE
Include <mpi.h> where necessary.

### DIFF
--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -28,6 +28,11 @@
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/parameter_handler.h>
 
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
+
+
 namespace aspect
 {
   template <int dim> class SimulatorAccess;

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -31,6 +31,10 @@
 
 #include <boost/core/demangle.hpp>
 
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
+
 #include <tuple>
 #include <string>
 #include <list>

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -36,6 +36,9 @@
 #include <aspect/coordinate_systems.h>
 #include <aspect/structured_data.h>
 
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
 
 
 namespace aspect

--- a/source/global.cc
+++ b/source/global.cc
@@ -32,6 +32,10 @@
 
 #include <cstring>
 
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
+
 
 
 template <class Stream>


### PR DESCRIPTION
These files all do MPI, and so need that header.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.