### PR TITLE
CMake: hide "Found X tests"

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -432,4 +432,4 @@ foreach(_test ${_tests})
   endif()
 endforeach()
 
-message("Found ${_n_tests} tests.")
+message(STATUS "Found ${_n_tests} tests.")


### PR DESCRIPTION
The top level configure hides the noisy test setup log but currently prints a somewhat misplaced final line "Found X tests.". Hide it by turning it from an error into a normal status message. Before:
```
-- ===== Configuring ASPECT build targets =============
-- Linking ASPECT against zlib
-- Linking ASPECT against NetCDF
-- Linking ASPECT against WorldBuilder
-- Linking ASPECT against dlopen
-- Precompiling common header files.
-- Combining source files into unity build.
-- Writing externally readable configuration information
-- Setting up test project, see tests/setup_tests.log for details.
Found 1 tests.
-- Writing configuration details into detailed.log...
```
After: That line is instead put into setup_tests.log