### PR TITLE
Added timing statistics postprocessor

### DIFF
--- a/doc/modules/changes/20250729_gassmoeller
+++ b/doc/modules/changes/20250729_gassmoeller
@@ -1,0 +1,5 @@
+Added: A new postprocessor 'timing statistics' that writes the
+information about wall time spent in different sections of the
+computation into the statistics file.
+<br>
+(Rene Gassmoeller, 2025/07/29)

--- a/include/aspect/postprocess/timing_statistics.h
+++ b/include/aspect/postprocess/timing_statistics.h
@@ -1,0 +1,57 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef _aspect_postprocess_timing_statistics_h
+#define _aspect_postprocess_timing_statistics_h
+
+#include <aspect/postprocess/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+
+  namespace Postprocess
+  {
+    /**
+     * A postprocessor that outputs timing information in
+     * the statistics file, in particular the total wall time spent
+     * in the different timing sections for each timestep.
+     * Note that this postprocessor cannot report accurate
+     * timings for the postprocessing section as it is
+     * executed before postprocessing is complete.
+     *
+     * @ingroup Postprocessing
+     */
+    template <int dim>
+    class TimingStatistics : public Interface<dim>, public ::aspect::SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Write all timing statistics columns into the statistics object.
+         */
+        std::pair<std::string,std::string>
+        execute (TableHandler &statistics) override;
+    };
+  }
+}
+
+
+#endif

