### PR TITLE
Break an include cycle.

### DIFF
--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -25,6 +25,9 @@
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
 
+// For SphericalManifold:
+#include <aspect/compat.h>
+
 namespace aspect
 {
   namespace GeometryModel

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -38,8 +38,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <boost/container/small_vector.hpp>
 
-#include <aspect/compat.h>
-
 namespace aspect
 {
   /**

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -23,6 +23,7 @@
 #define _aspect_utilities_h
 
 #include <aspect/global.h>
+#include <aspect/compat.h>
 
 #include <array>
 #include <random>

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -17,10 +17,15 @@
   along with ASPECT; see the file LICENSE.  If not see
   <http://www.gnu.org/licenses/>.
 */
+
 #include <aspect/global.h>
 #include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
 #include <aspect/geometry_model/interface.h>
+
+// For big_mpi:
+#include <aspect/compat.h>
+
 
 #ifdef ASPECT_WITH_LIBDAP
 #include <D4Connect.h>


### PR DESCRIPTION
We had an include cycle between `global.h` and `compat.h`. This is easily broken by making sure that the places that needed stuff from `compat.h` `#include` it directly.

Part of #6558 and https://github.com/dealii/dealii/issues/18071.