### PR TITLE
Sort solver schemes systematically

### DIFF
--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -438,28 +438,14 @@ namespace aspect
        * This function implements one scheme for the various
        * steps necessary to assemble and solve the nonlinear problem.
        *
-       * If `single Advection, single Stokes' is selected as the nonlinear solver scheme,
-       * no nonlinear iterations are done, and the temperature, compositional fields and
-       * Stokes equations are solved exactly once per time step, one after the other.
+       * The `no Advection, no Stokes' scheme skips solving the temperature,
+       * composition and Stokes equations, which permits to go directly to
+       * postprocessing after setting up the initial condition.
        *
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_single_advection_single_stokes ();
-
-      /**
-       * This function implements one scheme for the various
-       * steps necessary to assemble and solve the nonlinear problem.
-       *
-       * The `no Advection, iterated Stokes' scheme only solves the Stokes system and
-       * ignores compositions and the temperature equation (careful, the material
-       * model must not depend on the temperature; mostly useful for
-       * Stokes benchmarks).
-       *
-       * This function is implemented in
-       * <code>source/simulator/solver_schemes.cc</code>.
-       */
-      void solve_no_advection_iterated_stokes ();
+      void solve_no_advection_no_stokes ();
 
       /**
        * This function implements one scheme for the various
@@ -484,35 +470,21 @@ namespace aspect
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_first_timestep_only_single_stokes ();
+      void solve_no_advection_single_stokes_first_timestep_only ();
 
       /**
        * This function implements one scheme for the various
        * steps necessary to assemble and solve the nonlinear problem.
        *
-       * The `iterated Advection and Stokes' scheme iterates
-       * by alternating the solution of the temperature, composition and Stokes systems.
-       * This is essentially a type of Picard iterations for the whole
-       * system of equations.
+       * The `no Advection, iterated Stokes' scheme only solves the Stokes system and
+       * ignores compositions and the temperature equation (careful, the material
+       * model must not depend on the temperature; mostly useful for
+       * Stokes benchmarks).
        *
        * This function is implemented in
        * <code>source/simulator/solver_schemes.cc</code>.
        */
-      void solve_iterated_advection_and_stokes ();
-
-      /**
-       * This function implements one scheme for the various
-       * steps necessary to assemble and solve the nonlinear problem.
-       *
-       * The `single Advection, iterated Stokes' scheme solves the temperature and
-       * composition equations once at the beginning of each time step
-       * and then iterates out the solution of the Stokes equation using
-       * Picard iterations.
-       *
-       * This function is implemented in
-       * <code>source/simulator/solver_schemes.cc</code>.
-       */
-      void solve_single_advection_iterated_stokes ();
+      void solve_no_advection_iterated_stokes ();
 
       /**
        * This function implements one scheme for the various
@@ -532,6 +504,46 @@ namespace aspect
        * This function implements one scheme for the various
        * steps necessary to assemble and solve the nonlinear problem.
        *
+       * The `single Advection, no Stokes' scheme only solves the temperature and other
+       * advection systems and instead of solving for the Stokes system,
+       * a prescribed velocity and pressure is used."
+       *
+       * This function is implemented in
+       * <code>source/simulator/solver_schemes.cc</code>.
+       */
+      void solve_single_advection_no_stokes ();
+
+      /**
+       * This function implements one scheme for the various
+       * steps necessary to assemble and solve the nonlinear problem.
+       *
+       * If `single Advection, single Stokes' is selected as the nonlinear solver scheme,
+       * no nonlinear iterations are done, and the temperature, compositional fields and
+       * Stokes equations are solved exactly once per time step, one after the other.
+       *
+       * This function is implemented in
+       * <code>source/simulator/solver_schemes.cc</code>.
+       */
+      void solve_single_advection_single_stokes ();
+
+      /**
+       * This function implements one scheme for the various
+       * steps necessary to assemble and solve the nonlinear problem.
+       *
+       * The `single Advection, iterated Stokes' scheme solves the temperature and
+       * composition equations once at the beginning of each time step
+       * and then iterates out the solution of the Stokes equation using
+       * Picard iterations.
+       *
+       * This function is implemented in
+       * <code>source/simulator/solver_schemes.cc</code>.
+       */
+      void solve_single_advection_iterated_stokes ();
+
+      /**
+       * This function implements one scheme for the various
+       * steps necessary to assemble and solve the nonlinear problem.
+       *
        * The `single Advection, iterated defect correction Stokes' scheme
        * solves the temperature and composition equations once at the beginning
        * of each time step and then iterates out the solution of the Stokes
@@ -541,6 +553,41 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       void solve_single_advection_iterated_defect_correction_stokes ();
+
+      /**
+       * This function implements one scheme for the various
+       * steps necessary to assemble and solve the nonlinear problem.
+       *
+       * The `single Advection, iterated Newton Stokes' scheme solves the temperature and
+       * composition equations once at the beginning of each time step
+       * and then iterates out the solution of the Stokes equation using Newton iterations.
+       * For the Stokes system it is able to switch from a defect correction form of
+       * Picard iterations to Newton iterations after a certain tolerance or
+       * number of iterations is reached. This can greatly improve the
+       * convergence rate for particularly nonlinear viscosities.
+       *
+       * @param use_newton_iterations Sets whether this function should only use defect
+       * correction iterations (use_newton_iterations = false) or also use Newton iterations
+       * (use_newton_iterations = true).
+       *
+       * This function is implemented in
+       * <code>source/simulator/solver_schemes.cc</code>.
+       */
+      void solve_single_advection_iterated_newton_stokes (bool use_newton_iterations);
+
+      /**
+       * This function implements one scheme for the various
+       * steps necessary to assemble and solve the nonlinear problem.
+       *
+       * The `iterated Advection and Stokes' scheme iterates
+       * by alternating the solution of the temperature, composition and Stokes systems.
+       * This is essentially a type of Picard iterations for the whole
+       * system of equations.
+       *
+       * This function is implemented in
+       * <code>source/simulator/solver_schemes.cc</code>.
+       */
+      void solve_iterated_advection_and_stokes ();
 
       /**
        * This function implements one scheme for the various
@@ -576,53 +623,6 @@ namespace aspect
        * <code>source/simulator/solver_schemes.cc</code>.
        */
       void solve_iterated_advection_and_newton_stokes (bool use_newton_iterations);
