### PR TITLE
Remove a destructor that is not necessary.

### DIFF
--- a/include/aspect/introspection.h
+++ b/include/aspect/introspection.h
@@ -132,12 +132,6 @@ namespace aspect
       Introspection (const std::vector<VariableDeclaration<dim>> &variables,
                      const Parameters<dim> &parameters);
 
-      /**
-       * Destructor.
-       */
-      ~Introspection ();
-
-
 
       /**
        * @name Things that are independent of the current mesh

--- a/source/simulator/introspection.cc
+++ b/source/simulator/introspection.cc
@@ -352,12 +352,6 @@ namespace aspect
 
 
 
-  template <int dim>
-  Introspection<dim>::~Introspection ()
-    = default;
-
-
-
   namespace
   {
     std::vector<FEValuesExtractors::Scalar>


### PR DESCRIPTION
We might as well let the compiler create the destructor for us in cases where it is not `virtual` and empty.