### PR TITLE
Fix update_parameters.sh path handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ pipeline {
 
         stage('Build Documentation') {
           steps {
-            sh 'cd doc && ./update_parameters.sh ./build/aspect'
+            sh 'cd doc && ./update_parameters.sh ../build/aspect'
           }
           post {
             failure

--- a/doc/update_parameters.sh
+++ b/doc/update_parameters.sh
@@ -1,16 +1,31 @@
 #!/bin/bash
 
-# run this script from the doc directory to update the parameters for the documentation.
-# Note that you need an in-source build or a symbolic link to the ASPECT binary in the
-# main directory.
+# update the parameters for the documentation.
+# This script can be run from any working directory; relative paths to the
+# ASPECT executable are interpreted relative to the caller's working directory.
+# Note that you need an in-source build or a symbolic link to the ASPECT binary
+# in the main directory.
 
-ASPECT=${1:-"./aspect"}
+ASPECT_INPUT=${1:-"./aspect"}
+CALLER_DIR="$(pwd)"
 
-pushd .
-cd ..
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+case "${ASPECT_INPUT}" in
+  /*)
+    ASPECT="${ASPECT_INPUT}"
+    ;;
+  *)
+    ASPECT="${CALLER_DIR}/${ASPECT_INPUT}"
+    ;;
+esac
+
+pushd . >/dev/null
+cd "${REPO_ROOT}" || exit 1
 
 if test ! -f $ASPECT ; then
-  echo "Please provide the absolute path of the ASPECT executable as the first argument to this script or create a link in the main source directory. "
+  echo "Please provide the path to the ASPECT executable as the first argument to this script, or create a link in the main source directory."
   exit 1
 fi
 
@@ -19,8 +34,12 @@ fi
 # documents all parameters and that we can use for the documentation
 echo Creating parameters.json
 rm -f output/parameters.json
-$ASPECT doc/manual/empty.prm >/dev/null 2>/dev/null \
-    || { echo "Running ASPECT for parameters.json failed"; exit 1; }
+$ASPECT doc/manual/empty.prm >/dev/null 2>/dev/null
+
+if test ! -f output/parameters.json ; then
+  echo "Running ASPECT for parameters.json failed"
+  exit 1
+fi
 
 echo Convert parameters to markdown files
 ./contrib/utilities/jsontomarkdown.py output/parameters.json \
@@ -29,6 +48,6 @@ echo Convert parameters to markdown files
 # The jsontomarkdown script currently can leave spaces at the ends of lines.  
 ./contrib/utilities/indent
 
-popd
+popd >/dev/null
 echo done
 exit 0


### PR DESCRIPTION
This PR improves `doc/update_parameters.sh` so it is easier to run reliably. This makes commands like:

```bash
./doc/update_parameters.sh build/aspect-debug
```