### PR TITLE
Do not access timer inside subsection

### DIFF
--- a/source/postprocess/timing_statistics.cc
+++ b/source/postprocess/timing_statistics.cc
@@ -30,8 +30,15 @@ namespace aspect
     std::pair<std::string,std::string>
     TimingStatistics<dim>::execute (TableHandler &statistics)
     {
-      const auto &timer = this->get_computing_timer();
+      auto &timer = this->get_computing_timer();
+
+      // The timer only allows access to its data outside of subsections
+      // Leaving and entering the subsection again here means there will be
+      // one additional call of this subsection per time step in the timing
+      // output.
+      timer.leave_subsection("Postprocessing");
       const std::map<std::string, double> &timing_map = timer.get_summary_data(TimerOutput::total_wall_time);
+      timer.enter_subsection("Postprocessing");
 
       for (const auto &section: timing_map)
         {


### PR DESCRIPTION
Since dealii/dealii#18909 it is not allowed to access the timer information while inside a subsection. The only place where this is relevant for ASPECT is inside the timing statistics postprocessor (which is inside the Postprocessing section).

Fix the postprocessor to leave the subsection before requesting information. Since this is not really relevant and also works for older deal.II versions, I didnt bother limiting this to deal.II 9.8.0.

This fixes a tester failure observed in #6660.