### PR TITLE
Return dynamic core timestep outputs as a tuple

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -26,6 +26,8 @@
 #include <aspect/boundary_temperature/interface.h>
 #include <aspect/simulator_access.h>
 
+#include <tuple>
+
 namespace aspect
 {
   namespace BoundaryTemperature
@@ -84,6 +86,12 @@ namespace aspect
 
         bool is_initialized;
       };
+
+      /**
+       * Updated values for light element concentration, CMB temperature,
+       * and inner core radius returned by solve_time_step().
+       */
+      using SolveTimeStepResult = std::tuple<double, double, double>;
     }
 
 
@@ -376,10 +384,12 @@ namespace aspect
          *    However, the core solidus is influenced by light components (e.g. S) and its slope is very close to an adiabat. So there is an alternative
          *    scenario that the crystallization happens first at the core mantle boundary instead of at the center, which is called a 'snowing core'
          *    (Stewart, A. J., et al. (2007). "Mars: a new core-crystallization regime." Science 316(5829): 1323-1325.). This also
-         *    provides a valid solution for the solver. The return value of the function is true for a 'normal core', and false for 'snowing core'.
-         *    TODO: The current code is only able to treat the normal core scenario, treating 'snowing core' scenario may be possible and could be added.
+         *    provides a valid solution for the solver. The current code treats the
+         *    normal core scenario and throws for the unsupported snowing core case.
+         *
+         * @return A tuple containing the updated X, T, and R values.
          */
-        bool solve_time_step(double &X, double &T, double &R) const;
+        internal::SolveTimeStepResult solve_time_step() const;
 
         /**
          * Compute the difference between solidus and adiabatic temperature at inner

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -210,10 +210,7 @@ namespace aspect
 
       if ((core_data.Q + core_data.Q_OES) * core_data.dt!=0.)
         {
-          double X1 = core_data.Xi;
-          double R1 = core_data.Ri;
-          double T1 = core_data.Ti;
-          solve_time_step(X1,T1,R1);
+          const auto [X1, T1, R1] = solve_time_step();
           if (core_data.dt != 0)
             {
               core_data.dR_dt = (R1-core_data.Ri)/core_data.dt;
@@ -359,8 +356,8 @@ namespace aspect
 
 
     template <int dim>
-    bool
-    DynamicCore<dim>::solve_time_step(double &X, double &T, double &R) const
+    internal::SolveTimeStepResult
+    DynamicCore<dim>::solve_time_step() const
     {
       // When solving the change in core-mantle boundary temperature T, inner core radius R, and
       //    light component (e.g. S, O, Si) composition X, the following relations has to be respected:
@@ -435,31 +432,31 @@ namespace aspect
             }
         }
 
-      // Calculate new R,T,X
-      R = R_1;
-      T = compute_Tc(R);
-      X = compute_X(R);
+      const internal::SolveTimeStepResult result = std::make_tuple(compute_X(R_1),
+                                                                   compute_Tc(R_1),
+                                                                   R_1);
 
       // Check the signs of dT at the boundaries to classify the solution
       if (dT0<0. && dT2>0.)
         {
           // Core partially molten, freezing from the inside, normal solution
-          return true;
+          return result;
         }
       else if (dT0>0. && dT2<0.)
         {
           // Core partially molten, snowing core solution
-          return false;
+          AssertThrow(false, ExcMessage("[Dynamic core] You had a 'Snowing Core' (i.e., core is freezing from CMB), "
+                                        "the treatment is not available at the moment."));
         }
       else if (dT0 >= 0. && dT2 >= 0.)
         {
           // Core fully molten, normal solution
-          return true;
+          return result;
         }
       else if (dT0 <= 0. && dT2 <= 0.)
         {
           // Core fully solid, normal solution
-          return true;
+          return result;
         }
       else
         {
@@ -471,7 +468,7 @@ namespace aspect
           AssertThrow(false, ExcMessage("[Dynamic core] No inner core radius solution found!"));
         }
 
-      return false;
+      return result;
     }
 
 


### PR DESCRIPTION
This PR follows up on the #6926 discussion that all three arguments of `solve_time_step()` are output variables and that the function interface should make that explicit.
