### PR TITLE
When solvers fail, make sure we get an exception message only on process zero.

### DIFF
--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -373,7 +373,21 @@ namespace aspect
       this->get_pcout() << "   Solving mesh surface diffusion" << std::endl;
       SolverControl solver_control(5*system_rhs.size(), this->get_parameters().linear_stokes_solver_tolerance*system_rhs.l2_norm());
       SolverCG<LinearAlgebra::Vector> cg(solver_control);
-      cg.solve (matrix, solution, system_rhs, preconditioner_mass);
+      try
+        {
+          cg.solve (matrix, solution, system_rhs, preconditioner_mass);
+        }
+      catch (const std::exception &exc)
+        {
+          // if the solver fails, report the error from processor 0 with some additional
+          // information about its location, and throw a quiet exception on all other
+          // processors
+          Utilities::throw_linear_solver_failure_exception("iterative diffusion surface deformation solver",
+                                                           "MeshDeformation::Diffusion::diffuse_boundary()",
+                                                           std::vector<SolverControl> {solver_control},
+                                                           exc,
+                                                           this->get_mpi_communicator());
+        }
 
       // Distribute constraints on mass matrix
       matrix_constraints.distribute (solution);

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -201,7 +201,22 @@ namespace aspect
 
       SolverControl solver_control(5*rhs.size(), this->get_parameters().linear_stokes_solver_tolerance*rhs.l2_norm());
       SolverCG<LinearAlgebra::Vector> cg(solver_control);
-      cg.solve (mass_matrix, dist_solution, rhs, preconditioner_mass);
+
+      try
+        {
+          cg.solve (mass_matrix, dist_solution, rhs, preconditioner_mass);
+        }
+      catch (const std::exception &exc)
+        {
+          // if the solver fails, report the error from processor 0 with some additional
+          // information about its location, and throw a quiet exception on all other
+          // processors
+          Utilities::throw_linear_solver_failure_exception("iterative free surface solver",
+                                                           "MeshDeformation::FreeSurface::project_velocity_onto_boundary()",
+                                                           std::vector<SolverControl> {solver_control},
+                                                           exc,
+                                                           this->get_mpi_communicator());
+        }
 
       mass_matrix_constraints.distribute (dist_solution);
       output = dist_solution;


### PR DESCRIPTION
As shown in https://community.geodynamics.org/t/cannot-increase-fastscape-eroding-box-resolution/4301, we sometimes get lots of repeated error messages when a solver fails. That's because the solver throws an exception on every process, and `main()` shows it on every process. But we have a system to avoid that, namely only generate the exception on process zero, and on all other processes, we create `QuietException` which `main()` just silently eats on all other processes.

This patch wraps all of the solvers I could find in the same way as we already do in `solver.cc`.