### PR TITLE
Add reaction to every iteration for multicomponent entropy averaging

### DIFF
--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -305,6 +305,8 @@ namespace aspect
                   // based on all elements of the entropy fields:
                   if (c == last_entropy_field_index)
                     {
+                      if (parameters.use_operator_splitting)
+                        compute_reactions ();
                       const AdvectionField T_field (AdvectionField::temperature());
                       interpolate_material_output_into_advection_field({T_field});
                     }


### PR DESCRIPTION
This pull request follows the change made in #6606 

Before this modification, the entropy of each component is only updated at the beginning of each timestep. But we want to update them together with temperature in every non linear iteration

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

