### PR TITLE
work around Python header error

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -58,6 +58,12 @@
 #include <catch.hpp>
 
 #ifdef ASPECT_WITH_PYTHON
+// Python does not like it if this macro is already defined. This happens at
+// least in some versions of Trilinos and can trigger only with certain unity
+// build options:
+#ifdef HAVE_SYS_TIME_H
+#  undef HAVE_SYS_TIME_H
+#endif
 #  define PY_SSIZE_T_CLEAN
 #  include <Python.h>
 #  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/tests/python_01.cc
+++ b/tests/python_01.cc
@@ -23,6 +23,12 @@
 
 #include <iostream>
 
+// Python does not like it if this macro is already defined. This happens at
+// least in some versions of Trilinos and can trigger only with certain unity
+// build options:
+#ifdef HAVE_SYS_TIME_H
+#  undef HAVE_SYS_TIME_H
+#endif
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION

--- a/unit_tests/python.cc
+++ b/unit_tests/python.cc
@@ -23,6 +23,12 @@
 
 #ifdef ASPECT_WITH_PYTHON
 
+// Python does not like it if this macro is already defined. This happens at
+// least in some versions of Trilinos and can trigger only with certain unity
+// build options:
+#ifdef HAVE_SYS_TIME_H
+#  undef HAVE_SYS_TIME_H
+#endif
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION


### PR DESCRIPTION
Fix an error about redfinition of HAVE_SYS_TIME_H that gets triggered in a unity build when a certain Trilinos header is included before the Python header. I think this workaround is harmless.