### PR TITLE
Minor cleanups in the visualization postprocessors.

### DIFF
--- a/include/aspect/postprocess/visualization/geoid.h
+++ b/include/aspect/postprocess/visualization/geoid.h
@@ -73,9 +73,6 @@ namespace aspect
            */
           std::list<std::string>
           required_other_postprocessors() const override;
-
-        private:
-
       };
     }
   }

--- a/include/aspect/postprocess/visualization/grain_lag_angle.h
+++ b/include/aspect/postprocess/visualization/grain_lag_angle.h
@@ -70,7 +70,6 @@ namespace aspect
            */
           std::pair<std::string, std::unique_ptr<Vector<float>>>
           execute() const override;
-
       };
     }
   }

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -96,6 +96,9 @@ namespace aspect
            * A temporary storage place for the point-wise heat flux
            * solution. Only initialized and used if output_point_wise_heat_flux
            * is set to true.
+           *
+           * This object is computed in update() and then used on every cell
+           * where evaluate_vector_field() is called.
            */
           LinearAlgebra::BlockVector heat_flux_density_solution;
 
@@ -103,6 +106,9 @@ namespace aspect
            * A temporary storage place for the cell-wise heat flux
            * solution. Only initialized and used if output_point_wise_heat_flux
            * is set to false.
+           *
+           * This object is computed in update() and then used on every cell
+           * where evaluate_vector_field() is called.
            */
           std::vector<std::vector<std::pair<double, double>>> heat_flux_and_area;
       };

--- a/include/aspect/postprocess/visualization/heating.h
+++ b/include/aspect/postprocess/visualization/heating.h
@@ -65,7 +65,6 @@ namespace aspect
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double>> &computed_quantities) const override;
-
       };
     }
   }

--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -62,7 +62,6 @@ namespace aspect
            */
           void
           parse_parameters (ParameterHandler &prm) override;
-
       };
     }
   }

--- a/include/aspect/postprocess/visualization/temperature_anomaly.h
+++ b/include/aspect/postprocess/visualization/temperature_anomaly.h
@@ -72,12 +72,7 @@ namespace aspect
            * Number of slices to use when computing depth average of temperature.
            */
           unsigned int n_slices;
-          /**
-           * Vector of temperature depth average values, padded to include two ghost values
-           * above and below the surface and bottom of the domain to allow interpolation at
-           * all depths.
-           */
-          std::vector<double> padded_temperature_depth_average;
+
           /**
            * Whether to extrapolate temperatures above/below the first/last depth-average slice
            * or, alternatively, interpolate above the center of the first slice using the surface
@@ -85,6 +80,16 @@ namespace aspect
            */
           bool extrapolate_surface;
           bool extrapolate_bottom;
+
+          /**
+           * Vector of temperature depth average values, padded to include two ghost values
+           * above and below the surface and bottom of the domain to allow interpolation at
+           * all depths.
+           *
+           * This object is computed in update() and then used on every cell
+           * where evaluate_vector_field() is called.
+           */
+          std::vector<double> padded_temperature_depth_average;
       };
     }
   }

--- a/source/postprocess/visualization/temperature_anomaly.cc
+++ b/source/postprocess/visualization/temperature_anomaly.cc
@@ -79,7 +79,6 @@ namespace aspect
             padded_temperature_depth_average[n_slices+1] = 2.*bottom_temperature - temperature_depth_average[n_slices-1];
           }
         std::copy ( temperature_depth_average.begin(), temperature_depth_average.end(), padded_temperature_depth_average.begin() + 1 );
-
       }
 
 


### PR DESCRIPTION
I looked into the visualization postprocessors for #6744 to find that none of them actually need to serialize anything (i.e., they don't keep any state). But one always finds some things that make you wonder and that should be better documented or cleaned up.