### PR TITLE
Experimental Tpetra support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,19 +123,27 @@ jobs:
             compare-tests: "ON"
             result-file: "changes-test-results-9.6.diff"
             container-options: '--user 0 --name container'
+            use-tpetra: "OFF"
           - image: "geodynamics/aspect-tester:jammy-dealii-9.7-v3"
             build-with-fastscape: "OFF"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-9.7.diff"
             container-options: '--user 0 --name container'
+            use-tpetra: "OFF"
           - image: "geodynamics/aspect-tester:jammy-dealii-master"
             build-with-fastscape: "ON"
             run-tests: "ON"
             compare-tests: "OFF"
             result-file: "changes-test-results-master.diff"
             container-options: '--user 0 --name container'
-
+            use-tpetra: "OFF"
+          - image: "geodynamics/aspect-tester:jammy-dealii-master"
+            run-tests: "ON"
+            compare-tests: "OFF"
+            result-file: "changes-test-results-master-tpetra.diff"
+            container-options: '--user 0 --name container'
+            use-tpetra: "ON"
     container: 
       image: ${{ matrix.image }}
       options: ${{ matrix.container-options }}
@@ -158,6 +166,7 @@ jobs:
         -D FASTSCAPE_DIR="$FASTSCAPE_DIR" \
         -D ASPECT_RUN_ALL_TESTS='${{ matrix.run-tests }}' \
         -D ASPECT_COMPARE_TEST_RESULTS='${{ matrix.compare-tests }}' \
+        -D ASPECT_USE_TPETRA='${{ matrix.use-tpetra }}' \
         -D CMAKE_UNITY_BUILD_BATCH_SIZE=8 \
         ..
         ninja -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 # Some other ASPECT configuration options:
 set(ASPECT_MAX_NUM_PARTICLE_SYSTEMS 2 CACHE STRING "The maximum number of particle systems supported at runtime.")
 
-set(ASPECT_USE_TPETRA OFF CACHE BOOL "If ON, use Tpetra classes of Trilinos. Requires a suitable Trilinos and deal.II.")
+set(ASPECT_USE_TPETRA OFF CACHE BOOL "If ON, use Tpetra packages in Trilinos. Requires a Trilinos with Tpetra support and deal.II version 9.8.0 or newer.")
 
 
 # ##############################################################################
@@ -124,29 +124,6 @@ endif()
 
 message(STATUS "Found deal.II version ${DEAL_II_PACKAGE_VERSION} at '${deal.II_DIR}'")
 
-if (ASPECT_USE_TPETRA)
-  message(STATUS "Using ASPECT_USE_TPETRA = '${ASPECT_USE_TPETRA}'")
-
-  if (NOT DEAL_II_TRILINOS_WITH_TPETRA OR NOT DEAL_II_TRILINOS_WITH_TPETRA_MUELU)
-      message(SEND_ERROR
-        "\n-- deal.II was built without support for Tpetra!\n"
-        )
-      set(_DEALII_GOOD OFF)
-  endif()
-
-  if (NOT ${DEAL_II_PACKAGE_VERSION} VERSION_GREATER_EQUAL 9.8.0)
-    message(SEND_ERROR
-          "\n-- Tpetra support is only available for deal.II versions greater or equal to 9.8.0!\n"
-          )
-        set(_DEALII_GOOD OFF)
-  endif()
-
-  message(SEND_ERROR
-      "\n-- Tpetra support is not yet complete. Only remove this check if you want to test Tpetra support.\n"
-      )
-    set(_DEALII_GOOD OFF)
-endif()
-
 set(_DEALII_GOOD ON)
 
 if(NOT DEAL_II_WITH_P4EST)
@@ -162,6 +139,58 @@ if(NOT DEAL_II_WITH_TRILINOS)
       )
     set(_DEALII_GOOD OFF)
 endif()
