### PR TITLE
Move an assertion.

### DIFF
--- a/include/aspect/postprocess/visualization/spd_factor.h
+++ b/include/aspect/postprocess/visualization/spd_factor.h
@@ -56,12 +56,6 @@ namespace aspect
           void
           evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                                 std::vector<Vector<double>> &computed_quantities) const override;
-
-          /**
-           * Read the parameters this class declares from the parameter file.
-           */
-          void
-          parse_parameters (ParameterHandler &prm) override;
       };
     }
   }

--- a/source/postprocess/visualization/spd_factor.cc
+++ b/source/postprocess/visualization/spd_factor.cc
@@ -48,6 +48,10 @@ namespace aspect
       evaluate_vector_field(const DataPostprocessorInputs::Vector<dim> &input_data,
                             std::vector<Vector<double>> &computed_quantities) const
       {
+        Assert(Parameters<dim>::is_defect_correction(this->get_parameters().nonlinear_solver),
+               ExcMessage("The SPD factor plugin can only be used with defect correction type Stokes or Newton Stokes "
+                          "solvers."));
+
         const unsigned int n_quadrature_points = input_data.solution_values.size();
         Assert (computed_quantities.size() == n_quadrature_points,                             ExcInternalError());
         Assert (computed_quantities[0].size() == 1,                                            ExcInternalError());
@@ -75,15 +79,6 @@ namespace aspect
                                                                            derivatives->viscosity_derivative_wrt_strain_rate[q],
                                                                            this->get_newton_handler().parameters.SPD_safety_factor);
           }
-      }
-
-      template <int dim>
-      void
-      SPD_Factor<dim>::parse_parameters (ParameterHandler &/*prm*/)
-      {
-        AssertThrow(Parameters<dim>::is_defect_correction(this->get_parameters().nonlinear_solver),
-                    ExcMessage("The SPD factor plugin can only be used with defect correction type Stokes or Newton Stokes "
-                               "solvers."));
       }
     }
   }


### PR DESCRIPTION
While working in #6775: I was wondering why a class that has no member variables has a `parse_parameters()` function -- if it parses anything, it has no place to put it. Turns out it doesn't: All we do there is verify an assertion. I think that might as well happen elsewhere. In practice, I think a regular `Assert` is enough for this.