### PR TITLE
Use the common form of header guards for ASPECT.

### DIFF
--- a/include/aspect/simulator/solver/block_stokes_preconditioner.h
+++ b/include/aspect/simulator/solver/block_stokes_preconditioner.h
@@ -19,8 +19,8 @@
 */
 
 
-#ifndef aspect_block_stokes_preconditioner_h
-#define aspect_block_stokes_preconditioner_h
+#ifndef _aspect_block_stokes_preconditioner_h
+#define _aspect_block_stokes_preconditioner_h
 
 #include <deal.II/lac/solver_bicgstab.h>
 #include <deal.II/lac/solver_cg.h>


### PR DESCRIPTION
Found while working on C++ modules (see https://github.com/dealii/dealii/issues/18071).