### PR TITLE
Fix fastscape warning

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1509,7 +1509,7 @@ namespace aspect
                 data_table(x,y,z) = values[(fastscape_nx+1)*use_ghost_nodes+fastscape_nx*y+x] / year_in_seconds;
         }
 
-      return std::move(data_table);
+      return data_table;
     }
 
 


### PR DESCRIPTION
```bash
/home/tiannh/aspect/source/mesh_deformation/fastscape.cc:1504:34: note: remove ‘std::move’ call
In file included from /home/tiannh/aspect/build-main/CMakeFiles/aspect.exe.debug.dir/Unity/unity_21_cxx.cxx:7:
/home/tiannh/aspect/source/mesh_deformation/fastscape.cc: In instantiation of ‘dealii::Table<dim, double> aspect::MeshDeformation::FastScape<dim>::fill_data_table(const std::vector<double>&, const dealii::TableIndices<N>&, const unsigned int&, const unsigned int&) const [with int dim = 2]’:
/home/tiannh/aspect/source/mesh_deformation/fastscape.cc:2120:5:   required from here
/home/tiannh/aspect/source/mesh_deformation/fastscape.cc:1504:34: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
 1504 |       return std::move(data_table);
      |
```
