### PR TITLE
Unify inclusion of exceptions.h

### DIFF
--- a/benchmarks/nsinker/nsinker.cc
+++ b/benchmarks/nsinker/nsinker.cc
@@ -23,7 +23,6 @@
 #include <aspect/simulator_signals.h>
 
 #include <deal.II/base/point.h>
-#include <deal.II/base/exceptions.h>
 
 
 namespace aspect

--- a/benchmarks/nsinker_spherical_shell/nsinker.cc
+++ b/benchmarks/nsinker_spherical_shell/nsinker.cc
@@ -22,7 +22,6 @@
 #include <aspect/material_model/interface.h>
 
 #include <deal.II/base/point.h>
-#include <deal.II/base/exceptions.h>
 
 
 namespace aspect

--- a/cookbooks/anisotropic_viscosity/av_material.cc
+++ b/cookbooks/anisotropic_viscosity/av_material.cc
@@ -22,7 +22,6 @@
 #include <aspect/material_model/interface.h>
 #include <aspect/plugins.h>
 #include <aspect/simulator/assemblers/interface.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/patterns.h>
 #include <deal.II/base/point.h>

--- a/include/aspect/global.h
+++ b/include/aspect/global.h
@@ -26,6 +26,7 @@
 #include <aspect/citation_info.h>
 
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/exceptions.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -27,7 +27,6 @@
 #include <deal.II/particles/particle.h>
 #include <deal.II/particles/generators.h>
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/exceptions.h>
 
 #include <random>
 

--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -26,7 +26,6 @@
 
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/parameter_handler.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/fe/component_mask.h>
 
 #include <boost/core/demangle.hpp>

--- a/source/adiabatic_conditions/interface.cc
+++ b/source/adiabatic_conditions/interface.cc
@@ -22,9 +22,7 @@
 #include <aspect/global.h>
 #include <aspect/adiabatic_conditions/interface.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/boundary_composition/interface.cc
+++ b/source/boundary_composition/interface.cc
@@ -25,10 +25,9 @@
 #include <aspect/utilities.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
-#include <tuple>
 
+#include <tuple>
 #include <list>
 
 

--- a/source/boundary_convective_heating/interface.cc
+++ b/source/boundary_convective_heating/interface.cc
@@ -24,7 +24,6 @@
 
 #include <aspect/utilities.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
 
 #include <list>

--- a/source/boundary_fluid_pressure/interface.cc
+++ b/source/boundary_fluid_pressure/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/boundary_fluid_pressure/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/boundary_heat_flux/interface.cc
+++ b/source/boundary_heat_flux/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/boundary_heat_flux/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/boundary_temperature/interface.cc
+++ b/source/boundary_temperature/interface.cc
@@ -25,7 +25,6 @@
 
 #include <aspect/utilities.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
 
 #include <list>

--- a/source/boundary_traction/interface.cc
+++ b/source/boundary_traction/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/boundary_traction/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/boundary_velocity/interface.cc
+++ b/source/boundary_velocity/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/boundary_velocity/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/geometry_model/initial_topography_model/interface.cc
+++ b/source/geometry_model/initial_topography_model/interface.cc
@@ -23,7 +23,6 @@
 #include <aspect/geometry_model/initial_topography_model/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
 #include <list>
 

--- a/source/geometry_model/interface.cc
+++ b/source/geometry_model/interface.cc
@@ -22,10 +22,11 @@
 #include <aspect/global.h>
 #include <aspect/geometry_model/interface.h>
 #include <aspect/simulator_access.h>
