### PR TITLE
Update deal.II devel tester image

### DIFF
--- a/.github/workflows/build_dealii_master.yml
+++ b/.github/workflows/build_dealii_master.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./contrib/docker/tester/
-          cache-from: type=registry,ref=ubuntu:20.04
+          cache-from: type=registry,ref=ubuntu:22.04
           cache-to: type=inline
           push: true
-          tags: geodynamics/aspect-tester:focal-dealii-master
+          tags: geodynamics/aspect-tester:jammy-dealii-master

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,7 +116,7 @@ jobs:
             compare-tests: "ON"
             result-file: "changes-test-results-9.6.diff"
             container-options: '--user 0 --name container'
-          - image: "geodynamics/aspect-tester:focal-dealii-master"
+          - image: "geodynamics/aspect-tester:jammy-dealii-master"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-master.diff"

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer <rene.gassmoeller@mailbox.org>
 

--- a/contrib/docker/tester/build.sh
+++ b/contrib/docker/tester/build.sh
@@ -2,4 +2,4 @@
 
 # This script generates a docker image for the ASPECT tester.
 
-docker build -t geodynamics/aspect-tester:focal-dealii-master .
+docker build -t geodynamics/aspect-tester:jammy-dealii-master .

--- a/contrib/docker/tester/local.cfg
+++ b/contrib/docker/tester/local.cfg
@@ -10,4 +10,4 @@ DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DCMAKE_BUILD_TYPE='DebugRel
 TRILINOS_CONFOPTS="-DTrilinos_ENABLE_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_FLOAT:BOOL=OFF -DTeuchos_ENABLE_COMPLEX:BOOL=OFF -DTrilinos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF -D CMAKE_CXX_FLAGS:STRING='-fPIC -O3' -D CMAKE_C_FLAGS:STRING='-fPIC -O3' -D CMAKE_FORTRAN_FLAGS:STRING='-O3'"
 
 # Compile packages necessary for all ASPECT functionality
-PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos once:sundials dealii"
+PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos once:scalapack once:sundials dealii"


### PR DESCRIPTION
This updates the deal.II development tester to build on Ubuntu 22.04 instead of 20.04 (which is no longer supported). I build one docker image manually and pushed it already. We will have to see if the nightly docker build process succeeds once this PR is merged.

I also included scalapack into the container, because it is used in #6615. This is only for the development tester though, the 9.6 tester (and eventually 9.7 tester) need it as well before we can test #6615 properly.

Related to #6807.