### PR TITLE
Fix input_t.prm in the nonlinear channel flow benchmark

### DIFF
--- a/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/input_t.prm
+++ b/benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow/input_t.prm
@@ -6,6 +6,19 @@ include $ASPECT_SOURCE_DIR/benchmarks/newton_solver_benchmark_set/nonlinear_chan
 
 set Output directory = output_t
 
+subsection Solver parameters
+  subsection Newton solver parameters
+    set Max pre-Newton nonlinear iterations = 3
+    set Nonlinear Newton solver switch tolerance = 1e-20
+    set Max Newton line search iterations = 5
+    set Maximum linear Stokes solver tolerance = 1e-2
+    set Use Newton residual scaling method = false
+    set Use Newton failsafe = false
+    set Stabilization preconditioner = SPD
+    set Stabilization velocity block = SPD
+  end
+end
+
 subsection Boundary velocity model
   # pressure bc: Prescribe a zero vertical velocity component on the vertical boundaries
   set Prescribed velocity boundary indicators = bottom x: function, top x: function


### PR DESCRIPTION
This PR is a follow-up of the latest issue displayed in #6471 . The template input file `input_t.prm` in `benchmarks/newton_solver_benchmark_set/nonlinear_channel_flow` uses `include input_v.prm` for simplicity, but it makes the bash script `run.sh` produce the same result for different cases, because commands like `-e "s/set Output directory .*/set Output directory = results\/$dirname_clean/g"` does not work. This PR replaces `include input_v.prm` by the actual parameter settings, and the problem is mended. The results with traction boundary conditions are show below:
<img width="1500" height="1000" alt="figure_t" src="https://github.com/user-attachments/assets/4d74f6dd-6ab4-469d-ba96-be5b8548bd59" />
