### PR TITLE
Simplify code and avoid dereferencing null pointer

### DIFF
--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -86,71 +86,91 @@ namespace aspect
                     std::vector<double> &melt_fractions,
                     const MaterialModel::MaterialModelOutputs<dim> *out) const
     {
-      std::shared_ptr<const MeltOutputs<dim>> fluid_out;
-      if (out != nullptr)
-        fluid_out = out->template get_additional_output_object<MeltOutputs<dim>>();
+      const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
-      if (fluid_out != nullptr && in.requests_property(MaterialProperties::additional_outputs))
+      for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
         {
-          const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
-
-          for (unsigned int q=0; q<in.n_evaluation_points(); ++q)
+          switch (fluid_solid_reaction_scheme)
             {
-              switch (fluid_solid_reaction_scheme)
-                {
-                  case no_reaction:
-                  {
-                    const double volume_fraction_porosity = in.composition[q][porosity_idx];
-                    // Melt fractions outputs the mass fraction of equilibrium free water at each quadrature point. However,
-                    // the free water is a volume fraction, while the bound water is a mass fraction. Convert the free water
-                    // to a mass fraction so that we correctly compare the two values.
-                    const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);
-                    const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
-                    // No reactions occur between the solid and fluid phases,
-                    // and the fluid mass fraction (stored in the melt_fractions
-                    // vector) is equal to the mass fraction of the porosity.
-                    melt_fractions[q] = mass_fraction_porosity;
-                    break;
-                  }
-                  case zero_solubility:
-                  {
-                    // The fluid volume fraction in equilibrium with the solid
-                    // at any point (stored in the melt_fractions vector) is
-                    // equal to the sum of the bound fluid content and porosity.
+              case no_reaction:
+              {
+                Assert(out != nullptr,
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires the material model "
+                                  "outputs in order to compute melt fractions, but none were provided."));
+                Assert(out->template has_additional_output_object<MeltOutputs<dim>>(),
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires melt material "
+                                  "outputs to compute the melt fractions, but none were provided."));
 
-                    const double volume_fraction_porosity = in.composition[q][porosity_idx];
-                    const unsigned int bound_fluid_idx = this->introspection().compositional_index_for_name("bound_fluid");
-                    // Melt fractions outputs the mass fraction of equilibrium free water at each quadrature point. However,
-                    // the free water is a volume fraction, while the bound water is a mass fraction. Convert the free water
-                    // to a mass fraction so that we correctly compare the two values.
-                    const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);
-                    const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
-                    melt_fractions[q] = in.composition[q][bound_fluid_idx] + mass_fraction_porosity;
-                    break;
-                  }
-                  case tian_approximation:
-                  {
-                    // The tian2019_model melt_fraction function requires the mass fraction of free water at each quadrature
-                    // point as an input. However, the free water is stored in the porosity field as a volume fraction.
-                    // We therefore convert the free water to a mass fraction so that we have the correct input.
-                    const double volume_fraction_porosity = in.composition[q][porosity_idx];
-                    const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);;
-                    const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
-                    melt_fractions[q] = tian2019_model.melt_fraction(in, mass_fraction_porosity, q);
-                    break;
-                  }
-                  case katz2003:
-                  {
-                    melt_fractions[q] = katz2003_model.melt_fraction(in.temperature[q],
-                                                                     this->get_adiabatic_conditions().pressure(in.position[q]));
-                    break;
-                  }
-                  default:
-                  {
-                    AssertThrow(false, ExcNotImplemented());
-                    break;
-                  }
-                }
+                const std::shared_ptr<const MeltOutputs<dim>> fluid_out = out->template get_additional_output_object<MeltOutputs<dim>>();
+
+                const double volume_fraction_porosity = in.composition[q][porosity_idx];
+                // Melt fractions outputs the mass fraction of equilibrium free water at each quadrature point. However,
+                // the free water is a volume fraction, while the bound water is a mass fraction. Convert the free water
+                // to a mass fraction so that we correctly compare the two values.
+                const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);
+                const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
+                // No reactions occur between the solid and fluid phases,
+                // and the fluid mass fraction (stored in the melt_fractions
+                // vector) is equal to the mass fraction of the porosity.
+                melt_fractions[q] = mass_fraction_porosity;
+                break;
+              }
+              case zero_solubility:
+              {
+                Assert(out != nullptr,
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires the material model "
+                                  "outputs in order to compute melt fractions, but none were provided."));
+                Assert(out->template has_additional_output_object<MeltOutputs<dim>>(),
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires melt material "
+                                  "outputs to compute the melt fractions, but none were provided."));
+
+                const std::shared_ptr<const MeltOutputs<dim>> fluid_out = out->template get_additional_output_object<MeltOutputs<dim>>();
+
+                // The fluid volume fraction in equilibrium with the solid
+                // at any point (stored in the melt_fractions vector) is
+                // equal to the sum of the bound fluid content and porosity.
+
+                const double volume_fraction_porosity = in.composition[q][porosity_idx];
+                const unsigned int bound_fluid_idx = this->introspection().compositional_index_for_name("bound_fluid");
+                // Melt fractions outputs the mass fraction of equilibrium free water at each quadrature point. However,
+                // the free water is a volume fraction, while the bound water is a mass fraction. Convert the free water
+                // to a mass fraction so that we correctly compare the two values.
+                const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);
+                const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
+                melt_fractions[q] = in.composition[q][bound_fluid_idx] + mass_fraction_porosity;
+                break;
+              }
+              case tian_approximation:
+              {
+                Assert(out != nullptr,
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires the material model "
+                                  "outputs in order to compute melt fractions, but none were provided."));
+                Assert(out->template has_additional_output_object<MeltOutputs<dim>>(),
+                       ExcMessage("The material model 'ReactiveFluidTransport' requires melt material "
+                                  "outputs to compute the melt fractions, but none were provided."));
+
+                const std::shared_ptr<const MeltOutputs<dim>> fluid_out = out->template get_additional_output_object<MeltOutputs<dim>>();
+
+                // The tian2019_model melt_fraction function requires the mass fraction of free water at each quadrature
+                // point as an input. However, the free water is stored in the porosity field as a volume fraction.
+                // We therefore convert the free water to a mass fraction so that we have the correct input.
+                const double volume_fraction_porosity = in.composition[q][porosity_idx];
+                const double bulk_density = compute_bulk_density(volume_fraction_porosity, out->densities[q], fluid_out->fluid_densities[q]);;
+                const double mass_fraction_porosity = compute_mass_fraction(volume_fraction_porosity, fluid_out->fluid_densities[q], bulk_density);
+                melt_fractions[q] = tian2019_model.melt_fraction(in, mass_fraction_porosity, q);
+                break;
+              }
+              case katz2003:
+              {
+                melt_fractions[q] = katz2003_model.melt_fraction(in.temperature[q],
+                                                                 this->get_adiabatic_conditions().pressure(in.position[q]));
+                break;
+              }
+              default:
+              {
+                AssertThrow(false, ExcNotImplemented());
+                break;
+              }
             }
         }
     }
