### PR TITLE
Make sure we re-run cmake when we add files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,10 +582,10 @@ configure_file(
 # ##############################################################################
 # Collect source files
 
-file(GLOB_RECURSE ASPECT_SOURCE_FILES_CC "source/*.cc")
+file(GLOB_RECURSE ASPECT_SOURCE_FILES_CC CONFIGURE_DEPENDS "source/*.cc")
 list(REMOVE_ITEM  ASPECT_SOURCE_FILES_CC ${CMAKE_CURRENT_SOURCE_DIR}/source/main.cc)
-file(GLOB_RECURSE ASPECT_SOURCE_FILES_H  "include/*.h")
-file(GLOB_RECURSE ASPECT_UNIT_TEST_FILES "unit_tests/*.cc" "contrib/catch/catch.hpp")
+file(GLOB_RECURSE ASPECT_SOURCE_FILES_H CONFIGURE_DEPENDS  "include/*.h")
+file(GLOB_RECURSE ASPECT_UNIT_TEST_FILES CONFIGURE_DEPENDS "unit_tests/*.cc" "contrib/catch/catch.hpp")
 set(ASPECT_MAIN_FILE "source/main.cc")
 
 # Create the combined set of source files that make up the project


### PR DESCRIPTION
We collect which files need to be built using `file(GLOB_RECURSE ...)` which is run at CMake time. As a consequence, when you add a file, it is not automatically picked up to be compiled *unless you call CMake by hand* -- that's because the build system (make or ninja) won't know about the file unless you call CMake. This is why generally the use of `GLOB` has been discouraged to list the source files by hand, and in deal.II for example we list all of them individually and by hand.

Newer CMake versions have introduced the `CONFIGURE_DEPENDS` option, which instructs make or ninja to re-glob the list of files and if it has changed, calls CMake. Use this where we collect our source files -- this way, new files will be automatically picked up, without anyone having to remember to call CMake by hand.