### PR TITLE
Replace TimerOutput::Scope to avoid deadlocks

### DIFF
--- a/doc/modules/changes/20250916_gassmoeller
+++ b/doc/modules/changes/20250916_gassmoeller
@@ -1,0 +1,7 @@
+Fixed: ASPECT used several features that could fail in MPI
+communication in case an assert was triggered. The model
+would end up in a communication deadlock (a model that hangs
+without output) instead of correctly crashing and producing
+an error message. This was fixed.
+<br>
+(Rene Gassmoeller, 2025/09/16)

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -316,7 +316,7 @@ namespace aspect
       if (this->get_timestep_number() == 0)
         return;
 
-      TimerOutput::Scope timer_section(this->get_computing_timer(), "FastScape plugin");
+      this->get_computing_timer().enter_subsection("FastScape plugin");
 
       const unsigned int current_timestep = this->get_timestep_number ();
       const double aspect_timestep_in_years = this->get_timestep() / year_in_seconds;
@@ -624,6 +624,8 @@ namespace aspect
                                                 *boundary_ids.begin(),
                                                 vector_function_object,
                                                 mesh_velocity_constraints);
+
+      this->get_computing_timer().leave_subsection("FastScape plugin");
     }
 
 
@@ -881,9 +883,13 @@ namespace aspect
                                            const double &fastscape_timestep_in_years,
                                            const unsigned int &fastscape_iterations) const
     {
-      TimerOutput::Scope timer_section(this->get_computing_timer(), "Execute FastScape");
+      this->get_computing_timer().enter_subsection("Execute FastScape");
+
       if (Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) != 0)
-        return;
+        {
+          this->get_computing_timer().leave_subsection("Execute FastScape");
+          return;
+        }
 
       // Because on the first timestep we will create an initial VTK file before running FastScape
       // and a second after, we first set the visualization step to zero.
@@ -997,6 +1003,8 @@ namespace aspect
 #endif
           }
       }
+
+      this->get_computing_timer().leave_subsection("Execute FastScape");
     }
 
 

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -540,7 +540,7 @@ namespace aspect
     {
       AssertThrow(sim.parameters.mesh_deformation_enabled, ExcInternalError());
 
-      TimerOutput::Scope timer (sim.computing_timer, "Mesh deformation");
+      this->get_computing_timer().enter_subsection("Mesh deformation");
 
       old_mesh_displacements = mesh_displacements;
 
@@ -561,6 +561,8 @@ namespace aspect
 
       // After changing the mesh we need to rebuild things
       sim.rebuild_stokes_matrix = sim.rebuild_stokes_preconditioner = true;
+
+      this->get_computing_timer().leave_subsection("Mesh deformation");
     }
 
 
@@ -1498,13 +1500,15 @@ namespace aspect
       if (this->simulator_is_past_initialization() == false ||
           this->get_timestep_number() == 0)
         {
-          TimerOutput::Scope timer (sim.computing_timer, "Mesh deformation initialize");
+          this->get_computing_timer().enter_subsection("Mesh deformation initialize");
 
           make_initial_constraints();
           if (this->is_stokes_matrix_free())
             compute_mesh_displacements_gmg();
           else
             compute_mesh_displacements();
+
+          this->get_computing_timer().leave_subsection("Mesh deformation initialize");
         }
 
       if (this->is_stokes_matrix_free())

--- a/source/postprocess/current_surface.cc
+++ b/source/postprocess/current_surface.cc
@@ -47,7 +47,7 @@ namespace aspect
       AssertThrow(dim==2,
                   ExcMessage("Depth with mesh deformation currently only works with a 2D model."));
 
-      TimerOutput::Scope timer_section(this->get_computing_timer(), "Geometry model surface update");
+      this->get_computing_timer().enter_subsection("Geometry model surface update");
 
       // loop over all of the surface cells and save the elevation to a stored value.
       // This needs to be sent to 1 processor, sorted, and broadcast so that every processor knows the entire surface.
@@ -127,6 +127,8 @@ namespace aspect
 
       // Create a surface function for the elevations.
       surface_function = std::make_unique<Functions::InterpolatedTensorProductGridData<dim-1>>(coordinates, data_table);
+
+      this->get_computing_timer().leave_subsection("Geometry model surface update");
 
       return std::make_pair ("Storing deformed surface topography: ",
                              "Done");

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -472,7 +472,7 @@ namespace aspect
     else
       AssertThrow(false, ExcNotImplemented());
 
-    TimerOutput::Scope timer (computing_timer, "Build Stokes preconditioner");
+    computing_timer.enter_subsection("Build Stokes preconditioner");
     pcout << "   Rebuilding Stokes preconditioner..." << std::flush;
 
     // first assemble the raw matrices necessary for the preconditioner
