### PR TITLE
Fix capitalization of ParticleDistributionStatistics

### DIFF
--- a/source/postprocess/particle_distribution_statistics.cc
+++ b/source/postprocess/particle_distribution_statistics.cc
@@ -233,7 +233,7 @@ namespace aspect
   namespace Postprocess
   {
     ASPECT_REGISTER_POSTPROCESSOR(ParticleDistributionStatistics,
-                                  "Particle Distribution Statistics",
+                                  "particle distribution statistics",
                                   "A postprocessor that computes some statistics about "
                                   "the particle distribution within grid cells. In particular "
                                   "it calculates a point-density function for every cell and derives "

--- a/tests/particle_distribution_statistics.prm
+++ b/tests/particle_distribution_statistics.prm
@@ -129,7 +129,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Statistics
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, particle distribution statistics
 
   subsection Visualization
     set Time between graphical output = .001

--- a/tests/particle_distribution_statistics_per_particle.prm
+++ b/tests/particle_distribution_statistics_per_particle.prm
@@ -129,7 +129,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Statistics
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, particle distribution statistics
 
   subsection Visualization
     set Time between graphical output = .001

--- a/tests/particle_distribution_statistics_singlecell.prm
+++ b/tests/particle_distribution_statistics_singlecell.prm
@@ -118,7 +118,7 @@ end
 
 
 subsection Postprocess
-  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, Particle Distribution Statistics, particle count statistics
+  set List of postprocessors = velocity statistics, temperature statistics, heat flux statistics, visualization, particles, particle distribution statistics, particle count statistics
 
   subsection Visualization
     set Time between graphical output = .001


### PR DESCRIPTION
This pull request should have been part of #6649, but I forgot to pull from the upstream ASPECT repository before creating the branch I used for that pull request and so my local branch did not have the Particle_distribution_statistics.cc file in it, which I needed to edit to fix the capitalization. I could not figure out a clean way to include that file in the branch used in pull request #6649 without including a lot of other merge information, so I thought the easiest solution would be to create a new pull request.