### PR TITLE
Disable unnecessary MPI warnings in Ubuntu 22.04 docker containers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,12 +106,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: "geodynamics/aspect-tester:jammy-dealii-9.6-v1"
+          - image: "geodynamics/aspect-tester:jammy-dealii-9.6-v2"
             run-tests: "ON"
             compare-tests: "ON"
             result-file: "changes-test-results-9.6.diff"
             container-options: '--user 0 --name container'
-          - image: "geodynamics/aspect-tester:jammy-dealii-9.7-v2"
+          - image: "geodynamics/aspect-tester:jammy-dealii-9.7-v3"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-9.7.diff"

--- a/contrib/docker/docker/Dockerfile
+++ b/contrib/docker/docker/Dockerfile
@@ -50,3 +50,6 @@ RUN git clone https://github.com/geodynamics/aspect.git $Aspect_DIR && \
 
 WORKDIR $Aspect_DIR
 ENV PATH $Aspect_DIR/bin:$PATH
+
+# Prevent an OpenMPI warning in Ubuntu 22.04 (see https://github.com/openwall/john/issues/5088)
+ENV HWLOC_HIDE_ERRORS=2

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -35,5 +35,7 @@ ENV OMPI_MCA_mpi_yield_when_idle=1
 ENV OMPI_MCA_rmaps_base_oversubscribe=1
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+# Prevent an OpenMPI warning in Ubuntu 22.04 (see https://github.com/openwall/john/issues/5088)
+ENV HWLOC_HIDE_ERRORS=2
 
 WORKDIR /opt

--- a/contrib/docker/tester/local.cfg
+++ b/contrib/docker/tester/local.cfg
@@ -10,4 +10,4 @@ DEAL_II_CONFOPTS="-DDEAL_II_WITH_COMPLEX_VALUES=OFF -DCMAKE_BUILD_TYPE='DebugRel
 TRILINOS_CONFOPTS="-DTrilinos_ENABLE_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_DOUBLE:BOOL=OFF -DTpetra_INST_COMPLEX_FLOAT:BOOL=OFF -DTeuchos_ENABLE_COMPLEX:BOOL=OFF -DTrilinos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF -D CMAKE_CXX_FLAGS:STRING='-fPIC -O3' -D CMAKE_C_FLAGS:STRING='-fPIC -O3' -D CMAKE_FORTRAN_FLAGS:STRING='-O3'"
 
 # Compile packages necessary for all ASPECT functionality
-PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos once:scalapack once:sundials dealii"
+PACKAGES="once:cmake once:astyle once:hdf5 once:netcdf once:p4est once:trilinos once:sundials dealii"


### PR DESCRIPTION
Our current tester containers and the official ASPECT container produce warnings when starting ASPECT on some hardware systems of the following sort:
```
hwloc/linux: Ignoring PCI device with non-16bit domain.
Pass --enable-32bits-pci-domain to configure to support such devices
(warning: it would break the library ABI, don't enable unless really needed).
hwloc/linux: Ignoring PCI device with non-16bit domain.
Pass --enable-32bits-pci-domain to configure to support such devices
(warning: it would break the library ABI, don't enable unless really needed).
```

This warnings are harmless and are fixed in the OpenMPI version that ships with Ubuntu 24.04, but updating all of our images will be a lot of work. In the meantime it is simpler to disable the warnings.

This problem was mostly annoying for me, because it made it hard to update test results if I run the test suite locally on my system (and I guess other users running Ubuntu 22.04 with OpenMPI as well).


Additionally this PR also reverts including Scalapack in the tester image (which was added in #6808). We decided to not use this in ASPECT, but it was already in the Dockerfile. This is the opportunity to get rid of it again.