### PR TITLE
Split docker workflows

### DIFF
--- a/.github/workflows/docker-tacc.yml
+++ b/.github/workflows/docker-tacc.yml
@@ -1,4 +1,4 @@
-name: github-docker
+name: github-docker-tacc
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 # is a waste of time, and (ii) it creates a race condition with the
 # upload.
 concurrency:
-  group: docker-build
+  group: docker-build-tacc
   cancel-in-progress: true
 
 permissions:
@@ -20,10 +20,10 @@ permissions:
   packages: write
 
 jobs:
-  build-docker:
+  build-docker-tacc:
     runs-on: ubuntu-latest
     if: github.repository == 'geodynamics/aspect'
-    steps:    
+    steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -33,6 +33,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_LOGIN }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -40,34 +46,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_LOGIN }}
-
       - name: Build and push Docker image for main
         if: contains(github.event_name, 'push')
         uses: docker/build-push-action@v7
         with:
-          context: ./contrib/docker/docker/
+          context: ./contrib/docker/docker_tacc/
           cache-from: type=registry,ref=ubuntu:22.04
           cache-to: type=inline
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:latest-tacc
+            ${{ github.repository }}:latest-tacc
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
         uses: docker/build-push-action@v7
         with:
-          context: ./contrib/docker/docker/
+          context: ./contrib/docker/docker_tacc/
           cache-from: type=registry,ref=ubuntu:22.04
           cache-to: type=inline
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{github.ref_name}}
-            ${{ github.repository }}:${{github.ref_name}}
+            ghcr.io/${{ github.repository }}:${{github.ref_name}}-tacc
+            ${{ github.repository }}:${{github.ref_name}}-tacc


### PR DESCRIPTION
The github actions workflow docker-tacc is currently broken because of changes in the TACC base image. Until I can look into and repair the workflow I would like to disable it. But I cannot, because it is in the same workflow as the normal docker image.

This PR splits the two workflows into separate files so I can disable the TACC workflow through the github interface.