### PR TITLE
add instantiation of plugin list

### DIFF
--- a/include/aspect/plugins.h
+++ b/include/aspect/plugins.h
@@ -1015,6 +1015,13 @@ namespace aspect
       }
 
 
+
+      // Add definition for plugins member:
+      template <typename InterfaceClass>
+      inline std::list<typename PluginList<InterfaceClass>::PluginInfo> *PluginList<InterfaceClass>::plugins = nullptr;
+
+
+
       /**
        * A placeholder class that is used wherever we need a PluginList object
        * for `dim==0` and `dim==1`, which of course are not dimensions we


### PR DESCRIPTION
Clang complains
```
./aspect/include/aspect/plugins.h:731:13: error: instantiation of
variable
'aspect::internal::Plugins::PluginList<aspect::BoundaryTemperature::Interface<3>>::plugins'
required here, but no definition is available
[-Werror,-Wundefined-var-template]
```