-#include <deal.II/base/exceptions.h>
-#include <tuple>
+
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/base/utilities.h>
+
+#include <tuple>
 
 namespace aspect
 {

--- a/source/gravity_model/interface.cc
+++ b/source/gravity_model/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/gravity_model/interface.h>
 #include <aspect/simulator_access.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/heating_model/interface.cc
+++ b/source/heating_model/interface.cc
@@ -25,10 +25,9 @@
 #include <aspect/heating_model/adiabatic_heating.h>
 #include <aspect/heating_model/shear_heating.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
-#include <tuple>
 
+#include <tuple>
 #include <list>
 
 

--- a/source/initial_composition/interface.cc
+++ b/source/initial_composition/interface.cc
@@ -23,9 +23,7 @@
 #include <aspect/utilities.h>
 #include <aspect/initial_composition/interface.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/initial_temperature/interface.cc
+++ b/source/initial_temperature/interface.cc
@@ -22,9 +22,7 @@
 #include <aspect/global.h>
 #include <aspect/initial_temperature/interface.h>
 
-#include <deal.II/base/exceptions.h>
 #include <tuple>
-
 #include <list>
 
 

--- a/source/material_model/interface.cc
+++ b/source/material_model/interface.cc
@@ -25,12 +25,11 @@
 #include <aspect/utilities.h>
 #include <aspect/newton.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
-#include <tuple>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/fe_q.h>
 
+#include <tuple>
 #include <list>
 
 #ifdef DEBUG

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -32,7 +32,6 @@
 #include <aspect/material_model/utilities.h>
 #include <aspect/utilities.h>
 
-#include <deal.II/base/exceptions.h>
 #include <boost/lexical_cast.hpp>
 #include <list>
 

--- a/source/particle/generator/uniform_box.cc
+++ b/source/particle/generator/uniform_box.cc
@@ -20,10 +20,7 @@
 
 #include <aspect/particle/generator/uniform_box.h>
 
-#include <random>
-
 #include <array>
-#include <deal.II/base/exceptions.h>
 
 
 namespace aspect

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -30,8 +30,6 @@
 #include <aspect/geometry_model/initial_topography_model/ascii_data.h>
 #include <aspect/geometry_model/two_merged_chunks.h>
 
-#include <deal.II/base/exceptions.h>
-
 #include <boost/lexical_cast.hpp>
 #include <regex>
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -36,7 +36,6 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/table_indices.h>
 #include <deal.II/base/function_lib.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/patterns.h>
 #include <deal.II/grid/grid_tools.h>

--- a/tests/drucker_prager_derivatives_2d.cc
+++ b/tests/drucker_prager_derivatives_2d.cc
@@ -19,7 +19,6 @@
 */
 
 #include <aspect/simulator.h>
-#include <deal.II/grid/tria.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/drucker_prager.h>
 #include <aspect/simulator_access.h>
@@ -27,10 +26,10 @@
 #include <aspect/utilities.h>
 #include <aspect/parameters.h>
 
-#include <deal.II/base/exceptions.h>
+#include <deal.II/grid/tria.h>
+
 #include <memory>
 #include <functional>
-
 #include <iostream>
 
 namespace aspect

--- a/tests/drucker_prager_derivatives_3d.cc
+++ b/tests/drucker_prager_derivatives_3d.cc
@@ -19,7 +19,6 @@
 */
 
 #include <aspect/simulator.h>
-#include <deal.II/grid/tria.h>
 #include <aspect/material_model/interface.h>
 #include <aspect/material_model/drucker_prager.h>
 #include <aspect/simulator_access.h>
@@ -27,10 +26,10 @@
 #include <aspect/utilities.h>
 #include <aspect/parameters.h>
 
-#include <deal.II/base/exceptions.h>
+#include <deal.II/grid/tria.h>
+
 #include <memory>
 #include <functional>
-
 #include <iostream>
 
 namespace aspect

--- a/tests/ellipsoidal_chunk_geometry.cc
+++ b/tests/ellipsoidal_chunk_geometry.cc
@@ -21,8 +21,6 @@
 #include <aspect/geometry_model/ellipsoidal_chunk.h>
 #include <aspect/geometry_model/initial_topography_model/zero_topography.h>
 
-#include <deal.II/base/exceptions.h>
-
 #include <iostream>
 
 using namespace aspect;

--- a/tests/visco_plastic_derivatives_2d.cc
+++ b/tests/visco_plastic_derivatives_2d.cc
@@ -28,10 +28,9 @@
 #include <aspect/parameters.h>
 
 #include <deal.II/grid/tria.h>
-#include <deal.II/base/exceptions.h>
+
 #include <memory>
 #include <functional>
-
 #include <iostream>
 
 namespace aspect

--- a/tests/visco_plastic_derivatives_3d.cc
+++ b/tests/visco_plastic_derivatives_3d.cc
@@ -28,10 +28,9 @@
 #include <aspect/parameters.h>
 
 #include <deal.II/grid/tria.h>
-#include <deal.II/base/exceptions.h>
+
 #include <memory>
 #include <functional>
-
 #include <iostream>
 
 namespace aspect

--- a/unit_tests/parse_map_to_double_array.cc
+++ b/unit_tests/parse_map_to_double_array.cc
@@ -20,7 +20,6 @@
 
 #include "common.h"
 #include <aspect/utilities.h>
-#include <deal.II/base/exceptions.h>
 
 
 TEST_CASE("Utilities::MapParsing::parse_map_to_double_array")


### PR DESCRIPTION
In #6422 it was discussed that `aspect/source/simulator/advection_field.cc` possibly does not include the header `#include <deal.II/base/exceptions.h>` leading (sometimes) to errors of the sort:
```
In file included from /work2/06806/hyli/frontera/Softwares/dealii/dealii-9.6.1-Native-32bit-candi-intel-19.1.1-impi-19.0.9-normal-07082025/deal.II-v9.6.1/include/deal.II/base/patterns.h(27),                                    from /work2/06806/hyli/frontera/Softwares/dealii/dealii-9.6.1-Native-32bit-candi-intel-19.1.1-impi-19.0.9-normal-07082025/deal.II-v9.6.1/include/deal.II/base/parameter_handler.h(22),
                 from /work2/06806/hyli/frontera/Softwares/aspect/aspect/include/aspect/parameters.h(25),
                 from /work2/06806/hyli/frontera/Softwares/aspect/aspect/include/aspect/advection_field.h(26),
                 from /work2/06806/hyli/frontera/Softwares/aspect/aspect/source/simulator/advection_field.cc(22),
                 from /work2/06806/hyli/frontera/Softwares/aspect/aspect/build_debugrelease/CMakeFiles/aspect.exe.debug.dir/Unity/unity_43_cxx.cxx(3):
/work2/06806/hyli/frontera/Softwares/dealii/dealii-9.6.1-Native-32bit-candi-intel-19.1.1-impi-19.0.9-normal-07082025/deal.II-v9.6.1/include/deal.II/fe/component_mask.h(236): error: namespace "aspect::dealii" has no member class "ExceptionBase"
    DeclExceptionMsg(ExcNoComponentSelected,
```

We could of course include the proper include to that file and be done with it, but I think we are currently very inconsistent about how we include that header file. Most plugins get it indirectly from `plugins.h`, but files that are not plugins have to include it manually. I think since it is such an integral header that is used for every Assert we may as well put it into `global.h` and clean up the remaining files.

As far as I understand when we (at some point in the future) include deal.II as a module we will have to include `exception_macros.h` manually in every file of ASPECT that uses the macros, but this is a slightly separate issue.
