### PR TITLE
Github Actions: do not compress diffs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,6 +75,7 @@ jobs:
       with:
         name: changes-astyle.diff
         path: changes-astyle.diff
+        archive: false
     - name: check indentation
       run: |
         git diff --exit-code
@@ -103,6 +104,7 @@ jobs:
       with:
         name: changes-parameters.diff
         path: doc/changes-parameters.diff
+        archive: false
     - name: check parameter documentation
       run: |
         git diff --exit-code
@@ -182,6 +184,7 @@ jobs:
       with:
         name: ${{ matrix.result-file }}
         path: build/${{ matrix.result-file }}
+        archive: false
     - name: check test results
       run: |
         if [ -f build/test_run_failed ] || [ -s build/${{ matrix.result-file}} ]; then


### PR DESCRIPTION
The archive options skips zipping the diffs, which is annoying (to apply you have to first unzip locally):
https://github.blog/changelog/2026-02-26-github-actions-now-supports-uploading-and-downloading-non-zipped-artifacts/
