### PR TITLE
Fix fastscape kf and kd output

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -512,32 +512,33 @@ namespace aspect
                 {
                   std::vector<double> basement(fastscape_array_size);
                   fastscape_copy_basement_(basement.data());
+                  const double sediment_thickness = elevation[i] - basement[i];
 
                   // The same incision rate is used for sediments as for bedrock
                   // if the sediment rate is set to something smaller than zero
                   // (by default -1).
-                  if (sediment_river_incision_rate < 0)
-                    {
-                      combined_kf[i] = bedrock_river_incision_rate_array[i];
-                    }
+                  if (sediment_river_incision_rate < 0. || sediment_thickness <= 1.)
+                    combined_kf[i] = bedrock_river_incision_rate_array[i];
                   // If a different rate is set for sediment and bedrock,
                   // the sediment rate is only used for sediment layers
                   // at least 1 m thick.
-                  else if (elevation[i] - basement[i] > 1.)
+                  else if (sediment_river_incision_rate >= 0. && sediment_thickness > 1.)
                     combined_kf[i] = sediment_river_incision_rate;
+                  else
+                    combined_kf[i] = numbers::signaling_nan<double>();
 
                   // The same diffusion coefficient is used for sediments as for bedrock.
                   // if the sediment coefficient is set to something smaller than zero
                   // (by default -1).
-                  if (sediment_river_incision_rate < 0)
-                    {
-                      combined_kd[i] = bedrock_transport_coefficient_array[i];
-                    }
+                  if (sediment_transport_coefficient < 0 || sediment_thickness <= 1.)
+                    combined_kd[i] = bedrock_transport_coefficient_array[i];
                   // If a different rate is set for sediment and bedrock,
                   // the sediment coefficient is only used for sediment layers
                   // at least 1 m thick.
-                  else if (elevation[i] - basement[i] > 1.)
+                  else if (sediment_transport_coefficient >= 0. && sediment_thickness > 1.)
                     combined_kd[i] = sediment_transport_coefficient;
+                  else
+                    combined_kd[i] = numbers::signaling_nan<double>();
                 }
               // Below sea level, when the marine component is used,
               // kf and kd are not used.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -508,16 +508,38 @@ namespace aspect
           for (unsigned int i = 0; i < fastscape_array_size; ++i)
             {
               // For cells above sea level, grep the continental erosion parameters.
-              if (elevation[i] >= current_sea_level)
+              if (elevation[i] >= current_sea_level || !use_marine_component)
                 {
+                  // The same incision rate is used for sediments as for bedrock
+                  // if the sediment rate is set to something smaller than zero
+                  // (by default -1).
+                  if (sediment_river_incision_rate < 0)
+                    {
                   combined_kf[i] = bedrock_river_incision_rate_array[i];
+                    }
+                  else
+                  combined_kf[i] = sediment_river_incision_rate;
+
+                  // The same diffusion coefficient is used for sediments as for bedrock.
+                  // if the sediment coefficient is set to something smaller than zero
+                  // (by default -1).
+                  if (sediment_river_incision_rate < 0)
+                    {
                   combined_kd[i] = bedrock_transport_coefficient_array[i];
+                    }
+                  else
+                  combined_kd[i] = sediment_transport_coefficient;
                 }
-              // For cells below sea level, grep the marine diffusion coefficients.
+              // Below sea level, when the marine component is used,
+              // kf and kd are not used.
+              else if (elevation[i] < current_sea_level && use_marine_component)
+                {
+                  combined_kf[i] = numbers::signaling_nan<double>();
+                  combined_kd[i] = numbers::signaling_nan<double>();
+                }
               else
                 {
-                  combined_kf[i] = sediment_river_incision_rate;
-                  combined_kd[i] = sediment_transport_coefficient;
+                  AssertThrow (false, ExcMessage ("Unexpected conditions reached while filling the kf and kd arrays in the FastScape interface."));
                 }
             }
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -501,27 +501,26 @@ namespace aspect
 
           // Generate a combined array for kf and kd both onshore and offshore.
           // Onshore, kf and kd can have different values for bedrock and
