### PR TITLE
[WIP] Use fully distributed vector in line search

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2664,6 +2664,15 @@ namespace aspect
                                                mpi_communicator);
     current_iterate = current_linearization_point;
 
+    // Also create a fully distributed copy of the search direction.
+    // TODO: This is only necessary because deal.II's .sadd function below creates a copy
+    // of the search direction and operates on that copy, which is not allowed on ghosted vectors.
+    // Once this behavior is fixed this vector could
+    // also be a ghosted vector like search_direction, and we could avoid this copy.
+    LinearAlgebra::BlockVector current_search_direction(introspection.index_sets.system_partitioning,
+                                                        mpi_communicator);
+    current_search_direction = search_direction;
+
     double step_length_factor = 1.0;
     unsigned int line_search_iteration = 0;
 
@@ -2676,8 +2685,8 @@ namespace aspect
         current_iterate.block(velocity_block_index) = original_iterate.block(velocity_block_index);
         current_iterate.block(pressure_block_index) = original_iterate.block(pressure_block_index);
 
-        current_iterate.block(velocity_block_index).sadd(1.0, step_length_factor, search_direction.block(velocity_block_index));
-        current_iterate.block(pressure_block_index).sadd(1.0, step_length_factor, search_direction.block(pressure_block_index));
+        current_iterate.block(velocity_block_index).sadd(1.0, step_length_factor, current_search_direction.block(velocity_block_index));
+        current_iterate.block(pressure_block_index).sadd(1.0, step_length_factor, current_search_direction.block(pressure_block_index));
 
         // Update the ghosted vector current_linearization_point with the new candidate solution.
         // This is the vector the following function calls then all work on.


### PR DESCRIPTION
Another follow-up PR to #6910.

Inside the `perform_line_search` function it looks like we no longer write into ghosted vectors, however the `.sadd` implementation for Tpetra vectors internally does, if the added vector is a ghosted vector. That is because `sadd` creates a copy of the added vector and then scales that copy. Therefore if the added vector is ghosted, the copy is ghosted, and modifying that copy is then not allowed.

This can (and should) be fixed in deal.II that is why I marked this as WIP here (I just want to document the problem and where it appears in ASPECT). When a proper patch is merged in deal.II this PR can be closed.