### PR TITLE
Expand resource usage report at model end to include energy and carbon intensity

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2256,7 +2256,10 @@ namespace aspect
                     << 's'
                     << std::endl;
 
-    if (resource_usage > 0.1)
+    // Provide output about the resources used during the computation, but only
+    // if the model run is longer than our test cases. This ensures the
+    // additional empty lines do not confuse our test system.
+    if (resource_usage > 0.2)
       resource_output << "\n-- Approximate resource usage including restarts:             "
                       << resource_usage
                       << " core hours"
@@ -2273,7 +2276,7 @@ namespace aspect
                       << resource_usage * 0.005 * 0.3
                       << " kgCO2"
                       << std::endl
-                      << "-- Please use ASPECT responsibly. "
+                      << "-- Please use ASPECT responsibly."
                       << std::endl << std::endl;
 
     pcout << resource_output.str();

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2246,9 +2246,37 @@ namespace aspect
     if (nonlinear_solver_failures > 0)
       pcout << "\nWARNING: During this computation " << nonlinear_solver_failures << " nonlinear solver failures occurred!" << std::endl;
 
-    pcout << "-- Total wallclock time elapsed including restarts: "
-          << std::round(wall_timer.wall_time()+total_walltime_until_last_snapshot)
-          << 's' << std::endl;
+    const double wallclock_time = wall_timer.wall_time()+total_walltime_until_last_snapshot;
+    const double resource_usage = wallclock_time / 3600. * Utilities::MPI::n_mpi_processes(mpi_communicator);
+
+    std::ostringstream resource_output;
+    resource_output << std::setprecision(2);
+    resource_output << "-- Total wallclock time elapsed including restarts: "
+                    << std::round(wallclock_time)
+                    << 's'
+                    << std::endl;
+
+    if (resource_usage > 0.1)
+      resource_output << "\n-- Approximate resource usage including restarts:             "
+                      << resource_usage
+                      << " core hours"
+                      << std::endl
+                      << "-- Approximate economic cost assuming 0.10 $/core hour:       "
+                      << resource_usage * 0.1
+                      << " $"
+                      << std::endl
+                      << "-- Approximate energy usage assuming 5 Wh/core hour:          "
+                      << resource_usage * 0.005
+                      << " kWh"
+                      << std::endl
+                      << "-- Approximate energy carbon footprint assuming 300 gCO2/kWh: "
+                      << resource_usage * 0.005 * 0.3
+                      << " kgCO2"
+                      << std::endl
+                      << "-- Please use ASPECT responsibly. "
+                      << std::endl << std::endl;
+
+    pcout << resource_output.str();
 
     CitationInfo::print_info_block (pcout);
 


### PR DESCRIPTION
Following a discussion on the environmental impact of scientific computing I thought it would be useful to output approximate resource usage information in our screen output. We already report total wall time, which can be approximately converted to total energy use and carbon emissions.

Of course these numbers are rough estimates, 5Wh/CPU hour is relatively optimistic for x86 server CPUs except for the latest generations, and carbon intensity of energy production varies a lot internationally and decreases rapidly in many countries in recent years. Additionally this does not include supply-chain energy use and carbon emission for producing the hardware/buildings/etc. Still I think it may be useful to report, simply to make users aware of the potential impact of their models. For most small models the numbers will be negligible, but large computations should be done responsibly.

The message looks like the following, and will be ignored in test output because of the preceding `--`:

```
+----------------------------------------------+------------+------------+
| Total wallclock time elapsed since start     |      2.03s |            |
|                                              |            |            |
| Section                          | no. calls |  wall time | % of total |
+----------------------------------+-----------+------------+------------+
| Assemble Stokes system rhs       |         1 |    0.0939s |       4.6% |
| Assemble temperature system      |         1 |     0.129s |       6.4% |
| Build Stokes preconditioner      |         1 |    0.0116s |      0.57% |
| Build temperature preconditioner |         1 |   0.00155s |         0% |
| Initialization                   |         1 |     0.658s |        32% |
| Postprocessing                   |         1 |    0.0824s |       4.1% |
| Setup dof systems                |         1 |     0.209s |        10% |
| Setup initial conditions         |         1 |    0.0552s |       2.7% |
| Setup matrices                   |         1 |    0.0219s |       1.1% |
| Solve Stokes system              |         1 |     0.597s |        29% |
| Solve temperature system         |         1 |   0.00202s |         0% |
+----------------------------------+-----------+------------+------------+

-- Total wallclock time elapsed including restarts: 2s
-- Approximate resource usage including restarts: 0.0068 CPU hours
-- Approximate economic cost assuming 0.1 $/CPU hour: 0.00068 $
-- Approximate energy usage assuming 5 Wh/CPU hour: 3.4e-05 kWh
-- Approximate energy carbon footprint assuming 300 gCO2/kWh: 1e-05 kgCO2
-- Please use ASPECT responsibly. 
-----------------------------------------------------------------------------
-- For information on how to cite ASPECT, see:
--   https://aspect.geodynamics.org/citing.html?ver=3.1.0-pre&cbfheatflux=1&mf=1&sha=0a585bea7e&src=code
-----------------------------------------------------------------------------