### PR TITLE
Set reasonable viscosities in tests

### DIFF
--- a/tests/adiabatic_conditions.prm
+++ b/tests/adiabatic_conditions.prm
@@ -52,7 +52,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 1e-6
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions.prm
+++ b/tests/adiabatic_initial_conditions.prm
@@ -66,7 +66,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions_chunk.prm
+++ b/tests/adiabatic_initial_conditions_chunk.prm
@@ -65,7 +65,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions_chunk_3d.prm
+++ b/tests/adiabatic_initial_conditions_chunk_3d.prm
@@ -69,7 +69,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions_compressible.prm
+++ b/tests/adiabatic_initial_conditions_compressible.prm
@@ -62,7 +62,7 @@ subsection Material model
     set Reference specific heat       = 1250
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions_constant.prm
+++ b/tests/adiabatic_initial_conditions_constant.prm
@@ -66,7 +66,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 4e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 

--- a/tests/adiabatic_initial_conditions_subadiabaticity.prm
+++ b/tests/adiabatic_initial_conditions_subadiabaticity.prm
@@ -66,7 +66,7 @@ subsection Material model
     set Reference temperature         = 1613
     set Thermal conductivity          = 4.125
     set Thermal expansion coefficient = 2e-5
-    set Viscosity                     = 1
+    set Viscosity                     = 1e21
   end
 end
 


### PR DESCRIPTION
These test cases have repeatedly caused issues when updating to new deal.II versions, because they use dimensional units, but set viscosity to 1, which leads to unreasonable Rayleigh numbers. All of the test cases are not made to test the Stokes solver, they just test the initial temperature profile, so it really doesnt play a role, unless that their velocity results can change significantly with small changes in the algorithm.

Replace the viscosities with something more reasonable, which will hopefully reduce future problems with these tests. I looked briefly through all tests that set viscosity to 1 and decided based on the other material parameters if they use nondimensional units (in which case I left the viscosity unchanged), or if they used dimensional units.

Let's see if the updated test results look reasonable.

Related to the discussion in #6638.