### PR TITLE
fix equation in material model documentation

### DIFF
--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -534,7 +534,7 @@ namespace aspect
                                    "\n\n"
                                    "The first plasticity mechanism limits viscous stress through a "
                                    "Drucker Prager yield criterion, where the yield stress in 3d is  "
-                                   "$\\sigma_y = \\frac{6C\\cos(\\phi) + 2P\\sin(\\phi)} "
+                                   "$\\sigma_y = \\frac{6C\\cos(\\phi) + 6P\\sin(\\phi)} "
                                    "{\\sqrt{3}(3+\\sin(\\phi))}$ "
                                    "and "
                                    "$\\sigma_y = C\\cos(\\phi) + P\\sin(\\phi)$ "


### PR DESCRIPTION
This PR fixes the discrepancy between the [code ](https://github.com/geodynamics/aspect/blob/main/source/material_model/rheology/drucker_prager.cc#L126) and [documentation](https://github.com/geodynamics/aspect/blob/main/source/material_model/visco_plastic.cc#L537) for the 3D Drucker Prager failure criterion noted in [this forum post](https://community.geodynamics.org/t/inquiry-for-material-model-viscoplastic-drucker-prager-yielding-stress/4317).

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
