### PR TITLE
Note that bilinear least squares is now an alias

### DIFF
--- a/source/particle/interpolator/interface.cc
+++ b/source/particle/interpolator/interface.cc
@@ -88,7 +88,12 @@ namespace aspect
                            Patterns::Selection (pattern_of_names + "|bilinear least squares"),
                            "Select one of the following models:\n\n"
                            +
-                           std::get<dim>(registered_plugins).get_description_string());
+                           std::get<dim>(registered_plugins).get_description_string()
+                           +
+                           "\n\n"
+                           "`bilinear least squares': "
+                           "Deprecated, now an alias for `linear least squares'. "
+                           "This alias will be removed in the future. ");
 
         std::get<dim>(registered_plugins).declare_parameters (prm);
       }


### PR DESCRIPTION
This pull request makes a minor update to the interpolation scheme selection in the `aspect` namespace. The change clarifies that "bilinear least squares" is deprecated, and now an alias for "linear least squares" in the parameter declaration.