### PR TITLE
Add a necessary header file.

### DIFF
--- a/include/aspect/coordinate_systems.h
+++ b/include/aspect/coordinate_systems.h
@@ -21,6 +21,9 @@
 #ifndef _aspect_coordinate_systems_h
 #define _aspect_coordinate_systems_h
 
+#include <deal.II/base/utilities.h>
+
+
 namespace aspect
 {
   namespace Utilities


### PR DESCRIPTION
This file currently had no header includes at all, even though it uses deal.II stuff. This could only work if files that include it *also* includes other things before. That's brittle design.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.