### PR TITLE
Remove unnecessary spaces in statistics output

### DIFF
--- a/source/postprocess/memory_statistics.cc
+++ b/source/postprocess/memory_statistics.cc
@@ -35,9 +35,9 @@ namespace aspect
       // memory consumption:
       const double mb = 1024*1024; // convert from bytes into mb
 
-      statistics.add_value ("System matrix memory consumption (MB) ", this->get_system_matrix().memory_consumption()/mb);
-      statistics.add_value ("Triangulation memory consumption (MB) ", this->get_triangulation().memory_consumption()/mb);
-      statistics.add_value ("p4est memory consumption (MB) ", this->get_triangulation().memory_consumption_p4est()/mb);
+      statistics.add_value ("System matrix memory consumption (MB)", this->get_system_matrix().memory_consumption()/mb);
+      statistics.add_value ("Triangulation memory consumption (MB)", this->get_triangulation().memory_consumption()/mb);
+      statistics.add_value ("p4est memory consumption (MB)", this->get_triangulation().memory_consumption_p4est()/mb);
 
       double dof_handler_mem = this->get_dof_handler().memory_consumption();
       double constraints_mem = this->get_current_constraints().memory_consumption();
@@ -46,18 +46,18 @@ namespace aspect
           dof_handler_mem += this->get_stokes_matrix_free().get_dof_handler_memory_consumption();
           constraints_mem += this->get_stokes_matrix_free().get_constraint_memory_consumption();
         }
-      statistics.add_value ("DoFHandler memory consumption (MB) ", dof_handler_mem/mb);
-      statistics.add_value ("AffineConstraints<double> memory consumption (MB) ", constraints_mem/mb);
+      statistics.add_value ("DoFHandler memory consumption (MB)", dof_handler_mem/mb);
+      statistics.add_value ("AffineConstraints<double> memory consumption (MB)", constraints_mem/mb);
 
-      statistics.add_value ("Solution vector memory consumption (MB) ", this->get_solution().memory_consumption()/mb);
+      statistics.add_value ("Solution vector memory consumption (MB)", this->get_solution().memory_consumption()/mb);
 
       if (this->is_stokes_matrix_free())
         {
           const double mg_transfer_mem = this->get_stokes_matrix_free().get_mg_transfer_memory_consumption();
-          statistics.add_value ("MGTransfer memory consumption (MB) ", mg_transfer_mem/mb);
+          statistics.add_value ("MGTransfer memory consumption (MB)", mg_transfer_mem/mb);
 
           const double cell_data_mem = this->get_stokes_matrix_free().get_cell_data_memory_consumption();
-          statistics.add_value ("Matrix-free cell data memory consumption (MB) ", cell_data_mem/mb);
+          statistics.add_value ("Matrix-free cell data memory consumption (MB)", cell_data_mem/mb);
         }
 
       if (output_vmpeak)
@@ -66,7 +66,7 @@ namespace aspect
           dealii::Utilities::System::MemoryStats stats;
           dealii::Utilities::System::get_memory_stats(stats);
           const double max_vmpeak = dealii::Utilities::MPI::max(stats.VmPeak/1024.0, this->get_mpi_communicator());
-          statistics.add_value ("Peak virtual memory usage (VmPeak) (MB) ", max_vmpeak);
+          statistics.add_value ("Peak virtual memory usage (VmPeak) (MB)", max_vmpeak);
         }
 
       std::ostringstream output;


### PR DESCRIPTION
A small fix to remove unnecessary spaces in the statistics output that I noticed while updating some test results. 

The memory statistics postprocessor appends spaces at the end of column names for the statistics file. This is not really wrong, but unnecessary and the other postprocessors (rightly) dont append spaces.

Lets see if the tester even notices this change.