### PR TITLE
Prevent negative adiabatic pT conditions in a benchmark

### DIFF
--- a/benchmarks/solcx/compositional_fields/solcx_particles.prm
+++ b/benchmarks/solcx/compositional_fields/solcx_particles.prm
@@ -12,6 +12,8 @@ set Start time                             = 0
 set End time                               = 0
 set Output directory                       = output
 set Pressure normalization                 = volume
+set Adiabatic surface temperature          = 1.0
+set Surface pressure                       = 1.0
 
 ############### Parameters describing the model
 


### PR DESCRIPTION
For the last few days we had failures of the deal.II development tester in the test `sol_cx_particles` like here: https://github.com/geodynamics/aspect/actions/runs/19635945253/job/56226561004?pr=6795#step:6:2028

The failure seems unrelated to any code change in either deal.II or ASPECT and at first I was a bit stumped as to what is happening. But looking at the benchmark I realize why this setup is a bit problematic. The adiabatic conditions start from p=0 and T=0. Density in parts of this benchmark is negative (or 0) and gravity is 1. Therefore the adiabatic reference profile contains negative pressures, which triggers the assert. Why this was not a problem in the past I cannot explain. We can argue if the assert is too sensitive (negative pressures in benchmark solutions are not impossible), but an easier fix is to change the start point of the reference profile. Since the profile is not used in this benchmark nothing will change.

I also have no clue why this is a problem for the particle test, but not the corresponding model with compositional fields, I can only guess that it is due to FP rounding errors.

Anyway, this should fix the confusing test failures.