### PR TITLE
avoid isnan() during visualization output

### DIFF
--- a/source/postprocess/visualization.cc
+++ b/source/postprocess/visualization.cc
@@ -322,7 +322,7 @@ namespace aspect
       output_interval (0),
       // initialize this to a nonsensical value; set it to the actual time
       // the first time around we get to check it
-      last_output_time (std::numeric_limits<double>::quiet_NaN()),
+      last_output_time (std::numeric_limits<double>::lowest()),
       maximum_timesteps_between_outputs (std::numeric_limits<int>::max()),
       last_output_timestep (numbers::invalid_unsigned_int),
       output_file_number (numbers::invalid_unsigned_int)
@@ -727,7 +727,7 @@ namespace aspect
       // if this is the first time we get here, set the last output time
       // to the current time - output_interval. this makes sure we
       // always produce data during the first time step
-      if (std::isnan(last_output_time))
+      if (last_output_time < this->get_parameters().start_time - output_interval)
         {
           last_output_time = this->get_time() - output_interval;
           last_output_timestep = this->get_timestep_number();


### PR DESCRIPTION
Avoid using NaN to determine if we need to generate graphical output. This might fix #6972.

If this works, we need to do something similar in many other places that mirror this setup.