### PR TITLE
Move point density function code from ParticleDistributionStatistics to ParticlePDF

### DIFF
--- a/include/aspect/postprocess/particle_distribution_statistics.h
+++ b/include/aspect/postprocess/particle_distribution_statistics.h
@@ -98,78 +98,10 @@ namespace aspect
         double bandwidth;
 
         /**
-         * The `KernelFunctions` enum class is a data structure which
-         * contains the kernel functions available for use in the Kernel
-         * Density Estimator.
-         */
-        enum class KernelFunctions
-        {
-          gaussian,
-          triangular,
-          uniform,
-          cutoff_function_w1_dealii
-        };
-
-        /**
          * `kernel_function` is an internal variable to keep track of which
          * kernel function was read from the .prm file.
          */
-        KernelFunctions kernel_function;
-
-        /**
-         * Fills the supplied PDF instance with values from the particles in the given cell.
-         * @param cell The cell whose particles to populate the PDF with.
-         * @param pdf The instance of ParticlePDF to fill with data from the cell's particles.
-         */
-        void fill_PDF_from_cell(const typename Triangulation<dim>::active_cell_iterator &cell, ParticlePDF<dim> &pdf);
-
-        /**
-         * This function is only called from `fill_PDF_from_cell`.
-         * It iterates through every particle in the cell and
-         * sums the value of the kernel function between the
-         * reference point and the position of the cell.
-         * @param cell The cell whose particles to populate the PDF with.
-         * @param pdf The instance of ParticlePDF to fill with data from the cell's particles.
-         * @param reference_point The point from which to get the value of the kernel function.
-         * @param table_index The index in the PDF to insert the data into.
-         * @param particles_in_cell The number of particles in the cell.
-         */
-        void insert_kernel_sum_into_pdf(
-          const typename Triangulation<dim>::active_cell_iterator &cell,
-          const Point<dim> reference_point,
-          std::array<unsigned int,dim> table_index,
-          const unsigned int particles_in_cell,
-          ParticlePDF<dim> &pdf);
-
-        /**
-         * Returns the value of the selected kernel function.
-         * @param distance the distance to pass to the selected kernel function.
-         * @param coordinates the coordinates representing the offset between the reference
-         * and sampled particle. This is needed because Functions::CutOffFunctionW1<dim>
-         * only takes a Point<dim> as input, not a double.
-         */
-        double apply_selected_kernel_function(const double distance) const;
-
-        /**
-         * The Uniform kernel function returns a value of 1.0 as long as the
-         * distance is less than the KDE's bandwidth.
-         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
-         */
-        double kernelfunction_uniform(const double distance) const;
-
-        /**
-         * The Triangular kernel function returns a value of 1.0 minus
-         * the distance variable.
-         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
-         */
-        double kernelfunction_triangular(const double distance) const;
-
-        /**
-         * The gaussian function returns the value of a gaussian distribution
-         * at the specified distance.
-         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
-         */
-        double kernelfunction_gaussian(const double distance) const;
+        typename ParticlePDF<dim>::KernelFunctions kernel_function;
     };
   }
 }

--- a/include/aspect/postprocess/particle_distribution_statistics.h
+++ b/include/aspect/postprocess/particle_distribution_statistics.h
@@ -25,7 +25,6 @@
 #include <aspect/postprocess/particle_pdf.h>
 #include <deal.II/base/function_lib.h>
 #include <aspect/particle/manager.h>
