### PR TITLE
Fix indent script to ensure files end with exactly one newline

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -112,6 +112,14 @@ indent_file() {
   file="${1}"
   tmpfile="$(mktemp "${TMPDIR}/$(basename "$1").tmp.XXXXXXXX")"
 
+  # Ensure exactly one trailing newline before astyle
+  perl -0pe 's/\n+$//' "${file}" > "${file}.tmp" && echo >> "${file}.tmp"
+  if ! diff -q "${file}" "${file}.tmp" >/dev/null; then
+    mv "${file}.tmp" "${file}"
+  else
+    rm "${file}.tmp"
+  fi
+
   perl -p -e 's/(?<=>)>/ >/g;' <"${file}" \
       | "${astyle}" --options=contrib/utilities/astyle.rc \
       | perl -p -e 's/(?<=>) >/>/g;' \


### PR DESCRIPTION
When writing code, it's easy to forget adding a trailing newline at the end of files. Without it, astyle formatting can produce errors like extraneous closing braces (`}`) or malformed #endif (`endiff`) directives, leading to incorrect formatting.

This PR updates the indent script to check and enforce exactly one trailing newline before running astyle. This prevents formatting issues and ensures consistent file endings across the codebase.

The change only affects file endings and does not alter blank lines within the file content.