### PR TITLE
fix WB macro

### DIFF
--- a/source/initial_composition/world_builder.cc
+++ b/source/initial_composition/world_builder.cc
@@ -23,7 +23,9 @@
 #include <aspect/initial_composition/world_builder.h>
 #include <aspect/geometry_model/interface.h>
 
+#ifdef ASPECT_WITH_WORLD_BUILDER
 #include <world_builder/world.h>
+#endif
 
 
 namespace aspect


### PR DESCRIPTION
Fixed macro definition error caused by disabling WorldBuilder (-D ASPECT_WITH_WORLD_BUILDER=OFF).