-
-      /**
-       * This function implements one scheme for the various
-       * steps necessary to assemble and solve the nonlinear problem.
-       *
-       * The `single Advection, iterated Newton Stokes' scheme solves the temperature and
-       * composition equations once at the beginning of each time step
-       * and then iterates out the solution of the Stokes equation using Newton iterations.
-       * For the Stokes system it is able to switch from a defect correction form of
-       * Picard iterations to Newton iterations after a certain tolerance or
-       * number of iterations is reached. This can greatly improve the
-       * convergence rate for particularly nonlinear viscosities.
-       *
-       * @param use_newton_iterations Sets whether this function should only use defect
-       * correction iterations (use_newton_iterations = false) or also use Newton iterations
-       * (use_newton_iterations = true).
-       *
-       * This function is implemented in
-       * <code>source/simulator/solver_schemes.cc</code>.
-       */
-      void solve_single_advection_and_iterated_newton_stokes (bool use_newton_iterations);
-
-      /**
-       * This function implements one scheme for the various
-       * steps necessary to assemble and solve the nonlinear problem.
-       *
-       * The `single Advection, no Stokes' scheme only solves the temperature and other
-       * advection systems and instead of solving for the Stokes system,
-       * a prescribed velocity and pressure is used."
-       *
-       * This function is implemented in
-       * <code>source/simulator/solver_schemes.cc</code>.
-       */
-      void solve_single_advection_no_stokes ();
-
-      /**
-       * This function implements one scheme for the various
-       * steps necessary to assemble and solve the nonlinear problem.
-       *
-       * The `no Advection, no Stokes' scheme skips solving the temperature,
-       * composition and Stokes equations, which permits to go directly to
-       * postprocessing after setting up the initial condition.
-       *
-       * This function is implemented in
-       * <code>source/simulator/solver_schemes.cc</code>.
-       */
-      void solve_no_advection_no_stokes ();
 
       /**
        * Initiate the assembly of the Stokes preconditioner matrix via

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -1904,15 +1904,9 @@ namespace aspect
       {
         switch (parameters.nonlinear_solver)
           {
-            case NonlinearSolver::single_Advection_single_Stokes:
+            case NonlinearSolver::no_Advection_no_Stokes:
             {
-              solve_single_advection_single_stokes();
-              break;
-            }
-
-            case NonlinearSolver::no_Advection_iterated_Stokes:
-            {
-              solve_no_advection_iterated_stokes();
+              solve_no_advection_no_stokes();
               break;
             }
 
@@ -1922,15 +1916,15 @@ namespace aspect
               break;
             }
 
-            case NonlinearSolver::iterated_Advection_and_Stokes:
+            case NonlinearSolver::first_timestep_only_single_Stokes:
             {
-              solve_iterated_advection_and_stokes();
+              solve_no_advection_single_stokes_first_timestep_only();
               break;
             }
 
-            case NonlinearSolver::single_Advection_iterated_Stokes:
+            case NonlinearSolver::no_Advection_iterated_Stokes:
             {
-              solve_single_advection_iterated_stokes();
+              solve_no_advection_iterated_stokes();
               break;
             }
 
@@ -1940,9 +1934,39 @@ namespace aspect
               break;
             }
 
+            case NonlinearSolver::single_Advection_no_Stokes:
+            {
+              solve_single_advection_no_stokes();
+              break;
+            }
+
+            case NonlinearSolver::single_Advection_single_Stokes:
+            {
+              solve_single_advection_single_stokes();
+              break;
+            }
+
+            case NonlinearSolver::single_Advection_iterated_Stokes:
+            {
+              solve_single_advection_iterated_stokes();
+              break;
+            }
+
             case NonlinearSolver::single_Advection_iterated_defect_correction_Stokes:
             {
               solve_single_advection_iterated_defect_correction_stokes();
+              break;
+            }
+
+            case NonlinearSolver::single_Advection_iterated_Newton_Stokes:
+            {
+              solve_single_advection_iterated_newton_stokes(/*use_newton_iterations =*/ true);
+              break;
+            }
+
+            case NonlinearSolver::iterated_Advection_and_Stokes:
+            {
+              solve_iterated_advection_and_stokes();
               break;
             }
 