@@ -232,6 +252,10 @@ namespace aspect
           if (this->get_parameters().use_operator_splitting && reaction_rate_out != nullptr
               && in.requests_property(MaterialProperties::reaction_rates))
             {
+              Assert(fluid_out != nullptr,
+                     ExcMessage("The material model 'ReactiveFluidTransport' requires melt material "
+                                "outputs to compute reaction rates, but none were provided."));
+
               // Fill reaction rate outputs if the model uses operator splitting.
               // Specifically, change the porosity (representing the amount of free fluid)
               // based on the water solubility and the fluid content.


### PR DESCRIPTION
While looking at #6556 I noticed that the code of the reactive fluid transport model is a bit confusing and in particular would potentially dereference a null pointer (if `out` is a null pointer the old line 89 would dereference it).

I fixed the null pointer dereference, but I still have an open question about the functionality of the function: In the current implementation this function will not do anything if `out` is not provided, even for the options that do not require access to `out`. This seems counterintuitive to the idea of an optional argument, either we should assert that `out` is always provided (if we only want to compute melt fractions if it exists), or we should support the case to compute melt fractions if possible even if `out` is not provided. Making an argument optional, but then disabling the whole function if it is not provided just seems like an unintuitive middle ground. I am happy to make either change, but am unsure which way is the correct way to go.

@danieldouglas92 any thoughts on this?

