### PR TITLE
Correct last name spelling of Kohlstedt.

### DIFF
--- a/doc/sphinx/parameters/Material_20model.md
+++ b/doc/sphinx/parameters/Material_20model.md
@@ -5104,7 +5104,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The minimum water content for the HK04 olivine hydration viscosity prefactor scheme. This acts as the cutoff between &rsquo;dry&rsquo; creep and &rsquo;wet&rsquo; creep for olivine, and the default value is chosen based on the value reported by Hirth & Kohlstaedt 2004. For a mass fraction of bound water beneath this value, this value is used instead to compute the water fugacity. Units: \si{\kg} / \si{\kg} %.
+**Documentation:** The minimum water content for the HK04 olivine hydration viscosity prefactor scheme. This acts as the cutoff between &rsquo;dry&rsquo; creep and &rsquo;wet&rsquo; creep for olivine, and the default value is chosen based on the value reported by Hirth & Kohlstedt 2004. For a mass fraction of bound water beneath this value, this value is used instead to compute the water fugacity. Units: \si{\kg} / \si{\kg} %.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum strain rate<parameters:Material_20model/Visco_20Plastic/Minimum_20strain_20rate>`
@@ -5610,7 +5610,7 @@ If a compositional field named &rsquo;noninitial\_plastic\_strain&rsquo; is incl
 
 **Pattern:** [Selection none|HK04 olivine hydration ]
 
-**Documentation:** Select what type of viscosity multiplicative prefactor scheme to apply. Allowed entries are &rsquo;none&rsquo;, and &rsquo;HK04 olivine hydration&rsquo;. HK04 olivine hydration calculates the viscosity change due to hydrogen incorporation into olivine following Hirth & Kohlstaedt 2004 (10.1029/138GM06). none does not modify the viscosity. Units: none.
+**Documentation:** Select what type of viscosity multiplicative prefactor scheme to apply. Allowed entries are &rsquo;none&rsquo;, and &rsquo;HK04 olivine hydration&rsquo;. HK04 olivine hydration calculates the viscosity change due to hydrogen incorporation into olivine following Hirth & Kohlstedt 2004 (10.1029/138GM06). none does not modify the viscosity. Units: none.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Viscosity ratios for Frank Kamenetskii<parameters:Material_20model/Visco_20Plastic/Viscosity_20ratios_20for_20Frank_20Kamenetskii>`

--- a/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
@@ -83,7 +83,7 @@ namespace aspect
            * parse_parameters() function. Users can choose between different schemes.
            * none: no viscosity change
            * hk04_olivine_hydration: calculate the viscosity change due to hydrogen
-           * incorporation into olivine using Hirth & Kohlstaedt 2004 10.1029/138GM06.
+           * incorporation into olivine using Hirth & Kohlstedt 2004 10.1029/138GM06.
            * This method requires a composition called 'bound_fluid' which tracks the wt%
            * water in the solid, which is used to compute an atomic ratio of H/Si ppm
            * assuming 90 mol% forsterite and 10 mol% fayalite, and finally calculates
@@ -103,7 +103,7 @@ namespace aspect
           std::vector<double> dislocation_water_fugacity_exponents;
           std::vector<double> minimum_mass_fraction_water_for_dry_creep;
 
-          // From Hirth & Kohlstaedt 2004, equation 6
+          // From Hirth & Kohlstedt 2004, equation 6
           const double A_H2O = 2.6e-5; // 1/Pa
           const double activation_energy_H2O = 40e3; // J/mol/K
           const double activation_volume_H2O = 10e-6; // m^3/mol

--- a/source/material_model/rheology/compositional_viscosity_prefactors.cc
+++ b/source/material_model/rheology/compositional_viscosity_prefactors.cc
@@ -61,7 +61,7 @@ namespace aspect
             {
               // We calculate the atomic H/Si ppm (C_OH) at each point to compute the water fugacity of
               // olivine assuming a composition of 90 mol% Forsterite and 10 mol% Fayalite from Hirth
-              // and Kohlstaedt 2004 10.1029/138GM06.
+              // and Kohlstedt 2004 10.1029/138GM06.
               const double temperature_for_fugacity = (this->simulator_is_past_initialization())
                                                       ?
                                                       in.temperature[q]
@@ -106,7 +106,7 @@ namespace aspect
                            "The minimum water content for the HK04 olivine hydration viscosity "
                            "prefactor scheme. This acts as the cutoff between 'dry' creep and 'wet' creep "
                            "for olivine, and the default value is chosen based on the value reported by "
-                           "Hirth & Kohlstaedt 2004. For a mass fraction of bound water beneath this value, "
+                           "Hirth & Kohlstedt 2004. For a mass fraction of bound water beneath this value, "
                            "this value is used instead to compute the water fugacity. Units: \\si{\\kg} / \\si{\\kg} %.");
 
         prm.declare_entry ("Water fugacity exponents for diffusion creep", "0.0",
@@ -134,7 +134,7 @@ namespace aspect
                            "Select what type of viscosity multiplicative prefactor scheme to apply. "
                            "Allowed entries are 'none', and 'HK04 olivine hydration'. HK04 olivine "
                            "hydration calculates the viscosity change due to hydrogen incorporation "
-                           "into olivine following Hirth & Kohlstaedt 2004 (10.1029/138GM06). none "
+                           "into olivine following Hirth & Kohlstedt 2004 (10.1029/138GM06). none "
                            "does not modify the viscosity. Units: none.");
       }
 


### PR DESCRIPTION
While reviewing a PR, I noticed that we are using a spelling mistake in the author's last name. This PR fixes it. 