-#include <deal.II/particles/particle_handler.h>
 
 namespace aspect
 {

--- a/include/aspect/postprocess/particle_distribution_statistics.h
+++ b/include/aspect/postprocess/particle_distribution_statistics.h
@@ -25,7 +25,7 @@
 #include <aspect/postprocess/particle_pdf.h>
 #include <deal.II/base/function_lib.h>
 #include <aspect/particle/manager.h>
-
+#include <deal.II/particles/particle_handler.h>
 
 namespace aspect
 {
@@ -102,6 +102,61 @@ namespace aspect
          * kernel function was read from the .prm file.
          */
         typename ParticlePDF<dim>::KernelFunctions kernel_function;
+
+        /**
+         * Fills the supplied PDF instance with values from the particles in the given cell.
+         * @param cell The cell whose particles to populate the PDF with.
+         * @param pdf The instance of ParticlePDF to fill with data from the cell's particles.
+         */
+        void fill_PDF_from_cell(const typename Triangulation<dim>::active_cell_iterator &cell, ParticlePDF<dim> &pdf);
+
+        /**
+         * This function is only called from `fill_PDF_from_cell`.
+         * It iterates through every particle in the cell and
+         * sums the value of the kernel function between the
+         * reference point and the position of the cell.
+         * @param cell The cell whose particles to populate the PDF with.
+         * @param pdf The instance of ParticlePDF to fill with data from the cell's particles.
+         * @param reference_point The point from which to get the value of the kernel function.
+         * @param table_index The index in the PDF to insert the data into.
+         * @param particles_in_cell The number of particles in the cell.
+         */
+        void insert_kernel_sum_into_pdf(
+          const typename Triangulation<dim>::active_cell_iterator &cell,
+          const Point<dim> reference_point,
+          std::array<unsigned int,dim> table_index,
+          const unsigned int particles_in_cell,
+          ParticlePDF<dim> &pdf);
+
+        /**
+         * Returns the value of the selected kernel function.
+         * @param distance the distance to pass to the selected kernel function.
+         * @param coordinates the coordinates representing the offset between the reference
+         * and sampled particle. This is needed because Functions::CutOffFunctionW1<dim>
+         * only takes a Point<dim> as input, not a double.
+         */
+        double apply_selected_kernel_function(const double distance) const;
+
+        /**
+         * The Uniform kernel function returns a value of 1.0 as long as the
+         * distance is less than the KDE's bandwidth.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_uniform(const double distance) const;
+
+        /**
+         * The Triangular kernel function returns a value of 1.0 minus
+         * the distance variable.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_triangular(const double distance) const;
+
+        /**
+         * The gaussian function returns the value of a gaussian distribution
+         * at the specified distance.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_gaussian(const double distance) const;
     };
   }
 }

--- a/include/aspect/postprocess/particle_pdf.h
+++ b/include/aspect/postprocess/particle_pdf.h
@@ -27,6 +27,8 @@
 #include <limits>
 #include <deal.II/base/table.h>
 #include <deal.II/particles/property_pool.h>
+#include <aspect/particle/manager.h>
+
 namespace aspect
 {
   namespace Postprocess

--- a/include/aspect/postprocess/particle_pdf.h
+++ b/include/aspect/postprocess/particle_pdf.h
@@ -86,7 +86,7 @@ namespace aspect
          * @param n_particles_in_cell The number of particles belonging to the particle manager in question within the cell.
          */
         void fill_from_particle_range(const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range,
-                            const unsigned int n_particles_in_cell);
+                                      const unsigned int n_particles_in_cell);
 
         /**
          * This function is only called from `fill_from_cell`.

--- a/include/aspect/postprocess/particle_pdf.h
+++ b/include/aspect/postprocess/particle_pdf.h
@@ -28,6 +28,7 @@
 #include <deal.II/base/table.h>
 #include <deal.II/particles/property_pool.h>
 #include <aspect/particle/manager.h>
+#include <deal.II/base/function_lib.h>
 
 namespace aspect
 {

--- a/include/aspect/postprocess/particle_pdf.h
+++ b/include/aspect/postprocess/particle_pdf.h
@@ -46,22 +46,63 @@ namespace aspect
       public:
 
         /**
+         * The `KernelFunctions` enum class is a data structure which
+         * contains the kernel functions available for use in the Kernel
+         * Density Estimator.
+         */
+        enum class KernelFunctions
+        {
+          gaussian,
+          triangular,
+          uniform,
+          cutoff_function_w1_dealii
+        };
+
+        /**
          * This is the constructor for ParticlePDF.
          * This constructor is called when creating a point-density function which is defined
          * at regular intervals throughout a cell, as opposed to a function which is defined
          * at the positions of each particle in the cell.
          * @param granularity determines the number of reference points to sum the kernel function
          * from. The point density function is only defined at these reference points.
+         * @param bandwidth determines the bandwidth to be used in the kernel function.
+         * @param kernel_function determines which kernel function to use when generating the point-density function.
          */
-        ParticlePDF(const unsigned int granularity);
+        ParticlePDF(const unsigned int granularity, const double bandwidth,KernelFunctions kernel_function);
 
         /**
          * This is the constructor for ParticlePDF.
          * This constructor is called when creating a point-density function
          * which is defined at the positions of the particles within the cell,
-         * as opposed to at regular intervals based on a granularity value
+         * as opposed to at regular intervals based on a granularity value.
+         * @param bandwidth determines the bandwidth to be used in the kernel function.
+         * @param kernel_function determines which kernel function to use when generating the point-density function.
          */
-        ParticlePDF();
+        ParticlePDF(const double bandwidth,KernelFunctions kernel_function);
+
+        /**
+         * Fills the point-density function with values from the particles in the given cell.
+         * @param particle_range The particle_iterator_range to operate on.
+         * @param n_particles_in_cell The number of particles belonging to the particle manager in question within the cell.
+         */
+        void fill_from_particle_range(const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range,
+                            const unsigned int n_particles_in_cell);
+
+        /**
+         * This function is only called from `fill_from_cell`.
+         * It iterates through every particle in the cell and
+         * sums the value of the kernel function between the
+         * reference point and the position of the cell.
+         * @param reference_point The point from which to get the value of the kernel function.
+         * @param table_index The index in the PDF to insert the data into.
+         * @param n_particles_in_cell The number of particles in the cell.
+         * @param particle_range The particle_iterator_range to sum particles from.
+         */
+        void insert_kernel_sum_from_particle_range(
+          const Point<dim> reference_point,
+          std::array<unsigned int,dim> table_index,
+          const unsigned int n_particles_in_cell,
+          const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range);
 
         /**
          * Inserts a value into the point-density function.
@@ -136,11 +177,27 @@ namespace aspect
         Table<dim,double> function_output_table;
 
         /**
-         * `pdf_granularity` determines the number of inputs at which
-         * the point-density function is defined. The function is defined for
-         * pdf_granularity^dim inputs.
+         * The `bandwidth` variable scales the point-density function.
+         * Choosing an appropriate bandwidth is important because a
+         * bandwidth value which is too low or too high can result
+         * in oversmoothing or undersmoothing of the point-density function.
+         * Oversmoothing or undersmoothing results in a function which
+         * represents the underlying data less accurately.
          */
-        unsigned int pdf_granularity;
+        double bandwidth;
+
+        /**
+         * `kernel_function` is an internal variable to keep track of which
+         * kernel function is being used by the ParticlePDF.
+         */
+        KernelFunctions kernel_function;
+
+        /**
+         * `granularity` determines the number of inputs at which
+         * the point-density function is defined. The function is defined for
+         * granularity^dim inputs.
+         */
+        unsigned int granularity;
 
         /**
          * `max` holds the maximum value of the point-density function after it has been computed.
@@ -187,6 +244,37 @@ namespace aspect
          * point-density function value.
          */
         types::particle_index min_particle_index;
+
+        /**
+         * Returns the value of the selected kernel function.
+         * @param distance the distance to pass to the selected kernel function.
+         * @param coordinates the coordinates representing the offset between the reference
+         * and sampled particle. This is needed because Functions::CutOffFunctionW1<dim>
+         * only takes a Point<dim> as input, not a double.
+         */
+        double apply_selected_kernel_function(const double distance) const;
+
+        /**
+         * The Uniform kernel function returns a value of 1.0 as long as the
+         * distance is less than the KDE's bandwidth.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_uniform(const double distance) const;
+
+        /**
+         * The Triangular kernel function returns a value of 1.0 minus
+         * the distance variable.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_triangular(const double distance) const;
+
+        /**
+         * The gaussian function returns the value of a gaussian distribution
+         * at the specified distance.
+         * @param distance the output of the kernel function depends on the distance between the reference point and the center of the kernel function.
+         */
+        double kernelfunction_gaussian(const double distance) const;
+
     };
   }
 }

