### PR TITLE
Forward-declare WorldBuilder::World.

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -74,6 +74,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <memory>
 #include <thread>
 
+namespace WorldBuilder
+{
+  class World;
+}
+
 
 namespace aspect
 {

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -25,6 +25,12 @@
 #include <aspect/mesh_deformation/interface.h>
 #include <aspect/particle/manager.h>
 
+namespace WorldBuilder
+{
+  class World;
+}
+
+
 namespace aspect
 {
   template <int dim>


### PR DESCRIPTION
These files have functions that return references to `WorldBuilder::World`, but don't have the necessary `#include` to actually declare that class. Because we don't actually do anything with these objects here, it is sufficient to just forward declare the class.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.