### PR TITLE
Ensure particle manager is destroyed before triangulation and mapping

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -1854,11 +1854,6 @@ namespace aspect
       const std::unique_ptr<BoundaryHeatFlux::Interface<dim>>   boundary_heat_flux;
 
       /**
-       * The managers holding different sets of particles
-       */
-      std::vector<Particle::Manager<dim>>                       particle_managers;
-
-      /**
        * @}
        */
       /**
@@ -1920,6 +1915,11 @@ namespace aspect
       DoFHandler<dim>                                           dof_handler;
 
       Postprocess::Manager<dim>                                 postprocess_manager;
+
+      /**
+       * The managers holding different sets of particles
+       */
+      std::vector<Particle::Manager<dim>>                       particle_managers;
 
       /**
        * Constraint objects. The first of these describes all constraints that


### PR DESCRIPTION
The particle handler objects owned by the particle manager class own an observer pointer to our `mapping` and the `triangulation` objects. Unfortunately the particle manager is currently listed higher up in simulator.h than those objects, which means it will be destroyed after the mapping and triangulation have already been destroyed. This can lead to crashes in the destructor, because the observer pointers complain that the object they point to has already been destroyed. I am somewhat confused why I only saw this error today in a test for the first time. But independent of the error, we initialize the particle managers right after the postprocess manager in core.cc:464, so it makes sense to have them in the same order in the header file.

Not sure if this warrants a changelog entry, it fixes a bug, but it is pretty esoteric, and apparently neither our tests nor our application models consistently complain about this (and the crash only happens during program termination).