--- a/source/postprocess/particle_distribution_statistics.cc
+++ b/source/postprocess/particle_distribution_statistics.cc
@@ -75,11 +75,11 @@ namespace aspect
                           function_max_sum += pdf.get_max();
                           function_min_min = std::min(function_min_min, pdf.get_min());
                           function_max_max = std::max(function_max_max, pdf.get_max());
-                      }
+                        }
                     }
                   else
                     {
-                        for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
+                      for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
                         {
                           ParticlePDF<dim> pdf(bandwidth,kernel_function);
                           const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range = this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);

--- a/source/postprocess/particle_distribution_statistics.cc
+++ b/source/postprocess/particle_distribution_statistics.cc
@@ -52,33 +52,51 @@ namespace aspect
 
                   if (KDE_per_particle == false)
                     {
-                      ParticlePDF<dim> pdf(granularity);
-                      fill_PDF_from_cell(cell,pdf);
-                      pdf.compute_statistical_values();
+                      /*
+                        Loop through every particle manager here, since the ParticlePDF class operates
+                        on a single particle_iterator_range. The ParticlePDF class is written to operate
+                        on a single particle_iterator_range at a time so that it can be called directly
+                        by the particle_manager class to assist in particle load balancing.
+                      */
+                      for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
+                        {
+                          ParticlePDF<dim> pdf(granularity,bandwidth,kernel_function);
+                          const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range = this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);
+                          const unsigned int this_manager_particles_in_cell = this->get_particle_manager(particle_manager_index).get_particle_handler().n_particles_in_cell(cell);
 
-                      standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());
-                      standard_deviation_max = std::max(standard_deviation_max, pdf.get_standard_deviation());
-                      standard_deviation_sum += pdf.get_standard_deviation();
+                          pdf.fill_from_particle_range(particle_range,this_manager_particles_in_cell);
+                          pdf.compute_statistical_values();
 
-                      function_min_sum += pdf.get_min();
-                      function_max_sum += pdf.get_max();
-                      function_min_min = std::min(function_min_min, pdf.get_min());
-                      function_max_max = std::max(function_max_max, pdf.get_max());
+                          standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());
+                          standard_deviation_max = std::max(standard_deviation_max, pdf.get_standard_deviation());
+                          standard_deviation_sum += pdf.get_standard_deviation();
+
+                          function_min_sum += pdf.get_min();
+                          function_max_sum += pdf.get_max();
+                          function_min_min = std::min(function_min_min, pdf.get_min());
+                          function_max_max = std::max(function_max_max, pdf.get_max());
+                      }
                     }
                   else
                     {
-                      ParticlePDF<dim> pdf;
-                      fill_PDF_from_cell(cell,pdf);
-                      pdf.compute_statistical_values();
+                        for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
+                        {
+                          ParticlePDF<dim> pdf(bandwidth,kernel_function);
+                          const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range = this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);
+                          const unsigned int this_manager_particles_in_cell = this->get_particle_manager(particle_manager_index).get_particle_handler().n_particles_in_cell(cell);
 
-                      standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());
-                      standard_deviation_max = std::max(standard_deviation_max, pdf.get_standard_deviation());
-                      standard_deviation_sum += pdf.get_standard_deviation();
+                          pdf.fill_from_particle_range(particle_range,this_manager_particles_in_cell);
+                          pdf.compute_statistical_values();
 
