### PR TITLE
Add a tester with deal.II 9.6

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,6 +108,11 @@ jobs:
             compare-tests: "ON"
             result-file: "changes-test-results-9.5.diff"
             container-options: '--name container'
+          - image: "geodynamics/aspect-tester:jammy-dealii-9.6-v1"
+            run-tests: "ON"
+            compare-tests: "OFF"
+            result-file: "changes-test-results-9.6.diff"
+            container-options: '--user 0 --name container'
           - image: "geodynamics/aspect-tester:focal-dealii-master"
             run-tests: "ON"
             compare-tests: "OFF"


### PR DESCRIPTION
As #6582 has shown we do not currently test ASPECT compiling and running with deal.II 9.6 (we only test 9.5 and the current development version). I have created a new [tester image for 9.6](https://hub.docker.com/layers/geodynamics/aspect-tester/jammy-dealii-9.6-v1/images/sha256-8caeae0f97a572f3eae18ccf621babaacca45776fa790230fd417338b9a7186b) and this PR activates this as one of our CI testers.

Currently this does not use the 9.6 results as reference test results, but in a follow-up I want to do that as well. Ultimately we want to drop support for 9.5 in the not so far future to be able to remove all the compatibility code we have acquired over the years.