### PR TITLE
Serialize the dynamic core boundary temperature plugin

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -181,6 +181,26 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm) override;
 
+        /**
+         * Serialize the contents of this class as far as they are not read
+         * from input parameter files.
+         */
+        template <class Archive>
+        void
+        serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Save the state of this object.
+         */
+        void
+        save (std::map<std::string, std::string> &status_strings) const override;
+
+        /**
+         * Restore the state of the object.
+         */
+        void
+        load (const std::map<std::string, std::string> &status_strings) override;
+
       private:
 
         /**
@@ -358,6 +378,13 @@ namespace aspect
         {
           double t;
           double w;
+
+          template <class Archive>
+          void serialize (Archive &ar, const unsigned int)
+          {
+            ar & t
+            & w;
+          }
         };
         std::vector<struct str_data_OES> data_OES;
         void read_data_OES();

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -31,6 +31,8 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/utilities.h>
 
+#include <boost/serialization/vector.hpp>
+
 #include <limits>
 
 
@@ -541,6 +543,77 @@ namespace aspect
     DynamicCore<dim>::get_core_data() const
     {
       return core_data;
+    }
+
+
+
+    template <int dim>
+    template <class Archive>
+    void
+    DynamicCore<dim>::serialize (Archive &ar, const unsigned int)
+    {
+      ar &core_data.Qs
+      & core_data.Qr
+      & core_data.Qg
+      & core_data.Qk
+      & core_data.Ql
+      & core_data.Es
+      & core_data.Er
+      & core_data.Eg
+      & core_data.Ek
+      & core_data.El
+      & core_data.Eh
+      & core_data.Ri
+      & core_data.Ti
+      & core_data.Xi
+      & core_data.Q
+      & core_data.H
+      & core_data.dt
+      & core_data.dR_dt
+      & core_data.dT_dt
+      & core_data.dX_dt
+      & core_data.Q_OES
+      & core_data.is_initialized
+      & inner_temperature
+      & is_first_call
+      & Rc
+      & Mc
+      & dTa
+      & data_OES;
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+      // Serialize into a stringstream. Put the following into a code
+      // block of its own to ensure the destruction of the 'oa'
+      // archive triggers a flush() on the stringstream so we can
+      // query the completed string below.
+      std::ostringstream os;
+      {
+        aspect::oarchive oa (os);
+        oa << (*this);
+      }
+
+      status_strings["DynamicCore"] = os.str();
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      // See if something was saved.
+      if (status_strings.find("DynamicCore") != status_strings.end())
+        {
+          std::istringstream is (status_strings.find("DynamicCore")->second);
+          aspect::iarchive ia (is);
+          ia >> (*this);
+        }
     }
 
 


### PR DESCRIPTION
This PR serializes the state of the dynamic core boundary temperature plugin so checkpoint/restart preserves its internal state across runs.

It also keeps compatibility with older checkpoints by falling back to the legacy restart data stored in the core statistics postprocessor.

Refs #6744.