-          // sediment. With use_marine_component = true, offshore only
+          // sediment. With use_marine_component = true, offshore
           // the silt and sand diffusion coefficients are used, not kf and kd.
           std::vector<double> combined_kd(fastscape_array_size);
           std::vector<double> combined_kf(fastscape_array_size);
+          std::vector<double> basement(fastscape_array_size);
           for (unsigned int i = 0; i < fastscape_array_size; ++i)
             {
               // For cells above sea level, grep the continental erosion parameters.
               if (elevation[i] >= current_sea_level || !use_marine_component)
                 {
-                  std::vector<double> basement(fastscape_array_size);
                   fastscape_copy_basement_(basement.data());
                   const double sediment_thickness = elevation[i] - basement[i];
 
                   // The same incision rate is used for sediments as for bedrock
                   // if the sediment rate is set to something smaller than zero
-                  // (by default -1).
+                  // (by default -1). If a different rate is set for sediment and
+                  // bedrock, the sediment rate is only used for sediment layers
+                  // at least 1 m thick.
                   if (sediment_river_incision_rate < 0. || sediment_thickness <= 1.)
                     combined_kf[i] = bedrock_river_incision_rate_array[i];
-                  // If a different rate is set for sediment and bedrock,
-                  // the sediment rate is only used for sediment layers
-                  // at least 1 m thick.
                   else if (sediment_river_incision_rate >= 0. && sediment_thickness > 1.)
                     combined_kf[i] = sediment_river_incision_rate;
                   else
@@ -529,12 +528,11 @@ namespace aspect
 
                   // The same diffusion coefficient is used for sediments as for bedrock.
                   // if the sediment coefficient is set to something smaller than zero
-                  // (by default -1).
-                  if (sediment_transport_coefficient < 0 || sediment_thickness <= 1.)
-                    combined_kd[i] = bedrock_transport_coefficient_array[i];
-                  // If a different rate is set for sediment and bedrock,
+                  // (by default -1). If a different rate is set for sediment and bedrock,
                   // the sediment coefficient is only used for sediment layers
                   // at least 1 m thick.
+                  if (sediment_transport_coefficient < 0 || sediment_thickness <= 1.)
+                    combined_kd[i] = bedrock_transport_coefficient_array[i];
                   else if (sediment_transport_coefficient >= 0. && sediment_thickness > 1.)
                     combined_kd[i] = sediment_transport_coefficient;
                   else

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -499,18 +499,21 @@ namespace aspect
                                              &sand_transport_coefficient,
                                              &silt_transport_coefficient);
 
-          // generate a combined array for kf and kd both onshore and offshore
+          // Generate a combined array for kf and kd both onshore and offshore.
+          // Onshore, kf and kd can have different values for bedrock and
+          // sediment. With use_marine_component = true, offshore only
+          // the silt and sand diffusion coefficients are used, not kf and kd.
           std::vector<double> combined_kd(fastscape_array_size);
           std::vector<double> combined_kf(fastscape_array_size);
           for (unsigned int i = 0; i < fastscape_array_size; ++i)
             {
-              // for cells below sea level, grep the marine sediment data
+              // For cells above sea level, grep the continental erosion parameters.
               if (elevation[i] >= current_sea_level)
                 {
                   combined_kf[i] = bedrock_river_incision_rate_array[i];
                   combined_kd[i] = bedrock_transport_coefficient_array[i];
                 }
-              // for cells below sea level, grep the marine sediment data
+              // For cells below sea level, grep the marine diffusion coefficients.
               else
                 {
                   combined_kf[i] = sediment_river_incision_rate;

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -510,25 +510,34 @@ namespace aspect
               // For cells above sea level, grep the continental erosion parameters.
               if (elevation[i] >= current_sea_level || !use_marine_component)
                 {
+                  std::vector<double> basement(fastscape_array_size);
+                  fastscape_copy_basement_(basement.data());
+
                   // The same incision rate is used for sediments as for bedrock
                   // if the sediment rate is set to something smaller than zero
                   // (by default -1).
                   if (sediment_river_incision_rate < 0)
                     {
-                  combined_kf[i] = bedrock_river_incision_rate_array[i];
+                      combined_kf[i] = bedrock_river_incision_rate_array[i];
                     }
-                  else
-                  combined_kf[i] = sediment_river_incision_rate;
+                  // If a different rate is set for sediment and bedrock,
+                  // the sediment rate is only used for sediment layers
+                  // at least 1 m thick.
+                  else if (elevation[i] - basement[i] > 1.)
+                    combined_kf[i] = sediment_river_incision_rate;
 
                   // The same diffusion coefficient is used for sediments as for bedrock.
                   // if the sediment coefficient is set to something smaller than zero
                   // (by default -1).
                   if (sediment_river_incision_rate < 0)
                     {
-                  combined_kd[i] = bedrock_transport_coefficient_array[i];
+                      combined_kd[i] = bedrock_transport_coefficient_array[i];
                     }
-                  else
-                  combined_kd[i] = sediment_transport_coefficient;
+                  // If a different rate is set for sediment and bedrock,
+                  // the sediment coefficient is only used for sediment layers
+                  // at least 1 m thick.
+                  else if (elevation[i] - basement[i] > 1.)
+                    combined_kd[i] = sediment_transport_coefficient;
                 }
               // Below sea level, when the marine component is used,
               // kf and kd are not used.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -503,9 +503,13 @@ namespace aspect
           // Onshore, kf and kd can have different values for bedrock and
           // sediment. With use_marine_component = true, offshore
           // the silt and sand diffusion coefficients are used, not kf and kd.
+          // We use a composite of the silt and sand diffusion coefficients
+          // to fill kd there (as they pertain to the same diffusion equation)
+          // but set kf to a signalling nan.
           std::vector<double> combined_kd(fastscape_array_size);
           std::vector<double> combined_kf(fastscape_array_size);
           std::vector<double> basement(fastscape_array_size);
+          std::vector<double> silt_fraction(fastscape_array_size);
           for (unsigned int i = 0; i < fastscape_array_size; ++i)
             {
               // For cells above sea level, grep the continental erosion parameters.
@@ -539,11 +543,20 @@ namespace aspect
                     combined_kd[i] = numbers::signaling_nan<double>();
                 }
               // Below sea level, when the marine component is used,
-              // kf and kd are not used.
+              // kf is not used. kd is set to the marine diffusion coefficients.
               else if (elevation[i] < current_sea_level && use_marine_component)
                 {
                   combined_kf[i] = numbers::signaling_nan<double>();
-                  combined_kd[i] = numbers::signaling_nan<double>();
+                  fastscape_copy_f_(silt_fraction.data());
+                  // The silt fraction represents the fraction of silt out of the
+                  // total marine sediments (i.e., silt / (sand + silt)).
+                  // Note that Fastscape does not know about the marine background
+                  // sedimentation and only considers sand and silt in the marine domain.
+                  // The combined marine diffusion coefficient is an approximation
+                  // of the actual diffusion, which is solved for both sediment
+                  // types separately in Fastscape.
+                  const double marine_diffusion_coefficient = silt_fraction * silt_transport_coefficient + (1. - silt_fraction) * sand_transport_coefficient;
+                  combined_kd[i] = marine_diffusion_coefficient;
                 }
               else
                 {


### PR DESCRIPTION
This PR addresses #6694. 

@Djneu do you think we should fill kd with the sand or silt diffusion coefficient below sealevel when the marine component is on? Or leave it as NaN as it is not strictly speaking kf?

@Wang-yijun This PR probably interferes with your work on making kf compositional field dependent. Do you have suggestions?

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
