### PR TITLE
remove redundant gmg operation

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -967,8 +967,6 @@ namespace aspect
           mesh_displacements = solution;
         }
 
-      if (this->is_stokes_matrix_free())
-        update_multilevel_deformation();
     }
 
 


### PR DESCRIPTION
While reading and studying the ASPECT codebase, I noticed that the GMG-related part in the `compute_mesh_displacements` function appears to never actually get executed—unless one specifically wants to use GMG to solve the Stokes system with an AMG solver nested for the Laplace equation. 

As far as I understand, this use case is currently not intended or commonly used. I have also tried both this combined GMG+AMG approach as well as pure AMG or GMG solvers, but the results are inconsistent. I still have many uncertainties about this part of the code, and I plan to organize and raise a related issue when I have more time.

Regardless, I believe this observation is meaningful for the project. If I have misunderstood something, please feel free to correct me.

```cpp
if (this->is_stokes_matrix_free())
    update_multilevel_deformation();
 ```