### PR TITLE
Create SchurApproximation class so BlockSchurPreconditioner can be used for both AMG and GMG.

### DIFF
--- a/include/aspect/simulator/solver/stokes_matrix_free.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free.h
@@ -302,7 +302,7 @@ namespace aspect
       dst.block(1) *= -1.0;
 
       {
-        BT_block.vmult(utmp,dst);
+        BT_block.vmult(utmp, dst);
         utmp.block(0) *= -1.0;
         utmp.block(0) += src.block(0);
       }

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -29,6 +29,7 @@
 #include <aspect/melt.h>
 #include <aspect/newton.h>
 
+#include <deal.II/base/template_constraints.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <deal.II/matrix_free/tools.h>
@@ -1210,26 +1211,53 @@ namespace aspect
     solver_control_cheap.enable_history_data();
     solver_control_expensive.enable_history_data();
 
-    // create a cheap preconditioner that consists of only a single V-cycle
-    const internal::BlockSchurGMGPreconditioner<StokesMatrixType, ABlockMatrixType, BTBlockOperatorType,SchurComplementMatrixType, GMGPreconditioner, GMGPreconditioner>
-    preconditioner_cheap (stokes_matrix, A_block_matrix, BT_block, Schur_complement_block_matrix,
-                          prec_A, prec_Schur,
-                          /*do_solve_A*/false,
-                          /*do_solve_Schur*/false,
-                          sim.stokes_A_block_is_symmetric(),
-                          this->get_parameters().linear_solver_A_block_tolerance,
-                          this->get_parameters().linear_solver_S_block_tolerance);
+    using GMGPreconditioner = PreconditionMG<dim, VectorType, MGTransferMF<dim,GMGNumberType>>;
+    internal::InverseVelocityBlock<GMGPreconditioner,VectorType,ABlockMatrixType> inverse_velocity_block_cheap(
+      A_block_matrix,
+      prec_A,
+      /* do_solve_A = */ false,
+      sim.stokes_A_block_is_symmetric(),
+      this->get_parameters().linear_solver_A_block_tolerance);
 
-    // create an expensive preconditioner that solves for the A block with CG
-    const internal::BlockSchurGMGPreconditioner<StokesMatrixType, ABlockMatrixType, BTBlockOperatorType, SchurComplementMatrixType, GMGPreconditioner, GMGPreconditioner>
-    preconditioner_expensive (stokes_matrix, A_block_matrix, BT_block,
-                              Schur_complement_block_matrix,
-                              prec_A, prec_Schur,
-                              /*do_solve_A*/true,
-                              /*do_solve_Schur*/true,
-                              sim.stokes_A_block_is_symmetric(),
-                              this->get_parameters().linear_solver_A_block_tolerance,
-                              this->get_parameters().linear_solver_S_block_tolerance);
+    internal::InverseVelocityBlock<GMGPreconditioner,VectorType, ABlockMatrixType> inverse_velocity_block_expensive(
+      A_block_matrix,
+      prec_A,
+      /* do_solve_A = */ true,
+      sim.stokes_A_block_is_symmetric(),
+      this->get_parameters().linear_solver_A_block_tolerance);
+
+    using SchurApproximationType = internal::SchurApproximation<GMGPreconditioner,StokesMatrixType,SchurComplementMatrixType, VectorType>;
+    internal::SchurApproximation<GMGPreconditioner, StokesMatrixType, SchurComplementMatrixType, VectorType> schur_approximation_cheap(
+      prec_Schur,
+      stokes_matrix,
+      Schur_complement_block_matrix,
+      /*do_solve_Schur*/ false,
+      this->get_parameters().linear_solver_S_block_tolerance);
+
+    internal::SchurApproximation<GMGPreconditioner, StokesMatrixType, SchurComplementMatrixType, VectorType> schur_approximation_expensive(
+      prec_Schur,
+      stokes_matrix,
+      Schur_complement_block_matrix,
+      /*do_solve_Schur*/ true,
+      this->get_parameters().linear_solver_S_block_tolerance);
+
+    const internal::BlockSchurPreconditioner<internal::InverseVelocityBlock<GMGPreconditioner,VectorType,ABlockMatrixType>,
+          SchurApproximationType,BTBlockOperatorType, dealii::LinearAlgebra::distributed::BlockVector<double>>
+          preconditioner_cheap (
+            inverse_velocity_block_cheap,
+            schur_approximation_cheap,
+            BT_block);
+
+    const internal::BlockSchurPreconditioner<internal::InverseVelocityBlock<GMGPreconditioner,VectorType,ABlockMatrixType>,
+          SchurApproximationType, BTBlockOperatorType, dealii::LinearAlgebra::distributed::BlockVector<double>>
+          preconditioner_expensive (
+            inverse_velocity_block_expensive,
+            schur_approximation_expensive,
+            BT_block);
+
+
+
+
 
     PrimitiveVectorMemory<dealii::LinearAlgebra::distributed::BlockVector<double>> mem;
 