@@ -588,6 +588,8 @@ namespace aspect
     rebuild_stokes_preconditioner = false;
 
     pcout << std::endl;
+
+    computing_timer.leave_subsection("Build Stokes preconditioner");
   }
 
 
@@ -770,8 +772,7 @@ namespace aspect
         timer_section_name += " rhs";
       }
 
-    TimerOutput::Scope timer (computing_timer,
-                              timer_section_name);
+    computing_timer.enter_subsection(timer_section_name);
 
     if (rebuild_stokes_matrix == true)
       system_matrix = 0;
@@ -891,6 +892,8 @@ namespace aspect
 
     // record that we have just rebuilt the matrix
     rebuild_stokes_matrix = false;
+
+    computing_timer.leave_subsection(timer_section_name);
   }
 
 
@@ -901,9 +904,9 @@ namespace aspect
                                                  LinearAlgebra::PreconditionILU &preconditioner,
                                                  const double diagonal_strengthening)
   {
-    TimerOutput::Scope timer (computing_timer, (advection_field.is_temperature() ?
-                                                "Build temperature preconditioner" :
-                                                "Build composition preconditioner"));
+    computing_timer.enter_subsection(advection_field.is_temperature() ?
+                                     "Build temperature preconditioner" :
+                                     "Build composition preconditioner");
 
     const unsigned int block_idx = advection_field.block_index(introspection);
 
@@ -912,6 +915,10 @@ namespace aspect
     data.ilu_atol = diagonal_strengthening;
 
     preconditioner.initialize (system_matrix.block(block_idx, block_idx), data);
+
+    computing_timer.leave_subsection(advection_field.is_temperature() ?
+                                     "Build temperature preconditioner" :
+                                     "Build composition preconditioner");
   }
 
 
@@ -1215,9 +1222,9 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::assemble_advection_system (const AdvectionField &advection_field)
   {
-    TimerOutput::Scope timer (computing_timer, (advection_field.is_temperature() ?
-                                                "Assemble temperature system" :
-                                                "Assemble composition system"));
+    computing_timer.enter_subsection(advection_field.is_temperature() ?
+                                     "Assemble temperature system" :
+                                     "Assemble composition system");
 
     const unsigned int block_idx = advection_field.block_index(introspection);
     const unsigned int sparsity_block_idx = advection_field.sparsity_pattern_block_index(introspection);
@@ -1324,6 +1331,10 @@ namespace aspect
 
     system_matrix.compress(VectorOperation::add);
     system_rhs.compress(VectorOperation::add);
+
+    computing_timer.leave_subsection(advection_field.is_temperature() ?
+                                     "Assemble temperature system" :
+                                     "Assemble composition system");
   }
 }
 

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -251,7 +251,7 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::create_snapshot()
   {
-    TimerOutput::Scope timer (computing_timer, "Create snapshot");
+    computing_timer.enter_subsection("Create snapshot");
 
     // Take elapsed time from timer so that we can serialize it:
     total_walltime_until_last_snapshot += wall_timer.wall_time();
@@ -387,6 +387,8 @@ namespace aspect
       }
 
     pcout << "*** Snapshot " << checkpoint_path << " created!" << std::endl << std::endl;
+
+    computing_timer.leave_subsection("Create snapshot");
   }
 
 

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -1604,7 +1604,7 @@ namespace aspect
     if (time_step == 0)
       return;
 
-    TimerOutput::Scope timer (computing_timer, "Solve composition reactions");
+    computing_timer.enter_subsection("Solve composition reactions");
 
     // we need some temporary vectors to store our updates to composition and temperature in
     // while we do the time stepping, before we copy them over to the solution vector in the end
@@ -1911,6 +1911,8 @@ namespace aspect
           << average_iteration_count
           << " substep(s)."
           << std::endl;
+
+    computing_timer.leave_subsection("Solve composition reactions");
   }
 
 

