### PR TITLE
Parameter deprecation warning: only trigger on rank 0

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -502,7 +502,7 @@ namespace aspect
      * declared.
      */
     static
-    void declare_parameters (ParameterHandler &prm);
+    void declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank);
 
     /**
      * Read run-time parameters from an object that has previously parsed an

--- a/include/aspect/simulator.h
+++ b/include/aspect/simulator.h
@@ -233,7 +233,7 @@ namespace aspect
        * <code>source/simulator/parameters.cc</code>.
        */
       static
-      void declare_parameters (ParameterHandler &prm);
+      void declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank);
 
       /**
        * The function that runs the overall algorithm. It contains the loop

--- a/source/main.cc
+++ b/source/main.cc
@@ -591,8 +591,9 @@ namespace
     using namespace dealii;
 
     ParameterHandler prm;
-    const bool i_am_proc_0 = (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0);
-    aspect::Simulator<dim>::declare_parameters(prm);
+    const unsigned int mpi_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+    const bool i_am_proc_0 = (mpi_rank == 0);
+    aspect::Simulator<dim>::declare_parameters(prm, mpi_rank);
 
     if (validate_only)
       {

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -48,7 +48,7 @@ namespace aspect
   template <int dim>
   void
   Parameters<dim>::
-  declare_parameters (ParameterHandler &prm)
+  declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank)
   {
     prm.declare_entry ("Dimension", "2",
                        Patterns::Integer (2,3),
@@ -134,7 +134,7 @@ namespace aspect
 
     prm.declare_alias ("Use years instead of seconds",
                        "Use years in output instead of seconds",
-                       true);
+                       (mpi_rank == 0) ? true : false); // trigger deprecation warning
 
     prm.declare_entry ("CFL number", "1.0",
                        Patterns::Double (0.),
@@ -1522,8 +1522,6 @@ namespace aspect
     }
     prm.leave_subsection ();
 
-    VolumeOfFluidHandler<dim>::declare_parameters(prm);
-
     // then, finally, let user additions that do not go through the usual
     // plugin mechanism, declare their parameters if they have subscribed
     // to the relevant signals
@@ -2429,9 +2427,10 @@ namespace aspect
 
 
   template <int dim>
-  void Simulator<dim>::declare_parameters (ParameterHandler &prm)
+  void Simulator<dim>::declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank)
   {
-    Parameters<dim>::declare_parameters (prm);
+    Parameters<dim>::declare_parameters (prm, mpi_rank);
+    VolumeOfFluidHandler<dim>::declare_parameters(prm);
     Melt::Parameters<dim>::declare_parameters (prm);
     Newton::Parameters::declare_parameters (prm);
     StokesMatrixFreeHandler<dim>::declare_parameters (prm);
@@ -2465,12 +2464,12 @@ namespace aspect
 #define INSTANTIATE(dim) \
   template Parameters<dim>::Parameters (ParameterHandler &prm, \
                                         const MPI_Comm mpi_communicator); \
-  template void Parameters<dim>::declare_parameters (ParameterHandler &prm); \
+  template void Parameters<dim>::declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank); \
   template void Parameters<dim>::parse_parameters(ParameterHandler &prm, \
                                                   const MPI_Comm mpi_communicator); \
   template void Parameters<dim>::parse_geometry_dependent_parameters(ParameterHandler &prm, \
                                                                      const GeometryModel::Interface<dim> &geometry_model); \
-  template void Simulator<dim>::declare_parameters (ParameterHandler &prm);
+  template void Simulator<dim>::declare_parameters (ParameterHandler &prm, const unsigned int mpi_rank);
 
   ASPECT_INSTANTIATE(INSTANTIATE)
 

--- a/unit_tests/introspection.cc
+++ b/unit_tests/introspection.cc
@@ -28,7 +28,7 @@ TEST_CASE("Introspection::basic")
 {
   using namespace aspect;
   dealii::ParameterHandler prm;
-  Simulator<2>::declare_parameters(prm);
+  Simulator<2>::declare_parameters(prm, 0 /* mpi rank */);
 
 
   prm.set("Output directory", "");
@@ -76,7 +76,7 @@ TEST_CASE("Introspection::different-composition-types")
 {
   using namespace aspect;
   dealii::ParameterHandler prm;
-  Simulator<2>::declare_parameters(prm);
+  Simulator<2>::declare_parameters(prm, 0 /* mpi rank */);
 
 
   prm.set("Output directory", "");
@@ -126,7 +126,7 @@ TEST_CASE("Introspection::different-composition-degrees")
 {
   using namespace aspect;
   dealii::ParameterHandler prm;
-  Simulator<2>::declare_parameters(prm);
+  Simulator<2>::declare_parameters(prm, 0 /* mpi rank */);
 
 
   prm.set("Output directory", "");


### PR DESCRIPTION
I don't see a way to silence these warnings in the ParameterHandler directly, but we can just mark it as deprecated only on rank 0. ;-)