### PR TITLE
Remove unused <array> include

### DIFF
--- a/benchmarks/solubility/plugin/solubility.cc
+++ b/benchmarks/solubility/plugin/solubility.cc
@@ -24,7 +24,6 @@
 #include <aspect/utilities.h>
 #include <aspect/geometry_model/interface.h>
 
-#include <array>
 #include <utility>
 #include <limits>
 

--- a/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.h
+++ b/cookbooks/tomography_based_plate_motions/plugins/tomography_based_plate_motions.h
@@ -27,7 +27,6 @@
 #include <aspect/material_model/grain_size.h>
 #include <aspect/simulator_access.h>
 #include <aspect/material_model/rheology/ascii_depth_profile.h>
-#include <array>
 
 namespace aspect
 {

--- a/include/aspect/compat.h
+++ b/include/aspect/compat.h
@@ -25,7 +25,6 @@
 #include <deal.II/base/mpi.h>
 
 // C++11 related includes.
-#include <array>
 #include <functional>
 #include <memory>
 

--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -24,7 +24,6 @@
 #include <aspect/particle/property/interface.h>
 #include <aspect/particle/property/crystal_preferred_orientation.h>
 #include <aspect/simulator_access.h>
-#include <array>
 
 namespace aspect
 {

--- a/source/material_model/averaging.cc
+++ b/source/material_model/averaging.cc
@@ -18,7 +18,6 @@
   <http://www.gnu.org/licenses/>.
 */
 
-#include <array>
 #include <aspect/material_model/averaging.h>
 #include <utility>
 #include <limits>

--- a/source/material_model/replace_lithosphere_viscosity.cc
+++ b/source/material_model/replace_lithosphere_viscosity.cc
@@ -25,7 +25,6 @@
 
 #include <limits>
 
-#include <array>
 #include <utility>
 
 

--- a/source/mesh_deformation/ascii_data.cc
+++ b/source/mesh_deformation/ascii_data.cc
@@ -25,7 +25,6 @@
 #include <aspect/geometry_model/interface.h>
 
 #include <deal.II/base/parameter_handler.h>
-#include <array>
 
 
 namespace aspect


### PR DESCRIPTION
This patch removes an unused `#include <array>` from source. No functional or behavioral changes — just a tiny clean-up to keep the codebase tidy.