### PR TITLE
Re-use rather than re-created std::regex objects.

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -91,8 +91,8 @@ namespace
           line.erase(line.size() - 1, std::string::npos);
 
         std::match_results<std::string::const_iterator> matches;
-        const std::string regex = "set[ \t]+" + parameter_name + "[ \t]*=[ \t]*(.*)";
-        if (std::regex_match(line, matches, std::regex(regex)))
+        const std::regex regex ("set[ \t]+" + parameter_name + "[ \t]*=[ \t]*(.*)");
+        if (std::regex_match(line, matches, regex))
           {
             // Since the line as a whole matched, the 'matches' variable needs to
             // contain two entries: [0] denotes the whole string, and [1] the
@@ -410,12 +410,12 @@ namespace
 
     // Now search for and replace include directives in the input string.
     std::match_results<std::string::const_iterator> matches;
-    const std::string search_regex = "(?:^|\n)[ \t]*include[ \t]+(.*?)[ \t]*(?:#|\n|$)";
-    const std::string replace_regex = "(?:^|\n)[ \t]*include[ \t]+.*";
+    const std::regex search_regex ("(?:^|\n)[ \t]*include[ \t]+(.*?)[ \t]*(?:#|\n|$)");
+    const std::regex replace_regex ("(?:^|\n)[ \t]*include[ \t]+.*");
 
     unsigned int n_included_files = 0;
 
-    while (std::regex_search(input_as_string, matches, std::regex(search_regex)))
+    while (std::regex_search(input_as_string, matches, search_regex))
       {
         // Make sure we are not circularly including files. This is not easily possible
         // by making sure included files are unique, because we may have multiple
@@ -444,7 +444,7 @@ namespace
         // Replace the include line with the content of the included file. Note that we only replace the first
         // include line we find (there may be several, which we will replace in subsequent iterations).
         input_as_string = std::regex_replace(input_as_string,
-                                             std::regex(replace_regex),
+                                             replace_regex,
                                              prefix + included_file_content,
                                              std::regex_constants::format_first_only);
 

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -2121,7 +2121,7 @@ namespace aspect
                                        "At the moment the type of field " + names_of_compositional_fields[i] + " is unspecified."));
               }
             else if ((names_of_compositional_fields[i].find("strain") != std::string::npos)
-                     || (std::regex_match(names_of_compositional_fields[i],std::regex("s[1-3][1-3]"))))
+                     || (std::regex_match(names_of_compositional_fields[i], std::regex("s[1-3][1-3]"))))
               x_compositional_field_types[i] = "strain";
             else if (names_of_compositional_fields[i].find("grain_size") != std::string::npos)
               x_compositional_field_types[i] = "grain size";


### PR DESCRIPTION
Inspired by looking at #6626: Creating `std::regex` object is expensive (or at least should be: good implementations compile the regex into a state machine), and so we should be creating them once when they are used repeatedly. This patch pulls the creation of the regexes out of loops.