### PR TITLE
GMG: correctly initialize cell data

### DIFF
--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -658,7 +658,10 @@ namespace aspect
           active_cell_data.dilation_derivative_wrt_strain_rate_table.reinit(TableIndices<2>(0,0));
 
           for (unsigned int level=0; level<n_levels; ++level)
-            level_cell_data[level].enable_newton_derivatives = false;
+            {
+              level_cell_data[level].enable_newton_derivatives = false;
+              level_cell_data[level].enable_prescribed_dilation = false;
+            }
         }
     }
 


### PR DESCRIPTION
This fixes failures with global coarsening, where we had invalid read from an empty Table<>.

This is difficult to test, as it relies on on uninitialized memory randomly causing ``prescribed_dilation == true``.

I went ahead and copied over the whole code section from local smoothing to global coarsening.