### PR TITLE
Provide a useful error message.

### DIFF
--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1069,7 +1069,19 @@ namespace aspect
           if (prm.get ("Material file format") == "perplex")
             material_file_format = perplex;
           else if (prm.get ("Material file format") == "hefesto")
-            material_file_format = hefesto;
+            {
+              material_file_format = hefesto;
+              AssertThrow (material_file_names.size() == derivatives_file_names.size(),
+                           ExcMessage ("When using HeFESTO files, you need to provide as many file names "
+                                       "for derivatives (via the `Derivatives file names' parameter "
+                                       "as for the material files (via the `Material file names' parameter). "
+                                       "But in your input file, you have the following:"
+                                       "\n   Material file names = " +
+                                       prm.get ("Material file names") +
+                                       "\n   Derivatives file names = " +
+                                       prm.get ("Derivatives file names") +
+                                       "\nThese do not have the same number of elements."));
+            }
           else
             AssertThrow (false, ExcNotImplemented());
 


### PR DESCRIPTION
This is in response to the forum post at https://community.geodynamics.org/t/grain-size-model-with-density-compositional-fields/4206/24 where we just access in invalid array element because we do not check that an array has the right size.