### PR TITLE
Build fastscape in dealii master tester image

### DIFF
--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /opt && \
     git checkout coupling_dev && \
     mkdir build && \
     cd build && \
-    cmake -DBUILD_FASTSCAPELIB_SHARED=ON .. && \
+    /opt/cmake-3.26.4-linux-x86_64/bin/cmake -DBUILD_FASTSCAPELIB_SHARED=ON .. && \
     make
 
 # Set environment variables for this image to be used

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-LABEL maintainer <rene.gassmoeller@mailbox.org>
+LABEL maintainer=<rene.gassmoeller@mailbox.org>
 
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -yq && \
   DEBIAN_FRONTEND=noninteractive apt install -yq --no-install-recommends \
@@ -37,9 +37,9 @@ RUN cd /opt && \
 # Set environment variables for this image to be used
 # by Github Actions
 ENV PATH="/opt/astyle-2.04:/opt/cmake-3.26.4-linux-x86_64/bin:$PATH"
-ENV DEAL_II_DIR /opt/deal.II-master
-ENV FASTSCAPE_DIR /opt/fastscapelib-fortran/build
-ENV NETCDF_DIR /opt/netcdf-4.7.4
+ENV DEAL_II_DIR=/opt/deal.II-master
+ENV FASTSCAPE_DIR=/opt/fastscapelib-fortran/build
+ENV NETCDF_DIR=/opt/netcdf-4.7.4
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 ENV OMPI_MCA_mpi_yield_when_idle=1
 ENV OMPI_MCA_rmaps_base_oversubscribe=1

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -25,10 +25,20 @@ RUN cd /opt && \
     ./candi.sh -p /opt -j4 && \
     rm -rf /opt/tmp
 
+# Install FastScape for ASPECT
+RUN cd /opt && \
+    git clone https://github.com/Djneu/fastscapelib-fortran.git && \
+    cd fastscapelib-fortran  && \
+    mdkir build && \
+    cd build && \
+    cmake -DBUILD_FASTSCAPELIB_SHARED=ON .. && \
+    make
+
 # Set environment variables for this image to be used
 # by Github Actions
 ENV PATH="/opt/astyle-2.04:/opt/cmake-3.26.4-linux-x86_64/bin:$PATH"
 ENV DEAL_II_DIR /opt/deal.II-master
+ENV FASTSCAPE_DIR /opt/fastscapelib-fortran/build
 ENV NETCDF_DIR /opt/netcdf-4.7.4
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 ENV OMPI_MCA_mpi_yield_when_idle=1

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -30,7 +30,7 @@ RUN cd /opt && \
     git clone https://github.com/Djneu/fastscapelib-fortran.git && \
     cd fastscapelib-fortran  && \
     git checkout coupling_dev && \
-    mdkir build && \
+    mkdir build && \
     cd build && \
     cmake -DBUILD_FASTSCAPELIB_SHARED=ON .. && \
     make

--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -29,6 +29,7 @@ RUN cd /opt && \
 RUN cd /opt && \
     git clone https://github.com/Djneu/fastscapelib-fortran.git && \
     cd fastscapelib-fortran  && \
+    git checkout coupling_dev && \
     mdkir build && \
     cd build && \
     cmake -DBUILD_FASTSCAPELIB_SHARED=ON .. && \


### PR DESCRIPTION
This PR clones our dev branch of FastScape (so not the archived official branch yet) and installs it for the master dealii docker image. The tests linux workflow then installs ASPECT with FastScape. 

Despite setting the env var FASTSCAPE_DIR, locally I still had to pass the directory of the FastScape install as a cmake flag, so I've done that here as well.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
