### PR TITLE
fix the invalid formula in the documentation of class ViscoPlastic

### DIFF
--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -107,9 +107,9 @@ namespace aspect
      * $\hat{D} = \hat{D_{e}} + \hat{D_{v}}$.
      * These terms further decompose into
      * $\hat{D_{v}} = \frac{\tau}{2\eta}$ and
-     * $\hat{D_{e}} = \frac{\overset{\triangledown}{\tau}}{2\mu}$, where
+     * $\hat{D_{e}} = \frac{\overset{\scriptscriptstyle\nabla}{\tau}}{2\mu}$, where
      * $\tau$ is the viscous deviatoric stress, $\eta$ is the shear viscosity,
-     * $\mu$ is the shear modulus and $\overset{\triangledown}{\tau}$ is the
+     * $\mu$ is the shear modulus and $\overset{\scriptscriptstyle\nabla}{\tau}$ is the
      * Jaumann corotational stress rate. If plasticity is included the
      * deviatoric rate of deformation may be written as:
      * $\hat{D} = \hat{D_{e}} + \hat{D_{v}} + \hat{D_{p}}$, where $\hat{D_{p}}$
@@ -120,14 +120,14 @@ namespace aspect
      * Above, the Jaumann corotational stress rate (eqn. 24) from the elastic
      * component contains the time derivative of the deviatoric stress ($\dot{\tau}$)
      * and terms that  account for material spin (e.g., rotation) due to advection:
-     * $\overset{\triangledown}{\tau} = \dot{\tau} + {\tau}W -W\tau$.
+     * $\overset{\scriptscriptstyle\nabla}{\tau} = \dot{\tau} + {\tau}W -W\tau$.
      * Above, $W$ is the material spin tensor (eqn. 25):
      * $W_{ij} = \frac{1}{2} \left (\frac{\partial V_{i}}{\partial x_{j}} -
      * \frac{\partial V_{j}}{\partial x_{i}} \right )$.
      *
      * The Jaumann stress-rate can also be approximated using terms from the time
      * at the previous time step ($t$) and current time step ($t + \Delta t^{e}$):
-     * $\smash[t]{\overset{\triangledown}{\tau}}^{t + \Delta t^{e}} \approx
+     * $\smash[t]{\overset{\scriptscriptstyle\nabla}{\tau}}^{t + \Delta t^{e}} \approx
      * \frac{\tau^{t + \Delta t^{e} - \tau^{t}}}{\Delta t^{e}} -
      * W^{t}\tau^{t} + \tau^{t}W^{t}$.
      * In this material model, the size of the time step above ($\Delta t^{e}$)


### PR DESCRIPTION
This PR replaces the symbol `\triangledown` by `\scriptscriptstyle\nabla` in the documentation of class `ViscoPlastic`. The original symbol cannot be recognized by doxygen. The resulting formulas are similar:
<img width="321" height="177" alt="image" src="https://github.com/user-attachments/assets/b29aa936-0247-4fc4-9ebd-90f0db0abc6e" />
Clearly, the best way to solve this problem is to make doxygen recognize the `\triangledown` symbol, which only requires the `amssymb` package in latex. Wikipedia also uses `\tiriangledown` to display the flipped triangle. But I have not figured out a way. Please leave comments if someone knows how to do it.