### PR TITLE
Consistently use vector types

### DIFF
--- a/include/aspect/simulator/solver/matrix_free_operators.h
+++ b/include/aspect/simulator/solver/matrix_free_operators.h
@@ -54,21 +54,21 @@ namespace aspect
      */
     namespace ChangeVectorTypes
     {
-      void import(TrilinosWrappers::MPI::Vector &out,
+      void import(aspect::LinearAlgebra::Vector &out,
                   const dealii::LinearAlgebra::ReadWriteVector<double> &rwv,
                   const VectorOperation::values                 operation);
 
-      void copy(TrilinosWrappers::MPI::Vector &out,
+      void copy(aspect::LinearAlgebra::Vector &out,
                 const dealii::LinearAlgebra::distributed::Vector<double> &in);
 
       void copy(dealii::LinearAlgebra::distributed::Vector<double> &out,
-                const TrilinosWrappers::MPI::Vector &in);
+                const aspect::LinearAlgebra::Vector &in);
 
-      void copy(TrilinosWrappers::MPI::BlockVector &out,
+      void copy(aspect::LinearAlgebra::BlockVector &out,
                 const dealii::LinearAlgebra::distributed::BlockVector<double> &in);
 
       void copy(dealii::LinearAlgebra::distributed::BlockVector<double> &out,
-                const TrilinosWrappers::MPI::BlockVector &in);
+                const aspect::LinearAlgebra::BlockVector &in);
     }
   }
 

--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -182,10 +182,10 @@ namespace aspect
       LinearAlgebra::SparseMatrix matrix;
 
       // Sparsity of the matrix
-      TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
-                                            mesh_locally_owned,
-                                            mesh_locally_relevant,
-                                            this->get_mpi_communicator());
+      LinearAlgebra::DynamicSparsityPattern sp (mesh_locally_owned,
+                                                mesh_locally_owned,
+                                                mesh_locally_relevant,
+                                                this->get_mpi_communicator());
       DoFTools::make_sparsity_pattern (mesh_deformation_dof_handler, sp, matrix_constraints, false,
                                        Utilities::MPI::this_mpi_process(this->get_mpi_communicator()));
 

--- a/source/mesh_deformation/free_surface.cc
+++ b/source/mesh_deformation/free_surface.cc
@@ -109,10 +109,10 @@ namespace aspect
 
       // set up the matrix
       LinearAlgebra::SparseMatrix mass_matrix;
-      TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
-                                            mesh_locally_owned,
-                                            mesh_locally_relevant,
-                                            this->get_mpi_communicator());
+      LinearAlgebra::DynamicSparsityPattern sp (mesh_locally_owned,
+                                                mesh_locally_owned,
+                                                mesh_locally_relevant,
+                                                this->get_mpi_communicator());
       DoFTools::make_sparsity_pattern (mesh_deformation_dof_handler, sp, mass_matrix_constraints, false,
                                        Utilities::MPI::this_mpi_process(this->get_mpi_communicator()));
       sp.compress();

--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -869,10 +869,10 @@ namespace aspect
         coupling[c][c] = DoFTools::always;
 
       LinearAlgebra::SparseMatrix mesh_matrix;
-      TrilinosWrappers::SparsityPattern sp (mesh_locally_owned,
-                                            mesh_locally_owned,
-                                            mesh_locally_relevant,
-                                            sim.mpi_communicator);
+      LinearAlgebra::DynamicSparsityPattern sp (mesh_locally_owned,
+                                                mesh_locally_owned,
+                                                mesh_locally_relevant,
+                                                sim.mpi_communicator);
       DoFTools::make_sparsity_pattern (mesh_deformation_dof_handler,
                                        coupling, sp,
                                        mesh_velocity_constraints, false,

--- a/source/simulator/solver/matrix_free_operators.cc
+++ b/source/simulator/solver/matrix_free_operators.cc
@@ -59,7 +59,7 @@ namespace aspect
      */
     namespace ChangeVectorTypes
     {
-      void copy(TrilinosWrappers::MPI::Vector &out,
+      void copy(aspect::LinearAlgebra::Vector &out,
                 const dealii::LinearAlgebra::distributed::Vector<double> &in)
       {
         dealii::LinearAlgebra::ReadWriteVector<double> rwv(out.locally_owned_elements());
@@ -68,14 +68,14 @@ namespace aspect
       }
 
       void copy(dealii::LinearAlgebra::distributed::Vector<double> &out,
-                const TrilinosWrappers::MPI::Vector &in)
+                const aspect::LinearAlgebra::Vector &in)
       {
         dealii::LinearAlgebra::ReadWriteVector<double> rwv;
         rwv.reinit(in);
         out.import_elements(rwv, VectorOperation::insert);
       }
 
-      void copy(TrilinosWrappers::MPI::BlockVector &out,
+      void copy(aspect::LinearAlgebra::BlockVector &out,
                 const dealii::LinearAlgebra::distributed::BlockVector<double> &in)
       {
         const unsigned int n_blocks = in.n_blocks();
@@ -84,7 +84,7 @@ namespace aspect
       }
 
       void copy(dealii::LinearAlgebra::distributed::BlockVector<double> &out,
-                const TrilinosWrappers::MPI::BlockVector &in)
+                const aspect::LinearAlgebra::BlockVector &in)
       {
         const unsigned int n_blocks = in.n_blocks();
         for (unsigned int b=0; b<n_blocks; ++b)

--- a/source/volume_of_fluid/solver.cc
+++ b/source/volume_of_fluid/solver.cc
@@ -42,7 +42,7 @@ namespace aspect
     SolverControl solver_control (1000, tolerance);
 
     TrilinosWrappers::SolverCG solver(solver_control);
-    TrilinosWrappers::PreconditionJacobi precondition;
+    LinearAlgebra::PreconditionJacobi precondition;
     precondition.initialize(sim.system_matrix.block(block_idx, block_idx));
 
     // Create distributed vector (we need all blocks here even though we only


### PR DESCRIPTION
Seen while reviewing #6711. We define some types for vectors and matrices in `aspect/global.h` that we commonly use. This is likely a leftover from the time when we supported both trilinos and petsc types, but it may be useful again in the future (e.g. in case we want to use deal.II types). But we do not consistently use them everywhere. In this PR I replaced all types from `dealii::TrilinosWrappers` that have a corresponding type in `aspect::LinearAlgebra` with those type. I dont particularly care which type we use, I just think it should be the same one throughout the code.

This conflicts with #6711, whichever one is merged later will have to rebase.