+
+# Determine if Trilinos provides all necessary packages
+if (${DEAL_II_PACKAGE_VERSION} VERSION_GREATER_EQUAL 9.8.0)
+  if (NOT DEAL_II_TRILINOS_WITH_TPETRA AND NOT DEAL_II_TRILINOS_WITH_EPETRA)
+    message(SEND_ERROR
+          "\n-- deal.II reports that Trilinos neither supports the Epetra nor the Tpetra stack. One of the two needs to be available!\n"
+          )
+        set(_DEALII_GOOD OFF)
+  endif()
+
+  # If Epetra is not available, always use Tpetra even if the user did not request it
+  if (NOT ASPECT_USE_TPETRA AND NOT DEAL_II_TRILINOS_WITH_EPETRA)
+    message(STATUS "Forcing ASPECT_USE_TPETRA=ON because Epetra support is unavailable.")
+    set(ASPECT_USE_TPETRA ON CACHE BOOL
+      "If ON, use the Tpetra packages in Trilinos. Requires a Trilinos with Tpetra support and deal.II version 9.8.0 or newer." FORCE)
+  endif()
+
+  # Now check if the selected package is actually available
+  if (ASPECT_USE_TPETRA)
+    if (NOT DEAL_II_TRILINOS_WITH_TPETRA)
+      message(SEND_ERROR
+        "\n-- deal.II was built without support for Trilinos Tpetra although it is required. This is not supported. \n"
+        )
+      set(_DEALII_GOOD OFF)
+    endif()
+    if (NOT DEAL_II_TRILINOS_WITH_TPETRA_MUELU)
+      message(SEND_ERROR
+        "\n-- deal.II was built without support for MueLu in Tpetra although it is required. This is not supported. \n"
+        )
+      set(_DEALII_GOOD OFF)
+    endif()
+  else()
+    if (NOT DEAL_II_TRILINOS_WITH_EPETRA)
+      message(SEND_ERROR
+        "\n-- deal.II was built without support for Trilinos Epetra although it is required. This is not supported. \n"
+        )
+      set(_DEALII_GOOD OFF)
+    endif()
+  endif()
+
+# deal.II older than 9.8.0 means we can only use Epetra, and Epetra is always
+# available if DEAL_II_WITH_TRILINOS is true, which was checked above.
+else()
+  if (ASPECT_USE_TPETRA)
+      message(SEND_ERROR
+            "\n-- Tpetra support is only available for deal.II versions greater or equal to 9.8.0!\n"
+            )
+      set(_DEALII_GOOD OFF)
+  endif()
+endif()
+
+message(STATUS "Using ASPECT_USE_TPETRA = '${ASPECT_USE_TPETRA}'")
 
 if(NOT DEAL_II_WITH_SUNDIALS)
     message(SEND_ERROR

--- a/doc/modules/changes/20260526_gassmoeller
+++ b/doc/modules/changes/20260526_gassmoeller
@@ -1,0 +1,9 @@
+New: ASPECT can now use the Tpetra packages provided by
+Trilinos if configured with deal.II 9.8.0 or higher.
+This means ASPECT can now use Trilinos 17 for its vector,
+matrix, and solver types. While accuracy and compatibility
+have been confirmed, performance may deteriorate
+compared to the older Epetra packages, until solver
+parameters have been investigated and tuned.
+<br>
+(Rene Gassmoeller, 2026/05/26)


### PR DESCRIPTION
With the changes in #6985 all ASPECT tests now finish the tester system that we also use for the deal.II development version when using the Tpetra vectors and solvers. I have also checked that the solkz and solcx results are similar in accuracy, which they are and the overall test output differences between Epetra and Tpetra solutions are reasonably small (see https://github.com/gassmoeller/aspect/tree/tpetra_test_differences). However, solver performance is another matter, sometimes the Tpetra Stokes solver needs many more iterations than the Epetra based solver (in particular for the Stokes equation, advection is almost equal), I have not checked runtime or scalability yet.

But by now it could be safe to enable using Tpetra, if the user requests it, or the user builds deal.II without Epetra (essentially equal to using Trilinos 17). But we could also keep this PR open for a while. I think eventually someone will have to spend a bit of time with the Stokes solver parameters and check if we should adjust any for Tpetra (similar to the experiments in https://github.com/geodynamics/aspect/pull/234).