--- a/source/simulator/initial_conditions.cc
+++ b/source/simulator/initial_conditions.cc
@@ -253,7 +253,7 @@ namespace aspect
   template <int dim>
   void Simulator<dim>::interpolate_particle_properties (const std::vector<AdvectionField> &advection_fields)
   {
-    TimerOutput::Scope timer (computing_timer, "Particles: Interpolate");
+    computing_timer.enter_subsection("Particles: Interpolate");
 
     // below, we would want to call VectorTools::interpolate on the
     // entire FESystem. there currently is no way to restrict the
@@ -473,6 +473,7 @@ namespace aspect
         Assert (particle_solution.block(b).l2_norm() == 0,
                 ExcInternalError());
 
+    computing_timer.leave_subsection("Particles: Interpolate");
   }
 
 

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -1881,13 +1881,15 @@ namespace aspect
   template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerLocalSmoothingImplementation<dim, velocity_degree>::build_preconditioner()
   {
-    TimerOutput::Scope timer (this->get_computing_timer(), "Build Stokes preconditioner");
+    this->get_computing_timer().enter_subsection("Build Stokes preconditioner");
 
     for (unsigned int level=0; level < this->get_triangulation().n_global_levels(); ++level)
       {
         mg_matrices_Schur_complement[level].compute_diagonal();
         mg_matrices_A_block[level].compute_diagonal();
       }
+
+    this->get_computing_timer().leave_subsection("Build Stokes preconditioner");
   }
 
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -154,7 +154,7 @@ namespace aspect
           // outputs into the prescribed field before we assemble and solve the equation
           if (parameters.temperature_method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
             {
-              TimerOutput::Scope timer (computing_timer, "Interpolate prescribed temperature");
+              computing_timer.enter_subsection("Interpolate prescribed temperature");
 
               interpolate_material_output_into_advection_field({adv_field});
 
@@ -162,6 +162,8 @@ namespace aspect
               // solution is the one that is used to assemble the diffusion system in
               // assemble_advection_system() for this solver scheme.
               old_solution.block(adv_field.block_index(introspection)) = solution.block(adv_field.block_index(introspection));
+
+              computing_timer.leave_subsection("Interpolate prescribed temperature");
             }
 
           assemble_advection_system (adv_field);
@@ -177,7 +179,7 @@ namespace aspect
         {
           const AdvectionField adv_field (AdvectionField::temperature());
 
-          TimerOutput::Scope timer (computing_timer, "Interpolate prescribed temperature");
+          computing_timer.enter_subsection("Interpolate prescribed temperature");
 
           interpolate_material_output_into_advection_field({adv_field});
 
@@ -187,6 +189,8 @@ namespace aspect
                                         adv_field.is_temperature(),
                                         adv_field.compositional_variable,
                                         dummy);
+
+          computing_timer.leave_subsection("Interpolate prescribed temperature");
 
           break;
         }
@@ -262,7 +266,7 @@ namespace aspect
               // outputs into the prescribed field before we assemble and solve the equation
               if (method == Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion)
                 {
-                  TimerOutput::Scope timer (computing_timer, "Interpolate prescribed composition");
+                  computing_timer.enter_subsection("Interpolate prescribed composition");
 
                   interpolate_material_output_into_advection_field({adv_field});
 
@@ -270,6 +274,8 @@ namespace aspect
                   // solution is the one that is used to assemble the diffusion system in
                   // assemble_advection_system() for this solver scheme.
                   old_solution.block(adv_field.block_index(introspection)) = solution.block(adv_field.block_index(introspection));
+
+                  computing_timer.leave_subsection("Interpolate prescribed composition");
                 }
 
               assemble_advection_system (adv_field);
@@ -362,7 +368,7 @@ namespace aspect
 
     if (fields_interpolated_from_material_output.size() > 0)
       {
-        TimerOutput::Scope timer (computing_timer, "Interpolate prescribed composition");
+        computing_timer.enter_subsection("Interpolate prescribed composition");
 
         interpolate_material_output_into_advection_field(fields_interpolated_from_material_output);
 
@@ -375,6 +381,8 @@ namespace aspect
                                           adv_field.compositional_variable,
                                           dummy);
           }
+
+        computing_timer.leave_subsection("Interpolate prescribed composition");
       }
 
     if (fields_advected_by_particles.size() > 0)
@@ -991,7 +999,7 @@ namespace aspect
     assemble_and_solve_composition();
 
     {
-      TimerOutput::Scope timer (computing_timer, "Interpolate Stokes solution");
+      computing_timer.enter_subsection("Interpolate Stokes solution");
 
       // Assign Stokes solution
       LinearAlgebra::BlockVector distributed_stokes_solution (introspection.index_sets.system_partitioning, mpi_communicator);
@@ -1023,6 +1031,7 @@ namespace aspect
           solution.block(block_p_f) = distributed_stokes_solution.block(block_p_f);
         }
 
+      computing_timer.leave_subsection("Interpolate Stokes solution");
     }
 
     if (parameters.run_postprocessors_on_nonlinear_iterations)

