### PR TITLE
Push down the functionality to serialize plugins to the ManagerBase level.

### DIFF
--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -272,6 +272,24 @@ namespace aspect
         const std::vector<std::string> &
         get_active_plugin_names () const;
 
+        /**
+         * Write the data of this object to a stream for the purpose of
+         * serialization.
+         */
+        template <class Archive>
+        void save (Archive &ar,
+                   const unsigned int version) const;
+
+        /**
+         * Read the data of this object from a stream for the purpose of
+         * serialization.
+         */
+        template <class Archive>
+        void load (Archive &ar,
+                   const unsigned int version);
+
+        BOOST_SERIALIZATION_SPLIT_MEMBER()
+
       protected:
         /**
          * A list of plugin objects that have been requested in the
@@ -359,6 +377,40 @@ namespace aspect
             }
         }
     }
+
+
+
+    template <typename InterfaceType>
+    template <class Archive>
+    void ManagerBase<InterfaceType>::save (Archive &ar,
+                                           const unsigned int) const
+    {
+      // let all the postprocessors save their data in a map and then
+      // serialize that
+      std::map<std::string,std::string> saved_text;
+      for (const auto &p : plugin_objects)
+        p->save (saved_text);
+
+      ar &saved_text;
+    }
+
+
+    template <typename InterfaceType>
+    template <class Archive>
+    void ManagerBase<InterfaceType>::load (Archive &ar,
+                                           const unsigned int)
+    {
+      // get the map back out of the stream; then let the postprocessors
+      // that we currently have get their data from there. note that this
+      // may not be the same set of postprocessors we had when we saved
+      // their data
+      std::map<std::string,std::string> saved_text;
+      ar &saved_text;
+
+      for (auto &p : plugin_objects)
+        p->load (saved_text);
+    }
+
 
 
     template <typename InterfaceType>

--- a/include/aspect/postprocess/interface.h
+++ b/include/aspect/postprocess/interface.h
@@ -243,25 +243,6 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
         /**
-         * Write the data of this object to a stream for the purpose of
-         * serialization.
-         */
-        template <class Archive>
-        void save (Archive &ar,
-                   const unsigned int version) const;
-
-        /**
-         * Read the data of this object from a stream for the purpose of
-         * serialization.
-         */
-        template <class Archive>
-        void load (Archive &ar,
-                   const unsigned int version);
-
-        BOOST_SERIALIZATION_SPLIT_MEMBER()
-
-
-        /**
          * A function that is used to register postprocessor objects in such a
          * way that the Manager can deal with all of them without having to
          * know them by name. This allows the files in which individual
@@ -310,39 +291,6 @@ namespace aspect
 
 
     /* -------------------------- inline and template functions ---------------------- */
-
-    template <int dim>
-    template <class Archive>
-    void Manager<dim>::save (Archive &ar,
-                             const unsigned int) const
-    {
-      // let all the postprocessors save their data in a map and then
-      // serialize that
-      std::map<std::string,std::string> saved_text;
-      for (const auto &p : this->plugin_objects)
-        p->save (saved_text);
-
-      ar &saved_text;
-    }
-
-
-    template <int dim>
-    template <class Archive>
-    void Manager<dim>::load (Archive &ar,
-                             const unsigned int)
-    {
-      // get the map back out of the stream; then let the postprocessors
-      // that we currently have get their data from there. note that this
-      // may not be the same set of postprocessors we had when we saved
-      // their data
-      std::map<std::string,std::string> saved_text;
-      ar &saved_text;
-
-      for (auto &p : this->plugin_objects)
-        p->load (saved_text);
-    }
-
-
 
     template <int dim>
     template <typename PostprocessorType, typename>


### PR DESCRIPTION
At the moment, none of the plugin `Manager` classes have the ability to serialize anything, with the exception of the `Postprocessors::Manager` class. This patch moves the ability to serialize down to the `ManagerBase` level. The patch does not actually ask any of the other plugin systems to serialize themselves, but this is the first step towards the goal.

Part of #6744 .