### PR TITLE
Rename fastscape parameter

### DIFF
--- a/contrib/utilities/update_scripts/prm_files/reformat.py
+++ b/contrib/utilities/update_scripts/prm_files/reformat.py
@@ -125,12 +125,22 @@ def rename_linear_least_squares(parameters):
 
     return parameters
 
+def rename_fastscape_vtk_output(parameters):
+    if "Mesh deformation" in parameters:
+        if "Fastscape" in parameters["Mesh deformation"]["value"]:
+            if "Additional output variables" in parameters ["Mesh deformation"]["value"]["Fastscape"]["value"]:
+               if "deposition coefficient" in parameters["Mesh deformation"]["value"]["Fastscape"]["value"]["Additional output variables"]["value"]:
+                  parameters["Mesh deformation"]["value"]["Fastscape"]["value"]["Additional output variables"]["value"] = "transport coefficient"
+
+    return parameters
+
 def main(input_file, output_file):
     """Echo the input arguments to standard output"""
     parameters = aspect.read_parameter_file(input_file)
     parameters = reformat(parameters)
     parameters = merge_deprecated_postprocessors_into_material_properties(parameters)
     parameters = rename_linear_least_squares(parameters)
+    parameters = rename_fastscape_vtk_output(parameters)
     aspect.write_parameter_file(parameters, output_file)
 
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1718,7 +1718,7 @@ namespace aspect
                             Patterns::Double(),
                             "Maximum topography change from the initial noise. Units: ${m}$");
           prm.declare_entry("Additional output variables", "river incision rate",
-                            Patterns::Selection("river incision rate|deposition coefficient|uplift rate"),
+                            Patterns::Selection("river incision rate|transport coefficient|uplift rate"),
                             "Select one additional Fastscape variable to output in the Fastcape vtk. "
                             "Output are in units of per year. "
                            );
@@ -1989,7 +1989,7 @@ namespace aspect
 
           if (output_choice == "river incision rate")
             additional_output_variable = FastscapeOutputVariable::kf;
-          else if (output_choice == "deposition coefficient")
+          else if (output_choice == "transport coefficient")
             additional_output_variable = FastscapeOutputVariable::kd;
           else if (output_choice == "uplift rate")
             additional_output_variable = FastscapeOutputVariable::uplift_rate;

--- a/tests/fastscape_output_test.prm
+++ b/tests/fastscape_output_test.prm
@@ -60,7 +60,7 @@ subsection Mesh deformation
     set Y extent in 2d = 20e3
     set Uplift and advect with fastscape = true
     set Use ghost nodes = true
-    set Additional output variables = deposition coefficient
+    set Additional output variables = transport coefficient
 
 
    subsection Boundary conditions    


### PR DESCRIPTION
This PR changes the name of an input parameter that describes the "transport coefficient" or "diffusivity" `kd` when selecting additional FastScape output. At the moment, it is called "deposition coefficient", which is actually the name of the parameter `G`, as also used in fastscape.cc, e.g.:
```
            bedrock_deposition_g = prm.get_double("Bedrock deposition coefficient");
            sediment_deposition_g = prm.get_double("Sediment deposition coefficient");
```

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
