### PR TITLE
Fix solver tolerance for Weighted BFBT

### DIFF
--- a/source/simulator/solver.cc
+++ b/source/simulator/solver.cc
@@ -270,6 +270,7 @@ namespace aspect
             system_matrix.block(1,0).vmult(ptmp,wtmp);
 
             dst=0;
+            solver_control.set_tolerance(1e-6*ptmp.l2_norm());
             solver.solve(pressure_laplace_matrix,
                          dst,
                          ptmp,


### PR DESCRIPTION
The solver tolerance is currently based on the wrong vector. This is flagged as work in progress because I need to update test results and run further tests using nsinker as a benchmark. @tjhei