@@ -1479,8 +1507,8 @@ namespace aspect
         catch (const std::exception &exc)
           {
             this->get_signals().post_stokes_solver(sim,
-                                                   preconditioner_cheap.n_iterations_Schur_complement() + preconditioner_expensive.n_iterations_Schur_complement(),
-                                                   preconditioner_cheap.n_iterations_A_block() + preconditioner_expensive.n_iterations_A_block(),
+                                                   schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
+                                                   inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                                    solver_control_cheap,
                                                    solver_control_expensive);
 
@@ -1501,8 +1529,8 @@ namespace aspect
 
     //signal successful solver
     this->get_signals().post_stokes_solver(sim,
-                                           preconditioner_cheap.n_iterations_Schur_complement() + preconditioner_expensive.n_iterations_Schur_complement(),
-                                           preconditioner_cheap.n_iterations_A_block() + preconditioner_expensive.n_iterations_A_block(),
+                                           schur_approximation_cheap.n_iterations() + schur_approximation_expensive.n_iterations(),
+                                           inverse_velocity_block_cheap.n_iterations() + inverse_velocity_block_expensive.n_iterations(),
                                            solver_control_cheap,
                                            solver_control_expensive);
 
@@ -1530,13 +1558,13 @@ namespace aspect
 
     if (print_details)
       {
-        this->get_pcout() << "     Schur complement preconditioner: " << preconditioner_cheap.n_iterations_Schur_complement()
+        this->get_pcout() << "     Schur complement preconditioner: " << schur_approximation_cheap.n_iterations()
                           << '+'
-                          << preconditioner_expensive.n_iterations_Schur_complement()
+                          << schur_approximation_expensive.n_iterations()
                           << " iterations." << std::endl;
-        this->get_pcout() << "     A block preconditioner: " << preconditioner_cheap.n_iterations_A_block()
+        this->get_pcout() << "     A block preconditioner: " << inverse_velocity_block_cheap.n_iterations()
                           << '+'
-                          << preconditioner_expensive.n_iterations_A_block()
+                          << inverse_velocity_block_expensive.n_iterations()
                           << " iterations." << std::endl;
       }
 

--- a/tests/stokes_solver_fail_cheap/screen-output
+++ b/tests/stokes_solver_fail_cheap/screen-output
@@ -31,16 +31,20 @@ Additional information:
     VectorType&, const VectorType&, const PreconditionerType&) [with
     MatrixType = aspect::MatrixFreeStokesOperators::StokesOperator<2, 2,
     double>; PreconditionerType =
-    aspect::internal::BlockSchurGMGPreconditioner<aspect::MatrixFreeStokesOperators::StokesOperator<2,
-    2, double>, aspect::MatrixFreeStokesOperators::ABlockOperator<2, 2,
-    double>, aspect::MatrixFreeStokesOperators::BTBlockOperator<2, 2,
-    double>, aspect::MatrixFreeStokesOperators::MassMatrixOperator<2, 1,
-    double>, dealii::PreconditionMG<2,
+    aspect::internal::BlockSchurPreconditioner<aspect::internal::InverseVelocityBlock<dealii::PreconditionMG<2,
     dealii::LinearAlgebra::distributed::Vector<double>,
-    dealii::MGTransferMF<2, double> >, dealii::PreconditionMG<2,
+    dealii::MGTransferMF<2, double> >,
     dealii::LinearAlgebra::distributed::Vector<double>,
-    dealii::MGTransferMF<2, double> > >; VectorType =
-    dealii::LinearAlgebra::distributed::BlockVector<double>]
+    aspect::MatrixFreeStokesOperators::ABlockOperator<2, 2, double> >,
+    aspect::internal::SchurApproximation<dealii::PreconditionMG<2,
+    dealii::LinearAlgebra::distributed::Vector<double>,
+    dealii::MGTransferMF<2, double> >,
+    aspect::MatrixFreeStokesOperators::StokesOperator<2, 2, double>,
+    aspect::MatrixFreeStokesOperators::MassMatrixOperator<2, 1, double>,
+    dealii::LinearAlgebra::distributed::Vector<double> >,
+    aspect::MatrixFreeStokesOperators::BTBlockOperator<2, 2, double>,
+    dealii::LinearAlgebra::distributed::BlockVector<double> >; VectorType
+    = dealii::LinearAlgebra::distributed::BlockVector<double>]
     The violated condition was:
     iteration_state == SolverControl::success
     Additional information:

