### PR TITLE
Replace deprecated functions in tests

### DIFF
--- a/tests/find_boundary_composition_model.cc
+++ b/tests/find_boundary_composition_model.cc
@@ -42,19 +42,19 @@ namespace aspect
     template <int dim>
     void Box2<dim>::update()
     {
-      if (this->get_boundary_composition_manager().template has_matching_boundary_composition_model<BoundaryComposition::Box<dim>>())
+      if (this->get_boundary_composition_manager().template has_matching_active_plugin<const BoundaryComposition::Box<dim>>())
         std::cout << "Box is found!" << std::endl;
       else
         std::cout << "Box is not found!" << std::endl;
 
-      if (this->get_boundary_composition_manager().template has_matching_boundary_composition_model<BoundaryComposition::InitialComposition<dim>>())
+      if (this->get_boundary_composition_manager().template has_matching_active_plugin<const BoundaryComposition::InitialComposition<dim>>())
         std::cout << "InitialComposition is found!" << std::endl;
       else
         std::cout << "InitialComposition is not found!" << std::endl;
 
       try
         {
-          this->get_boundary_composition_manager().template get_matching_boundary_composition_model<BoundaryComposition::Box<dim>>();
+          this->get_boundary_composition_manager().template get_matching_active_plugin<const BoundaryComposition::Box<dim>>();
           std::cout << "Box is found!" << std::endl;
         }
       catch (...)
@@ -64,7 +64,7 @@ namespace aspect
 
       try
         {
-          this->get_boundary_composition_manager().template get_matching_boundary_composition_model<BoundaryComposition::InitialComposition<dim>>();
+          this->get_boundary_composition_manager().template get_matching_active_plugin<const BoundaryComposition::InitialComposition<dim>>();
           std::cout << "InitialComposition is found!" << std::endl;
         }
       catch (...)

--- a/tests/find_boundary_composition_model_fail_1.cc
+++ b/tests/find_boundary_composition_model_fail_1.cc
@@ -42,7 +42,7 @@ namespace aspect
     template <int dim>
     void Box2<dim>::update()
     {
-      this->get_boundary_composition_manager().template get_matching_boundary_composition_model<BoundaryComposition::Box<dim>>();
+      this->get_boundary_composition_manager().template get_matching_active_plugin<const BoundaryComposition::Box<dim>>();
       std::cout << "Box is found!" << std::endl;
     }
   }


### PR DESCRIPTION
Replace two deprecated functions from two tests. The deprecated warning showed up when running the tester locally (tests still pass). 

No tests .cc files use the new functions. There are four other tests that could be updated:

find_mesh_refinement
find_mesh_refinement_fail_1
find_postprocess
find_postprocess_fail_1

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
