### PR TITLE
cmake: allow installing GWB as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,6 +655,7 @@ if(${ASPECT_BUILD_DEBUG} STREQUAL "ON")
     "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_DEBUG}"
     )
   target_link_libraries(${TARGET_EXE_DEBUG} dealii::dealii_debug)
+  set_target_properties(${TARGET_EXE_DEBUG} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
 if(${ASPECT_BUILD_RELEASE} STREQUAL "ON")
@@ -670,6 +671,7 @@ if(${ASPECT_BUILD_RELEASE} STREQUAL "ON")
     "${DEAL_II_LINKER_FLAGS} ${DEAL_II_LINKER_FLAGS_RELEASE}"
     )
   target_link_libraries(${TARGET_EXE_RELEASE} dealii::dealii_release)
+  set_target_properties(${TARGET_EXE_RELEASE} PROPERTIES INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
 # Make sure we have the rpath to our dependencies set:

--- a/contrib/world_builder/CMakeLists.txt
+++ b/contrib/world_builder/CMakeLists.txt
@@ -559,7 +559,7 @@ endif()
 
 # binary:
 install(CODE "message(Installing...)")
-install(TARGETS ${WB_TARGET} EXPORT WorldBuilder DESTINATION bin)
+install(TARGETS ${WB_TARGET} EXPORT WorldBuilder DESTINATION lib)
 install(EXPORT WorldBuilder  DESTINATION bin)
 
 if(WB_MAKE_FORTRAN_WRAPPER)


### PR DESCRIPTION
- Put GWB shared libs in the correct install folder (lib not bin)
- Let ASPECT find shared libs in the installdir/libs folder

Fixes the problem mentioned in #6716 when the user specifies BUILD_SHARED_LIBS or configures GWB separately as a shared lib.

@MFraters Should this also go into GWB itself?