### PR TITLE
Allow recursive includes from command line

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -407,8 +407,7 @@ namespace
                                                     /*root=*/0);
       }
 
-
-    // Search and replace include directives in the input file.
+    // Now search for and replace include directives in the input string.
     std::match_results<std::string::const_iterator> matches;
     const std::string search_regex = "(?:^|\n)[ \t]*include[ \t]+(.*?)[ \t]*(?:#|\n|$)";
     const std::string replace_regex = "(?:^|\n)[ \t]*include[ \t]+.*";

--- a/source/main.cc
+++ b/source/main.cc
@@ -392,49 +392,6 @@ namespace
           }
 
         input_as_string = aspect::Utilities::read_and_distribute_file_content(parameter_file_name, comm);
-
-        // Search and replace include directives in the input file.
-        std::match_results<std::string::const_iterator> matches;
-        const std::string search_regex = "(?:^|\n)[ \t]*include[ \t]+(.*?)[ \t]*(?:#|\n|$)";
-        const std::string replace_regex = "(?:^|\n)[ \t]*include[ \t]+.*";
-
-        unsigned int n_included_files = 0;
-
-        while (std::regex_search(input_as_string, matches, std::regex(search_regex)))
-          {
-            // Make sure we are not circularly including files. This is not easily possible
-            // by making sure included files are unique, because we may have multiple
-            // files including the same file in a non-circular way. So we just limit
-            // the number of included files to a reasonable number.
-            AssertThrow(n_included_files < 15,
-                        dealii::ExcMessage("Too many included files in parameter file. You likely have a circular include."));
-
-            // Since the line as a whole matched, the 'matches' variable needs to
-            // contain two entries: [0] denotes the whole line, and [1] the
-            // part that was matched by the '(.*?)' expression.
-            Assert (matches.size() == 2, dealii::ExcInternalError());
-
-            const std::string included_filename(matches.str(1));
-            const std::string prefix = "\n# Included content from " + included_filename + ":\n\n";
-
-            // Expand ASPECT_SOURCE_DIR in the included file name, but not the content of the file
-            // (to keep the formatting of all parameter files intact, which we will copy into the output directory).
-            const std::string expanded_filename = aspect::Utilities::expand_ASPECT_SOURCE_DIR(matches.str(1));
-
-            // Prepend a newline character to the included file content, because if the include directive
-            // is not in the first line, we will replace one newlince character
-            // from the original input file in the regex_replace below.
-            const std::string included_file_content = aspect::Utilities::read_and_distribute_file_content(expanded_filename, comm);
-
-            // Replace the include line with the content of the included file. Note that we only replace the first
-            // include line we find (there may be several, which we will replace in subsequent iterations).
-            input_as_string = std::regex_replace(input_as_string,
-                                                 std::regex(replace_regex),
-                                                 prefix + included_file_content,
-                                                 std::regex_constants::format_first_only);
-
-            ++n_included_files;
-          }
       }
     else
       {
@@ -448,6 +405,50 @@ namespace
           input_as_string = read_until_end (std::cin);
         input_as_string = Utilities::MPI::broadcast(MPI_COMM_WORLD, input_as_string,
                                                     /*root=*/0);
+      }
+
+
+    // Search and replace include directives in the input file.
+    std::match_results<std::string::const_iterator> matches;
+    const std::string search_regex = "(?:^|\n)[ \t]*include[ \t]+(.*?)[ \t]*(?:#|\n|$)";
+    const std::string replace_regex = "(?:^|\n)[ \t]*include[ \t]+.*";
+
+    unsigned int n_included_files = 0;
+
+    while (std::regex_search(input_as_string, matches, std::regex(search_regex)))
+      {
+        // Make sure we are not circularly including files. This is not easily possible
+        // by making sure included files are unique, because we may have multiple
+        // files including the same file in a non-circular way. So we just limit
+        // the number of included files to a reasonable number.
+        AssertThrow(n_included_files < 15,
+                    dealii::ExcMessage("Too many included files in parameter file. You likely have a circular include."));
+
+        // Since the line as a whole matched, the 'matches' variable needs to
+        // contain two entries: [0] denotes the whole line, and [1] the
+        // part that was matched by the '(.*?)' expression.
+        Assert (matches.size() == 2, dealii::ExcInternalError());
+
+        const std::string included_filename(matches.str(1));
+        const std::string prefix = "\n# Included content from " + included_filename + ":\n\n";
+
+        // Expand ASPECT_SOURCE_DIR in the included file name, but not the content of the file
+        // (to keep the formatting of all parameter files intact, which we will copy into the output directory).
+        const std::string expanded_filename = aspect::Utilities::expand_ASPECT_SOURCE_DIR(matches.str(1));
+
+        // Prepend a newline character to the included file content, because if the include directive
+        // is not in the first line, we will replace one newlince character
+        // from the original input file in the regex_replace below.
+        const std::string included_file_content = aspect::Utilities::read_and_distribute_file_content(expanded_filename, comm);
+
+        // Replace the include line with the content of the included file. Note that we only replace the first
+        // include line we find (there may be several, which we will replace in subsequent iterations).
+        input_as_string = std::regex_replace(input_as_string,
+                                             std::regex(replace_regex),
+                                             prefix + included_file_content,
+                                             std::regex_constants::format_first_only);
+
+        ++n_included_files;
       }
 
     return input_as_string;