-                      function_min_sum += pdf.get_min();
-                      function_max_sum += pdf.get_max();
-                      function_min_min = std::min(function_min_min, pdf.get_min());
-                      function_max_max = std::max(function_max_max, pdf.get_max());
+                          standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());
+                          standard_deviation_max = std::max(standard_deviation_max, pdf.get_standard_deviation());
+                          standard_deviation_sum += pdf.get_standard_deviation();
+
+                          function_min_sum += pdf.get_min();
+                          function_max_sum += pdf.get_max();
+                          function_min_min = std::min(function_min_min, pdf.get_min());
+                          function_max_max = std::max(function_max_max, pdf.get_max());
+                        }
                     }
                 }
             }
@@ -125,184 +143,6 @@ namespace aspect
     ParticleDistributionStatistics<dim>::required_other_postprocessors() const
     {
       return {"particles"};
-    }
-
-
-
-    template <int dim>
-    void ParticleDistributionStatistics<dim>::fill_PDF_from_cell(
-      const typename Triangulation<dim>::active_cell_iterator &cell,
-      ParticlePDF<dim> &pdf)
-    {
-      unsigned int particles_in_cell = 0;
-      for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
-        particles_in_cell += this->get_particle_manager(particle_manager_index).get_particle_handler().n_particles_in_cell(cell);
-
-      if (KDE_per_particle == false)
-        {
-          for (unsigned int x=0; x<granularity; ++x)
-            {
-              for (unsigned int y=0; y<granularity; ++y)
-                {
-                  double granularity_double = static_cast<double>(granularity);
-                  double x_double = static_cast<double>(x);
-                  double y_double = static_cast<double>(y);
-
-                  if (dim == 3)
-                    {
-                      for (unsigned int z=0; z<granularity; ++z)
-                        {
-                          const double z_double = static_cast<double>(z);
-                          Point<dim> reference_point;
-                          reference_point[0] = x_double/granularity_double;
-                          reference_point[1] = y_double/granularity_double;
-                          reference_point[2] = z_double/granularity_double;
-                          std::array<unsigned int,dim> table_index;
-                          table_index[0] = x;
-                          table_index[1] = y;
-                          table_index[2] = z;
-                          insert_kernel_sum_into_pdf(cell,reference_point,table_index,particles_in_cell,pdf);
-                        }
-                    }
-                  else
-                    {
-                      Point<dim> reference_point;
-                      reference_point[0] = x_double/granularity_double;
-                      reference_point[1] = y_double/granularity_double;
-                      std::array<unsigned int,dim> table_index;
-                      table_index[0] = x;
-                      table_index[1] = y;
-                      insert_kernel_sum_into_pdf(cell,reference_point,table_index,particles_in_cell,pdf);
-                    }
-                }
-            }
-        }
-      else
-        {
-          // Sum the value of the kernel function on that position from every other particle.
-          for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
-            {
-              const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range =
-                this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);
-
-              for (const auto &reference_particle: particle_range)
-                {
-                  const auto reference_coordinates = reference_particle.get_reference_location();
-                  double function_value = 0;
-
-                  for (const auto &kernel_position_particle: particle_range)
-                    {
-                      const auto kernel_coordinates = kernel_position_particle.get_reference_location();
-                      const double distance = reference_coordinates.distance(kernel_coordinates);
-                      function_value += apply_selected_kernel_function(distance);
-                    }
-
-                  pdf.add_value_to_function_table(function_value/particles_in_cell,reference_particle.get_id());
-                }
-            }
-        }
-    }
-
-
-
-    template <int dim>
-    void ParticleDistributionStatistics<dim>::insert_kernel_sum_into_pdf(
-      const typename Triangulation<dim>::active_cell_iterator &cell,
-      const Point<dim> reference_point,
-      std::array<unsigned int,dim> table_index,
-      const unsigned int particles_in_cell,
-      ParticlePDF<dim> &pdf)
-    {
-      // Add every particle in the cell using the kernel function and add that value to the PDF.
-      for (unsigned int particle_manager_index = 0; particle_manager_index < this->n_particle_managers(); ++particle_manager_index)
-        {
-
-          const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range = this->get_particle_manager(particle_manager_index).get_particle_handler().particles_in_cell(cell);
-
-          for (const auto &particle: particle_range)
-            {
-              const auto coordinates = particle.get_reference_location();
-              const double distance = coordinates.distance(reference_point);
-              const double kernel_function_value = apply_selected_kernel_function(distance);
-              pdf.add_value_to_function_table(table_index,kernel_function_value/particles_in_cell);
-            }
-        }
-    }
-
-
-
-    template <int dim>
-    double ParticleDistributionStatistics<dim>::apply_selected_kernel_function(const double distance) const
-    {
-      if (kernel_function == KernelFunctions::uniform)
-        {
-          return kernelfunction_uniform(distance);
-        }
-      else if (kernel_function == KernelFunctions::triangular)
-        {
-          return kernelfunction_triangular(distance);
-        }
-      else if (kernel_function == KernelFunctions::gaussian)
-        {
-          return kernelfunction_gaussian(distance);
-        }
-      else if (kernel_function == KernelFunctions::cutoff_function_w1_dealii)
-        {
-          Functions::CutOffFunctionW1<1> cutoff_function(bandwidth);
-          return cutoff_function.value(Point<1>(distance));
-        }
-      else
-        {
-          Assert(false, ExcMessage("Unknown kernel function used in insert_kernel_sum_into_pdf."));
-          return 0.0;
-        }
-    }
-
-
-
-    template <int dim>
-    double ParticleDistributionStatistics<dim>::kernelfunction_uniform(double distance) const
-    {
-      if (distance < bandwidth)
-        {
-          return 1;
-        }
-      else
-        {
-          return 0.0;
-        }
-    }
-
-
-
-    template <int dim>
-    double ParticleDistributionStatistics<dim>::kernelfunction_triangular(double distance) const
-    {
-      if (distance < bandwidth)
-        {
-          return (1.0-distance)*bandwidth;
-        }
-      else
-        {
-          return 0.0;
-        }
-    }
-
-
-
-    template <int dim>
-    double ParticleDistributionStatistics<dim>::kernelfunction_gaussian(double distance) const
-    {
-      if (distance < bandwidth)
-        {
-          const double exponent = distance * distance / (2.*bandwidth*bandwidth);
-          const double gaussian = (1 / (bandwidth * std::sqrt(2*numbers::PI))) * std::exp(-exponent);
-          return gaussian;
-        }
-      else
-        {
-          return 0.0;
-        }
     }
 
 
