### PR TITLE
Serialize the dynamic core boundary temperature plugin

### DIFF
--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -181,6 +181,26 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm) override;
 
+        /**
+         * Serialize the contents of this class as far as they are not read
+         * from input parameter files.
+         */
+        template <class Archive>
+        void
+        serialize (Archive &ar, const unsigned int version);
+
+        /**
+         * Save the state of this object.
+         */
+        void
+        save (std::map<std::string, std::string> &status_strings) const override;
+
+        /**
+         * Restore the state of the object.
+         */
+        void
+        load (const std::map<std::string, std::string> &status_strings) override;
+
       private:
 
         /**
@@ -358,6 +378,13 @@ namespace aspect
         {
           double t;
           double w;
+
+          template <class Archive>
+          void serialize (Archive &ar, const unsigned int)
+          {
+            ar & t
+            & w;
+          }
         };
         std::vector<struct str_data_OES> data_OES;
         void read_data_OES();

--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -382,7 +382,7 @@ namespace aspect
           template <class Archive>
           void serialize (Archive &ar, const unsigned int)
           {
-            ar & t
+            ar &t
             & w;
           }
         };

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -31,6 +31,8 @@
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/utilities.h>
 
+#include <boost/serialization/vector.hpp>
+
 #include <limits>
 
 
@@ -541,6 +543,77 @@ namespace aspect
     DynamicCore<dim>::get_core_data() const
     {
       return core_data;
+    }
+
+
+
+    template <int dim>
+    template <class Archive>
+    void
+    DynamicCore<dim>::serialize (Archive &ar, const unsigned int)
+    {
+      ar &core_data.Qs
+      & core_data.Qr
+      & core_data.Qg
+      & core_data.Qk
+      & core_data.Ql
+      & core_data.Es
+      & core_data.Er
+      & core_data.Eg
+      & core_data.Ek
+      & core_data.El
+      & core_data.Eh
+      & core_data.Ri
+      & core_data.Ti
+      & core_data.Xi
+      & core_data.Q
+      & core_data.H
+      & core_data.dt
+      & core_data.dR_dt
+      & core_data.dT_dt
+      & core_data.dX_dt
+      & core_data.Q_OES
+      & core_data.is_initialized
+      & inner_temperature
+      & is_first_call
+      & Rc
+      & Mc
+      & dTa
+      & data_OES;
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::save (std::map<std::string, std::string> &status_strings) const
+    {
+      // Serialize into a stringstream. Put the following into a code
+      // block of its own to ensure the destruction of the 'oa'
+      // archive triggers a flush() on the stringstream so we can
+      // query the completed string below.
+      std::ostringstream os;
+      {
+        aspect::oarchive oa (os);
+        oa << (*this);
+      }
+
+      status_strings["DynamicCore"] = os.str();
+    }
+
+
+
+    template <int dim>
+    void
+    DynamicCore<dim>::load (const std::map<std::string, std::string> &status_strings)
+    {
+      // See if something was saved.
+      if (status_strings.find("DynamicCore") != status_strings.end())
+        {
+          std::istringstream is (status_strings.find("DynamicCore")->second);
+          aspect::iarchive ia (is);
+          ia >> (*this);
+        }
     }
 
 


### PR DESCRIPTION
This reworks the old #6918 branch on top of current `main` and keeps the patch limited to the serialization hooks requested in review.

The PR adds `serialize()`, `save()`, and `load()` to the dynamic core boundary temperature plugin. It serializes the dynamic core state plus the small amount of runtime state needed for checkpoint/restart to restore the plugin object itself, including the OES data table when present. It does not add extra restart-path logic in `update()`.

Validation run locally:

- `git diff --check`
- `cmake --build build-debug --target aspect -j20`
- `cmake --build build-debug-nounity --target aspect -j20`
- manual checkpoint/resume smoke test for `dynamic_core`: resumed run continues with `Dynamic core data updated`
- `ASPECT_SOURCE_DIR=/home/francyrad/Documenti/aspect_debug/aspect_pr_6918_work ctest --output-on-failure -R dynamic_core`: `dynamic_core` and `dynamic_core_fully_solid` pass; `dynamic_core_fully_molten` only differs in the last digit of two statistics time values on this machine

Refs #6744. Follow-up to #6918.