### PR TITLE
Fix typos, Minor Documentation Improvements

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1665,7 +1665,7 @@ namespace aspect
         {
           prm.declare_entry("Number of fastscape timesteps per aspect timestep", "5",
                             Patterns::Integer(),
-                            "Initial number of fastscape time steps per ASPECT timestep, this value will double if"
+                            "Initial number of fastscape time steps per ASPECT timestep, this value will double if "
                             "the FastScape timestep is above the maximum FastScape timestep.");
           prm.declare_entry("Maximum timestep length", "10e3",
                             Patterns::Double(0),
@@ -1675,11 +1675,11 @@ namespace aspect
                             "Vertical exaggeration for FastScape's VTK file. -1 outputs topography, basement, and sealevel.");
           prm.declare_entry("Additional fastscape refinement", "0",
                             Patterns::Integer(),
-                            "How many levels above ASPECT FastScape should be refined.");
+                            "How many levels above the ASPECT mesh the FastScape mesh should be refined.");
           prm.declare_entry ("Average out of plane surface topography in 2d", "true",
                              Patterns::Bool (),
                              "If this is set to false, then a 2D model will only consider the "
-                             "center slice FastScape gives. If set to true, then ASPECT will"
+                             "center slice FastScape gives. If set to true, then ASPECT will "
                              "average the mesh along Y excluding the ghost nodes.");
           prm.declare_entry("Fastscape seed", "1000",
                             Patterns::Integer(),
@@ -1690,7 +1690,7 @@ namespace aspect
           prm.declare_entry("Surface refinement difference", "0",
                             Patterns::Integer(),
                             "The difference between the lowest and highest refinement level at the surface. E.g., if three resolution "
-                            "levels are expected, this would be set to 2.");
+                            "levels are expected, this would be set to two.");
           prm.declare_entry ("Use marine component", "false",
                              Patterns::Bool (),
                              "Flag to use the marine component of FastScape.");
@@ -1699,18 +1699,18 @@ namespace aspect
                             "FastScape Y extent when using a 2D ASPECT model. Units: $\\{m}$");
           prm.declare_entry ("Use ghost nodes", "true",
                              Patterns::Bool (),
-                             "Flag to use ghost nodes");
+                             "Flag to use ghost nodes.");
           prm.declare_entry ("Uplift and advect with fastscape", "true",
                              Patterns::Bool (),
                              "Flag to use FastScape advection and uplift.");
           prm.declare_entry("Node tolerance", "0.001",
                             Patterns::Double(),
-                            "Node tolerance for how close an ASPECT node must be to the FastScape node for the value to be transferred.");
+                            "Node tolerance for how close an ASPECT node must be to a FastScape node for the value to be transferred.");
           prm.declare_entry ("Sediment rain rates", "0,0",
                              Patterns::List (Patterns::Double(0)),
                              "Sediment rain rates given as a list 1 greater than the number of sediment rain time intervals. E.g, "
-                             " If the time interval is given at 5 Myr, there will be one value for 0-5 Myr model time and a second value "
-                             " for 5+ Myr. Units: $\\{m/yr}$");
+                             "If the time interval is given at 5 Myr, there will be one value for 0-5 Myr model time and a second value "
+                             "for 5+ Myr. Units: $\\{m/yr}$");
           prm.declare_entry ("Sediment rain time intervals", "0",
                              Patterns::List (Patterns::Double(0)),
                              "A list of times to change the sediment rain rate. Units: $\\{yrs}$");
@@ -1719,7 +1719,7 @@ namespace aspect
                             "Maximum topography change from the initial noise. Units: $\\{m}$");
           prm.declare_entry("Additional output variables", "river incision rate",
                             Patterns::Selection("river incision rate|deposition coefficient|uplift rate"),
-                            "Select one type of Fastscape variable as output in Fastcape vtk."
+                            "Select one additional Fastscape variable to output in the Fastcape vtk. "
                             "Output are in units of per year. "
                            );
 
