### PR TITLE
Fix deprecation warnings with deal.II master

### DIFF
--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -180,22 +180,9 @@ namespace aspect
         ode_data.relative_tolerance = 1e-3;
         ode_data.absolute_tolerance = 0;
 
-#if DEAL_II_VERSION_GTE(9,8,0)
-        SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
-        stepper_data.order = 3;
-        stepper_data.maximum_non_linear_iterations = 30;
-
-        SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
-        SUNDIALS::ARKode<VectorType> ode(stepper, ode_data);
-#else
-        ode_data.maximum_order = 3;
-        ode_data.maximum_non_linear_iterations = 30;
-        SUNDIALS::ARKode<VectorType> ode(ode_data);
-#endif
-
-        ode.explicit_function = [&] (const double     /*time*/,
-                                     const VectorType &y,
-                                     VectorType       &grain_size_rates_of_change)
+        const auto explicit_function = [&] (const double     /*time*/,
+                                            const VectorType &y,
+                                            VectorType       &grain_size_rates_of_change)
         {
           for (unsigned int i=0; i<n_evaluation_points; ++i)
             {
@@ -278,6 +265,20 @@ namespace aspect
             }
         };
 
+#if DEAL_II_VERSION_GTE(9,8,0)
+        SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+        stepper_data.order = 3;
+        stepper_data.maximum_non_linear_iterations = 30;
+
+        SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+        stepper.explicit_function = explicit_function;
+        SUNDIALS::ARKode<VectorType> ode(stepper, ode_data);
+#else
+        ode_data.maximum_order = 3;
+        ode_data.maximum_non_linear_iterations = 30;
+        SUNDIALS::ARKode<VectorType> ode(ode_data);
+        ode.explicit_function = explicit_function;
+#endif
 
         const unsigned int iteration_count = ode.solve_ode(grain_sizes);
         this->get_signals().post_ARKode_solve(*this, iteration_count);

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -168,23 +168,31 @@ namespace aspect
         || timestep == 0.0)
         return;
 
-        SUNDIALS::ARKode<VectorType>::AdditionalData data;
-
-        data.initial_time = 0.0;
-        data.final_time = this->get_timestep();
-
-        data.initial_step_size = arkode_initial_step_size * this->get_timestep();
-        data.output_period = this->get_timestep();
-        data.minimum_step_size = arkode_minimum_step_size * this->get_timestep();
-        data.maximum_order = 3;
-        data.maximum_non_linear_iterations = 30;
+        SUNDIALS::ARKode<VectorType>::AdditionalData ode_data;
+        ode_data.initial_time = 0.0;
+        ode_data.final_time = this->get_timestep();
+        ode_data.initial_step_size = arkode_initial_step_size * this->get_timestep();
+        ode_data.output_period = this->get_timestep();
+        ode_data.minimum_step_size = arkode_minimum_step_size * this->get_timestep();
 
         // Because both tolerances are added, we set the absolute
         // tolerance to 0.
-        data.relative_tolerance = 1e-3;
-        data.absolute_tolerance = 0;
+        ode_data.relative_tolerance = 1e-3;
+        ode_data.absolute_tolerance = 0;
 
-        SUNDIALS::ARKode<VectorType> ode(data);
+#if DEAL_II_VERSION_GTE(9,8,0)
+        SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+        stepper_data.order = 3;
+        stepper_data.maximum_non_linear_iterations = 30;
+
+        SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+        SUNDIALS::ARKode<VectorType> ode(stepper, ode_data);
+#else
+        ode_data.maximum_order = 3;
+        ode_data.maximum_non_linear_iterations = 30;
+        SUNDIALS::ARKode<VectorType> ode(ode_data);
+#endif
+
         ode.explicit_function = [&] (const double     /*time*/,
                                      const VectorType &y,
                                      VectorType       &grain_size_rates_of_change)


### PR DESCRIPTION
Fix some of the remaining deprecation warnings introduced by dealii/dealii#19282.

This now compiles without warnings, but I receive the error I attach below when I run our tests. I would have understood if we got another deprecation warning (because we assign an explicit function to `ARKode.explicit_function` which is now deprecated), but I dont understand the error.

@vovannikov: I thought I saw code in 19282 that kept the existing functions working?
Could you take a look if we are using the class wrong, or if there is a bug in the compatibility? The relevant code is here: https://github.com/geodynamics/aspect/blob/a646ade2e30013d650efcd03180f8eadfa2a8dd3/source/material_model/reaction_model/grain_size_evolution.cc#L188



```
*** Timestep 1:  t=15625 years, dt=15625 years
   Solving temperature system... 0 iterations.


----------------------------------------------------
Exception 'ExcMessage( "Unable to assign the function since the target is not set in the " "proxy. Most probably, you tried to use it with a stepper that does " "not support this type of callback.")' on rank 0 on processing: 

--------------------------------------------------------
An error occurred in line <122> of file </home/rene/software/dealii/include/deal.II/sundials/arkode.h> in function
    dealii::SUNDIALS::ARKode<VectorType>::FunctionProxy<Fn>& dealii::SUNDIALS::ARKode<VectorType>::FunctionProxy<Fn>::operator=(std::function<_Signature>) [with Fn = void(double, const dealii::Vector<double>&, dealii::Vector<double>&); VectorType = dealii::Vector<double>]
The violated condition was: 
    target
Additional information: 
    Unable to assign the function since the target is not set in the
    proxy. Most probably, you tried to use it with a stepper that does not
    support this type of callback.

Stacktrace:
-----------
#0  ./aspect: dealii::SUNDIALS::ARKode<dealii::Vector<double> >::FunctionProxy<void (double, dealii::Vector<double> const&, dealii::Vector<double>&)>::operator=(std::function<void (double, dealii::Vector<double> const&, dealii::Vector<double>&)>)
#1  ./aspect: aspect::MaterialModel::ReactionModel::GrainSizeEvolution<2>::calculate_reaction_terms(aspect::MaterialModel::MaterialModelInputs<2> const&, std::vector<double, std::allocator<double> > const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, std::function<double (double, double, double, dealii::SymmetricTensor<2, 2, double> const&, unsigned int, double, double)> const&, std::function<double (double, double, double, double, double, unsigned int)> const&, double, double, aspect::MaterialModel::MaterialModelOutputs<2>&) const
#2  ./aspect: aspect::MaterialModel::GrainSize<2>::evaluate(aspect::MaterialModel::MaterialModelInputs<2> const&, aspect::MaterialModel::MaterialModelOutputs<2>&) const
#3  ./aspect: void aspect::Simulator<2>::get_artificial_viscosity<double>(dealii::Vector<double>&, aspect::AdvectionField const&, bool) const
#4  ./aspect: aspect::Simulator<2>::assemble_advection_system(aspect::AdvectionField const&)
#5  ./aspect: aspect::Simulator<2>::assemble_and_solve_composition(std::vector<double, std::allocator<double> > const&, unsigned int, std::vector<double, std::allocator<double> >*)
#6  ./aspect: aspect::Simulator<2>::solve_single_advection_single_stokes()
#7  ./aspect: aspect::Simulator<2>::solve_timestep()
#8  ./aspect: aspect::Simulator<2>::run()
#9  ./aspect: 
#10  ./aspect: main
--------------------------------------------------------
```

