### PR TITLE
Add get_checkpoint_id() function to simulator_access

### DIFF
--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -361,6 +361,14 @@ namespace aspect
       get_output_directory () const;
 
       /**
+       * Return the ID of the checkpoint that ASPECT is currently writing.
+       * Can be used in plugins to override the save() function and synchronize
+       * the checkpointing of plugins with the main ASPECT checkpoint.
+       */
+      unsigned int
+      get_checkpoint_id () const;
+
+      /**
        * Return whether we use the adiabatic heating term.
        */
       bool

--- a/include/aspect/simulator_access.h
+++ b/include/aspect/simulator_access.h
@@ -361,9 +361,10 @@ namespace aspect
       get_output_directory () const;
 
       /**
-       * Return the ID of the checkpoint that ASPECT is currently writing.
-       * Can be used in plugins to override the save() function and synchronize
-       * the checkpointing of plugins with the main ASPECT checkpoint.
+       * Return the ID of the checkpoint that ASPECT is currently writing or was last
+       * written, depending on where this function gets called. Can be used in plugins
+       * to override the save() function and synchronize the checkpointing of plugins
+       * with the main ASPECT checkpoint.
        */
       unsigned int
       get_checkpoint_id () const;

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -371,6 +371,9 @@ namespace aspect
     {
       std::ostringstream oss;
 
+      // Update the checkpoint ID to the current checkpoint ID.
+      last_checkpoint_id = checkpoint_id;
+
       // Serialize into a stringstream. Put the following into a code
       // block of its own to ensure the destruction of the 'oa'
       // archive triggers a flush() on the stringstream so we can
@@ -441,7 +444,6 @@ namespace aspect
     // can be slow, and the model might be cancelled during writing.
     // This way restart remains usable even if restart.new is not completely
     // written.
-    last_checkpoint_id = checkpoint_id;
     if (my_id == 0)
       {
         write_checkpoint_metadata(checkpoint_path, time, timestep_number);

--- a/source/simulator/simulator_access.cc
+++ b/source/simulator/simulator_access.cc
@@ -217,6 +217,15 @@ namespace aspect
 
 
   template <int dim>
+  unsigned int
+  SimulatorAccess<dim>::get_checkpoint_id () const
+  {
+    return simulator->last_checkpoint_id;
+  }
+
+
+
+  template <int dim>
   bool
   SimulatorAccess<dim>::convert_output_to_years () const
   {

--- a/tests/get_checkpoint_id.cc
+++ b/tests/get_checkpoint_id.cc
@@ -1,0 +1,49 @@
+/*
+  Copyright (C) 2022 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/mesh_deformation/interface.h>
+
+namespace aspect
+{
+  namespace MeshDeformation
+  {
+    template <int dim>
+    class TestMeshDeformation : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+        void save (std::map<std::string, std::string> &status_strings) const override
+        {
+          this->get_pcout() << "checkpoint_id: " << this->get_checkpoint_id() << std::endl;
+        }
+    };
+  }
+}
+
+
+namespace aspect
+{
+  namespace MeshDeformation
+  {
+    ASPECT_REGISTER_MESH_DEFORMATION_MODEL(TestMeshDeformation,
+                                           "Test mesh deformation",
+                                           "Test mesh deformation plugin for checking that the checkpoint id is equal to "
+                                           "the current checkpoint id in the simulator when the save() function is called.");
+  }
+}

--- a/tests/get_checkpoint_id.prm
+++ b/tests/get_checkpoint_id.prm
@@ -1,0 +1,17 @@
+# test the function get_checkpoint_id() in simulator_access.
+
+include $ASPECT_SOURCE_DIR/tests/checkpoint_02.prm
+
+set End time                               = 0.5e7
+
+subsection Checkpointing
+  set Steps between checkpoint = 1
+end
+
+subsection Mesh deformation
+  set Mesh deformation boundary indicators = top: Test mesh deformation
+end
+
+subsection Postprocess
+  set List of postprocessors = 
+end

--- a/tests/get_checkpoint_id/screen-output
+++ b/tests/get_checkpoint_id/screen-output
@@ -1,0 +1,72 @@
+
+Loading shared library <./libget_checkpoint_id.debug.so>
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 13,764 (8,450+1,089+4,225)
+
+Number of mesh deformation degrees of freedom: 8,450
+   Solving mesh displacement system... 0 iterations.
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG)... 16+0 iterations.
+
+   Postprocessing:
+
+checkpoint_id: 1
+*** Snapshot output-get_checkpoint_id/restart/01/ created!
+
+*** Timestep 1:  t=1.02774e+06 seconds, dt=1.02774e+06 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 25 iterations.
+   Solving Stokes system (GMG)... 15+0 iterations.
+
+   Postprocessing:
+
+checkpoint_id: 2
+*** Snapshot output-get_checkpoint_id/restart/02/ created!
+
+*** Timestep 2:  t=2.1003e+06 seconds, dt=1.07256e+06 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 19 iterations.
+   Solving Stokes system (GMG)... 13+0 iterations.
+
+   Postprocessing:
+
+checkpoint_id: 3
+*** Snapshot output-get_checkpoint_id/restart/03/ created!
+
+*** Timestep 3:  t=3.22036e+06 seconds, dt=1.12006e+06 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 19 iterations.
+   Solving Stokes system (GMG)... 13+0 iterations.
+
+   Postprocessing:
+
+checkpoint_id: 1
+*** Snapshot output-get_checkpoint_id/restart/01/ created!
+
+*** Timestep 4:  t=4.39059e+06 seconds, dt=1.17022e+06 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 19 iterations.
+   Solving Stokes system (GMG)... 13+0 iterations.
+
+   Postprocessing:
+
+checkpoint_id: 2
+*** Snapshot output-get_checkpoint_id/restart/02/ created!
+
+*** Timestep 5:  t=5e+06 seconds, dt=609412 seconds
+   Solving mesh displacement system... 0 iterations.
+   Solving temperature system... 13 iterations.
+   Solving Stokes system (GMG)... 12+0 iterations.
+
+   Postprocessing:
+
+Termination requested by criterion: end time
+checkpoint_id: 3
+*** Snapshot output-get_checkpoint_id/restart/03/ created!
+
+
+
+


### PR DESCRIPTION
This PR creates a function that enables other ASPECT plugins to access the last checkpoint id created by ASPECT. This is something that is currently useful for my postdoc work, and may also be useful to other groups who are coupling ASPECT to external softwares.