@@ -363,19 +203,19 @@ namespace aspect
 
           if (kernel_function_string =="Triangular")
             {
-              kernel_function = KernelFunctions::triangular;
+              kernel_function = ParticlePDF<dim>::KernelFunctions::triangular;
             }
           else if (kernel_function_string =="Gaussian")
             {
-              kernel_function = KernelFunctions::gaussian;
+              kernel_function = ParticlePDF<dim>::KernelFunctions::gaussian;
             }
           else if (kernel_function_string == "CutoffFunctionW1")
             {
-              kernel_function = KernelFunctions::cutoff_function_w1_dealii;
+              kernel_function = ParticlePDF<dim>::KernelFunctions::cutoff_function_w1_dealii;
             }
           else
             {
-              kernel_function = KernelFunctions::uniform;
+              kernel_function = ParticlePDF<dim>::KernelFunctions::uniform;
             }
         }
         prm.leave_subsection ();
@@ -384,6 +224,7 @@ namespace aspect
     }
   }
 }
+
 
 
 // explicit instantiations

--- a/source/postprocess/particle_pdf.cc
+++ b/source/postprocess/particle_pdf.cc
@@ -65,7 +65,7 @@ namespace aspect
 
     template <int dim>
     void ParticlePDF<dim>::fill_from_particle_range(const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range,
-                                          const unsigned int n_particles_in_cell)
+                                                    const unsigned int n_particles_in_cell)
     {
       if (is_defined_per_particle == false)
         {
@@ -106,24 +106,24 @@ namespace aspect
                 }
             }
         }
