### PR TITLE
Support empty cells in particlePDF

### DIFF
--- a/include/aspect/particle/distribution.h
+++ b/include/aspect/particle/distribution.h
@@ -94,20 +94,19 @@ namespace aspect
          * @param particle_ranges_to_sum_over The particle_iterator_range of the current and neighboring cells.
          * The KDE uses both the particles in the given cell and those in neighboring cells when constructing the point density function.
          * @param n_particles_in_cell The number of particles belonging to the particle manager in question within the cell.
-         * @param mapping A reference to a mapping object to use to translate cell coordinates into
-         * real coordinates. `fill_from_particle_range` does not use this parameter directly but passes it to
-         * `insert_kernel_sum_from_particle_range.`
+         * @param mapping The mapping object used to translate cell coordinates into real coordinates.
+         * @param cell The cell for which the ParticlePDF is to be computed.
          */
         void
         fill_from_particle_range(const typename Particles::ParticleHandler<dim>::particle_iterator_range &particle_range,
                                  const std::vector<typename Particles::ParticleHandler<dim>::particle_iterator_range>
                                  &particle_ranges_to_sum_over,
                                  const unsigned int n_particles_in_cell,
-                                 const typename dealii::Mapping<dim> &mapping);
+                                 const typename dealii::Mapping<dim> &mapping,
+                                 const typename Triangulation<dim>::active_cell_iterator &cell);
 
         /**
-         * This function is only called from `fill_from_particle_range`.
-         * It iterates through every particle in the cell and
+         * This function iterates through every particle in the cell and
          * sums the value of the kernel function between the
          * reference point and the position of the cell.
          * @param reference_point The point from which to get the value of the kernel function.
@@ -121,7 +120,7 @@ namespace aspect
         void
         insert_kernel_sum_from_particle_range(const Point<dim> &reference_point,
                                               const std::array<unsigned int,dim> &table_index,
-                                              const typename Triangulation<dim>::cell_iterator &cell,
+                                              const typename Triangulation<dim>::active_cell_iterator &cell,
                                               const std::vector<typename Particles::ParticleHandler<dim>::particle_iterator_range>
                                               &particle_ranges_to_sum_over,
                                               const typename dealii::Mapping<dim> &mapping);

--- a/source/particle/manager.cc
+++ b/source/particle/manager.cc
@@ -363,7 +363,8 @@ namespace aspect
                             pdf.fill_from_particle_range(particle_handler->particles_in_cell(cell),
                                                          particle_ranges_to_sum_over,
                                                          current_n_particles_in_cell,
-                                                         this->get_mapping());
+                                                         this->get_mapping(),
+                                                         cell);
                             pdf.compute_statistical_values();
 
                             const std::vector<Point<dim>> min_density_positions = pdf.get_min_positions();
@@ -564,7 +565,8 @@ namespace aspect
                             pdf.fill_from_particle_range(particle_handler->particles_in_cell(cell),
                                                          particle_ranges_to_sum_over,
                                                          current_n_particles_in_cell,
-                                                         this->get_mapping());
+                                                         this->get_mapping(),
+                                                         cell);
                             pdf.compute_statistical_values();
 
                             const types::particle_index index_max = pdf.get_max_particle();

--- a/source/postprocess/particle_distribution_statistics.cc
+++ b/source/postprocess/particle_distribution_statistics.cc
@@ -76,7 +76,8 @@ namespace aspect
                           pdf.fill_from_particle_range(particle_handler.particles_in_cell(cell),
                                                        particle_ranges_to_sum_over,
                                                        particle_handler.n_particles_in_cell(cell),
-                                                       this->get_mapping());
+                                                       this->get_mapping(),
+                                                       cell);
                           pdf.compute_statistical_values();
 
                           standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());
@@ -100,7 +101,8 @@ namespace aspect
                           pdf.fill_from_particle_range(particle_handler.particles_in_cell(cell),
                                                        particle_ranges_to_sum_over,
                                                        particle_handler.n_particles_in_cell(cell),
-                                                       this->get_mapping());
+                                                       this->get_mapping(),
+                                                       cell);
                           pdf.compute_statistical_values();
 
                           standard_deviation_min = std::min(standard_deviation_min, pdf.get_standard_deviation());

--- a/tests/particle_KDE_addition_empty_cells.prm
+++ b/tests/particle_KDE_addition_empty_cells.prm
@@ -1,0 +1,22 @@
+# This parameter file is intended to test adding particles using kernel density estimation.
+# It is identical to particle_KDE_addition.prm, but starts without pre-generated particles,
+# therefore testing that the KDE supports empty cells.
+
+include $ASPECT_SOURCE_DIR/benchmarks/particle_distribution/addition_algorithm_benchmarks.prm
+
+set End time = 0.18
+
+subsection Particles
+  set Particle generator name = random uniform
+  set Maximum particles per cell = 19
+  set Minimum particles per cell = 16
+  set Load balancing strategy = add particles
+  set Particle removal algorithm = random
+  set Particle addition algorithm = point density function
+  set Allow cells without particles = true
+  subsection Generator
+    subsection Random uniform
+      set Number of particles = 0
+    end
+  end
+end

--- a/tests/particle_KDE_addition_empty_cells/screen-output
+++ b/tests/particle_KDE_addition_empty_cells/screen-output
@@ -1,0 +1,111 @@
+
+Number of active cells: 40 (on 2 levels)
+Number of degrees of freedom: 678 (410+63+205)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+
+Number of active cells: 160 (on 3 levels)
+Number of degrees of freedom: 2,392 (1,458+205+729)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+
+Number of active cells: 256 (on 4 levels)
+Number of degrees of freedom: 3,736 (2,282+313+1,141)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0 m/s, 0 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9248 K, 1.125 K
+     Heat fluxes through boundary parts:                                                0.001117 W, 0.001117 W, 0 W, 0 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00000
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00000
+     Particle distribution score min/avg/max/stdev:                                     0/0.00911458/0.03125/0.00665235
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.00835976/0.0218704, 0.0477263/0.0704903, 0.025/0.125
+
+*** Timestep 1:  t=0.03 seconds, dt=0.03 seconds
+   Solving temperature system... 8 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.0471 m/s, 0.0471 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9248 K, 1.125 K
+     Heat fluxes through boundary parts:                                                0.001331 W, 0.001331 W, -0.02157 W, 0.02157 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00001
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00001
+     Particle distribution score min/avg/max/stdev:                                     0/0.00911458/0.03125/0.00665235
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.00835976/0.0218704, 0.0477263/0.0704903, 0.025/0.125
+
+*** Timestep 2:  t=0.06 seconds, dt=0.03 seconds
+   Solving temperature system... 9 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.0937 m/s, 0.0937 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9248 K, 1.126 K
+     Heat fluxes through boundary parts:                                                0.00134 W, 0.00134 W, -0.04297 W, 0.04297 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00002
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00002
+     Particle distribution score min/avg/max/stdev:                                     0/0.00911458/0.03125/0.00665235
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.00961779/0.0270633, 0.048656/0.0743512, 0.025/0.15
+
+*** Timestep 3:  t=0.09 seconds, dt=0.03 seconds
+   Solving temperature system... 9 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.139 m/s, 0.139 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9247 K, 1.128 K
+     Heat fluxes through boundary parts:                                                0.001365 W, 0.001365 W, -0.06406 W, 0.06406 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00003
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00003
+     Particle distribution score min/avg/max/stdev:                                     0/0.0107204/0.046832/0.00786717
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.011467/0.02779, 0.0490891/0.0788573, 0.0245399/0.146341
+
+*** Timestep 4:  t=0.12 seconds, dt=0.03 seconds
+   Solving temperature system... 10 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.184 m/s, 0.184 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9247 K, 1.131 K
+     Heat fluxes through boundary parts:                                                0.001413 W, 0.001413 W, -0.08468 W, 0.08468 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00004
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00004
+     Particle distribution score min/avg/max/stdev:                                     0/0.0108059/0.0333333/0.0076509
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.0106842/0.0335023, 0.0479764/0.0756488, 0.0245399/0.152174
+
+*** Timestep 5:  t=0.15 seconds, dt=0.03 seconds
+   Solving temperature system... 10 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.227 m/s, 0.227 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9246 K, 1.136 K
+     Heat fluxes through boundary parts:                                                0.001488 W, 0.001488 W, -0.1047 W, 0.1047 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00005
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00005
+     Particle distribution score min/avg/max/stdev:                                     0/0.00976826/0.0818473/0.00913077
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.0106776/0.0485621, 0.0487525/0.0762532, 0.0319149/0.171429
+
+*** Timestep 6:  t=0.18 seconds, dt=0.03 seconds
+   Solving temperature system... 11 iterations.
+   Advecting particles...  done.
+
+   Postprocessing:
+     RMS, max velocity:                                                                 0.268 m/s, 0.268 m/s
+     Temperature min/avg/max:                                                           0 K, 0.9246 K, 1.142 K
+     Heat fluxes through boundary parts:                                                0.001589 W, 0.001589 W, -0.1241 W, 0.1241 W
+     Writing graphical output:                                                          output-particle_KDE_addition_empty_cells/solution/solution-00006
+     Writing particle output:                                                           output-particle_KDE_addition_empty_cells/particles/particles-00006
+     Particle distribution score min/avg/max/stdev:                                     0/0.0104683/0.0918367/0.00996519
+     Particle Distribution Stats (stddev min/mean/max, mean min/max, absolute min/max): 0/0.0105381/0.048104, 0.0485847/0.0758484, 0.0315789/0.169811
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/particle_KDE_addition_empty_cells/statistics
+++ b/tests/particle_KDE_addition_empty_cells/statistics
@@ -1,0 +1,37 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: RMS velocity (m/s)
+# 9: Max. velocity (m/s)
+# 10: Minimal temperature (K)
+# 11: Average temperature (K)
+# 12: Maximal temperature (K)
+# 13: Outward heat flux through boundary with indicator 0 ("left") (W)
+# 14: Outward heat flux through boundary with indicator 1 ("right") (W)
+# 15: Outward heat flux through boundary with indicator 2 ("bottom") (W)
+# 16: Outward heat flux through boundary with indicator 3 ("top") (W)
+# 17: Visualization file name
+# 18: Number of advected particles
+# 19: Particle file name
+# 20: Minimal particle distribution score: 
+# 21: Average particle distribution score: 
+# 22: Maximal particle distribution score: 
+# 23: Cell Score Standard Deviation: 
+# 24: Minimum PDF standard deviation: 
+# 25: Mean of PDF standard deviation: 
+# 26: Maximum PDF standard deviation: 
+# 27: Mean of PDF minimum values: 
+# 28: Mean PDF maximum values: 
+# 29: Minimum of PDF minimum values: 
+# 30: Maximum of PDF maximum values: 
+0 0.000000000000e+00 0.000000000000e+00 256 2595 1141  0 0.00000000e+00 0.00000000e+00 0.00000000e+00 9.24826389e-01 1.12500000e+00 1.11666667e-03 1.11666667e-03  0.00000000e+00 0.00000000e+00 output-particle_KDE_addition_empty_cells/solution/solution-00000 4096 output-particle_KDE_addition_empty_cells/particles/particles-00000 0.0000 0.0091 0.0312 0.0067 0.0000 0.0084 0.0219 0.0477 0.0705 0.0250 0.1250 
+1 3.000000000000e-02 3.000000000000e-02 256 2595 1141  8 4.70541567e-02 4.70541567e-02 0.00000000e+00 9.24794341e-01 1.12496653e+00 1.33107704e-03 1.33107704e-03 -2.15661638e-02 2.15661638e-02 output-particle_KDE_addition_empty_cells/solution/solution-00001 4096 output-particle_KDE_addition_empty_cells/particles/particles-00001 0.0000 0.0091 0.0312 0.0067 0.0000 0.0084 0.0219 0.0477 0.0705 0.0250 0.1250 
+2 6.000000000000e-02 3.000000000000e-02 256 2595 1141  9 9.36906573e-02 9.36906573e-02 0.00000000e+00 9.24761678e-01 1.12602061e+00 1.33950321e-03 1.33950321e-03 -4.29700065e-02 4.29700065e-02 output-particle_KDE_addition_empty_cells/solution/solution-00002 4096 output-particle_KDE_addition_empty_cells/particles/particles-00002 0.0000 0.0091 0.0312 0.0067 0.0000 0.0096 0.0271 0.0487 0.0744 0.0250 0.1500 
+3 9.000000000000e-02 3.000000000000e-02 256 2595 1141  9 1.39495553e-01 1.39495553e-01 0.00000000e+00 9.24726991e-01 1.12787772e+00 1.36522699e-03 1.36522699e-03 -6.40552852e-02 6.40552852e-02 output-particle_KDE_addition_empty_cells/solution/solution-00003 4155 output-particle_KDE_addition_empty_cells/particles/particles-00003 0.0000 0.0107 0.0468 0.0079 0.0000 0.0115 0.0278 0.0491 0.0789 0.0245 0.1463 
+4 1.200000000000e-01 3.000000000000e-02 256 2595 1141 10 1.84062276e-01 1.84062276e-01 0.00000000e+00 9.24688385e-01 1.13085067e+00 1.41310936e-03 1.41310936e-03 -8.46776807e-02 8.46776807e-02 output-particle_KDE_addition_empty_cells/solution/solution-00004 4183 output-particle_KDE_addition_empty_cells/particles/particles-00004 0.0000 0.0108 0.0333 0.0077 0.0000 0.0107 0.0335 0.0480 0.0756 0.0245 0.1522 
+5 1.500000000000e-01 3.000000000000e-02 256 2595 1141 10 2.26995250e-01 2.26995250e-01 0.00000000e+00 9.24643665e-01 1.13550372e+00 1.48807091e-03 1.48807091e-03 -1.04716103e-01 1.04716103e-01 output-particle_KDE_addition_empty_cells/solution/solution-00005 4207 output-particle_KDE_addition_empty_cells/particles/particles-00005 0.0000 0.0098 0.0818 0.0091 0.0000 0.0107 0.0486 0.0488 0.0763 0.0319 0.1714 
+6 1.800000000000e-01 3.000000000000e-02 256 2595 1141 11 2.67913397e-01 2.67913397e-01 0.00000000e+00 9.24590818e-01 1.14224846e+00 1.58888768e-03 1.58888768e-03 -1.24062041e-01 1.24062041e-01 output-particle_KDE_addition_empty_cells/solution/solution-00006 4230 output-particle_KDE_addition_empty_cells/particles/particles-00006 0.0000 0.0105 0.0918 0.0100 0.0000 0.0105 0.0481 0.0486 0.0758 0.0316 0.1698 


### PR DESCRIPTION
This PR should fix #6781.

The ParticlePDF class needs access to the cell and got that by asking the first particle of a particle range for its surrounding cell. However, if the particle range is empty that of course fails. The better approach is to let the calling function hand over a reference to the cell.

Another problem with empty cells arose when normalizing the kernel density estimate by the number of particles added. If no particles were found in the current or neighbor cells, we would divide by 0. I fixed this as well, and improved a few comments.