### PR TITLE
MeshDeformation: new initial deformation from constraints

### DIFF
--- a/doc/modules/changes/20260204_tjhei
+++ b/doc/modules/changes/20260204_tjhei
@@ -1,0 +1,5 @@
+New: Initial topography for mesh deformation plugins
+can now alternatively be provided by modifying constraints
+directly.
+<br>
+(Timo Heister, 2026/02/04)

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -107,6 +107,24 @@ namespace aspect
         compute_initial_deformation_on_boundary(const types::boundary_id boundary_indicator,
                                                 const Point<dim> &position) const;
 
+
+        /**
+         * A function that creates constraints for the initial deformation of the mesh.
+         *
+         * This function gives an alternative way to determine the initial deformation
+         * instead of using the compute_initial_deformation_on_boundary function. The
+         * default implementation of this function calls compute_initial_deformation_on_boundary()
+         * with the coordinates of each point on the boundary. If you need lower level control
+         * over the initial deformation or it is more efficient to provide constraints directly,
+         * override this function.
+         */
+        virtual
+        void
+        compute_initial_deformation_as_constraints(const Mapping<dim> &mapping,
+                                                   const DoFHandler<dim> &mesh_deformation_dof_handler,
+                                                   const types::boundary_id boundary_indicator,
+                                                   AffineConstraints<double> &constraints) const;
+
         /**
          * A function that creates constraints for the velocity of certain mesh
          * vertices (e.g. the surface vertices) for a specific set of boundaries.

--- a/tests/mesh_deformation_initial_constraints.cc
+++ b/tests/mesh_deformation_initial_constraints.cc
@@ -1,0 +1,88 @@
+/*
+  Copyright (C) 2020 - 2024 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <aspect/mesh_deformation/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/simulator_access.h>
+#include <deal.II/dofs/dof_tools.h>
+
+namespace aspect
+{
+  namespace MeshDeformation
+  {
+    template <int dim>
+    class PrescribedDeformation : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Constructor.
+         */
+        PrescribedDeformation()
+        {}
+
+        virtual
+        void
+        compute_initial_deformation_as_constraints(const Mapping<dim> &/*mapping*/,
+                                                   const DoFHandler<dim> &mesh_deformation_dof_handler,
+                                                   const types::boundary_id boundary_indicator,
+                                                   AffineConstraints<double> &constraints) const override
+        {
+
+          const IndexSet constrained_dofs =
+            DoFTools::extract_boundary_dofs(mesh_deformation_dof_handler,
+                                            ComponentMask(dim, true),
+          {boundary_indicator});
+
+          for (const types::global_dof_index index : constrained_dofs)
+            {
+              if (constraints.can_store_line(index))
+                if (constraints.is_constrained(index)==false)
+                  {
+                    // set some nonsensical values:
+                    const double value = static_cast<double>(index) * 10.0;
+#if DEAL_II_VERSION_GTE(9,6,0)
+                    constraints.add_constraint(index,
+                                               {},
+                                               value);
+#else
+                    constraints.add_line(index);
+                    constraints.set_inhomogeneity(index, value);
+#endif
+                  }
+            }
+
+        }
+
+    };
+  }
+}
+
+
+// explicit instantiation of the functions we implement in this file
+namespace aspect
+{
+  namespace MeshDeformation
+  {
+    ASPECT_REGISTER_MESH_DEFORMATION_MODEL(PrescribedDeformation,
+                                           "prescribed deformation",
+                                           "A test plugin for initial mesh deformation.")
+  }
+}

--- a/tests/mesh_deformation_initial_constraints.prm
+++ b/tests/mesh_deformation_initial_constraints.prm
@@ -1,0 +1,73 @@
+# Test providing initial deformation using compute_initial_deformation_as_constraints()
+
+set Dimension = 2
+set CFL number                             = 1.0
+set End time                               = 0
+set Start time                             = 0
+set Adiabatic surface temperature          = 1613.0
+set Surface pressure                       = 0
+set Use years instead of seconds           = true
+set Nonlinear solver scheme                = single Advection, single Stokes
+
+subsection Gravity model
+  set Model name = vertical
+
+  subsection Vertical
+    set Magnitude = 10
+  end
+end
+
+subsection Geometry model
+  set Model name = box
+
+  subsection Box
+    set X extent = 660000
+    set Y extent = 660000
+  end
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: prescribed deformation
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Function expression = 1613.0
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators   = top
+  set List of model names = function
+
+  subsection Function
+    set Function expression = 1613.0
+  end
+end
+
+subsection Material model
+  set Model name = simple
+
+  subsection Simple model
+    set Reference density = 3340
+    set Reference specific heat = 1200
+    set Thermal expansion coefficient = 3e-5
+    set Viscosity = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial adaptive refinement        = 0
+  set Initial global refinement          = 3
+  set Strategy                           = minimum refinement function
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = left, right, top, bottom
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, topography
+end

--- a/tests/mesh_deformation_initial_constraints/screen-output
+++ b/tests/mesh_deformation_initial_constraints/screen-output
@@ -1,0 +1,32 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Loading shared library <./libmesh_deformation_initial_constraints.debug.so>
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 64 (on 4 levels)
+Number of degrees of freedom: 948 (578+81+289)
+
+Number of mesh deformation degrees of freedom: 162
+   Solving mesh displacement system... 6 iterations.
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 17+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-mesh_deformation_initial_constraints/solution/solution-00000
+     RMS, max velocity:        7.12e-11 m/year, 1.89e-10 m/year
+     Topography min/max:       0 m, 1590 m
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/mesh_deformation_initial_constraints/statistics
+++ b/tests/mesh_deformation_initial_constraints/statistics
@@ -1,0 +1,16 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimum topography (m)
+# 15: Maximum topography (m)
+0 0.000000000000e+00 0.000000000000e+00 64 659 289 0 17 18 18 output-mesh_deformation_initial_constraints/solution/solution-00000 7.12331958e-11 1.88514074e-10 0.00000000e+00 1.59000000e+03 


### PR DESCRIPTION
Introduce an alternative way to provide initial topography for mesh deformation plugins that fills an AffineConstraints object directly instead of providing the function compute_initial_deformation_on_boundary(), which is evaluated at each surface point.