### PR TITLE
doxygen: fix formulas using good mathjax location

### DIFF
--- a/doc/options.dox
+++ b/doc/options.dox
@@ -1168,7 +1168,7 @@ USE_MATHJAX            = YES
 # However, it is strongly recommended to install a local
 # copy of MathJax from http://www.mathjax.org before deployment.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension
 # names that should be enabled during MathJax rendering.


### PR DESCRIPTION
1. Use https, otherwise browsers request the cross-site request.
2. Update to cloudflare cdn as the mathjax one is deprecated and will forward to cdnjs anyways, see
https://cdn.mathjax.org/mathjax/latest/MathJax.js

fixes #6695