@@ -1955,30 +1979,6 @@ namespace aspect
             case NonlinearSolver::iterated_Advection_and_Newton_Stokes:
             {
               solve_iterated_advection_and_newton_stokes(/*use_newton_iterations =*/ true);
-              break;
-            }
-
-            case NonlinearSolver::single_Advection_iterated_Newton_Stokes:
-            {
-              solve_single_advection_and_iterated_newton_stokes(/*use_newton_iterations =*/ true);
-              break;
-            }
-
-            case NonlinearSolver::single_Advection_no_Stokes:
-            {
-              solve_single_advection_no_stokes();
-              break;
-            }
-
-            case NonlinearSolver::first_timestep_only_single_Stokes:
-            {
-              solve_first_timestep_only_single_stokes();
-              break;
-            }
-
-            case NonlinearSolver::no_Advection_no_Stokes:
-            {
-              solve_no_advection_no_stokes();
               break;
             }
 


### PR DESCRIPTION
This PR contains no functional changes but sorts the solver scheme code in a systematic order. As part of the sort I had to rename two solver schemes that didnt fit our naming scheme, namely 

`solve_single_advection_and_iterated_newton_stokes` -> `solve_single_advection_iterated_newton_stokes` (`and` is reserved for equations that are iterated together and this change is in the code only as the input parameter was already named correctly)

`solve_first_timestep_only_single_stokes` -> `solve_no_advection_single_stokes_first_timestep_only` (to make more clear what the scheme does and how it relates to the other scheme that is almost identical). I left the input parameters for this scheme unchanged for backward compatibility.


The new order is:

```
  template void Simulator<dim>::solve_no_advection_no_stokes(); \
  template void Simulator<dim>::solve_no_advection_single_stokes(); \
  template void Simulator<dim>::solve_no_advection_single_stokes_first_timestep_only(); \
  template void Simulator<dim>::solve_no_advection_iterated_stokes(); \
  template void Simulator<dim>::solve_no_advection_iterated_defect_correction_stokes(); \
  template void Simulator<dim>::solve_single_advection_no_stokes(); \
  template void Simulator<dim>::solve_single_advection_single_stokes(); \
  template void Simulator<dim>::solve_single_advection_iterated_stokes(); \
  template void Simulator<dim>::solve_single_advection_iterated_defect_correction_stokes(); \
  template void Simulator<dim>::solve_single_advection_iterated_newton_stokes(bool); \
  template void Simulator<dim>::solve_iterated_advection_and_stokes(); \
  template void Simulator<dim>::solve_iterated_advection_and_defect_correction_stokes(); \
  template void Simulator<dim>::solve_iterated_advection_and_newton_stokes(bool); \
```