### PR TITLE
doxygen: add AMS extensions

### DIFF
--- a/doc/options.dox
+++ b/doc/options.dox
@@ -1173,7 +1173,7 @@ MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/
 # The MATHJAX_EXTENSIONS tag can be used to specify one or MathJax extension
 # names that should be enabled during MathJax rendering.
 
-MATHJAX_EXTENSIONS     =
+MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
 
 # When the SEARCHENGINE tag is enabled doxygen will generate a search box
 # for the HTML output. The underlying search engine uses javascript


### PR DESCRIPTION
This allows us to use additional symbols.

alternative to #6701