-        else
+      else
         {
-         // Sum the value of the kernel function on that position from every other particle.
-            for (const auto &reference_particle: particle_range)
-              {
-                const auto reference_coordinates = reference_particle.get_reference_location();
-                double function_value = 0;
+          // Sum the value of the kernel function on that position from every other particle.
+          for (const auto &reference_particle: particle_range)
+            {
+              const auto reference_coordinates = reference_particle.get_reference_location();
+              double function_value = 0;
 
-                for (const auto &kernel_position_particle: particle_range)
-                  {
-                    const auto kernel_coordinates = kernel_position_particle.get_reference_location();
-                    const double distance = reference_coordinates.distance(kernel_coordinates);
-                    function_value += apply_selected_kernel_function(distance);
-                  }
+              for (const auto &kernel_position_particle: particle_range)
+                {
+                  const auto kernel_coordinates = kernel_position_particle.get_reference_location();
+                  const double distance = reference_coordinates.distance(kernel_coordinates);
+                  function_value += apply_selected_kernel_function(distance);
+                }
 
-                add_value_to_function_table(function_value/n_particles_in_cell,reference_particle.get_id());
-              }
-          
+              add_value_to_function_table(function_value/n_particles_in_cell,reference_particle.get_id());
+            }
+
         }
 
 
@@ -132,7 +132,7 @@ namespace aspect
     template <int dim>
     void ParticlePDF<dim>::insert_kernel_sum_from_particle_range(
       const Point<dim> reference_point,
-      std::array<unsigned int, dim> table_index, 
+      std::array<unsigned int, dim> table_index,
       const unsigned int n_particles_in_cell,
       const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range)
     {


### PR DESCRIPTION
This pull request moves all of the code related to generating the point-density function from the ParticleDistributionStatistics postprocessor class to the ParticlePDF class. 

The point of this is so that individual particle managers can instantiate the ParticlePDF class separate from any postprocessors, in order to help with particle load balancing. In order to make it possible for particle managers to use the ParticlePDF class, all of the functions which generate the point-density function have been changed to operate on particle_ranges instead of on entire cells.