--- a/include/aspect/postprocess/timing_statistics.h
+++ b/include/aspect/postprocess/timing_statistics.h
@@ -33,7 +33,7 @@ namespace aspect
     /**
      * A postprocessor that outputs timing information in
      * the statistics file, in particular the total wall time spent
-     * in the different timing sections for each timestep.
+     * in the different timing sections until the current timestep.
      * Note that this postprocessor cannot report accurate
      * timings for the postprocessing section as it is
      * executed before postprocessing is complete.

--- a/source/postprocess/timing_statistics.cc
+++ b/source/postprocess/timing_statistics.cc
@@ -1,0 +1,64 @@
+/*
+  Copyright (C) 2025 - by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/postprocess/timing_statistics.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    template <int dim>
+    std::pair<std::string,std::string>
+    TimingStatistics<dim>::execute (TableHandler &statistics)
+    {
+      const auto &timer = this->get_computing_timer();
+      const std::map<std::string, double> &timing_map = timer.get_summary_data(TimerOutput::total_wall_time);
+
+      for (const auto &section: timing_map)
+        {
+          const std::string section_name = "Wall time: " + section.first;
+          statistics.add_value(section_name,
+                               section.second);
+          statistics.set_scientific(section_name, true);
+        }
+
+      return std::make_pair (std::string(),std::string());
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace Postprocess
+  {
+    ASPECT_REGISTER_POSTPROCESSOR(TimingStatistics,
+                                  "timing statistics",
+                                  "A postprocessor that outputs timing information in "
+                                  "the statistics file, in particular the total wall time spent "
+                                  "in the different timing sections for each timestep. "
+                                  "Note that this postprocessor cannot report accurate "
+                                  "timings for the postprocessing section as it is "
+                                  "executed before postprocessing is complete.")
+  }
+}

--- a/source/postprocess/timing_statistics.cc
+++ b/source/postprocess/timing_statistics.cc
@@ -35,7 +35,7 @@ namespace aspect
 
       for (const auto &section: timing_map)
         {
-          const std::string section_name = "Wall time: " + section.first;
+          const std::string section_name = "Total wall time: " + section.first;
           statistics.add_value(section_name,
                                section.second);
           statistics.set_scientific(section_name, true);
@@ -56,7 +56,7 @@ namespace aspect
                                   "timing statistics",
                                   "A postprocessor that outputs timing information in "
                                   "the statistics file, in particular the total wall time spent "
-                                  "in the different timing sections for each timestep. "
+                                  "in the different timing sections until the current timestep. "
                                   "Note that this postprocessor cannot report accurate "
                                   "timings for the postprocessing section as it is "
                                   "executed before postprocessing is complete.")

--- a/tests/timing_statistics.prm
+++ b/tests/timing_statistics.prm
@@ -1,0 +1,80 @@
+# This test makes sure the timing statistics postprocessor
+# works as intended.
+
+set Dimension                              = 2
+set Use years in output instead of seconds = true
+set End time                               = 1
+set Pressure normalization                 = surface
+set Surface pressure                       = 0
+set Adiabatic surface temperature          = 1723.15   # 1450°C adiabat
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 1000000
+    set Y extent = 1000000
+  end
+end
+
+subsection Compositional fields
+  set Number of fields = 2
+  set Names of fields = porosity, peridotite
+end
+
+subsection Initial temperature model
+  set Model name = harmonic perturbation
+
+  subsection Harmonic perturbation
+    set Magnitude = 100
+  end
+end
+
+subsection Initial composition model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 0.1; 0.0
+  end
+end
+
+subsection Boundary temperature model
+  set List of model names = initial temperature
+  set Fixed temperature boundary indicators = left, right, top, bottom
+end
+
+subsection Boundary composition model
+  set List of model names = initial composition
+  set Fixed composition boundary indicators = left, right, top, bottom
+end
+
+subsection Boundary velocity model
+  set Tangential velocity boundary indicators = left, right, top, bottom
+end
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+subsection Material model
+  set Model name = simpler
+
+  subsection Simpler model
+    set Reference density = 3400
+    set Viscosity = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement                = 1
+  set Initial adaptive refinement              = 0
+  set Time steps between mesh refinement       = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = temperature statistics, velocity statistics, timing statistics
+end

--- a/tests/timing_statistics/screen-output
+++ b/tests/timing_statistics/screen-output
@@ -1,0 +1,28 @@
+
+Number of active cells: 4 (on 2 levels)
+Number of degrees of freedom: 134 (50+9+25+25+25)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 6+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max: 1500 K, 1619 K, 1671 K
+     RMS, max velocity:       0.00723 m/year, 0.0207 m/year
+
+*** Timestep 1:  t=1 years, dt=1 years
+   Solving temperature system... 2 iterations.
+   Solving porosity system ... 0 iterations.
+   Skipping peridotite composition solve because RHS is zero.
+   Solving Stokes system (GMG)... 2+0 iterations.
+
+   Postprocessing:
+     Temperature min/avg/max: 1500 K, 1619 K, 1671 K
+     RMS, max velocity:       0.00723 m/year, 0.0207 m/year
+
+Termination requested by criterion: end time
+
+
+


### PR DESCRIPTION
I added a new postprocessor for wall time information. Once I thought of this I was surprised we didnt introduce this years ago. I regret the amount of time I must have wasted reading the timing information (via script) out of the log files and reformatting it for various benchmark projects ...

Unfortunately the test result cannot include the output of the postprocessor as it is run dependent. But to show what it looks like in the statistics file:

```
# 1: Time step number
# 2: Time (years)
# 3: Time step size (years)
# 4: Number of mesh cells
# 5: Number of Stokes degrees of freedom
# 6: Number of temperature degrees of freedom
# 7: Number of degrees of freedom for all compositions
# 8: Iterations for temperature solver
# 9: Iterations for composition solver 1
# 10: Iterations for composition solver 2
# 11: Iterations for Stokes solver
# 12: Velocity iterations in Stokes preconditioner
# 13: Schur complement iterations in Stokes preconditioner
# 14: Minimal temperature (K)
# 15: Average temperature (K)
# 16: Maximal temperature (K)
# 17: Average nondimensional temperature (K)
# 18: RMS velocity (m/year)
# 19: Max. velocity (m/year)
# 20: Wall time: Assemble Stokes system rhs
# 21: Wall time: Assemble composition system
# 22: Wall time: Assemble temperature system
# 23: Wall time: Build Stokes preconditioner
# 24: Wall time: Build composition preconditioner
# 25: Wall time: Build temperature preconditioner
# 26: Wall time: Initialization
# 27: Wall time: Postprocessing
# 28: Wall time: Setup dof systems
# 29: Wall time: Setup initial conditions
# 30: Wall time: Setup matrices
# 31: Wall time: Solve Stokes system
# 32: Wall time: Solve composition system
# 33: Wall time: Solve temperature system
0 0.000000000000e+00 0.000000000000e+00 4 59 25 50 0 0 0 6 7 7 1.50000000e+03 1.61944444e+03 1.67071068e+03 3.16576847e-02 7.23402504e-03 2.07302931e-02 5.8707e-03 8.1252e-03 3.5802e-03 4.3295e-04 6.4490e-05 3.1395e-04 2.8781e-01 0.0000e+00 1.5699e-02 9.6020e-03 2.3794e-03 9.0064e-03 1.9060e-04 2.8902e-04 
1 1.000000000000e+00 1.000000000000e+00 4 59 25 50 2 0 0 2 3 3 1.50000000e+03 1.61944444e+03 1.67071068e+03 3.16576845e-02 7.23402508e-03 2.07302913e-02 1.0191e-02 1.6695e-02 6.6729e-03 8.7232e-04 1.3190e-04 3.8580e-04 2.8781e-01 1.0043e-03 1.5699e-02 9.6020e-03 2.3794e-03 1.3765e-02 3.7376e-04 5.4207e-04 
```
