### PR TITLE
Remove an unnecessary header include.

### DIFF
--- a/include/aspect/simulator/solver/matrix_free_operators.h
+++ b/include/aspect/simulator/solver/matrix_free_operators.h
@@ -23,7 +23,6 @@
 
 #include <aspect/global.h>
 #include <aspect/simulator/solver/interface.h>
-#include <aspect/simulator/solver/stokes_matrix_free.h>
 #include <aspect/simulator.h>
 
 #include <deal.II/matrix_free/matrix_free.h>


### PR DESCRIPTION
This `#include` was unnecessary, and moreover created a cycle in header files. Remove it.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.