--- a/tests/stokes_solver_fail_gmg/screen-output
+++ b/tests/stokes_solver_fail_gmg/screen-output
@@ -30,16 +30,20 @@ Additional information:
     VectorType&, const VectorType&, const PreconditionerType&) [with
     MatrixType = aspect::MatrixFreeStokesOperators::StokesOperator<2, 2,
     double>; PreconditionerType =
-    aspect::internal::BlockSchurGMGPreconditioner<aspect::MatrixFreeStokesOperators::StokesOperator<2,
-    2, double>, aspect::MatrixFreeStokesOperators::ABlockOperator<2, 2,
-    double>, aspect::MatrixFreeStokesOperators::BTBlockOperator<2, 2,
-    double>, aspect::MatrixFreeStokesOperators::MassMatrixOperator<2, 1,
-    double>, dealii::PreconditionMG<2,
+    aspect::internal::BlockSchurPreconditioner<aspect::internal::InverseVelocityBlock<dealii::PreconditionMG<2,
     dealii::LinearAlgebra::distributed::Vector<double>,
-    dealii::MGTransferMF<2, double> >, dealii::PreconditionMG<2,
+    dealii::MGTransferMF<2, double> >,
     dealii::LinearAlgebra::distributed::Vector<double>,
-    dealii::MGTransferMF<2, double> > >; VectorType =
-    dealii::LinearAlgebra::distributed::BlockVector<double>]
+    aspect::MatrixFreeStokesOperators::ABlockOperator<2, 2, double> >,
+    aspect::internal::SchurApproximation<dealii::PreconditionMG<2,
+    dealii::LinearAlgebra::distributed::Vector<double>,
+    dealii::MGTransferMF<2, double> >,
+    aspect::MatrixFreeStokesOperators::StokesOperator<2, 2, double>,
+    aspect::MatrixFreeStokesOperators::MassMatrixOperator<2, 1, double>,
+    dealii::LinearAlgebra::distributed::Vector<double> >,
+    aspect::MatrixFreeStokesOperators::BTBlockOperator<2, 2, double>,
+    dealii::LinearAlgebra::distributed::BlockVector<double> >; VectorType
+    = dealii::LinearAlgebra::distributed::BlockVector<double>]
     Additional information:
     Iterative method reported convergence failure in step 10. The residual
     in the last step was 1239.44.


### PR DESCRIPTION
Currently ASPECT uses separate classes, BlockSchurPreconditioner and BlockSchurGMGPreconditioner, for AMG and GMG respectively. This pull request refactors the code so only BlockSchurPreconditioner is used in both cases.