### PR TITLE
PythonHelper: follow-up fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,11 @@ if(ASPECT_UNITY_BUILD)
     foreach(_T ${TARGET_EXECUTABLES})
       set_property(TARGET ${_T} PROPERTY UNITY_BUILD TRUE)
     endforeach()
+
+    # exclude main.cc from unity builds as this file needs to define the special
+    # Python numpy static object:
+    set_property(SOURCE ${ASPECT_MAIN_FILE} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE )
+
     message(STATUS "Combining source files into unity build.")
   elseif(CMAKE_VERSION VERSION_LESS 3.16)
     message(FATAL_ERROR "ASPECT_UNITY_BUILD is currently only supported for CMake 3.16 and newer versions.")

--- a/source/main.cc
+++ b/source/main.cc
@@ -773,9 +773,12 @@ int main (int argc, char *argv[])
 
 #ifdef ASPECT_WITH_PYTHON
   Py_Initialize();
-  // required for Numpy interop
+  // Required for Numpy interop:
   if (_import_array() < 0)
-    AssertThrow(false, ExcMessage("Numpy init failed!"));
+    {
+      PyErr_Print();
+      AssertThrow(false, ExcMessage("Numpy init failed!"));
+    }
 
   ScopeExit python_cleanup(
     []()

--- a/tests/python_01.cc
+++ b/tests/python_01.cc
@@ -37,7 +37,11 @@ int f()
 
   PyRun_SimpleString("import sys; sys.path.append(\"" ASPECT_SOURCE_DIR "/tests\")");
   PyObject *pModule = PyImport_ImportModule("python_01");
-  AssertThrow(pModule != nullptr, dealii::ExcMessage("Failed to load Python module"));
+  if (pModule == nullptr)
+    {
+      PyErr_Print();
+      AssertThrow(false, dealii::ExcMessage("Failed to load Python module"));
+    }
 
   std::vector<double> x = {1.0, 2.0, 3.0};
   auto arr = aspect::PythonHelper::vector_to_numpy_object(x);


### PR DESCRIPTION
- print error information if any of the steps fail
- make sure main.cc is not combined with other files in unity builds to correctly initialize Python