--- a/source/volume_of_fluid/handler.cc
+++ b/source/volume_of_fluid/handler.cc
@@ -538,7 +538,7 @@ namespace aspect
                                                                    const unsigned int dir,
                                                                    const bool update_from_old)
   {
-    TimerOutput::Scope timer (sim.computing_timer, "Assemble volume of fluid system");
+    this->get_computing_timer().enter_subsection("Assemble volume of fluid system");
 
     const unsigned int block0_idx = field_struct_for_field_index(0).volume_fraction.block_index;
     const unsigned int block_idx = field.volume_fraction.block_index;
@@ -597,6 +597,8 @@ namespace aspect
 
     sim.system_matrix.compress(VectorOperation::add);
     sim.system_rhs.compress(VectorOperation::add);
+
+    this->get_computing_timer().leave_subsection("Assemble volume of fluid system");
   }
 
 

--- a/source/volume_of_fluid/reconstruct.cc
+++ b/source/volume_of_fluid/reconstruct.cc
@@ -34,7 +34,7 @@ namespace aspect
 
     LinearAlgebra::BlockVector initial_solution;
 
-    TimerOutput::Scope timer (sim.computing_timer, "Reconstruct VolumeOfFluid interfaces");
+    this->get_computing_timer().enter_subsection("Reconstruct VolumeOfFluid interfaces");
 
     initial_solution.reinit(sim.system_rhs, false);
 
@@ -413,6 +413,8 @@ namespace aspect
 
     solution.block(volume_of_fluidN_blockidx) = initial_solution.block(volume_of_fluidN_blockidx);
     solution.block(volume_of_fluidLS_blockidx) = initial_solution.block(volume_of_fluidLS_blockidx);
+
+    this->get_computing_timer().leave_subsection("Reconstruct VolumeOfFluid interfaces");
   }
 
 
@@ -432,7 +434,7 @@ namespace aspect
 
     LinearAlgebra::BlockVector initial_solution;
 
-    TimerOutput::Scope timer (sim.computing_timer, "Compute VolumeOfFluid compositions");
+    this->get_computing_timer().enter_subsection("Compute VolumeOfFluid compositions");
 
     initial_solution.reinit(sim.system_rhs, false);
 
@@ -503,6 +505,8 @@ namespace aspect
 
     const unsigned int blockidx = composition_field.block_index(this->introspection());
     solution.block(blockidx) = initial_solution.block(blockidx);
+
+    this->get_computing_timer().leave_subsection("Compute VolumeOfFluid compositions");
   }
 
 

--- a/source/volume_of_fluid/solver.cc
+++ b/source/volume_of_fluid/solver.cc
@@ -33,7 +33,7 @@ namespace aspect
   {
     const unsigned int block_idx = field.volume_fraction.block_index;
 
-    TimerOutput::Scope timer (sim.computing_timer, "Solve volume of fluid system");
+    this->get_computing_timer().enter_subsection("Solve volume of fluid system");
     this->get_pcout() << "   Solving volume of fluid system... " << std::flush;
 
     const double tolerance = std::max(1e-50,
@@ -91,6 +91,8 @@ namespace aspect
     // Do not add VolumeOfFluid solver iterations to statistics, duplication due to
     // dimensional splitting results in incorrect line formatting (lines of
     // data split inconsistently with missing values)
+
+    this->get_computing_timer().leave_subsection("Solve volume of fluid system");
   }
 }
 


### PR DESCRIPTION
Related to #6663.

I would like to discuss replacing all instances of `TimerOutput::Scope` with `timer.enter_subsection`/`leave_subsection` in ASPECT. The problem with `TimerOutput::Scope` was discussed in dealii/dealii#12248, but I dont see a good path to fix this consistently inside deal.II (at least not without changing the behavior of `TimerOutput::Scope`). In essence, because the destructor of `TimerOutput::Scope` triggers MPI communication it is very prone to deadlocks if an exception is not triggered on all ranks, a scenario that is pretty common in ASPECT. In such a case the unwinding of the stack of the throwing MPI rank needs to reach an MPI_abort statement without triggering MPI communication otherwise we deadlock. Using `computing_timer.leave_subsection();` means the throwing MPI rank will not leave the subsection and at least have the possibility to unwind the stack.

I am aware that this undoes #2087, but I feel the current situation is not sustainable. About once a year I spend a day chasing down a deadlock, which would usually be fixed in minutes if I had the correct error message on the screen. Additionally, we occasionally have users reporting stalling simulations in the forum (e.g. https://community.geodynamics.org/t/aspect-hangs-at-same-timesteps-when-using-isosurfaces-stratagey/3917/2). Of course not all the reports will be caused by this, but I suspect a number are, and this is almost impossible to debug for a new user.