### PR TITLE
Do not guard inclusion of <mpi.h> with DEAL_II_WITH_MPI.

### DIFF
--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -28,9 +28,7 @@
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/parameter_handler.h>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
+#include <mpi.h>
 
 
 namespace aspect

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -31,10 +31,6 @@
 
 #include <boost/core/demangle.hpp>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
-
 #include <tuple>
 #include <string>
 #include <list>
@@ -43,6 +39,8 @@
 #include <iostream>
 #include <typeinfo>
 #include <type_traits>
+
+#include <mpi.h>
 
 
 namespace aspect

--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -36,9 +36,7 @@
 #include <aspect/coordinate_systems.h>
 #include <aspect/structured_data.h>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
+#include <mpi.h>
 
 
 namespace aspect

--- a/source/global.cc
+++ b/source/global.cc
@@ -32,9 +32,7 @@
 
 #include <cstring>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
+#include <mpi.h>
 
 
 namespace aspect

--- a/source/postprocess/matrix_statistics.cc
+++ b/source/postprocess/matrix_statistics.cc
@@ -26,9 +26,7 @@
 
 #include <string>
 
-#ifdef DEAL_II_WITH_MPI
-#  include <mpi.h>
-#endif
+#include <mpi.h>
 
 
 namespace aspect


### PR DESCRIPTION
See the discussion in #6565. This covers all places where we `#include <mpi.h>`.