### PR TITLE
Activate tester with deal.II 9.7

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -111,6 +111,11 @@ jobs:
             compare-tests: "ON"
             result-file: "changes-test-results-9.6.diff"
             container-options: '--user 0 --name container'
+          - image: "geodynamics/aspect-tester:jammy-dealii-9.7-v2"
+            run-tests: "ON"
+            compare-tests: "OFF"
+            result-file: "changes-test-results-9.7.diff"
+            container-options: '--user 0 --name container'
           - image: "geodynamics/aspect-tester:jammy-dealii-master"
             run-tests: "ON"
             compare-tests: "OFF"


### PR DESCRIPTION
Follow-up to to #6807 and #6808 that adds a new tester with the deal.II 9.7 release. The image has tag v2 because v1 was a version I pushed earlier without scalapack (see #6811).