--- a/tests/include_prm_file_recursive_command_line.cc
+++ b/tests/include_prm_file_recursive_command_line.cc
@@ -1,0 +1,67 @@
+/*
+  Copyright (C) 2025 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/simulator.h>
+#include <iostream>
+
+/*
+ * Launch the following function when this plugin is created. Launch ASPECT
+ * from the command line and then continue with the outer ASPECT run.
+ */
+int f()
+{
+  std::cout << "* Starting from command line ..." << std::endl;
+
+  // call ASPECT with "--" and pipe an existing input file into it.
+  int ret;
+  std::string command;
+
+  command = ("cd output-include_prm_file_recursive_command_line ; "
+             "(cat " ASPECT_SOURCE_DIR "/tests/include_prm_file_recursive_command_line.prm "
+             " ; "
+             " echo 'set Output directory = output1.tmp' "
+             " ; "
+             " rm -rf output1.tmp ; mkdir output1.tmp "
+             ") "
+             "| ../../aspect -- > /dev/null");
+  std::cout << "* Executing the following command:\n"
+            << command
+            << std::endl;
+  ret = system (command.c_str());
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  std::cout << "* Copying output files ..." << std::endl;
+
+  ret = system ("cd output-include_prm_file_recursive_command_line ; "
+                "cp output1.tmp/log.txt log_command_line.txt;"
+                "cp output1.tmp/statistics statistics_command_line;"
+                "");
+  if (ret!=0)
+    std::cout << "system() returned error " << ret << std::endl;
+
+  std::cout << "* Continuing run from parameter file ..." << std::endl;
+
+  return 42;
+}
+
+
+// run this function by initializing a global variable by it
+int i = f();

--- a/tests/include_prm_file_recursive_command_line.prm
+++ b/tests/include_prm_file_recursive_command_line.prm
@@ -1,0 +1,8 @@
+# Test for recursively including prm files when starting ASPECT
+# from the command line. The shared library loaded with this
+# test will first execute this test from the terminal, then
+# continue to execute the regular file. Both outputs should
+# be identical except for the status messages of the
+# shared library.
+
+include $ASPECT_SOURCE_DIR/tests/include_prm_file.prm

--- a/tests/include_prm_file_recursive_command_line/log_command_line.txt
+++ b/tests/include_prm_file_recursive_command_line/log_command_line.txt
@@ -1,0 +1,18 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 17+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output1.tmp/solution/solution-00000
+     RMS, max velocity:                  9e-09 m/s, 3.27e-08 m/s
+     Temperature min/avg/max:            0 K, 1.035 K, 1.1 K
+     Heat fluxes through boundary parts: 1.667e-07 W, 6.239e-05 W, 0 W, 0 W
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/include_prm_file_recursive_command_line/screen-output
+++ b/tests/include_prm_file_recursive_command_line/screen-output
@@ -1,0 +1,25 @@
+
+Loading shared library <./libinclude_prm_file_recursive_command_line.debug.so>
+* Starting from command line ...
+* Executing the following command:
+cd output-include_prm_file_recursive_command_line ; (cat ASPECT_DIR/tests/include_prm_file_recursive_command_line.prm  ;  echo 'set Output directory = output1.tmp'  ;  rm -rf output1.tmp ; mkdir output1.tmp ) | ../../aspect -- > /dev/null
+* Copying output files ...
+* Continuing run from parameter file ...
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 17+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:           output-include_prm_file_recursive_command_line/solution/solution-00000
+     RMS, max velocity:                  9e-09 m/s, 3.27e-08 m/s
+     Temperature min/avg/max:            0 K, 1.035 K, 1.1 K
+     Heat fluxes through boundary parts: 1.667e-07 W, 6.239e-05 W, 0 W, 0 W
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/include_prm_file_recursive_command_line/statistics
+++ b/tests/include_prm_file_recursive_command_line/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/s)
+# 13: Max. velocity (m/s)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 0 17 18 18 output-include_prm_file_recursive_command_line/solution/solution-00000 9.00076535e-09 3.27314390e-08 0.00000000e+00 1.03532014e+00 1.10000000e+00 1.03532014e+00 1.66666640e-07 6.23888889e-05 0.00000000e+00 0.00000000e+00 

--- a/tests/include_prm_file_recursive_command_line/statistics_command_line
+++ b/tests/include_prm_file_recursive_command_line/statistics_command_line
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/s)
+# 13: Max. velocity (m/s)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+# 18: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 19: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 20: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 21: Outward heat flux through boundary with indicator 3 ("top") (W)
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 0 17 18 18 output1.tmp/solution/solution-00000 9.00076535e-09 3.27314390e-08 0.00000000e+00 1.03532014e+00 1.10000000e+00 1.03532014e+00 1.66666640e-07 6.23888889e-05 0.00000000e+00 0.00000000e+00 


### PR DESCRIPTION
#6175 allowed to recursively include parameter files and correctly read parameters like `Dimension` from these files. 

Unfortunately, that was not implemented for models started from the command line. Therefore we can have models that work fine if started as `aspect input.prm`, but not if started as `cat input.prm | aspect --`.

This PR fixes this oversight, by moving the code responsible for recursive inclusion after reading from the command line (no change in the code was made, except for the starting comment). I also added a test that executes the same model, once from file, once from command line, and makes sure the output is identical.