### PR TITLE
Remove unused dynamic core gravity helper

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -443,11 +443,6 @@ namespace aspect
         double compute_rho(const double r) const;
 
         /**
-         * Calculate gravitational acceleration at given radius @p r.
-         */
-        double compute_g(const double r) const;
-
-        /**
          * Calculate the core temperature at given radius @p r and
          * temperature at CMB @p Tc.
          */

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -628,16 +628,6 @@ namespace aspect
     template <int dim>
     double
     DynamicCore<dim>::
-    compute_g(const double r) const
-    {
-      return (4*numbers::PI/3)*constants::big_g*Rho_cen*r*(1-3*Utilities::fixed_power<2>(r)/(5*Utilities::fixed_power<2>(L)));
-    }
-
-
-
-    template <int dim>
-    double
-    DynamicCore<dim>::
     compute_T(const double Tc, const double r) const
     {
       return Tc*std::exp((Utilities::fixed_power<2>(Rc)-Utilities::fixed_power<2>(r))/Utilities::fixed_power<2>(D));


### PR DESCRIPTION
This PR removes the unused `DynamicCore::compute_g()` helper from the dynamic core boundary temperature plugin.

The function was declared and defined, but it was not called anywhere. Removing it completes the dead-code cleanup around the old dynamic core gravity handling without changing model behavior.

Validation:
- `git diff --check`
- `cmake --build build-debug --target aspect -j20`
- `ASPECT_SOURCE_DIR=/home/francyrad/Documenti/aspect_debug/aspect_issue_6926_work ctest --output-on-failure -R "dynamic_core|dynamic_core_fully_molten|dynamic_core_fully_solid"`

Results on this x86_64 Debug setup:
- `dynamic_core` passes
- `dynamic_core_fully_solid` passes
- `dynamic_core_fully_molten` still reports the known last-digit statistics diff on this setup

Refs #6926.
