### PR TITLE
Move Jacky to the 'principal developer emeriti' category.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,7 +19,6 @@ following *Maintainers*:
 The following people currently serve as *Principal Developers* -- people
 who have and are providing substantial technical contributions to ASPECT:
 
-* Jacky Austermann (Columbia University and Lamont-Doherty Earth Observatory, USA)
 * Wolfgang Bangerth (Colorado State University, USA)
 * Juliane Dannberg (GEOMAR Helmholtz Centre for Ocean Research, Germany)
 * Menno Fraters (University of Graz, Austria)
@@ -29,6 +28,15 @@ who have and are providing substantial technical contributions to ASPECT:
 * Bob Myhill (University of Bristol, UK)
 * John Naliboff (New Mexico Tech, USA)
 * Cedric Thieulot (Utrecht University, Netherlands)
+
+## Principal developers emeriti
+
+We are grateful to those that have served as Principal Developers of
+ASPECT in the past, contributing to the project's code and documentation,
+and offering their time to help others:
+
+* Jacky Austermann (Columbia University and Lamont-Doherty Earth Observatory, USA; principal developer 2015-2025)
+
 
 ## Community
 


### PR DESCRIPTION
With real gratitude for @jaustermann 's contributions!