### PR TITLE
Compile against Fastscape on dealii master image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,16 +118,19 @@ jobs:
       matrix:
         include:
           - image: "geodynamics/aspect-tester:jammy-dealii-9.6-v2"
+            build-with-fastscape: "OFF"
             run-tests: "ON"
             compare-tests: "ON"
             result-file: "changes-test-results-9.6.diff"
             container-options: '--user 0 --name container'
           - image: "geodynamics/aspect-tester:jammy-dealii-9.7-v3"
+            build-with-fastscape: "OFF"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-9.7.diff"
             container-options: '--user 0 --name container'
           - image: "geodynamics/aspect-tester:jammy-dealii-master"
+            build-with-fastscape: "ON"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-master.diff"
@@ -151,6 +154,8 @@ jobs:
         -D ASPECT_TEST_GENERATOR='Ninja' \
         -D ASPECT_PRECOMPILE_HEADERS=ON \
         -D ASPECT_UNITY_BUILD=ON \
+        -D ASPECT_WITH_FASTSCAPE='${{ matrix.build-with-fastscape }}' \
+        -D FASTSCAPE_DIR="$FASTSCAPE_DIR" \
         -D ASPECT_RUN_ALL_TESTS='${{ matrix.run-tests }}' \
         -D ASPECT_COMPARE_TEST_RESULTS='${{ matrix.compare-tests }}' \
         -D CMAKE_UNITY_BUILD_BATCH_SIZE=8 \


### PR DESCRIPTION
This PR includes CMake flags that link to FastScape during installation on the dealii master image.
It now checks which dealii image from the matrix is used to determine the CMake flags, but I'll look into changing the CMake FastScape settings so that CMake could pick up on FastScape automatically.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
