### PR TITLE
Fix capitalization of ParticleDistributionScore postprocessor

### DIFF
--- a/source/postprocess/particle_distribution_score.cc
+++ b/source/postprocess/particle_distribution_score.cc
@@ -263,7 +263,7 @@ namespace aspect
   namespace Postprocess
   {
     ASPECT_REGISTER_POSTPROCESSOR(ParticleDistributionScore,
-                                  "Particle Distribution Score",
+                                  "particle distribution score",
                                   "This postprocessor is intended to help evaluate how much the density of particles "
                                   "varies within cells, with the goal of supporting the development of algorithms "
                                   "to select particles for deletion and addition during load balancing. "

--- a/tests/particle_distribution_score.prm
+++ b/tests/particle_distribution_score.prm
@@ -127,7 +127,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Score
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, particle distribution score
 
   subsection Visualization
     set Time between graphical output = .001

--- a/tests/particle_distribution_score_3d.prm
+++ b/tests/particle_distribution_score_3d.prm
@@ -129,7 +129,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Score
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, particle distribution score
 
   subsection Visualization
     set Time between graphical output = .001


### PR DESCRIPTION
This pull request contains one commit which changes the capitalization of the ParticleDistributionScore postprocessor in the ASPECT_REGISTER_POSTPROCESSOR() function to be the same as every other postprocessor.

It was miss-capitalized as "Particle Distribution Score," now it's correctly capitalized as "particle distribution score".