### PR TITLE
Check file size before broadcasting

### DIFF
--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -1294,7 +1294,8 @@ namespace aspect
 
                           // The url Array contains a separate array for each column of data.
                           // This will put each of these individual arrays into its own vector.
-                          urlArray->value(&tmp[0]);
+                          if (!tmp.empty())
+                            urlArray->value(tmp.data());
                           columns.push_back(tmp);
                         }
                       else
@@ -1416,7 +1417,8 @@ namespace aspect
           // Distribute data_size and data across processes
           std::ignore = Utilities::MPI::broadcast (comm, filesize, 0);
 
-          big_mpi::broadcast(&data_string[0], filesize, 0, comm);
+          if (filesize > 0)
+            big_mpi::broadcast(data_string.data(), filesize, 0, comm);
         }
       else
         {
@@ -1428,7 +1430,8 @@ namespace aspect
           data_string.resize(filesize);
 
           // Receive and store data
-          big_mpi::broadcast(&data_string[0], filesize, 0, comm);
+          if (filesize > 0)
+            big_mpi::broadcast(data_string.data(), filesize, 0, comm);
         }
 
       return data_string;


### PR DESCRIPTION
Another follow-up to #6927, this time ensuring we do not access the address of the first element of an empty string. (this is only a problem if someone would load an empty data file).