### PR TITLE
Move material into namespace aspect.

### DIFF
--- a/include/aspect/citation_info.h
+++ b/include/aspect/citation_info.h
@@ -24,39 +24,45 @@
 #include <string>
 #include <iostream>
 
-/**
- * A namespace to provide information to the user about stuff to cite.
- */
-namespace CitationInfo
+
+namespace aspect
 {
   /**
-   * Get the URL in the format "citing.html?(parameters)" that describes how to
-   * cite ASPECT based on the current model you are running.
+   * A namespace to provide information to the user about stuff to cite.
    */
-  const std::string get_url_part ();
-
-  /**
-   * Add the paper identified by the given id to the currently used list of
-   * papers. See citing.html for the list of ids. For specific features inside
-   * ASPECT that have associated publications, call this function if the
-   * feature is used in the current computation. For example, if the
-   * computation requires melt migration, call <tt>add("melt")</tt>.
-   */
-  void add (const std::string &id);
-
-  /**
-   * Print the info text containing the citation info into the given
-   * stream.
-   */
-  template <class Stream>
-  void print_info_block (Stream &stream)
+  namespace CitationInfo
   {
-    stream << "-----------------------------------------------------------------------------\n"
-           << "-- For information on how to cite ASPECT, see:\n"
-           << "--   https://aspect.geodynamics.org/" << get_url_part() << "\n"
-           << "-----------------------------------------------------------------------------"
-           << std::endl;
+    /**
+     * Get the URL in the format "citing.html?(parameters)" that describes how to
+     * cite ASPECT based on the current model you are running.
+     */
+    const std::string get_url_part ();
+
+    /**
+     * Add the paper identified by the given id to the currently used list of
+     * papers. See citing.html for the list of ids. For specific features inside
+     * ASPECT that have associated publications, call this function if the
+     * feature is used in the current computation. For example, if the
+     * computation requires melt migration, call <tt>add("melt")</tt>.
+     */
+    void add (const std::string &id);
+
+    /**
+     * Print the info text containing the citation info into the given
+     * stream.
+     */
+    template <class Stream>
+    void print_info_block (Stream &stream)
+    {
+      stream << "-----------------------------------------------------------------------------\n"
+             << "-- For information on how to cite ASPECT, see:\n"
+             << "--   https://aspect.geodynamics.org/" << get_url_part() << "\n"
+             << "-----------------------------------------------------------------------------"
+             << std::endl;
+    }
   }
+
 }
+
 
 #endif

--- a/source/citation_info.cc
+++ b/source/citation_info.cc
@@ -24,32 +24,35 @@
 #include <iostream>
 #include <set>
 
-namespace CitationInfo
+namespace aspect
 {
-  std::set<std::string> citation_ids;
-
-  const std::string get_url_part ()
+  namespace CitationInfo
   {
-    // version:
-    std::string url = "citing.html?ver=";
-    url += ASPECT_PACKAGE_VERSION;
+    std::set<std::string> citation_ids;
 
-    // all ids:
-    for (const auto &id : citation_ids)
-      url += "&" + id + "=1";
+    const std::string get_url_part ()
+    {
+      // version:
+      std::string url = "citing.html?ver=";
+      url += ASPECT_PACKAGE_VERSION;
 
-    // sha1:
-    url += "&sha=";
-    url += ASPECT_GIT_SHORTREV;
+      // all ids:
+      for (const auto &id : citation_ids)
+        url += "&" + id + "=1";
 
-    // src:
-    url += "&src=code";
+      // sha1:
+      url += "&sha=";
+      url += ASPECT_GIT_SHORTREV;
 
-    return url;
-  }
+      // src:
+      url += "&src=code";
 
-  void add (const std::string &id)
-  {
-    citation_ids.insert(id);
+      return url;
+    }
+
+    void add (const std::string &id)
+    {
+      citation_ids.insert(id);
+    }
   }
 }


### PR DESCRIPTION
We had a namespace `::CitationInfo`. A better place for it is `aspect::CitationInfo`.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.