### PR TITLE
Change github actions runner image to avoid test failures

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -110,7 +110,7 @@ jobs:
   tests:
     #linux build including tests
     name: tests
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-22.04]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Do not merge this PR!

We have acquired some weird test failures on the github actions tester. I just want to use this PR to investigate them.

Start by trying to revert #6928 and #6929 and check the tester results.