### PR TITLE
Fix default parameter value to point to existing file

### DIFF
--- a/doc/modules/changes/20250704_gassmoeller
+++ b/doc/modules/changes/20250704_gassmoeller
@@ -1,0 +1,5 @@
+Fixed: The default value for the parameter 'Lateral viscosity file name'
+in the material model 'entropy model' referred to a non-existent file.
+This parameter now refers to an example data file.
+<br>
+(Rene Gassmoeller, 2025/07/04)

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -480,7 +480,7 @@ namespace aspect
                              "The viscosity that is used in this model. "
                              "\n\n"
                              "Units: \\si{\\pascal\\second}");
-          prm.declare_entry ("Lateral viscosity file name", "temp-viscosity-prefactor.txt",
+          prm.declare_entry ("Lateral viscosity file name", "constant_lateral_vis_prefactor.txt",
                              Patterns::Anything (),
                              "The file name of the lateral viscosity prefactor.");
           prm.declare_entry ("Minimum viscosity", "1e19",

--- a/tests/entropy_initial_lookup.prm
+++ b/tests/entropy_initial_lookup.prm
@@ -109,7 +109,6 @@ subsection Material model
   subsection Entropy model
     set Data directory                   = $ASPECT_SOURCE_DIR/data/material-model/entropy-table/pyrtable/
     set Material file name               = material_table_entropy_pressure.txt
-    set Lateral viscosity file name      = constant_lateral_vis_prefactor.txt
     set Thermal conductivity formulation = constant
     set Thermal conductivity             = 0.1
   end


### PR DESCRIPTION
This parameter had a default value that pointed to a file that does not exist. It was a copy-paste value from another material model which uses a different data directory (where this file does exist). I fixed the value to refer to an existing file that was used by most tests anyway. To test that the model can now be used with the default value I removed the value from one of the tests.