### PR TITLE
Only get basement and silt_fraction once, get silt_fraction component

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -510,12 +510,15 @@ namespace aspect
           std::vector<double> combined_kf(fastscape_array_size);
           std::vector<double> basement(fastscape_array_size);
           std::vector<double> silt_fraction(fastscape_array_size);
+          fastscape_copy_basement_(basement.data());
+          if (use_marine_component)
+            fastscape_copy_f_(silt_fraction.data());
+
           for (unsigned int i = 0; i < fastscape_array_size; ++i)
             {
               // For cells above sea level, grep the continental erosion parameters.
               if (elevation[i] >= current_sea_level || !use_marine_component)
                 {
-                  fastscape_copy_basement_(basement.data());
                   const double sediment_thickness = elevation[i] - basement[i];
 
                   // The same incision rate is used for sediments as for bedrock
@@ -547,7 +550,6 @@ namespace aspect
               else if (elevation[i] < current_sea_level && use_marine_component)
                 {
                   combined_kf[i] = numbers::signaling_nan<double>();
-                  fastscape_copy_f_(silt_fraction.data());
                   // The silt fraction represents the fraction of silt out of the
                   // total marine sediments (i.e., silt / (sand + silt)).
                   // Note that Fastscape does not know about the marine background
@@ -555,7 +557,7 @@ namespace aspect
                   // The combined marine diffusion coefficient is an approximation
                   // of the actual diffusion, which is solved for both sediment
                   // types separately in Fastscape.
-                  const double marine_diffusion_coefficient = silt_fraction * silt_transport_coefficient + (1. - silt_fraction) * sand_transport_coefficient;
+                  const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient + (1. - silt_fraction[i]) * sand_transport_coefficient;
                   combined_kd[i] = marine_diffusion_coefficient;
                 }
               else


### PR DESCRIPTION
In #6984 I realized I introduced a bug in #6964. Also, there is no need to get the FastScape data in the loop, we can get it once.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
