### PR TITLE
Remove an assert related to GMG global coarsening.

### DIFF
--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -1574,7 +1574,6 @@ namespace aspect
 
             if (this->get_boundary_velocity_manager().get_tangential_boundary_velocity_indicators().size() > 0)
               {
-                Assert(false, dealii::StandardExceptions::ExcNotImplemented("This is not tested."));
                 VectorTools::compute_no_normal_flux_constraints (dof_handler,
                                                                  0 /* first_vector_component */,
                                                                  this->get_boundary_velocity_manager().get_tangential_boundary_velocity_indicators(),


### PR DESCRIPTION
The assert exists because GMG global coarsening had not been tested for tangential boundary conditions. Given the results from #6752, which I tested on a finer mesh as well, I think we can remove this line of code. 

@tjhei 

