### PR TITLE
add missing mpi.templates.h include

### DIFF
--- a/source/postprocess/current_surface.cc
+++ b/source/postprocess/current_surface.cc
@@ -26,6 +26,7 @@
 #include <aspect/geometry_model/box.h>
 
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe.h>


### PR DESCRIPTION
We are using ``MPI::compute_set_union`` with ``T=std::vector<std::vector<double>>`` but it is only instantiated in deal.II for ints. I am getting a linker error (but only on a branch, not sure why). This should fix it.

see:
https://github.com/geodynamics/aspect/blob/443cedb74086a212ac08256b20530436393f1425/source/postprocess/current_surface.cc#L88