### PR TITLE
Properly compress initial pressure vector

### DIFF
--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -245,8 +245,6 @@ namespace aspect
         return;
       },
       active_viscosity_vector);
-
-      active_viscosity_vector.compress(VectorOperation::insert);
     }
 
     minimum_viscosity = dealii::Utilities::MPI::min(minimum_viscosity_local, this->get_mpi_communicator());

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -278,8 +278,6 @@ namespace aspect
         return;
       },
       active_viscosity_vector);
-
-      active_viscosity_vector.compress(VectorOperation::insert);
     }
 
     minimum_viscosity = dealii::Utilities::MPI::min(minimum_viscosity_local, this->get_mpi_communicator());

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -2770,6 +2770,7 @@ namespace aspect
             // then set the global solution vector to the values just computed
             cell->set_dof_values (local_projection, vec_result);
           }
+      vec_result.compress(VectorOperation::insert);
     }
 
 


### PR DESCRIPTION
Working through a few more issues discovered as part of #6910.

The function `Utilities::project_cellwise` writes into all Dofs of a solution vector, but does not call `compress` afterwards. Two of the three places using this function called compress manually afterwards, but a third did not (in initial_conditions.cc:549, setting the initial pressure only for discontinuous pressure elements). I could have added the call to compress in the third calling place, but it seemed safer to just call it inside the utilities functions. Since this function performs a loop over all cells, the compress call should not be too expensive, compared to the work the function does.

We did not notice this earlier, because `TrilinosVector::operator=` does not complain when a not compressed vector is assigned to another vector, while `TpetraWrappers::Vector::operator=` does check and complain. (this seems like a bug in deal.II as well, but since TrilinosVector will perspectively be replaced by the Tpetra Vector I am not sure it is worth fixing?)