@@ -1739,16 +1739,16 @@ namespace aspect
                                "Left boundary condition, where 1 is fixed and 0 is reflective.");
             prm.declare_entry("Left mass flux", "0",
                               Patterns::Double(),
-                              "Flux per unit length through left boundary. Units: $\\{m^2/yr}$ ");
+                              "Flux per unit length through the left boundary. Units: $\\{m^2/yr}$ ");
             prm.declare_entry("Right mass flux", "0",
                               Patterns::Double(),
-                              "Flux per unit length through right boundary. Units: $\\{m^2/yr}$ ");
+                              "Flux per unit length through the right boundary. Units: $\\{m^2/yr}$ ");
             prm.declare_entry("Back mass flux", "0",
                               Patterns::Double(),
-                              "Flux per unit length through back boundary. Units: $\\{m^2/yr}$ ");
+                              "Flux per unit length through the back boundary. Units: $\\{m^2/yr}$ ");
             prm.declare_entry("Front mass flux", "0",
                               Patterns::Double(),
-                              "Flux per unit length through front boundary. Units: $\\{m^2/yr}$ ");
+                              "Flux per unit length through the front boundary. Units: $\\{m^2/yr}$ ");
             prm.declare_entry ("Back front ghost nodes periodic", "false",
                                Patterns::Bool (),
                                "Whether to set the ghost nodes at the FastScape back and front boundary "
@@ -1764,13 +1764,13 @@ namespace aspect
           {
             prm.declare_entry("Drainage area exponent", "0.4",
                               Patterns::Double(),
-                              "Exponent for drainage area.");
+                              "The drainage area exponent for the Stream Power Law (m).");
             prm.declare_entry("Slope exponent", "1",
                               Patterns::Double(),
-                              "The  slope  exponent  for  SPL (n).  Generally  m/n  should  equal  approximately 0.4");
+                              "The slope exponent for the Stream Power Law (n). Generally m/n should equal approximately 0.4");
             prm.declare_entry("Multi-direction slope exponent", "1",
                               Patterns::Double(),
-                              "Exponent to determine the distribution from the SPL to neighbor nodes, with"
+                              "Exponent to determine the distribution from the SPL to neighbor nodes, with "
                               "10 being steepest decent and 1 being more varied.");
             prm.declare_entry("Bedrock deposition coefficient", "1",
                               Patterns::Double(),
@@ -1785,7 +1785,9 @@ namespace aspect
                               "If false, a constant kf value will be used.");
             prm.declare_entry("Bedrock river incision rate", "1e-5",
                               Patterns::Double(),
-                              "River incision rate for bedrock in the Stream Power Law. Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$");
+                              "River incision rate for bedrock in the Stream Power Law. "
+                              "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; "
+                              "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$");
             prm.enter_subsection ("kf distribution function");
             {
               Functions::ParsedFunction<2>::declare_parameters(prm, 2);
@@ -1793,7 +1795,9 @@ namespace aspect
             prm.leave_subsection();
             prm.declare_entry("Sediment river incision rate", "-1",
                               Patterns::Double(),
-                              "River incision rate for sediment in the Stream Power Law. -1 sets this to the bedrock river incision rate. Units: $m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; otherwise, the units are $m^(1-2drainage_area_exponent)/s}$");
+                              "River incision rate for sediment in the Stream Power Law. -1 sets this to the bedrock river incision rate. "
+                              "Units: $m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; "
+                              "otherwise, the units are $m^(1-2drainage_area_exponent)/s}$");
 
             // Define Bedrock transport coefficient (Kd) as a constant value of time dependent user-defined function
             prm.declare_entry("Use kd distribution function", "false",
@@ -1802,7 +1806,8 @@ namespace aspect
                               "If false, a constant kd value will be used.");
             prm.declare_entry("Bedrock diffusivity", "1e-2",
                               Patterns::Double(),
-                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds in output'' is true; otherwise, the units are ${m^2/s}$.");
+                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds in output'' "
+                              "is true; otherwise, the units are ${m^2/s}$.");
             prm.enter_subsection ("kd distribution function");
             {
               Functions::ParsedFunction<2>::declare_parameters(prm, 2);
@@ -1820,10 +1825,10 @@ namespace aspect
                               "When terrain reaches this height the wind barrier factor is applied. Units: $\\{m}$");
             prm.declare_entry("Elevation factor", "1",
                               Patterns::Double(),
-                              "Amount to multiply the bedrock river incision rate nad transport coefficient by past the given orographic elevation control.");
+                              "Amount to multiply the bedrock river incision rate and transport coefficient by past the given orographic elevation control.");
             prm.declare_entry("Wind barrier factor", "1",
                               Patterns::Double(),
-                              "Amount to multiply the bedrock river incision rate nad transport coefficient by past given wind barrier height.");
+                              "Amount to multiply the bedrock river incision rate and transport coefficient by past given wind barrier height.");
             prm.declare_entry ("Stack orographic controls", "true",
                                Patterns::Bool (),
                                "Whether or not to apply both controls to a point, or only a maximum of one set as the wind barrier.");
@@ -1867,7 +1872,8 @@ namespace aspect
 
             prm.declare_entry("Sea level", "0.0",
                               Patterns::Double(),
-                              "Constant sea level relative to the ASPECT surface, where the maximum Z or Y extent in ASPECT is a sea level of zero. Units: $\\{m}$ ");
+                              "Constant sea level relative to the ASPECT surface, where the maximum Z or Y extent in ASPECT is a sea level of zero. "
+                              "Units: $\\{m}$ ");
 
             prm.enter_subsection ("Sea level function");
             {


### PR DESCRIPTION
When reading through fastscape.cc I noticed a few typos which I fixed here. I also added some minor documentation that I thought would have been helpful when I was first trying to wrap my head around landscape evolution parameters.