### PR TITLE
Avoid circular include

### DIFF
--- a/include/aspect/particle/distribution.h
+++ b/include/aspect/particle/distribution.h
@@ -27,7 +27,7 @@
 #include <limits>
 #include <deal.II/base/table.h>
 #include <deal.II/particles/property_pool.h>
-#include <aspect/particle/manager.h>
+#include <deal.II/particles/particle_handler.h>
 #include <deal.II/base/function_lib.h>
 
 namespace aspect
@@ -92,7 +92,7 @@ namespace aspect
          * @param n_particles_in_cell The number of particles belonging to the particle manager in question within the cell.
          */
         void
-        fill_from_particle_range(const typename ParticleHandler<dim>::particle_iterator_range particle_range,
+        fill_from_particle_range(const typename Particles::ParticleHandler<dim>::particle_iterator_range particle_range,
                                  const unsigned int n_particles_in_cell);
 
         /**
@@ -109,7 +109,7 @@ namespace aspect
         insert_kernel_sum_from_particle_range(const Point<dim> reference_point,
                                               std::array<unsigned int,dim> table_index,
                                               const unsigned int n_particles_in_cell,
-                                              const typename ParticleHandler<dim>::particle_iterator_range particle_range);
+                                              const typename Particles::ParticleHandler<dim>::particle_iterator_range particle_range);
 
         /**
          * Inserts a value into the point-density function.

--- a/source/particle/distribution.cc
+++ b/source/particle/distribution.cc
@@ -67,7 +67,7 @@ namespace aspect
 
     template <int dim>
     void
-    ParticlePDF<dim>::fill_from_particle_range(const typename ParticleHandler<dim>::particle_iterator_range particle_range,
+    ParticlePDF<dim>::fill_from_particle_range(const typename Particles::ParticleHandler<dim>::particle_iterator_range particle_range,
                                                const unsigned int n_particles_in_cell)
     {
       if (is_defined_per_particle == false)
@@ -137,7 +137,7 @@ namespace aspect
     ParticlePDF<dim>::insert_kernel_sum_from_particle_range(const Point<dim> reference_point,
                                                             const std::array<unsigned int, dim> table_index,
                                                             const unsigned int n_particles_in_cell,
-                                                            const typename Particle::ParticleHandler<dim>::particle_iterator_range particle_range)
+                                                            const typename Particles::ParticleHandler<dim>::particle_iterator_range particle_range)
     {
       for (const auto &particle: particle_range)
         {


### PR DESCRIPTION
Only include the necessary headers in particle/distribution.h/.cc. Including `aspect/particle/manager.h` would otherwise lead to a circular include in the PR #6651.