### PR TITLE
Serialize the Topography postprocessor.

### DIFF
--- a/include/aspect/postprocess/topography.h
+++ b/include/aspect/postprocess/topography.h
@@ -65,6 +65,23 @@ namespace aspect
          * @}
          */
 
+        /**
+         * Serialize the contents of this class as far as they are not read
+         * from input parameter files.
+         */
+        template <class Archive>
+        void serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Save the state of this object.
+         */
+        void save (std::map<std::string, std::string> &status_strings) const override;
+
+        /**
+         * Restore the state of the object.
+         */
+        void load (const std::map<std::string, std::string> &status_strings) override;
+
       private:
         /**
          * Whether or not to produce text files with topography values

--- a/source/postprocess/topography.cc
+++ b/source/postprocess/topography.cc
@@ -217,6 +217,44 @@ namespace aspect
 
 
 
+    template <int dim>
+    template <class Archive>
+    void Topography<dim>::serialize (Archive &ar, const unsigned int)
+    {
+      ar &last_output_time;
+    }
+
+
+
+    template <int dim>
+    void Topography<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+      // Serialize into a stringstream. Put the following into a code
+      // block of its own to ensure the destruction of the 'oa'
+      // archive triggers a flush() on the stringstream so we can
+      // query the completed string below.
+      std::ostringstream os;
+      {
+        aspect::oarchive oa (os);
+        oa << (*this);
+      }
+
+      status_strings["Topography"] = os.str();
+    }
+
+
+
+    template <int dim>
+    void Topography<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      // see if something was saved
+      if (status_strings.find("Topography") != status_strings.end())
+        {
+          std::istringstream is (status_strings.find("Topography")->second);
+          aspect::iarchive ia (is);
+          ia >> (*this);
+        }
+    }
 
   }
 }


### PR DESCRIPTION
This is part of #6744: The `Postprocessors::Topography` class stores state, but does not actually serialize it during checkpointing. This is a bug.

Since this is the first of the patches that actually fix something for #6744: I have a hard time thinking about how we would create good tests for these kinds of things. We have some tests for checkpointing, but for these postprocessors we'd have to run them for long enough that they create output, checkpoint, restart, run long enough that they create more output, and then check that there is an observable change in output. That require looking into each of these postprocessor classes to see what they actually do, find a test that exercise it, adjust it to the (complicated) structure we use to test checkpointing, and make something of that. That will be a lot of work. I'm not sure that's worth it -- thoughts?