### PR TITLE
Fix compiler warning

### DIFF
--- a/source/compat.cc
+++ b/source/compat.cc
@@ -902,15 +902,10 @@ namespace aspect
         }
   }
 
-#define INSTANTIATE(dim) \
-  template void colorize_quarter_hyper_shell<dim>(Triangulation<dim> &, \
-                                                  const Point<dim>   &, \
-                                                  const double      , \
-                                                  const double)     ;
-
-  ASPECT_INSTANTIATE(INSTANTIATE)
-
-#undef INSTANTIATE
+  template void colorize_quarter_hyper_shell<2>(Triangulation<2> &,
+                                                const Point<2> &,
+                                                const double,
+                                                const double);
 }
 
 #endif


### PR DESCRIPTION
When compiling aspect on my mac I kept getting this warning:

```
/Users/danieldouglas/software/aspect/source/compat.cc:911:22: warning: explicit instantiation of 'colorize_quarter_hyper_shell<3>' that occurs after an explicit specialization has no effect [-Winstantiation-after-specialization]
```

The line deleted in this PR fixes this warning on my local machine.