### PR TITLE
Manual cleanup

### DIFF
--- a/doc/make_si_html.py
+++ b/doc/make_si_html.py
@@ -1,0 +1,72 @@
+import re
+from glob import glob
+
+si_units_map = {
+    r"\meter"    : "m",
+    r"\kilogram" : "kg",
+    r"\second"   : "s",
+    r"\joule"    : "J",
+    r"\kilo"     : "k",
+    r"\pascal"   : "Pa",
+    r"\kelvin"   : "K",
+    r"\watt"     : "W",
+    r"\mole"     : "mol",
+}
+
+def get_source_files(source_dir):
+    pattern = f"{source_dir}/**/*.cc"
+    return glob(pattern, recursive=True)
+
+
+def si_to_md(sym, exp):
+    # define how we want to format the symbol if
+    # an exponent is there
+    # put the exponent in braces for -ve exponents
+    # so that the minus sign is included.
+    if exp:
+        return rf"\\text{{{sym}}}^{{{exp}}}"   
+    return rf"\\text{{{sym}}}"
+
+
+def parse_units(content, units_map):
+    # we first find all \si{...} occurrences and extract the content inside
+    si_units = re.findall(r"\\si\{([^}]*)\}", content)
+
+    for si_unit in si_units:
+        # target defines the list of (symbol, exponent) tuples 
+        # we want to convert to markdown
+        target   = []
+        in_denom = False
+        units = re.findall(r"\\[a-zA-Z]+", si_unit)
+
+        # for each of si_unit, i.e., \\per\\meter\\squared, 
+        # convert  tuples, e.g., [("m", "-2")]
+        for unit in units:
+            match = units_map.get(unit, None)
+            if unit == r"\per":
+                in_denom = True
+            elif unit in (r"\squared", r"\cubed"):
+                # apply exponent to the last unit added
+                # if it is in denominator, make exponent negative
+                exp = "2" if unit == r"\squared" else "3"
+                if in_denom:
+                    exp = str(int(exp) * -1)
+                if target:
+                    target[-1] = (target[-1][0], exp)
+            elif match:
+                exp = -1 if in_denom else None
+                target.append((match, exp))
+
+        md_string = "".join(si_to_md(sym, exp) for sym, exp in target)
+        content = content.replace(f"\\\\si{{{si_unit}}}", f"${md_string}$")
+
+    return content
+
+filenames = get_source_files("/home/arushi/opt/aspect/source/")
+
+for filename in filenames:
+    with open(filename, 'r') as f:
+        content = f.read()
+
+    with open(filename, 'w') as f:
+        f.write(parse_units(content, si_units_map))

--- a/doc/sphinx/parameters/Boundary_20convective_20heating_20model.md
+++ b/doc/sphinx/parameters/Boundary_20convective_20heating_20model.md
@@ -76,7 +76,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [MultipleSelection function ]
 
-**Documentation:** A comma-separated list of boundary convective heating models that will be used to determine the heat transfer coefficient across the boundary. The heat transfer coefficient characterises the heat exchange between the solid model interior and an adjacent fluid. In the context of a Robin boundary condition, the heat transfer coefficient governs the strength of the convective coupling: For heat transfer coefficient --> zero, the boundary approaches insulating (Neumann) behaviour; For heat transfer coefficient --> infinity, the boundary approaches a prescribed-temperature (Dirichlet) condition. The unit of the heat transfer coefficient is \si{\watt\per\meter\squared\per\kelvin}.At the moment, this list can only have one entry.
+**Documentation:** A comma-separated list of boundary convective heating models that will be used to determine the heat transfer coefficient across the boundary. The heat transfer coefficient characterises the heat exchange between the solid model interior and an adjacent fluid. In the context of a Robin boundary condition, the heat transfer coefficient governs the strength of the convective coupling: For heat transfer coefficient --> zero, the boundary approaches insulating (Neumann) behaviour; For heat transfer coefficient --> infinity, the boundary approaches a prescribed-temperature (Dirichlet) condition. The unit of the heat transfer coefficient is $\text{W}\text{m}^{-2}\text{K}^{-1}$.At the moment, this list can only have one entry.
 
 The following heat transfer coefficient models are available:
 

--- a/doc/sphinx/parameters/Boundary_20temperature_20model.md
+++ b/doc/sphinx/parameters/Boundary_20temperature_20model.md
@@ -304,7 +304,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Pressure at CMB. Units: \si{\pascal}.
+**Documentation:** Pressure at CMB. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Core conductivity<parameters:Boundary_20temperature_20model/Dynamic_20core/Core_20conductivity>`
@@ -376,7 +376,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The latent heat of core freeze. Units: \si{\joule\per\kilogram}.
+**Documentation:** The latent heat of core freeze. Units: $\text{J}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Max iteration<parameters:Boundary_20temperature_20model/Dynamic_20core/Max_20iteration>`
@@ -403,7 +403,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The heat of reaction. Units: \si{\joule\per\kilogram}.
+**Documentation:** The heat of reaction. Units: $\text{J}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Rho0<parameters:Boundary_20temperature_20model/Dynamic_20core/Rho0>`
@@ -421,7 +421,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Initial inner core radius changing rate. Units: \si{\kilo\meter}/year.
+**Documentation:** Initial inner core radius changing rate. Units: $\text{k}\text{m}$/year.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`dT over dt<parameters:Boundary_20temperature_20model/Dynamic_20core/dT_20over_20dt>`
@@ -477,7 +477,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Melting curve ({cite}`NPB+04` eq. (40)) parameter Tm1. Units: \si{\per\pascal}.
+**Documentation:** Melting curve ({cite}`NPB+04` eq. (40)) parameter Tm1. Units: $\text{Pa}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Tm2<parameters:Boundary_20temperature_20model/Dynamic_20core/Geotherm_20parameters/Tm2>`
@@ -486,7 +486,7 @@ Because this class simply takes what the initial temperature had described, this
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Melting curve ({cite}`NPB+04` eq. (40)) parameter Tm2. Units: \si{\per\pascal\squared}.
+**Documentation:** Melting curve ({cite}`NPB+04` eq. (40)) parameter Tm2. Units: $\text{Pa}^{-2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Use BW11<parameters:Boundary_20temperature_20model/Dynamic_20core/Geotherm_20parameters/Use_20BW11>`

--- a/doc/sphinx/parameters/Boundary_20traction_20model.md
+++ b/doc/sphinx/parameters/Boundary_20traction_20model.md
@@ -183,5 +183,5 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The point where the pressure profile will be calculated. Cartesian coordinates $(x,y,z)$ when geometry is a box, otherwise enter radius, longitude, and in 3d latitude. Note that the coordinate related to the depth ($y$ in 2d Cartesian, $z$ in 3d Cartesian and radius in spherical coordinates) is not used. Units: \si{\meter} or degrees.
+**Documentation:** The point where the pressure profile will be calculated. Cartesian coordinates $(x,y,z)$ when geometry is a box, otherwise enter radius, longitude, and in 3d latitude. Note that the coordinate related to the depth ($y$ in 2d Cartesian, $z$ in 3d Cartesian and radius in spherical coordinates) is not used. Units: $\text{m}$ or degrees.
 ::::

--- a/doc/sphinx/parameters/Geometry_20model.md
+++ b/doc/sphinx/parameters/Geometry_20model.md
@@ -60,7 +60,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** X coordinate of box origin. Units: \si{\meter}.
+**Documentation:** X coordinate of box origin. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Box origin Y coordinate<parameters:Geometry_20model/Box/Box_20origin_20Y_20coordinate>`
@@ -69,7 +69,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Y coordinate of box origin. Units: \si{\meter}.
+**Documentation:** Y coordinate of box origin. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Box origin Z coordinate<parameters:Geometry_20model/Box/Box_20origin_20Z_20coordinate>`
@@ -78,7 +78,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: \si{\meter}.
+**Documentation:** Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`X extent<parameters:Geometry_20model/Box/X_20extent>`
@@ -87,7 +87,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in x-direction. Units: \si{\meter}.
+**Documentation:** Extent of the box in x-direction. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`X periodic<parameters:Geometry_20model/Box/X_20periodic>`
@@ -114,7 +114,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in y-direction. Units: \si{\meter}.
+**Documentation:** Extent of the box in y-direction. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Y periodic<parameters:Geometry_20model/Box/Y_20periodic>`
@@ -141,7 +141,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: \si{\meter}.
+**Documentation:** Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Z periodic<parameters:Geometry_20model/Box/Z_20periodic>`
@@ -170,7 +170,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** X coordinate of box origin. Units: \si{\meter}.
+**Documentation:** X coordinate of box origin. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Box origin Y coordinate<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Box_20origin_20Y_20coordinate>`
@@ -179,7 +179,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Y coordinate of box origin. Units: \si{\meter}.
+**Documentation:** Y coordinate of box origin. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Box origin Z coordinate<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Box_20origin_20Z_20coordinate>`
@@ -188,7 +188,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: \si{\meter}.
+**Documentation:** Z coordinate of box origin. This value is ignored if the simulation is in 2d. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithospheric thickness<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Lithospheric_20thickness>`
@@ -215,7 +215,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in x-direction. Units: \si{\meter}.
+**Documentation:** Extent of the box in x-direction. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`X periodic<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/X_20periodic>`
@@ -251,7 +251,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in y-direction. Units: \si{\meter}.
+**Documentation:** Extent of the box in y-direction. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Y periodic<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Y_20periodic>`
@@ -296,7 +296,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: \si{\meter}.
+**Documentation:** Extent of the box in z-direction. This value is ignored if the simulation is in 2d. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Z periodic<parameters:Geometry_20model/Box_20with_20lithosphere_20boundary_20indicators/Z_20periodic>`
@@ -334,7 +334,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius at the bottom surface of the chunk. Units: \si{\meter}.
+**Documentation:** Radius at the bottom surface of the chunk. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Chunk maximum latitude<parameters:Geometry_20model/Chunk/Chunk_20maximum_20latitude>`
@@ -379,7 +379,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius at the top surface of the chunk. Units: \si{\meter}.
+**Documentation:** Radius at the top surface of the chunk. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Latitude repetitions<parameters:Geometry_20model/Chunk/Latitude_20repetitions>`
@@ -417,7 +417,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius at the bottom surface of the chunk. Units: \si{\meter}.
+**Documentation:** Radius at the bottom surface of the chunk. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Chunk maximum latitude<parameters:Geometry_20model/Chunk_20with_20lithosphere_20boundary_20indicators/Chunk_20maximum_20latitude>`
@@ -444,7 +444,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius at the top surface of the lower chunk, where it merges with the upper chunk. Units: \si{\meter}.
+**Documentation:** Radius at the top surface of the lower chunk, where it merges with the upper chunk. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Chunk minimum latitude<parameters:Geometry_20model/Chunk_20with_20lithosphere_20boundary_20indicators/Chunk_20minimum_20latitude>`
@@ -471,7 +471,7 @@ In 3d, inner and outer indicators are treated as in 2d. If the opening angle is 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius at the top surface of the chunk. Units: \si{\meter}.
+**Documentation:** Radius at the top surface of the chunk. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Inner chunk radius repetitions<parameters:Geometry_20model/Chunk_20with_20lithosphere_20boundary_20indicators/Inner_20chunk_20radius_20repetitions>`
@@ -729,7 +729,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Radius of the sphere. Units: \si{\meter}.
+**Documentation:** Radius of the sphere. Units: $\text{m}$.
 ::::
 
 (parameters:Geometry_20model/Spherical_20shell)=
@@ -771,7 +771,7 @@ In either case, this parameter is ignored unless the opening angle of the domain
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Inner radius of the spherical shell. Units: \si{\meter}.
+**Documentation:** Inner radius of the spherical shell. Units: $\text{m}$.
 
 :::{note}
 The default value of 3,481,000 m equals the radius of a sphere with equal volume as Earth (i.e., 6371 km) minus the average depth of the core-mantle boundary (i.e., 2890 km).
@@ -784,7 +784,7 @@ The default value of 3,481,000 m equals the radius of a sphere with equal volume
 
 **Pattern:** [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** List of radial values for the custom mesh scheme. Units: $\si{m}$. A list of radial values subdivides the spherical shell at specified radii. The list must be strictly ascending, and the first value must be greater than the inner radius while the last must be less than the outer radius.
+**Documentation:** List of radial values for the custom mesh scheme. Units: $\text{m}$. A list of radial values subdivides the spherical shell at specified radii. The list must be strictly ascending, and the first value must be greater than the inner radius while the last must be less than the outer radius.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Number of slices<parameters:Geometry_20model/Spherical_20shell/Number_20of_20slices>`
@@ -811,7 +811,7 @@ The default value of 3,481,000 m equals the radius of a sphere with equal volume
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Outer radius of the spherical shell. Units: \si{\meter}.
+**Documentation:** Outer radius of the spherical shell. Units: $\text{m}$.
 
 :::{note}
 The default value of 6,336,000 m equals the radius of a sphere with equal volume as Earth (i.e., 6371 km) minus the average depth of the mantle-crust interface (i.e., 35 km).

--- a/doc/sphinx/parameters/Gravity_20model.md
+++ b/doc/sphinx/parameters/Gravity_20model.md
@@ -114,7 +114,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Magnitude of the radial gravity vector at the bottom of the domain. &lsquo;Bottom&rsquo; means themaximum depth in the chosen geometry, and for example represents the core-mantle boundary in the case of the &lsquo;spherical shell&rsquo; geometry model, and the center in the case of the &lsquo;sphere&rsquo; geometry model. Units: \si{\meter\per\second\squared}.
+**Documentation:** Magnitude of the radial gravity vector at the bottom of the domain. &lsquo;Bottom&rsquo; means themaximum depth in the chosen geometry, and for example represents the core-mantle boundary in the case of the &lsquo;spherical shell&rsquo; geometry model, and the center in the case of the &lsquo;sphere&rsquo; geometry model. Units: $\text{m}\text{s}^{-2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Magnitude at surface<parameters:Gravity_20model/Radial_20linear/Magnitude_20at_20surface>`
@@ -123,7 +123,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Magnitude of the radial gravity vector at the surface of the domain. Units: \si{\meter\per\second\squared}.
+**Documentation:** Magnitude of the radial gravity vector at the surface of the domain. Units: $\text{m}\text{s}^{-2}$.
 ::::
 
 (parameters:Gravity_20model/Vertical)=

--- a/doc/sphinx/parameters/Heating_20model.md
+++ b/doc/sphinx/parameters/Heating_20model.md
@@ -23,7 +23,7 @@ For full adiabatic heating, this has to be used in combination with the heating 
 
 &lsquo;anisotropic shear heating&rsquo;: Implementation of a standard model for shear heating extended for an anisotropic viscosity tensor. If the material model provides a stress-strain director tensor, then the strain-rate is multiplied with this tensor to compute the stress that is used when computing the shear heating.
 
-&lsquo;compositional heating&rsquo;: Implementation of a model in which magnitude of internal heat production is determined from fixed values assigned to each compositional field. These values are interpreted as having units \si{\watt\per\meter\cubed}.
+&lsquo;compositional heating&rsquo;: Implementation of a model in which magnitude of internal heat production is determined from fixed values assigned to each compositional field. These values are interpreted as having units $\text{W}\text{m}^{-3}$.
 
 &lsquo;constant heating&rsquo;: Implementation of a model in which the heating rate is constant.
 
@@ -80,7 +80,7 @@ The formula is interpreted as having units W/kg.
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** List of heat production per unit volume values for background and compositional fields, for a total of N+1 values, where the first value corresponds to the background material, and N is the number of compositional fields. Units: \si{\watt\per\meter\cubed}.
+**Documentation:** List of heat production per unit volume values for background and compositional fields, for a total of N+1 values, where the first value corresponds to the background material, and N is the number of compositional fields. Units: $\text{W}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Use compositional field for heat production averaging<parameters:Heating_20model/Compositional_20heating/Use_20compositional_20field_20for_20heat_20production_20averaging>`
@@ -191,7 +191,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Depth of the crust when crust if defined by depth. Units: \si{\meter}.
+**Documentation:** Depth of the crust when crust if defined by depth. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Half decay times<parameters:Heating_20model/Radioactive_20decay/Half_20decay_20times>`

--- a/doc/sphinx/parameters/Initial_20temperature_20model.md
+++ b/doc/sphinx/parameters/Initial_20temperature_20model.md
@@ -196,7 +196,7 @@ Make sure the top and bottom temperatures of the lithosphere agree with temperat
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the lithosphere for plate cooling model. \si{\m}
+**Documentation:** Thickness of the lithosphere for plate cooling model. $\text{m}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Position<parameters:Initial_20temperature_20model/Adiabatic/Position>`
@@ -329,7 +329,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the adiabatic temperature gradient. Units: \si{\kelvin\per\meter}.
+**Documentation:** The value of the adiabatic temperature gradient. Units: $\text{K}\text{m}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Initial_20temperature_20model/Adiabatic_20boundary/Data_20directory>`
@@ -488,7 +488,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** List of the 3 thicknesses of the lithospheric layers &rsquo;upper\_crust&rsquo;, &rsquo;lower\_crust&rsquo; and &rsquo;mantle\_lithosphere&rsquo;. If only one thickness is given, then the same thickness is used for all layers. Units: \si{meter}.
+**Documentation:** List of the 3 thicknesses of the lithospheric layers &rsquo;upper\_crust&rsquo;, &rsquo;lower\_crust&rsquo; and &rsquo;mantle\_lithosphere&rsquo;. If only one thickness is given, then the same thickness is used for all layers. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithosphere-Asthenosphere boundary isotherm<parameters:Initial_20temperature_20model/Continental_20geotherm/Lithosphere_2dAsthenosphere_20boundary_20isotherm>`
@@ -716,7 +716,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Units: \si{\meter}.The maximum depth of the lithosphere. The model will be NaNs below this depth.
+**Documentation:** Units: $\text{m}$.The maximum depth of the lithosphere. The model will be NaNs below this depth.
 ::::
 
 (parameters:Initial_20temperature_20model/Patch_20on_20S40RTS)=
@@ -803,7 +803,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The Gaussian RMS width of the perturbations. Units: \si{\meter}.
+**Documentation:** The Gaussian RMS width of the perturbations. Units: $\text{m}$.
 ::::
 
 (parameters:Initial_20temperature_20model/S40RTS_20perturbation)=

--- a/doc/sphinx/parameters/Material_20model.md
+++ b/doc/sphinx/parameters/Material_20model.md
@@ -250,7 +250,7 @@ Viscous stress may also be limited by a non-linear stress limiter that has a for
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of depths where the viscosity changes. Values must monotonically increase. Units: \si{\meter}.
+**Documentation:** A list of depths where the viscosity changes. Values must monotonically increase. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Use TALA<parameters:Material_20model/Ascii_20reference_20profile/Use_20TALA>`
@@ -680,7 +680,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\joule\per\mole}.
+**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation energies for dislocation creep<parameters:Material_20model/Diffusion_20dislocation/Activation_20energies_20for_20dislocation_20creep>`
@@ -689,7 +689,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\joule\per\mole}.
+**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for diffusion creep<parameters:Material_20model/Diffusion_20dislocation/Activation_20volumes_20for_20diffusion_20creep>`
@@ -698,7 +698,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for dislocation creep<parameters:Material_20model/Diffusion_20dislocation/Activation_20volumes_20for_20dislocation_20creep>`
@@ -707,7 +707,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Densities<parameters:Material_20model/Diffusion_20dislocation/Densities>`
@@ -734,7 +734,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The fixed grain size of the material. This grain size is only used if the parent material model does not provide its own (possibly variable) grain size when calling this rheology.Units: \si{\meter}.
+**Documentation:** The fixed grain size of the material. This grain size is only used if the parent material model does not provide its own (possibly variable) grain size when calling this rheology.Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain size exponents for diffusion creep<parameters:Material_20model/Diffusion_20dislocation/Grain_20size_20exponents_20for_20diffusion_20creep>`
@@ -779,7 +779,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Stabilizes strain dependent viscosity. Units: \si{\per\second}.
+**Documentation:** Stabilizes strain dependent viscosity. Units: $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum viscosity<parameters:Material_20model/Diffusion_20dislocation/Minimum_20viscosity>`
@@ -797,7 +797,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\per\pascal\meter}$^{m_{\text{diffusion}}}$\si{\per\second}.
+**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}^{-1}\text{m}^{-1}$$^{m_{\text{diffusion}}}$$\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for dislocation creep<parameters:Material_20model/Diffusion_20dislocation/Prefactors_20for_20dislocation_20creep>`
@@ -806,7 +806,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\pascal}$^{-n_{\text{dislocation}}}$ \si{\per\second}.
+**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}$$^{-n_{\text{dislocation}}}$ $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Diffusion_20dislocation/Reference_20temperature>`
@@ -851,7 +851,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Units: \si{\meter\squared\per\second}.
+**Documentation:** Units: $\text{m}^{2}\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal expansivities<parameters:Material_20model/Diffusion_20dislocation/Thermal_20expansivities>`
@@ -898,7 +898,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The reference temperature $T_0$. The reference temperature is used in the density calculation. Units: \si{\kelvin}.
+**Documentation:** The reference temperature $T_0$. The reference temperature is used in the density calculation. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal conductivity<parameters:Material_20model/Drucker_20Prager/Thermal_20conductivity>`
@@ -907,7 +907,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the thermal conductivity $k$. Units: \si{\watt\per\meter\per\kelvin}.
+**Documentation:** The value of the thermal conductivity $k$. Units: $\text{W}\text{m}^{-1}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal expansion coefficient<parameters:Material_20model/Drucker_20Prager/Thermal_20expansion_20coefficient>`
@@ -936,7 +936,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the cohesion $C$. Units: \si{\pascal}.
+**Documentation:** The value of the cohesion $C$. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Maximum viscosity<parameters:Material_20model/Drucker_20Prager/Viscosity/Maximum_20viscosity>`
@@ -945,7 +945,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the maximum viscosity cutoff $\eta_max$. Units: \si{\pascal\second}.
+**Documentation:** The value of the maximum viscosity cutoff $\eta_max$. Units: $\text{Pa}\text{s}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum viscosity<parameters:Material_20model/Drucker_20Prager/Viscosity/Minimum_20viscosity>`
@@ -954,7 +954,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the minimum viscosity cutoff $\eta_min$. Units: \si{\pascal\second}.
+**Documentation:** The value of the minimum viscosity cutoff $\eta_min$. Units: $\text{Pa}\text{s}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference strain rate<parameters:Material_20model/Drucker_20Prager/Viscosity/Reference_20strain_20rate>`
@@ -963,7 +963,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the initial strain rate prescribed during the first nonlinear iteration $\dot{\epsilon}_ref$. Units: \si{\per\second}.
+**Documentation:** The value of the initial strain rate prescribed during the first nonlinear iteration $\dot{\epsilon}_ref$. Units: $\text{s}^{-1}$.
 ::::
 
 (parameters:Material_20model/Entropy_20model)=
@@ -983,7 +983,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the cohesion, $C$. The extremely large defaultcohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: \si{\pascal}.
+**Documentation:** The value of the cohesion, $C$. The extremely large defaultcohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Material_20model/Entropy_20model/Data_20directory>`
@@ -1073,7 +1073,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of values that determine the linear scaling of the thermal conductivity with pressure. Units: \si{\watt\per\meter\per\kelvin\per\pascal}.
+**Documentation:** A list of values that determine the linear scaling of the thermal conductivity with pressure. Units: $\text{W}\text{m}^{-1}\text{K}^{-1}\text{Pa}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperatures for thermal conductivity<parameters:Material_20model/Entropy_20model/Reference_20temperatures_20for_20thermal_20conductivity>`
@@ -1102,7 +1102,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Documentation:** The viscosity that is used in this model.
 
-Units: \si{\pascal\second}
+Units: $\text{Pa}\text{s}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Saturation prefactors<parameters:Material_20model/Entropy_20model/Saturation_20prefactors>`
@@ -1147,7 +1147,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of depth values that indicate where the transitions between the different conductivity parameter sets should occur (in most cases, these will be the depths of major phase transitions). Units: \si{\meter}.
+**Documentation:** A list of depth values that indicate where the transitions between the different conductivity parameter sets should occur (in most cases, these will be the depths of major phase transitions). Units: $\text{m}$.
 ::::
 
 (parameters:Material_20model/Grain_20size_20model)=
@@ -1203,7 +1203,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The average specific grain boundary energy $\gamma$. List must have one more entry than the Phase transition depths. Units: \si{\joule\per\meter\squared}.
+**Documentation:** The average specific grain boundary energy $\gamma$. List must have one more entry than the Phase transition depths. Units: $\text{J}\text{m}^{-2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Bilinear interpolation<parameters:Material_20model/Grain_20size_20model/Bilinear_20interpolation>`
@@ -1221,7 +1221,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: \si{\pascal}.
+**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Material_20model/Grain_20size_20model/Data_20directory>`
@@ -1365,7 +1365,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The activation energy for grain growth $E_g$. List must have one more entry than the Phase transition depths. Units: \si{\joule\per\mole}.
+**Documentation:** The activation energy for grain growth $E_g$. List must have one more entry than the Phase transition depths. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain growth activation volume<parameters:Material_20model/Grain_20size_20model/Grain_20growth_20activation_20volume>`
@@ -1374,7 +1374,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The activation volume for grain growth $V_g$. List must have one more entry than the Phase transition depths. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** The activation volume for grain growth $V_g$. List must have one more entry than the Phase transition depths. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain growth exponent<parameters:Material_20model/Grain_20size_20model/Grain_20growth_20exponent>`
@@ -1392,7 +1392,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The prefactor for the Ostwald ripening grain growth law $G_0$. This is dependent on water content, which is assumed to be 50 H/$10^6$ Si for the default value. List must have one more entry than the Phase transition depths. Units: \si{\meter}$^{p_g}$\si{\per\second}.
+**Documentation:** The prefactor for the Ostwald ripening grain growth law $G_0$. This is dependent on water content, which is assumed to be 50 H/$10^6$ Si for the default value. List must have one more entry than the Phase transition depths. Units: $\text{m}$$^{p_g}$$\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain size evolution formulation<parameters:Material_20model/Grain_20size_20model/Grain_20size_20evolution_20formulation>`
@@ -1482,7 +1482,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: \si{\pascal}.
+**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum grain size<parameters:Material_20model/Grain_20size_20model/Minimum_20grain_20size>`
@@ -1491,7 +1491,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The minimum grain size that is used for the material model. This parameter is introduced to limit local viscosity contrasts, but still allows for a widely varying viscosity over the whole mantle range. Units: \si{\meter}.
+**Documentation:** The minimum grain size that is used for the material model. This parameter is introduced to limit local viscosity contrasts, but still allows for a widely varying viscosity over the whole mantle range. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum specific heat<parameters:Material_20model/Grain_20size_20model/Minimum_20specific_20heat>`
@@ -1527,7 +1527,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: \si{\pascal\per\kelvin}.
+**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $\text{Pa}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition depths<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20depths>`
@@ -1536,7 +1536,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: \si{\meter}.
+**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressure widths<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20pressure_20widths>`
@@ -1545,7 +1545,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressures<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20pressures>`
@@ -1554,7 +1554,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature lower limits<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20temperature_20lower_20limits>`
@@ -1563,7 +1563,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature upper limits<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20temperature_20upper_20limits>`
@@ -1572,7 +1572,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperatures<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20temperatures>`
@@ -1581,7 +1581,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: \si{\kelvin}.
+**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition widths<parameters:Material_20model/Grain_20size_20model/Phase_20transition_20widths>`
@@ -1590,7 +1590,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: \si{\meter}.
+**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase volume fraction<parameters:Material_20model/Grain_20size_20model/Phase_20volume_20fraction>`
@@ -1608,7 +1608,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: \si{\pascal\second}
+**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: $\text{Pa}\text{s}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for yield stress<parameters:Material_20model/Grain_20size_20model/Prefactors_20for_20yield_20stress>`
@@ -1635,7 +1635,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The grain size $d_{ph}$ to that a phase will be reduced to when crossing a phase transition. When set to zero, grain size will not be reduced. List must have the same number of entries as Phase transition depths. Units: \si{\meter}.
+**Documentation:** The grain size $d_{ph}$ to that a phase will be reduced to when crossing a phase transition. When set to zero, grain size will not be reduced. List must have the same number of entries as Phase transition depths. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference compressibility<parameters:Material_20model/Grain_20size_20model/Reference_20compressibility>`
@@ -1761,7 +1761,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The fraction $\chi$ of work done by dislocation creep to change the grain boundary area. List must have one more entry than the Phase transition depths. Units: \si{\joule\per\meter\squared}.
+**Documentation:** The fraction $\chi$ of work done by dislocation creep to change the grain boundary area. List must have one more entry than the Phase transition depths. Units: $\text{J}\text{m}^{-2}$.
 ::::
 
 (parameters:Material_20model/Grain_20size_20model/Grain_20damage_20partitioning)=
@@ -1837,7 +1837,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [List of <[Integer range 0...2147483647 (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of phases, which correspond to the Phase transition density jumps. The density jumps occur only in the phase that is given by this phase value. 0 stands for the 1st compositional fields, 1 for the second compositional field and -1 for none of them. List must have the same number of entries as Phase transition depths. Units: \si{\pascal\per\kelvin}.
+**Documentation:** A list of phases, which correspond to the Phase transition density jumps. The density jumps occur only in the phase that is given by this phase value. 0 stands for the 1st compositional fields, 1 for the second compositional field and -1 for none of them. List must have the same number of entries as Phase transition depths. Units: $\text{Pa}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Define transition by depth instead of pressure<parameters:Material_20model/Latent_20heat/Define_20transition_20by_20depth_20instead_20of_20pressure>`
@@ -1882,7 +1882,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: \si{\pascal\per\kelvin}.
+**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $\text{Pa}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition density jumps<parameters:Material_20model/Latent_20heat/Phase_20transition_20density_20jumps>`
@@ -1900,7 +1900,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: \si{\meter}.
+**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressure widths<parameters:Material_20model/Latent_20heat/Phase_20transition_20pressure_20widths>`
@@ -1909,7 +1909,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressures<parameters:Material_20model/Latent_20heat/Phase_20transition_20pressures>`
@@ -1918,7 +1918,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature lower limits<parameters:Material_20model/Latent_20heat/Phase_20transition_20temperature_20lower_20limits>`
@@ -1927,7 +1927,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature upper limits<parameters:Material_20model/Latent_20heat/Phase_20transition_20temperature_20upper_20limits>`
@@ -1936,7 +1936,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperatures<parameters:Material_20model/Latent_20heat/Phase_20transition_20temperatures>`
@@ -1945,7 +1945,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: \si{\kelvin}.
+**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition widths<parameters:Material_20model/Latent_20heat/Phase_20transition_20widths>`
@@ -1954,7 +1954,7 @@ Units: \si{\pascal\second}
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: \si{\meter}.
+**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference density<parameters:Material_20model/Latent_20heat/Reference_20density>`
@@ -2747,7 +2747,7 @@ Also note that the melting time scale has to be larger than or equal to the reac
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference permeability of the solid host rock.Units: \si{\meter\squared}.
+**Documentation:** Reference permeability of the solid host rock.Units: $\text{m}^{2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference shear viscosity<parameters:Material_20model/Melt_20global/Reference_20shear_20viscosity>`
@@ -2992,7 +2992,7 @@ Also note that the melting time scale has to be larger than or equal to the reac
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Depth above that melt will be extracted from the model, which is done by a negative reaction term proportional to the porosity field. Units: \si{\meter}.
+**Documentation:** Depth above that melt will be extracted from the model, which is done by a negative reaction term proportional to the porosity field. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Melting time scale for operator splitting<parameters:Material_20model/Melt_20simple/Melting_20time_20scale_20for_20operator_20splitting>`
@@ -3048,7 +3048,7 @@ Also note that the melting time scale has to be larger than or equal to the reac
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference permeability of the solid host rock.Units: \si{\meter\squared}.
+**Documentation:** Reference permeability of the solid host rock.Units: $\text{m}^{2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference shear viscosity<parameters:Material_20model/Melt_20simple/Reference_20shear_20viscosity>`
@@ -3214,7 +3214,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The isothermal bulk modulus at the reference pressure and temperature. Units: \si{\pascal}.
+**Documentation:** The isothermal bulk modulus at the reference pressure and temperature. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference pressure<parameters:Material_20model/Modified_20Tait_20model/Reference_20pressure>`
@@ -3223,7 +3223,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference pressure $P_0$. Units: \si{\pascal}.
+**Documentation:** Reference pressure $P_0$. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Modified_20Tait_20model/Reference_20temperature>`
@@ -3301,7 +3301,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\kilogram\per\meter\cubed}.
+**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{kg}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Heat capacities<parameters:Material_20model/Multicomponent/Heat_20capacities>`
@@ -3310,7 +3310,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\joule\per\kelvin\per\kilogram}.
+**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{J}\text{K}^{-1}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Multicomponent/Reference_20temperature>`
@@ -3344,7 +3344,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\per\kelvin}.
+**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Viscosities<parameters:Material_20model/Multicomponent/Viscosities>`
@@ -3391,7 +3391,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of isochoric specific heats for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\joule\per\kelvin\per\kilogram}.
+**Documentation:** List of isochoric specific heats for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{J}\text{K}^{-1}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Isothermal bulk modulus pressure derivatives<parameters:Material_20model/Multicomponent_20compressible/Isothermal_20bulk_20modulus_20pressure_20derivatives>`
@@ -3409,7 +3409,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: \si{\pascal\per\kelvin}.
+**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $\text{Pa}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition depths<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20depths>`
@@ -3418,7 +3418,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: \si{\meter}.
+**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressure widths<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20pressure_20widths>`
@@ -3427,7 +3427,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressures<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20pressures>`
@@ -3436,7 +3436,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature lower limits<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20temperature_20lower_20limits>`
@@ -3445,7 +3445,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature upper limits<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20temperature_20upper_20limits>`
@@ -3454,7 +3454,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperatures<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20temperatures>`
@@ -3463,7 +3463,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: \si{\kelvin}.
+**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition widths<parameters:Material_20model/Multicomponent_20compressible/Phase_20transition_20widths>`
@@ -3472,7 +3472,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: \si{\meter}.
+**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference densities<parameters:Material_20model/Multicomponent_20compressible/Reference_20densities>`
@@ -3481,7 +3481,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of reference densities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\kilogram\per\meter\cubed}.
+**Documentation:** List of reference densities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{kg}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference isothermal compressibilities<parameters:Material_20model/Multicomponent_20compressible/Reference_20isothermal_20compressibilities>`
@@ -3490,7 +3490,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of isothermal compressibilities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\per\pascal}.
+**Documentation:** List of isothermal compressibilities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{Pa}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperatures<parameters:Material_20model/Multicomponent_20compressible/Reference_20temperatures>`
@@ -3499,7 +3499,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of reference temperatures $T_0$ for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\kelvin}.
+**Documentation:** List of reference temperatures $T_0$ for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference thermal expansivities<parameters:Material_20model/Multicomponent_20compressible/Reference_20thermal_20expansivities>`
@@ -3508,7 +3508,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of reference thermal expansivities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\per\kelvin}.
+**Documentation:** List of reference thermal expansivities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal conductivities<parameters:Material_20model/Multicomponent_20compressible/Thermal_20conductivities>`
@@ -3517,7 +3517,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of thermal conductivities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\watt\per\meter\per\kelvin}.
+**Documentation:** List of thermal conductivities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{W}\text{m}^{-1}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Viscosities<parameters:Material_20model/Multicomponent_20compressible/Viscosities>`
@@ -3526,7 +3526,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: \si{\pascal\second}.
+**Documentation:** List of viscosities for background and compositional fields (N), for a total of N+1 values for models with no phase transitions (or models where the value does not change across any of the phase transitions). For models with phase transitions, the list needs to contain each field name, including the background, for a total of N+1 names, and for each of these names, specify the value for each phase (giving P_c+1 values for each field, with P_c being the number of phase transitions for field c). Therefore, the total number of values given is N+P+1, with P = sum(P_c) the total number of phase transitions, summed over all phases. The format is background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. If only one value is given, then all fields/phases use the same value. Units: $\text{Pa}\text{s}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Viscosity averaging scheme<parameters:Material_20model/Multicomponent_20compressible/Viscosity_20averaging_20scheme>`
@@ -3620,7 +3620,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the maximum pressure used to query PerpleX. Units: \si{\pascal}.
+**Documentation:** The value of the maximum pressure used to query PerpleX. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Maximum material temperature<parameters:Material_20model/PerpleX_20lookup_20model/Maximum_20material_20temperature>`
@@ -3638,7 +3638,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The value of the minimum pressure used to query PerpleX. Units: \si{\pascal}.
+**Documentation:** The value of the minimum pressure used to query PerpleX. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum material temperature<parameters:Material_20model/PerpleX_20lookup_20model/Minimum_20material_20temperature>`
@@ -3827,7 +3827,7 @@ Also note that the fluid reaction time scale has to be larger than or equal to t
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference density of the melt/fluid$\rho_{f,0}$. Units: \si{\kilogram\per\meter\cubed}.
+**Documentation:** Reference density of the melt/fluid$\rho_{f,0}$. Units: $\text{kg}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference fluid viscosity<parameters:Material_20model/Reactive_20Fluid_20Transport_20Model/Reference_20fluid_20viscosity>`
@@ -3845,7 +3845,7 @@ Also note that the fluid reaction time scale has to be larger than or equal to t
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference permeability of the solid host rock.Units: \si{\meter\squared}.
+**Documentation:** Reference permeability of the solid host rock.Units: $\text{m}^{2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Reactive_20Fluid_20Transport_20Model/Reference_20temperature>`
@@ -3854,7 +3854,7 @@ Also note that the fluid reaction time scale has to be larger than or equal to t
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The reference temperature $T_0$ for the katz2003 reaction model. The reference temperature is used in both the density and viscosity formulas of this model. Units: \si{\kelvin}.
+**Documentation:** The reference temperature $T_0$ for the katz2003 reaction model. The reference temperature is used in both the density and viscosity formulas of this model. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Shear to bulk viscosity ratio<parameters:Material_20model/Reactive_20Fluid_20Transport_20Model/Shear_20to_20bulk_20viscosity_20ratio>`
@@ -4009,7 +4009,7 @@ Also note that the fluid reaction time scale has to be larger than or equal to t
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Depth above that melt will be extracted from the model, which is done by a negative reaction term proportional to the porosity field. Units: \si{\meter}.
+**Documentation:** Depth above that melt will be extracted from the model, which is done by a negative reaction term proportional to the porosity field. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Melting time scale for operator splitting<parameters:Material_20model/Reactive_20Fluid_20Transport_20Model/Katz_202003_20model/Melting_20time_20scale_20for_20operator_20splitting>`
@@ -4065,7 +4065,7 @@ Also note that the melting time scale has to be larger than or equal to the reac
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference permeability of the solid host rock.Units: \si{\meter\squared}.
+**Documentation:** Reference permeability of the solid host rock.Units: $\text{m}^{2}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal bulk viscosity exponent<parameters:Material_20model/Reactive_20Fluid_20Transport_20Model/Katz_202003_20model/Thermal_20bulk_20viscosity_20exponent>`
@@ -4215,7 +4215,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Units: \si{\meter}.The maximum depth of the lithosphere. The model will be NaNs below this depth.
+**Documentation:** Units: $\text{m}$.The maximum depth of the lithosphere. The model will be NaNs below this depth.
 ::::
 
 (parameters:Material_20model/Simple_20compressible_20model)=
@@ -4466,7 +4466,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: \si{\pascal}.
+**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Composition viscosity prefactors<parameters:Material_20model/Steinberger_20model/Composition_20viscosity_20prefactors>`
@@ -4574,7 +4574,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: \si{\pascal}.
+**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum viscosity<parameters:Material_20model/Steinberger_20model/Minimum_20viscosity>`
@@ -4601,7 +4601,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: \si{\pascal\second}
+**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: $\text{Pa}\text{s}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for yield stress<parameters:Material_20model/Steinberger_20model/Prefactors_20for_20yield_20stress>`
@@ -4619,7 +4619,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [List of <[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of values that determine the linear scaling of the thermal conductivity with pressure. Units: \si{\watt\per\meter\per\kelvin\per\pascal}.
+**Documentation:** A list of values that determine the linear scaling of the thermal conductivity with pressure. Units: $\text{W}\text{m}^{-1}\text{K}^{-1}\text{Pa}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Radial viscosity file name<parameters:Material_20model/Steinberger_20model/Radial_20viscosity_20file_20name>`
@@ -4691,7 +4691,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** A list of depth values that indicate where the transitions between the different conductivity parameter sets should occur (in most cases, these will be the depths of major phase transitions). Units: \si{\meter}.
+**Documentation:** A list of depth values that indicate where the transitions between the different conductivity parameter sets should occur (in most cases, these will be the depths of major phase transitions). Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Use Drucker-Prager rheology<parameters:Material_20model/Steinberger_20model/Use_20Drucker_2dPrager_20rheology>`
@@ -4738,7 +4738,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation energies, $E$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\joule\per\mole}.
+**Documentation:** List of activation energies, $E$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation energies for diffusion creep<parameters:Material_20model/Visco_20Plastic/Activation_20energies_20for_20diffusion_20creep>`
@@ -4747,7 +4747,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\joule\per\mole}.
+**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation energies for dislocation creep<parameters:Material_20model/Visco_20Plastic/Activation_20energies_20for_20dislocation_20creep>`
@@ -4756,7 +4756,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\joule\per\mole}.
+**Documentation:** List of activation energies, $E_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for Peierls creep<parameters:Material_20model/Visco_20Plastic/Activation_20volumes_20for_20Peierls_20creep>`
@@ -4765,7 +4765,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation volumes, $V$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** List of activation volumes, $V$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for diffusion creep<parameters:Material_20model/Visco_20Plastic/Activation_20volumes_20for_20diffusion_20creep>`
@@ -4774,7 +4774,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for dislocation creep<parameters:Material_20model/Visco_20Plastic/Activation_20volumes_20for_20dislocation_20creep>`
@@ -4783,7 +4783,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** List of activation volumes, $V_a$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Adiabat temperature gradient for viscosity<parameters:Material_20model/Visco_20Plastic/Adiabat_20temperature_20gradient_20for_20viscosity>`
@@ -4792,7 +4792,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Add an adiabatic temperature gradient to the temperature used in the flow law so that the activation volume is consistent with what one would use in a earth-like (compressible) model. Default is set so this is off. Note that this is a linear approximation of the real adiabatic gradient, which is okay for the upper mantle, but is not really accurate for the lower mantle. Using a pressure gradient of 32436 Pa/m, then a value of 0.3 K/km = 0.0003 K/m = 9.24e-09 K/Pa gives an earth-like adiabat.Units: \si{\kelvin\per\pascal}.
+**Documentation:** Add an adiabatic temperature gradient to the temperature used in the flow law so that the activation volume is consistent with what one would use in a earth-like (compressible) model. Default is set so this is off. Note that this is a linear approximation of the real adiabatic gradient, which is okay for the upper mantle, but is not really accurate for the lower mantle. Using a pressure gradient of 32436 Pa/m, then a value of 0.3 K/km = 0.0003 K/m = 9.24e-09 K/Pa gives an earth-like adiabat.Units: $\text{K}\text{Pa}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Allow negative pressures in plasticity<parameters:Material_20model/Visco_20Plastic/Allow_20negative_20pressures_20in_20plasticity>`
@@ -4846,7 +4846,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: \si{\pascal}.
+**Documentation:** List of cohesions, $C$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from exceeding the yield stress. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Constant viscosity prefactors<parameters:Material_20model/Visco_20Plastic/Constant_20viscosity_20prefactors>`
@@ -4864,7 +4864,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of the Stress thresholds below which the strain rate is solved for as a quadratic function of stress to aid with convergence when stress exponent n=0. Units: \si{\pascal}
+**Documentation:** List of the Stress thresholds below which the strain rate is solved for as a quadratic function of stress to aid with convergence when stress exponent n=0. Units: $\text{Pa}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Data directory<parameters:Material_20model/Visco_20Plastic/Data_20directory>`
@@ -4900,7 +4900,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\kilogram\per\meter\cubed}.
+**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{kg}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Dynamic angles of internal friction<parameters:Material_20model/Visco_20Plastic/Dynamic_20angles_20of_20internal_20friction>`
@@ -4909,7 +4909,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** List of dynamic angles of internal friction, $\phi$, for background material and compositional fields, for a total of N$+$1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. Dynamic angles of friction are used as the current friction angle when the effective strain rate is well above the &rsquo;dynamic characteristic strain rate&rsquo;. Units: \si{\degree}.
+**Documentation:** List of dynamic angles of internal friction, $\phi$, for background material and compositional fields, for a total of N$+$1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. Dynamic angles of friction are used as the current friction angle when the effective strain rate is well above the &rsquo;dynamic characteristic strain rate&rsquo;. Units: $\text{degree}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Dynamic characteristic strain rate<parameters:Material_20model/Visco_20Plastic/Dynamic_20characteristic_20strain_20rate>`
@@ -4918,7 +4918,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The characteristic strain rate value at which the angle of friction is equal to $\mu = (\mu_s+\mu_d)/2$. When the effective strain rate is very high, the dynamic angle of friction is taken, when it is very low, the static angle of internal friction is used. Around the dynamic characteristic strain rate, there is a smooth gradient from the static to the dynamic angle of internal friction. Units: \si{\per\second}.
+**Documentation:** The characteristic strain rate value at which the angle of friction is equal to $\mu = (\mu_s+\mu_d)/2$. When the effective strain rate is very high, the dynamic angle of friction is taken, when it is very low, the static angle of internal friction is used. Around the dynamic characteristic strain rate, there is a smooth gradient from the static to the dynamic angle of internal friction. Units: $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Dynamic friction smoothness exponent<parameters:Material_20model/Visco_20Plastic/Dynamic_20friction_20smoothness_20exponent>`
@@ -5005,7 +5005,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The fixed grain size of the material. This grain size is only used if the parent material model does not provide its own (possibly variable) grain size when calling this rheology.Units: \si{\meter}.
+**Documentation:** The fixed grain size of the material. This grain size is only used if the parent material model does not provide its own (possibly variable) grain size when calling this rheology.Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain size exponents for diffusion creep<parameters:Material_20model/Visco_20Plastic/Grain_20size_20exponents_20for_20diffusion_20creep>`
@@ -5023,7 +5023,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\joule\per\kelvin\per\kilogram}.
+**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{J}\text{K}^{-1}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Include Grain Boundary Sliding<parameters:Material_20model/Visco_20Plastic/Include_20Grain_20Boundary_20Sliding>`
@@ -5095,7 +5095,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: \si{\pascal}.
+**Documentation:** List of maximum yield stresses, for background material and compositional fields, , which limits the maximum value of the yield stress determined by the Drucker-Prager plasticity parameters. Default value is chosen so this is not automatically used. Values of 100e6--1000e6 $Pa$ have been used in previous models. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum mass fraction bound water content for fugacity<parameters:Material_20model/Visco_20Plastic/Minimum_20mass_20fraction_20bound_20water_20content_20for_20fugacity>`
@@ -5104,7 +5104,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** The minimum water content for the HK04 olivine hydration viscosity prefactor scheme. This acts as the cutoff between &rsquo;dry&rsquo; creep and &rsquo;wet&rsquo; creep for olivine, and the default value is chosen based on the value reported by Hirth & Kohlstedt 2004. For a mass fraction of bound water beneath this value, this value is used instead to compute the water fugacity. Units: \si{\kg} / \si{\kg} %.
+**Documentation:** The minimum water content for the HK04 olivine hydration viscosity prefactor scheme. This acts as the cutoff between &rsquo;dry&rsquo; creep and &rsquo;wet&rsquo; creep for olivine, and the default value is chosen based on the value reported by Hirth & Kohlstedt 2004. For a mass fraction of bound water beneath this value, this value is used instead to compute the water fugacity. Units: $\text{kg}$ / $\text{kg}$ %.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum strain rate<parameters:Material_20model/Visco_20Plastic/Minimum_20strain_20rate>`
@@ -5113,7 +5113,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Stabilizes strain dependent viscosity. Units: \si{\per\second}.
+**Documentation:** Stabilizes strain dependent viscosity. Units: $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Minimum viscosity<parameters:Material_20model/Visco_20Plastic/Minimum_20viscosity>`
@@ -5176,7 +5176,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of stress limits for Peierls creep $\sigma_{\text{peierls}}$ for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\pascal}
+**Documentation:** List of stress limits for Peierls creep $\sigma_{\text{peierls}}$ for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition Clapeyron slopes<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20Clapeyron_20slopes>`
@@ -5185,7 +5185,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: \si{\pascal\per\kelvin}.
+**Documentation:** A list of Clapeyron slopes for each phase transition. A positive Clapeyron slope indicates that the phase transition will occur in a greater depth, if the temperature is higher than the one given in Phase transition temperatures and in a smaller depth, if the temperature is smaller than the one given in Phase transition temperatures. For negative slopes the other way round. List must have the same number of entries as Phase transition depths. Units: $\text{Pa}\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition depths<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20depths>`
@@ -5194,7 +5194,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: \si{\meter}.
+**Documentation:** A list of depths where phase transitions occur. Values must monotonically increase. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition indicators<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20indicators>`
@@ -5212,7 +5212,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of widths for each phase transition, in terms of pressure. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition pressures. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition pressures<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20pressures>`
@@ -5221,7 +5221,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: \si{\pascal}.
+**Documentation:** A list of pressures where phase transitions occur. Values must monotonically increase. Define transition by depth instead of pressure must be set to false to use this parameter. Units: $\text{Pa}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature lower limits<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20temperature_20lower_20limits>`
@@ -5230,7 +5230,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of lower temperature limits for each phase transition. Below this temperature the respective phase transition is deactivated. The default value means there is no lower limit for any phase transition. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperature upper limits<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20temperature_20upper_20limits>`
@@ -5239,7 +5239,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: \si{\kelvin}.
+**Documentation:** A list of upper temperature limits for each phase transition. Above this temperature the respective phase transition is deactivated. The default value means there is no upper limit for any phase transitions. List must have the same number of entries as Phase transition depths. When the optional temperature limits are applied, the user has to be careful about the consistency between adjacent phases. Phase transitions should be continuous in pressure-temperature space. We recommend producing a phase diagram with simple model setups to check the implementation as a starting point.Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition temperatures<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20temperatures>`
@@ -5248,7 +5248,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: \si{\kelvin}.
+**Documentation:** A list of temperatures where phase transitions occur. Higher or lower temperatures lead to phase transition occurring in smaller or greater depths than given in Phase transition depths, depending on the Clapeyron slope given in Phase transition Clapeyron slopes. List must have the same number of entries as Phase transition depths. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Phase transition widths<parameters:Material_20model/Visco_20Plastic/Phase_20transition_20widths>`
@@ -5257,7 +5257,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: \si{\meter}.
+**Documentation:** A list of widths for each phase transition, in terms of depth. The phase functions are scaled with these values, leading to a jump between phases for a value of zero and a gradual transition for larger values. List must have the same number of entries as Phase transition depths. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Plastic damper viscosity<parameters:Material_20model/Visco_20Plastic/Plastic_20damper_20viscosity>`
@@ -5266,7 +5266,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: \si{\pascal\second}
+**Documentation:** Viscosity of the damper that acts in parallel with the plastic viscosity to produce mesh-independent behavior at sufficient resolutions. Units: $\text{Pa}\text{s}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactor strain weakening factors<parameters:Material_20model/Visco_20Plastic/Prefactor_20strain_20weakening_20factors>`
@@ -5293,7 +5293,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\pascal}$^{-n_{\text{peierls}}}$ \si{\per\second}
+**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}$$^{-n_{\text{peierls}}}$ $\text{s}^{-1}$
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for diffusion creep<parameters:Material_20model/Visco_20Plastic/Prefactors_20for_20diffusion_20creep>`
@@ -5302,7 +5302,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\per\pascal\meter}$^{m_{\text{diffusion}}}$\si{\per\second}.
+**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}^{-1}\text{m}^{-1}$$^{m_{\text{diffusion}}}$$\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for dislocation creep<parameters:Material_20model/Visco_20Plastic/Prefactors_20for_20dislocation_20creep>`
@@ -5311,7 +5311,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Anything]
 
-**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: \si{\pascal}$^{-n_{\text{dislocation}}}$ \si{\per\second}.
+**Documentation:** List of viscosity prefactors, $A$, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value. Units: $\text{Pa}$$^{-n_{\text{dislocation}}}$ $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Prefactors for yield stress<parameters:Material_20model/Visco_20Plastic/Prefactors_20for_20yield_20stress>`
@@ -5347,7 +5347,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Reference strain rate for first time step. Units: \si{\per\second}.
+**Documentation:** Reference strain rate for first time step. Units: $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Visco_20Plastic/Reference_20temperature>`
@@ -5356,7 +5356,7 @@ Note that melt does not freeze unless the &rsquo;Freezing rate&rsquo; parameter 
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The reference temperature $T_0$. Units: \si{\kelvin}.
+**Documentation:** The reference temperature $T_0$. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperatures for Frank Kamenetskii<parameters:Material_20model/Visco_20Plastic/Reference_20temperatures_20for_20Frank_20Kamenetskii>`
@@ -5511,7 +5511,7 @@ If a compositional field named &rsquo;noninitial\_plastic\_strain&rsquo; is incl
 
 **Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
 
-**Documentation:** List of thermal diffusivities, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value.  Units: \si{\meter\squared\per\second}.
+**Documentation:** List of thermal diffusivities, for background material and compositional fields, for a total of N+1 values, where N is the number of all compositional fields or only those corresponding to chemical compositions. If only one value is given, then all use the same value.  Units: $\text{m}^{2}\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Thermal expansivities<parameters:Material_20model/Visco_20Plastic/Thermal_20expansivities>`
@@ -5520,7 +5520,7 @@ If a compositional field named &rsquo;noninitial\_plastic\_strain&rsquo; is incl
 
 **Pattern:** [Anything]
 
-**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\per\kelvin}.
+**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Upper temperature for maximum strain weakening<parameters:Material_20model/Visco_20Plastic/Upper_20temperature_20for_20maximum_20strain_20weakening>`
@@ -5708,7 +5708,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** Here we use the default values for ice at T < 255 K as given in Goldsby & Kohlstedt, 2001. Units: \si{\joule\per\mole}.
+**Documentation:** Here we use the default values for ice at T < 255 K as given in Goldsby & Kohlstedt, 2001. Units: $\text{J}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Activation volumes for grain boundary sliding<parameters:Material_20model/Visco_20Plastic/Grain_20boundary_20sliding/Activation_20volumes_20for_20grain_20boundary_20sliding>`
@@ -5717,7 +5717,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: \si{\meter\cubed\per\mole}.
+**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: $\text{m}^{3}\text{mol}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain size<parameters:Material_20model/Visco_20Plastic/Grain_20boundary_20sliding/Grain_20size>`
@@ -5726,7 +5726,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: \si{\meter}.
+**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Grain size exponents for grain boundary sliding<parameters:Material_20model/Visco_20Plastic/Grain_20boundary_20sliding/Grain_20size_20exponents_20for_20grain_20boundary_20sliding>`
@@ -5744,7 +5744,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: \si{\pascal}$^{-n_{\text{grain boundary sliding}}}$ \si{\meter}$^{m_{\text{grain boundary sliding}}}$ \si{\per\second}.
+**Documentation:** Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: $\text{Pa}$$^{-n_{\text{grain boundary sliding}}}$ $\text{m}$$^{m_{\text{grain boundary sliding}}}$ $\text{s}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Stress exponents for grain boundary sliding<parameters:Material_20model/Visco_20Plastic/Grain_20boundary_20sliding/Stress_20exponents_20for_20grain_20boundary_20sliding>`
@@ -5764,7 +5764,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\kilogram\per\meter\cubed}.
+**Documentation:** List of densities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{kg}\text{m}^{-3}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Elastic damper viscosity<parameters:Material_20model/Viscoelastic/Elastic_20damper_20viscosity>`
@@ -5800,7 +5800,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\joule\per\kelvin\per\kilogram}.
+**Documentation:** List of specific heats $C_p$ for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{J}\text{K}^{-1}\text{kg}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Reference temperature<parameters:Material_20model/Viscoelastic/Reference_20temperature>`
@@ -5809,7 +5809,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The reference temperature $T_0$. Units: \si{\kelvin}.
+**Documentation:** The reference temperature $T_0$. Units: $\text{K}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Specific heats<parameters:Material_20model/Viscoelastic/Specific_20heats>`
@@ -5843,7 +5843,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: \si{\per\kelvin}.
+**Documentation:** List of thermal expansivities for background mantle and compositional fields,for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. If only one value is given, then all use the same value. Units: $\text{K}^{-1}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Use fixed elastic time step<parameters:Material_20model/Viscoelastic/Use_20fixed_20elastic_20time_20step>`

--- a/doc/sphinx/parameters/Mesh_20deformation.md
+++ b/doc/sphinx/parameters/Mesh_20deformation.md
@@ -118,7 +118,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** The hillslope transport coefficient $\kappa$ used to diffuse the free surface, either as a  stabilization step or to mimic erosional and depositional processes. Units: $\si{m^2/s}$.
+**Documentation:** The hillslope transport coefficient $\kappa$ used to diffuse the free surface, either as a  stabilization step or to mimic erosional and depositional processes. Units: $\text{m}^2/\text{s}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Time steps between diffusion<parameters:Mesh_20deformation/Diffusion/Time_20steps_20between_20diffusion>`

--- a/doc/sphinx/parameters/Particles.md
+++ b/doc/sphinx/parameters/Particles.md
@@ -383,7 +383,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the crustal layer generated at the surface.Units: \si{\meter}.
+**Documentation:** Thickness of the crustal layer generated at the surface.Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithosphere thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Lithosphere_20thickness>`
@@ -392,7 +392,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: \si{\meter}.
+**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: $\text{m}$.
 ::::
 
 (parameters:Particles/Crystal_20Preferred_20Orientation)=

--- a/doc/sphinx/parameters/Particles_202.md
+++ b/doc/sphinx/parameters/Particles_202.md
@@ -374,7 +374,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the crustal layer generated at the surface.Units: \si{\meter}.
+**Documentation:** Thickness of the crustal layer generated at the surface.Units: $\text{m}$.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithosphere thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Lithosphere_20thickness>`
@@ -383,7 +383,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: \si{\meter}.
+**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: $\text{m}$.
 ::::
 
 (parameters:Particles_202/Crystal_20Preferred_20Orientation)=

--- a/doc/sphinx/parameters/Postprocess.md
+++ b/doc/sphinx/parameters/Postprocess.md
@@ -1120,7 +1120,7 @@ Physical units: $\frac{\text{m}}{\text{s}}$ or $\frac{\text{m}}{\text{year}}$, d
 
 &lsquo;density anomaly&rsquo;: A visualization output postprocessor that outputs the density minus the depth-average of the density.In the &ldquo;lateral average&rdquo; scheme, the average density is calculated using the lateral averaging functionfrom the &ldquo;depth average&rdquo; postprocessor and interpolated linearly between the layers specified through &ldquo;Number of depth slices&rdquo;. In the &ldquo;reference profile&rdquo; scheme, the adiabatic density is used as theaverage density.
 
-Physical units: \si{\kg/m^3}.
+Physical units: $\text{kg}/\text{m}^3$.
 
 &lsquo;depth&rsquo;: A visualization output postprocessor that outputs the depth for all points inside the domain, as determined by the geometry model.
 
@@ -1130,7 +1130,7 @@ Physical units: $\text{m}$.
 
 &lsquo;depth including mesh deformation&rsquo;: A visualization output postprocessor that outputs the depth for all points inside the domain, as determined by the current model surface. This plugin will include changes to the surface from mesh deformation.
 
-Physical units: \si{\meter}.
+Physical units: $\text{m}$.
 
 &lsquo;dynamic topography&rsquo;: A visualization output object that generates output for the dynamic topography at the top and bottom of the model space. The actual computation of this topography is handled inside the &rsquo;dynamic topography&rsquo; postprocessor, please check its documentation for details about the numerical methods.
 
@@ -1142,7 +1142,7 @@ Physical units: $\text{m}$.
 
 &lsquo;entropy average&rsquo;: A visualization output object that generates output for the averaged entropy of multiple components.
 
-Physical units: \si{\J/kg/K}.
+Physical units: $\text{J/kg/K}$.
 
 &lsquo;error indicator&rsquo;: A visualization output object that generates output showing the estimated error or other mesh refinement indicator as a spatially variable function with one value per cell.
 
@@ -1166,7 +1166,7 @@ Physical units: $\frac{\text{W}}{\text{m}^2}$.
 
 &lsquo;heating&rsquo;: A visualization output object that generates output for all the heating terms used in the energy equation.
 
-Physical units: $\frac{\text{W}}{\text{m}^3}$\si{\watt\per\cubic\meter}.
+Physical units: $\frac{\text{W}}{\text{m}^3}$.
 
 &lsquo;material properties&rsquo;: A visualization output object that generates output for the material properties given by the material model. The current postprocessor allows to output a (potentially large) subset of all of the information provided by material models at once, with just a single material model evaluation per output point. Although individual properties can still be listed in the &ldquo;List of output variables&rdquo;, this visualization plugin is called internally to avoid duplicated evaluations of the material model.
 
@@ -1250,7 +1250,7 @@ Physical units: $\frac{1}{\text{s}}$.
 
 This postprocessor outputs the quantity computed herein as a tensor, i.e., programs such as VisIt or Pararview can visualize it as tensors represented by ellipses, not just as individual fields. That said, you can also visualize individual tensor components, by noting that the components that are written to the output file correspond to the tensor components $t_{xx}, t_{xy}, t_{yx}, t_{yy}$ (in 2d) or  $t_{xx}, t_{xy}, t_{xz}, t_{yx}, t_{yy}, t_{yz}, t_{zx}, t_{zy}, t_{zz}$ (in 3d) of a tensor $t$ in a Cartesian coordinate system. Even though the tensor we output is symmetric, the output contains all components of the tensor because that is what the file format requires.
 
-Physical units: \si{\per\second}.
+Physical units: $\text{s}^{-1}$.
 
 &lsquo;stress&rsquo;: A visualization output object that generates output for the 3 (in 2d) or 6 (in 3d) components of the stress tensor, i.e., for the components of the tensor $-2\eta\varepsilon(\mathbf u)+pI$ in the incompressible case and $-2\eta\left[\varepsilon(\mathbf u)-\tfrac 13(\textrm{tr}\;\varepsilon(\mathbf u))\mathbf I\right]+pI$ in the compressible case. If elasticity is used, the elastic contribution is being accounted for. Note that the convention of positive compressive stress is followed.
 

--- a/doc/sphinx/parameters/Solver_20parameters.md
+++ b/doc/sphinx/parameters/Solver_20parameters.md
@@ -80,7 +80,7 @@
 
 **Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Set a length scale for the diffusion of advection fields if the &ldquo;prescribed field with diffusion&rdquo; method is selected for a field. More precisely, this length scale represents the square root of the product of diffusivity and time in the diffusion equation, and controls the distance over which features are diffused. Units: \si{\meter}.
+**Documentation:** Set a length scale for the diffusion of advection fields if the &ldquo;prescribed field with diffusion&rdquo; method is selected for a field. More precisely, this length scale represents the square root of the product of diffusivity and time in the diffusion equation, and controls the distance over which features are diffused. Units: $\text{m}$.
 ::::
 
 (parameters:Solver_20parameters/Matrix_20Free)=

--- a/source/boundary_convective_heating/interface.cc
+++ b/source/boundary_convective_heating/interface.cc
@@ -320,7 +320,7 @@ namespace aspect
                           "insulating (Neumann) behaviour; "
                           "For heat transfer coefficient --> infinity, the boundary approaches "
                           "a prescribed-temperature (Dirichlet) condition. "
-                          "The unit of the heat transfer coefficient is \\si{\\watt\\per\\meter\\squared\\per\\kelvin}."
+                          "The unit of the heat transfer coefficient is $\\text{W}\\text{m}^{-2}\\text{K}^{-1}$."
                           "At the moment, this list can only have one entry. \n\n"
                           "The following heat transfer coefficient models are available:\n\n"
                           +

--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -956,7 +956,7 @@ namespace aspect
           prm.declare_entry ("dR over dt", "0.",
                              Patterns::Double (),
                              "Initial inner core radius changing rate. "
-                             "Units: \\si{\\kilo\\meter}/year.");
+                             "Units: $\\text{k}\\text{m}$/year.");
           prm.declare_entry ("dX over dt", "0.",
                              Patterns::Double (),
                              "Initial light composition changing rate. "
@@ -967,7 +967,7 @@ namespace aspect
                              "Units: $\\frac{\\text{kg}}{\\text{m}^3}$.");
           prm.declare_entry ("CMB pressure", "0.14e12",
                              Patterns::Double (),
-                             "Pressure at CMB. Units: \\si{\\pascal}.");
+                             "Pressure at CMB. Units: $\\text{Pa}$.");
           prm.declare_entry ("Initial light composition", "0.01",
                              Patterns::Double (0.),
                              "Initial light composition (eg. S,O) concentration "
@@ -994,11 +994,11 @@ namespace aspect
           prm.declare_entry ("Lh", "750e3",
                              Patterns::Double (0.),
                              "The latent heat of core freeze. "
-                             "Units: \\si{\\joule\\per\\kilogram}.");
+                             "Units: $\\text{J}\\text{kg}^{-1}$.");
           prm.declare_entry ("Rh","-27.7e6",
                              Patterns::Double (),
                              "The heat of reaction. "
-                             "Units: \\si{\\joule\\per\\kilogram}.");
+                             "Units: $\\text{J}\\text{kg}^{-1}$.");
           prm.declare_entry ("Beta composition", "1.1",
                              Patterns::Double (0.),
                              "Compositional expansion coefficient $Beta_c$. "
@@ -1017,11 +1017,11 @@ namespace aspect
             prm.declare_entry ("Tm1","10.9e-12",
                                Patterns::Double (),
                                "Melting curve (\\cite{NPB+04} eq. (40)) parameter Tm1. "
-                               "Units: \\si{\\per\\pascal}.");
+                               "Units: $\\text{Pa}^{-1}$.");
             prm.declare_entry ("Tm2","-8.0e-24",
                                Patterns::Double (),
                                "Melting curve (\\cite{NPB+04} eq. (40)) parameter Tm2. "
-                               "Units: \\si{\\per\\pascal\\squared}.");
+                               "Units: $\\text{Pa}^{-2}$.");
             prm.declare_entry ("Theta","0.11",
                                Patterns::Double (),
                                "Melting curve (\\cite{NPB+04} eq. (40)) parameter Theta.");

--- a/source/boundary_traction/initial_lithostatic_pressure.cc
+++ b/source/boundary_traction/initial_lithostatic_pressure.cc
@@ -353,7 +353,7 @@ namespace aspect
                              "longitude, and in 3d latitude. Note that the coordinate related to the depth "
                              "($y$ in 2d Cartesian, $z$ in 3d Cartesian and radius in spherical coordinates) is "
                              "not used. "
-                             "Units: \\si{\\meter} or degrees.");
+                             "Units: $\\text{m}$ or degrees.");
           prm.declare_entry("Number of integration points", "1000",
                             Patterns::Integer(0),
                             "The number of integration points over which we integrate the lithostatic pressure "

--- a/source/geometry_model/box.cc
+++ b/source/geometry_model/box.cc
@@ -426,25 +426,25 @@ namespace aspect
         {
           prm.declare_entry ("X extent", "1.",
                              Patterns::Double (0.),
-                             "Extent of the box in x-direction. Units: \\si{\\meter}.");
+                             "Extent of the box in x-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Y extent", "1.",
                              Patterns::Double (0.),
-                             "Extent of the box in y-direction. Units: \\si{\\meter}.");
+                             "Extent of the box in y-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Z extent", "1.",
                              Patterns::Double (0.),
                              "Extent of the box in z-direction. This value is ignored "
-                             "if the simulation is in 2d. Units: \\si{\\meter}.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           prm.declare_entry ("Box origin X coordinate", "0.",
                              Patterns::Double (),
-                             "X coordinate of box origin. Units: \\si{\\meter}.");
+                             "X coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Y coordinate", "0.",
                              Patterns::Double (),
-                             "Y coordinate of box origin. Units: \\si{\\meter}.");
+                             "Y coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Z coordinate", "0.",
                              Patterns::Double (),
                              "Z coordinate of box origin. This value is ignored "
-                             "if the simulation is in 2d. Units: \\si{\\meter}.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           prm.declare_entry ("X repetitions", "1",
                              Patterns::Integer (1),

--- a/source/geometry_model/chunk.cc
+++ b/source/geometry_model/chunk.cc
@@ -833,10 +833,10 @@ namespace aspect
         {
           prm.declare_entry ("Chunk inner radius", "0.",
                              Patterns::Double (0.),
-                             "Radius at the bottom surface of the chunk. Units: \\si{\\meter}.");
+                             "Radius at the bottom surface of the chunk. Units: $\\text{m}$.");
           prm.declare_entry ("Chunk outer radius", "1.",
                              Patterns::Double (0.),
-                             "Radius at the top surface of the chunk. Units: \\si{\\meter}.");
+                             "Radius at the top surface of the chunk. Units: $\\text{m}$.");
 
           prm.declare_entry ("Chunk minimum longitude", "0.",
                              Patterns::Double (-180., 360.), // enables crossing of either hemisphere

--- a/source/geometry_model/sphere.cc
+++ b/source/geometry_model/sphere.cc
@@ -184,7 +184,7 @@ namespace aspect
         {
           prm.declare_entry ("Radius", "6371000.",
                              Patterns::Double (0.),
-                             "Radius of the sphere. Units: \\si{\\meter}.");
+                             "Radius of the sphere. Units: $\\text{m}$.");
         }
         prm.leave_subsection();
       }

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -933,7 +933,7 @@ namespace aspect
           prm.declare_entry ("List of radial values", "",
                              Patterns::List(Patterns::Double ()),
                              "List of radial values for the custom mesh scheme. Units: "
-                             "$\\si{m}$. "
+                             "$\\text{m}$. "
                              "A list of radial values subdivides the spherical shell at "
                              "specified radii. The list must be strictly ascending, and "
                              "the first value must be greater than the inner radius "
@@ -954,7 +954,7 @@ namespace aspect
                              "the mesh.");
           prm.declare_entry ("Inner radius", "3481000.",  // 6371-2890 in km
                              Patterns::Double (0.),
-                             "Inner radius of the spherical shell. Units: \\si{\\meter}."
+                             "Inner radius of the spherical shell. Units: $\\text{m}$."
                              "\n\n"
                              ":::{note}\n"
                              "The default value of 3,481,000 m equals the "
@@ -964,7 +964,7 @@ namespace aspect
                              ":::");
           prm.declare_entry ("Outer radius", "6336000.",  // 6371-35 in km
                              Patterns::Double (0.),
-                             "Outer radius of the spherical shell. Units: \\si{\\meter}."
+                             "Outer radius of the spherical shell. Units: $\\text{m}$."
                              "\n\n"
                              ":::{note}\n"
                              "The default value of 6,336,000 m equals the "

--- a/source/geometry_model/two_merged_boxes.cc
+++ b/source/geometry_model/two_merged_boxes.cc
@@ -479,26 +479,26 @@ namespace aspect
           // Total box extents
           prm.declare_entry ("X extent", "1.",
                              Patterns::Double (0.),
-                             "Extent of the box in x-direction. Units: \\si{\\meter}.");
+                             "Extent of the box in x-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Y extent", "1.",
                              Patterns::Double (0.),
-                             "Extent of the box in y-direction. Units: \\si{\\meter}.");
+                             "Extent of the box in y-direction. Units: $\\text{m}$.");
           prm.declare_entry ("Z extent", "1.",
                              Patterns::Double (0.),
                              "Extent of the box in z-direction. This value is ignored "
-                             "if the simulation is in 2d. Units: \\si{\\meter}.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           // Total box origin
           prm.declare_entry ("Box origin X coordinate", "0.",
                              Patterns::Double (),
-                             "X coordinate of box origin. Units: \\si{\\meter}.");
+                             "X coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Y coordinate", "0.",
                              Patterns::Double (),
-                             "Y coordinate of box origin. Units: \\si{\\meter}.");
+                             "Y coordinate of box origin. Units: $\\text{m}$.");
           prm.declare_entry ("Box origin Z coordinate", "0.",
                              Patterns::Double (),
                              "Z coordinate of box origin. This value is ignored "
-                             "if the simulation is in 2d. Units: \\si{\\meter}.");
+                             "if the simulation is in 2d. Units: $\\text{m}$.");
 
           // Lower box repetitions
           prm.declare_entry ("X repetitions", "1",

--- a/source/geometry_model/two_merged_chunks.cc
+++ b/source/geometry_model/two_merged_chunks.cc
@@ -464,14 +464,14 @@ namespace aspect
         {
           prm.declare_entry ("Chunk inner radius", "0.",
                              Patterns::Double (0.),
-                             "Radius at the bottom surface of the chunk. Units: \\si{\\meter}.");
+                             "Radius at the bottom surface of the chunk. Units: $\\text{m}$.");
           prm.declare_entry ("Chunk outer radius", "1.",
                              Patterns::Double (0.),
-                             "Radius at the top surface of the chunk. Units: \\si{\\meter}.");
+                             "Radius at the top surface of the chunk. Units: $\\text{m}$.");
           prm.declare_entry ("Chunk middle boundary radius", "1",
                              Patterns::Double (0),
                              "Radius at the top surface of the lower chunk, "
-                             "where it merges with the upper chunk. Units: \\si{\\meter}.");
+                             "where it merges with the upper chunk. Units: $\\text{m}$.");
 
           prm.declare_entry ("Chunk minimum longitude", "0.",
                              Patterns::Double (-180., 360.), // enables crossing of either hemisphere

--- a/source/gravity_model/radial_linear.cc
+++ b/source/gravity_model/radial_linear.cc
@@ -59,7 +59,7 @@ namespace aspect
                              Patterns::Double (),
                              "Magnitude of the radial gravity vector "
                              "at the surface of the domain. "
-                             "Units: \\si{\\meter\\per\\second\\squared}.");
+                             "Units: $\\text{m}\\text{s}^{-2}$.");
           prm.declare_entry ("Magnitude at bottom", "10.7",
                              Patterns::Double (),
                              "Magnitude of the radial gravity vector "
@@ -68,7 +68,7 @@ namespace aspect
                              "example represents the core-mantle boundary in "
                              "the case of the `spherical shell' geometry model, "
                              "and the center in the case of the `sphere' "
-                             "geometry model. Units: \\si{\\meter\\per\\second\\squared}.");
+                             "geometry model. Units: $\\text{m}\\text{s}^{-2}$.");
         }
         prm.leave_subsection ();
       }

--- a/source/heating_model/compositional_heating.cc
+++ b/source/heating_model/compositional_heating.cc
@@ -78,7 +78,7 @@ namespace aspect
                             "background and compositional fields, for a total of "
                             "N+1 values, where the first value corresponds to the "
                             "background material, and N is the number of compositional fields. "
-                            "Units: \\si{\\watt\\per\\meter\\cubed}.");
+                            "Units: $\\text{W}\\text{m}^{-3}$.");
           prm.declare_entry ("Use compositional field for heat production averaging", "1",
                              Patterns::List(Patterns::Integer(0,1)),
                              "A list of integers with as many entries as compositional fields plus one. "
@@ -147,6 +147,6 @@ namespace aspect
                                   "Implementation of a model in which magnitude of internal heat production "
                                   "is determined from fixed values assigned to each compositional "
                                   "field. These values are interpreted as having units "
-                                  "\\si{\\watt\\per\\meter\\cubed}.")
+                                  "$\\text{W}\\text{m}^{-3}$.")
   }
 }

--- a/source/heating_model/radioactive_decay.cc
+++ b/source/heating_model/radioactive_decay.cc
@@ -124,7 +124,7 @@ namespace aspect
           prm.declare_entry("Crust depth","0.",
                             Patterns::Double(),
                             "Depth of the crust when crust if defined by depth. "
-                            "Units: \\si{\\meter}.");
+                            "Units: $\\text{m}$.");
           prm.declare_entry("Crust composition number","0",
                             Patterns::Integer(0),
                             "Which composition field should be treated as crust");

--- a/source/initial_temperature/adiabatic.cc
+++ b/source/initial_temperature/adiabatic.cc
@@ -428,7 +428,7 @@ namespace aspect
                              "Whether to use the half space cooling model or the plate cooling model");
           prm.declare_entry ("Lithosphere thickness", "125e3",
                              Patterns::Double (0.),
-                             "Thickness of the lithosphere for plate cooling model. \\si{\\m}");
+                             "Thickness of the lithosphere for plate cooling model. $\\text{m}$");
 
           prm.enter_subsection("Function");
           {

--- a/source/initial_temperature/adiabatic_boundary.cc
+++ b/source/initial_temperature/adiabatic_boundary.cc
@@ -82,7 +82,7 @@ namespace aspect
           prm.declare_entry ("Adiabatic temperature gradient", "0.0005",
                              Patterns::Double (0.),
                              "The value of the adiabatic temperature gradient. "
-                             "Units: \\si{\\kelvin\\per\\meter}.");
+                             "Units: $\\text{K}\\text{m}^{-1}$.");
         }
         prm.leave_subsection();
       }

--- a/source/initial_temperature/continental_geotherm.cc
+++ b/source/initial_temperature/continental_geotherm.cc
@@ -109,7 +109,7 @@ namespace aspect
                              "List of the 3 thicknesses of the lithospheric layers "
                              "'upper\\_crust', 'lower\\_crust' and 'mantle\\_lithosphere'. "
                              "If only one thickness is given, then the same thickness is used "
-                             "for all layers. Units: \\si{meter}.");
+                             "for all layers. Units: $\\text{m}$.");
           prm.declare_entry ("Surface temperature", "273.15",
                              Patterns::Double (0.),
                              "The value of the surface temperature. Units: $\\text{K}$.");

--- a/source/initial_temperature/lithosphere_mask.cc
+++ b/source/initial_temperature/lithosphere_mask.cc
@@ -95,7 +95,7 @@ namespace aspect
                            Patterns::Selection("File|Value"),
                            "Method that is used to specify the depth of the lithosphere-asthenosphere boundary.");
         prm.declare_entry ("Maximum lithosphere depth", "200000.0",
-                           Patterns::Double (0.),"Units: \\si{\\meter}."
+                           Patterns::Double (0.),"Units: $\\text{m}$."
                            "The maximum depth of the lithosphere. The model will be "
                            "NaNs below this depth.");
         prm.declare_entry ("Data directory", "$ASPECT_SOURCE_DIR/data/initial-temperature/lithosphere-mask/",

--- a/source/initial_temperature/random_gaussian_perturbation.cc
+++ b/source/initial_temperature/random_gaussian_perturbation.cc
@@ -161,7 +161,7 @@ namespace aspect
           prm.declare_entry ("Width", "1000.0",
                              Patterns::Double (0.),
                              "The Gaussian RMS width of the perturbations. "
-                             "Units: \\si{\\meter}.");
+                             "Units: $\\text{m}$.");
         }
         prm.leave_subsection ();
       }

--- a/source/material_model/ascii_reference_profile.cc
+++ b/source/material_model/ascii_reference_profile.cc
@@ -160,7 +160,7 @@ namespace aspect
                              Patterns::List (Patterns::Double(0.)),
                              "A list of depths where the viscosity changes. Values must "
                              "monotonically increase. "
-                             "Units: \\si{\\meter}.");
+                             "Units: $\\text{m}$.");
           prm.declare_entry ("Viscosity prefactors", "10., 0.1, 1., 10.",
                              Patterns::List (Patterns::Double(0.)),
                              "A list of prefactors for the viscosity that determine the viscosity "

--- a/source/material_model/drucker_prager.cc
+++ b/source/material_model/drucker_prager.cc
@@ -193,24 +193,24 @@ namespace aspect
           prm.declare_entry ("Reference temperature", "293.",
                              Patterns::Double (0.),
                              "The reference temperature $T_0$. The reference temperature is used "
-                             "in the density calculation. Units: \\si{\\kelvin}.");
+                             "in the density calculation. Units: $\\text{K}$.");
           prm.declare_entry ("Thermal conductivity", "4.7",
                              Patterns::Double (0.),
                              "The value of the thermal conductivity $k$. "
-                             "Units: \\si{\\watt\\per\\meter\\per\\kelvin}.");
+                             "Units: $\\text{W}\\text{m}^{-1}\\text{K}^{-1}$.");
           prm.enter_subsection ("Viscosity");
           {
 
             prm.declare_entry ("Minimum viscosity", "1e19",
                                Patterns::Double (0.),
-                               "The value of the minimum viscosity cutoff $\\eta_min$. Units: \\si{\\pascal\\second}.");
+                               "The value of the minimum viscosity cutoff $\\eta_min$. Units: $\\text{Pa}\\text{s}$.");
             prm.declare_entry ("Maximum viscosity", "1e24",
                                Patterns::Double (0.),
-                               "The value of the maximum viscosity cutoff $\\eta_max$. Units: \\si{\\pascal\\second}.");
+                               "The value of the maximum viscosity cutoff $\\eta_max$. Units: $\\text{Pa}\\text{s}$.");
             prm.declare_entry ("Reference strain rate", "1e-15",
                                Patterns::Double (0.),
                                "The value of the initial strain rate prescribed during the "
-                               "first nonlinear iteration $\\dot{\\epsilon}_ref$. Units: \\si{\\per\\second}.");
+                               "first nonlinear iteration $\\dot{\\epsilon}_ref$. Units: $\\text{s}^{-1}$.");
             prm.declare_entry ("Angle of internal friction", "0.",
                                Patterns::Double (0.),
                                "The value of the angle of internal friction $\\phi$. "
@@ -219,7 +219,7 @@ namespace aspect
                                "harder to solve numerically. Units: degrees.");
             prm.declare_entry ("Cohesion", "2e7",
                                Patterns::Double (0.),
-                               "The value of the cohesion $C$. Units: \\si{\\pascal}.");
+                               "The value of the cohesion $C$. Units: $\\text{Pa}$.");
           }
           prm.leave_subsection();
         }

--- a/source/material_model/entropy_model.cc
+++ b/source/material_model/entropy_model.cc
@@ -482,7 +482,7 @@ namespace aspect
                              Patterns::Double(0),
                              "The viscosity that is used in this model. "
                              "\n\n"
-                             "Units: \\si{\\pascal\\second}");
+                             "Units: $\\text{Pa}\\text{s}$");
           prm.declare_entry ("Lateral viscosity file name", "constant_lateral_vis_prefactor.txt",
                              Patterns::Anything (),
                              "The file name of the lateral viscosity prefactor.");
@@ -509,7 +509,7 @@ namespace aspect
                              Patterns::Double (0.),
                              "The value of the cohesion, $C$. The extremely large default"
                              "cohesion value (1e20 Pa) prevents the viscous stress from "
-                             "exceeding the yield stress. Units: \\si{\\pascal}.");
+                             "exceeding the yield stress. Units: $\\text{Pa}$.");
 
           // Multicomponent equilibration parameters
           prm.declare_entry ("Maximum iteration for multicomponent equilibration", "50",

--- a/source/material_model/equation_of_state/multicomponent_compressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_compressible.cc
@@ -94,7 +94,7 @@ namespace aspect
                            "the total number of phase transitions, summed over all phases. The format is "
                            "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                            "If only one value is given, then all fields/phases use the same value. "
-                           "Units: \\si{\\kelvin}.");
+                           "Units: $\\text{K}$.");
         prm.declare_entry ("Reference densities", "3300.",
                            Patterns::Anything(),
                            "List of reference densities for background and compositional fields (N), "
@@ -107,7 +107,7 @@ namespace aspect
                            "the total number of phase transitions, summed over all phases. The format is "
                            "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                            "If only one value is given, then all fields/phases use the same value. "
-                           "Units: \\si{\\kilogram\\per\\meter\\cubed}.");
+                           "Units: $\\text{kg}\\text{m}^{-3}$.");
         prm.declare_entry ("Reference isothermal compressibilities", "4e-12",
                            Patterns::Anything(),
                            "List of isothermal compressibilities for background and compositional fields (N), "
@@ -120,7 +120,7 @@ namespace aspect
                            "the total number of phase transitions, summed over all phases. The format is "
                            "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                            "If only one value is given, then all fields/phases use the same value. "
-                           "Units: \\si{\\per\\pascal}.");
+                           "Units: $\\text{Pa}^{-1}$.");
         prm.declare_entry ("Isothermal bulk modulus pressure derivatives", "4.",
                            Patterns::Anything(),
                            "List of isothermal bulk modulus pressure derivatives for background and compositional fields (N), "
@@ -146,7 +146,7 @@ namespace aspect
                            "the total number of phase transitions, summed over all phases. The format is "
                            "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                            "If only one value is given, then all fields/phases use the same value. "
-                           "Units: \\si{\\per\\kelvin}.");
+                           "Units: $\\text{K}^{-1}$.");
         prm.declare_entry ("Isochoric specific heats", "1250.",
                            Patterns::Anything(),
                            "List of isochoric specific heats for background and compositional fields (N), "
@@ -159,7 +159,7 @@ namespace aspect
                            "the total number of phase transitions, summed over all phases. The format is "
                            "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                            "If only one value is given, then all fields/phases use the same value. "
-                           "Units: \\si{\\joule\\per\\kelvin\\per\\kilogram}.");
+                           "Units: $\\text{J}\\text{K}^{-1}\\text{kg}^{-1}$.");
         prm.declare_entry ("Enable phase transitions", "false",
                            Patterns::Bool (),
                            "Whether to enable the use of phase transitions, which break the thermodynamic "

--- a/source/material_model/equation_of_state/multicomponent_incompressible.cc
+++ b/source/material_model/equation_of_state/multicomponent_incompressible.cc
@@ -75,24 +75,24 @@ namespace aspect
       {
         prm.declare_entry ("Reference temperature", "293.",
                            Patterns::Double (0.),
-                           "The reference temperature $T_0$. Units: \\si{\\kelvin}.");
+                           "The reference temperature $T_0$. Units: $\\text{K}$.");
         prm.declare_entry ("Densities", "3300.",
                            Patterns::Anything(),
                            "List of densities for background mantle and compositional fields,"
                            "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\kilogram\\per\\meter\\cubed}.");
+                           "Units: $\\text{kg}\\text{m}^{-3}$.");
         prm.declare_entry ("Thermal expansivities", std::to_string(default_thermal_expansion),
                            Patterns::Anything(),
                            "List of thermal expansivities for background mantle and compositional fields,"
                            "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
-                           "If only one value is given, then all use the same value. Units: \\si{\\per\\kelvin}.");
+                           "If only one value is given, then all use the same value. Units: $\\text{K}^{-1}$.");
         prm.declare_entry ("Heat capacities", "1250.",
                            Patterns::Anything(),
                            "List of specific heats $C_p$ for background mantle and compositional fields,"
                            "for a total of N+M+1 values, where N is the number of compositional fields and M is the number of phases. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\joule\\per\\kelvin\\per\\kilogram}.");
+                           "Units: $\\text{J}\\text{K}^{-1}\\text{kg}^{-1}$.");
         prm.declare_alias ("Heat capacities", "Specific heats");
       }
 

--- a/source/material_model/latent_heat.cc
+++ b/source/material_model/latent_heat.cc
@@ -310,7 +310,7 @@ namespace aspect
                              "0 stands for the 1st compositional fields, 1 for the second compositional field "
                              "and -1 for none of them. "
                              "List must have the same number of entries as Phase transition depths. "
-                             "Units: \\si{\\pascal\\per\\kelvin}.");
+                             "Units: $\\text{Pa}\\text{K}^{-1}$.");
           prm.declare_entry ("Viscosity prefactors", "all:1",
                              Patterns::Anything(),
                              "A list of prefactors for the viscosity for each phase. The ``Viscosity'' "

--- a/source/material_model/melt_global.cc
+++ b/source/material_model/melt_global.cc
@@ -364,7 +364,7 @@ namespace aspect
           prm.declare_entry ("Reference permeability", "1e-8",
                              Patterns::Double(),
                              "Reference permeability of the solid host rock."
-                             "Units: \\si{\\meter\\squared}.");
+                             "Units: $\\text{m}^{2}$.");
           prm.declare_entry ("Depletion density change", "0.0",
                              Patterns::Double (),
                              "The density contrast between material with a depletion of 1 and a "

--- a/source/material_model/modified_tait.cc
+++ b/source/material_model/modified_tait.cc
@@ -136,7 +136,7 @@ namespace aspect
         {
           prm.declare_entry ("Reference pressure", "1e5",
                              Patterns::Double (0.),
-                             "Reference pressure $P_0$. Units: \\si{\\pascal}.");
+                             "Reference pressure $P_0$. Units: $\\text{Pa}$.");
           prm.declare_entry ("Reference temperature", "298.15",
                              Patterns::Double (0.),
                              "Reference temperature $T_0$. Units: $\\text{K}$.");
@@ -147,7 +147,7 @@ namespace aspect
           prm.declare_entry ("Reference isothermal bulk modulus", "125e9",
                              Patterns::Double (0.),
                              "The isothermal bulk modulus at the reference pressure and temperature. "
-                             "Units: \\si{\\pascal}.");
+                             "Units: $\\text{Pa}$.");
           prm.declare_entry ("Reference bulk modulus derivative", "4.",
                              Patterns::Double (0.),
                              "The value of the first pressure derivative of the isothermal bulk modulus "

--- a/source/material_model/multicomponent_compressible.cc
+++ b/source/material_model/multicomponent_compressible.cc
@@ -177,7 +177,7 @@ namespace aspect
                              "the total number of phase transitions, summed over all phases. The format is "
                              "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                              "If only one value is given, then all fields/phases use the same value. "
-                             "Units: \\si{\\pascal\\second}.");
+                             "Units: $\\text{Pa}\\text{s}$.");
           prm.declare_entry ("Thermal conductivities", "4.7",
                              Patterns::Anything(),
                              "List of thermal conductivities for background and compositional fields (N), "
@@ -190,7 +190,7 @@ namespace aspect
                              "the total number of phase transitions, summed over all phases. The format is "
                              "background: value1|value2|...|valueP_1+1, field1:value1|...|valueP_2+1, ..., fieldN: value1|...|valueP_N+1. "
                              "If only one value is given, then all fields/phases use the same value. "
-                             "Units: \\si{\\watt\\per\\meter\\per\\kelvin}.");
+                             "Units: $\\text{W}\\text{m}^{-1}\\text{K}^{-1}$.");
           prm.declare_entry ("Viscosity averaging scheme", "harmonic",
                              Patterns::Selection("arithmetic|harmonic|geometric|maximum composition"),
                              "When more than one compositional field is present at a point "

--- a/source/material_model/perplex_lookup.cc
+++ b/source/material_model/perplex_lookup.cc
@@ -162,11 +162,11 @@ namespace aspect
           prm.declare_entry ("Minimum material pressure", "1.e5",
                              Patterns::Double (0.),
                              "The value of the minimum pressure used to query PerpleX. "
-                             "Units: \\si{\\pascal}.");
+                             "Units: $\\text{Pa}$.");
           prm.declare_entry ("Maximum material pressure", "1.e12",
                              Patterns::Double (0.),
                              "The value of the maximum pressure used to query PerpleX. "
-                             "Units: \\si{\\pascal}.");
+                             "Units: $\\text{Pa}$.");
 
         }
         prm.leave_subsection();

--- a/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
+++ b/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
@@ -103,12 +103,12 @@ namespace aspect
                            Patterns::Double (),
                            "Thickness of the crustal layer generated "
                            "at the surface."
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Lithosphere thickness", "63000",
                            Patterns::Double (),
                            "Thickness of the lithosphere layer generated "
                            "below the crust."
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
       }
 
 

--- a/source/material_model/reaction_model/grain_size_evolution.cc
+++ b/source/material_model/reaction_model/grain_size_evolution.cc
@@ -349,12 +349,12 @@ namespace aspect
                            Patterns::List (Patterns::Double (0.)),
                            "The activation energy for grain growth $E_g$. "
                            "List must have one more entry than the Phase transition depths. "
-                           "Units: \\si{\\joule\\per\\mole}.");
+                           "Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Grain growth activation volume", "8e-6",
                            Patterns::List (Patterns::Double (0.)),
                            "The activation volume for grain growth $V_g$. "
                            "List must have one more entry than the Phase transition depths. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
         prm.declare_entry ("Grain growth exponent", "3.",
                            Patterns::List (Patterns::Double (0.)),
                            "The exponent of the grain growth law $p_g$. This is an experimentally determined "
@@ -367,7 +367,7 @@ namespace aspect
                            "This is dependent on water content, which is assumed to be "
                            "50 H/$10^6$ Si for the default value. "
                            "List must have one more entry than the Phase transition depths. "
-                           "Units: \\si{\\meter}$^{p_g}$\\si{\\per\\second}.");
+                           "Units: $\\text{m}$$^{p_g}$$\\text{s}^{-1}$.");
         prm.declare_entry ("Reciprocal required strain", "10.",
                            Patterns::List (Patterns::Double (0.)),
                            "This parameter ($\\lambda$) gives an estimate of the strain necessary "
@@ -378,7 +378,7 @@ namespace aspect
                            "The grain size $d_{ph}$ to that a phase will be reduced to when crossing a phase transition. "
                            "When set to zero, grain size will not be reduced. "
                            "List must have the same number of entries as Phase transition depths. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Phase volume fraction", "0.4",
                            Patterns::Double (0., 1.),
                            "The volume fraction of one of the phases in the two-phase damage model of Bercovici and Ricard (2012). "
@@ -403,12 +403,12 @@ namespace aspect
                            Patterns::List (Patterns::Double (0.)),
                            "The average specific grain boundary energy $\\gamma$. "
                            "List must have one more entry than the Phase transition depths. "
-                           "Units: \\si{\\joule\\per\\meter\\squared}.");
+                           "Units: $\\text{J}\\text{m}^{-2}$.");
         prm.declare_entry ("Work fraction for boundary area change", "0.1",
                            Patterns::List (Patterns::Double (0.)),
                            "The fraction $\\chi$ of work done by dislocation creep to change the grain boundary area. "
                            "List must have one more entry than the Phase transition depths. "
-                           "Units: \\si{\\joule\\per\\meter\\squared}.");
+                           "Units: $\\text{J}\\text{m}^{-2}$.");
         prm.declare_entry ("Geometric constant", "3.",
                            Patterns::List (Patterns::Double (0.)),
                            "The geometric constant $c$ used in the paleowattmeter grain size reduction law. "
@@ -419,7 +419,7 @@ namespace aspect
                            "The minimum grain size that is used for the material model. This parameter "
                            "is introduced to limit local viscosity contrasts, but still allows for a widely "
                            "varying viscosity over the whole mantle range. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Lower mantle grain size scaling", "1.0",
                            Patterns::Double (0.),
                            "This option does not exist any more.");

--- a/source/material_model/reaction_model/katz2003_mantle_melting.cc
+++ b/source/material_model/reaction_model/katz2003_mantle_melting.cc
@@ -473,7 +473,7 @@ namespace aspect
                            "Depth above that melt will be extracted from the model, "
                            "which is done by a negative reaction term proportional to the "
                            "porosity field. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Melt compressibility", "0.0",
                            Patterns::Double (0.),
                            "The value of the compressibility of the melt. "
@@ -548,7 +548,7 @@ namespace aspect
         prm.declare_entry ("Reference permeability", "1e-8",
                            Patterns::Double(),
                            "Reference permeability of the solid host rock."
-                           "Units: \\si{\\meter\\squared}.");
+                           "Units: $\\text{m}^{2}$.");
 
 
       }

--- a/source/material_model/reactive_fluid_transport.cc
+++ b/source/material_model/reactive_fluid_transport.cc
@@ -363,7 +363,7 @@ namespace aspect
                             "that for more information.");
           prm.declare_entry ("Reference fluid density", "2500",
                              Patterns::Double (0),
-                             "Reference density of the melt/fluid$\\rho_{f,0}$. Units: \\si{\\kilogram\\per\\meter\\cubed}.");
+                             "Reference density of the melt/fluid$\\rho_{f,0}$. Units: $\\text{kg}\\text{m}^{-3}$.");
           prm.declare_entry ("Shear to bulk viscosity ratio", "0.1",
                              Patterns::Double (0),
                              "Ratio between shear and bulk viscosity at the reference "
@@ -386,7 +386,7 @@ namespace aspect
           prm.declare_entry ("Reference permeability", "1e-8",
                              Patterns::Double(),
                              "Reference permeability of the solid host rock."
-                             "Units: \\si{\\meter\\squared}.");
+                             "Units: $\\text{m}^{2}$.");
           prm.declare_entry ("Fluid compressibility", "0.0",
                              Patterns::Double (0),
                              "The value of the compressibility of the fluid. "
@@ -423,7 +423,7 @@ namespace aspect
                              Patterns::Double (0.),
                              "The reference temperature $T_0$ for the katz2003 reaction model. "
                              "The reference temperature is used in both the density and "
-                             "viscosity formulas of this model. Units: \\si{\\kelvin}.");
+                             "viscosity formulas of this model. Units: $\\text{K}$.");
         }
         prm.leave_subsection();
 

--- a/source/material_model/rheology/composite_visco_plastic.cc
+++ b/source/material_model/rheology/composite_visco_plastic.cc
@@ -714,7 +714,7 @@ namespace aspect
         // rheology models. The new defaults will apply both to
         // this rheology model and to the subordinate rheology modules.
         prm.declare_entry ("Minimum strain rate", "1.4e-20", Patterns::Double(0.),
-                           "Stabilizes strain dependent viscosity. Units: \\si{\\per\\second}.");
+                           "Stabilizes strain dependent viscosity. Units: $\\text{s}^{-1}$.");
 
         // Viscosity iteration parameters
         prm.declare_entry ("Strain rate residual tolerance", "1e-10", Patterns::Double(0.),

--- a/source/material_model/rheology/compositional_viscosity_prefactors.cc
+++ b/source/material_model/rheology/compositional_viscosity_prefactors.cc
@@ -107,7 +107,7 @@ namespace aspect
                            "prefactor scheme. This acts as the cutoff between 'dry' creep and 'wet' creep "
                            "for olivine, and the default value is chosen based on the value reported by "
                            "Hirth & Kohlstedt 2004. For a mass fraction of bound water beneath this value, "
-                           "this value is used instead to compute the water fugacity. Units: \\si{\\kg} / \\si{\\kg} %.");
+                           "this value is used instead to compute the water fugacity. Units: $\\text{kg}$ / $\\text{kg}$ %.");
 
         prm.declare_entry ("Water fugacity exponents for diffusion creep", "0.0",
                            Patterns::List(Patterns::Double(0)),

--- a/source/material_model/rheology/diffusion_creep.cc
+++ b/source/material_model/rheology/diffusion_creep.cc
@@ -228,7 +228,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\per\\pascal\\meter}$^{m_{\\text{diffusion}}}$\\si{\\per\\second}.");
+                           "Units: $\\text{Pa}^{-1}\\text{m}^{-1}$$^{m_{\\text{diffusion}}}$$\\text{s}^{-1}$.");
         prm.declare_entry ("Stress exponents for diffusion creep", "1.",
                            Patterns::List(Patterns::Double(0.)),
                            "List of stress exponents, $n_{\\text{diffusion}}$, for background mantle and compositional fields, "
@@ -248,21 +248,21 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\joule\\per\\mole}.");
+                           "Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Activation volumes for diffusion creep", "6e-6",
                            Patterns::Anything(),
                            "List of activation volumes, $V_a$, for background material and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
         prm.declare_entry ("Grain size", "1e-3", Patterns::Double (0.),
                            "The fixed grain size of the material. "
                            "This grain size is only used if the parent "
                            "material model does not provide its own "
                            "(possibly variable) grain size when "
                            "calling this rheology."
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
       }
 
 

--- a/source/material_model/rheology/diffusion_dislocation.cc
+++ b/source/material_model/rheology/diffusion_dislocation.cc
@@ -211,7 +211,7 @@ namespace aspect
         prm.declare_entry ("Reference temperature", "293.", Patterns::Double(0.),
                            "For calculating density by thermal expansivity. Units: $\\text{K}$.");
         prm.declare_entry ("Minimum strain rate", "1.4e-20", Patterns::Double(0.),
-                           "Stabilizes strain dependent viscosity. Units: \\si{\\per\\second}.");
+                           "Stabilizes strain dependent viscosity. Units: $\\text{s}^{-1}$.");
         prm.declare_entry ("Minimum viscosity", "1e17", Patterns::Double(0.),
                            "Lower cutoff for effective viscosity. Units: $\\text{Pa}\\text{s}$.");
         prm.declare_entry ("Maximum viscosity", "1e28", Patterns::Double(0.),
@@ -233,7 +233,7 @@ namespace aspect
 
         // Equation of state parameters
         prm.declare_entry ("Thermal diffusivity", "0.8e-6", Patterns::Double(0.),
-                           "Units: \\si{\\meter\\squared\\per\\second}.");
+                           "Units: $\\text{m}^{2}\\text{s}^{-1}$.");
         prm.declare_entry ("Heat capacity", "1.25e3",
                            Patterns::Double(0.),
                            "The value of the specific heat $C_p$. "
@@ -266,7 +266,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: $\\frac{1}{\\text{Pa}}$ \\si{\\meter}$^{m_{\\text{diffusion}}}$ \\si{\\per\\second}.");
+                           "Units: $\\frac{1}{\\text{Pa}}$ $\\text{m}$$^{m_{\\text{diffusion}}}$ $\\text{s}^{-1}$.");
         prm.declare_entry ("Stress exponents for diffusion creep", "1.",
                            Patterns::List(Patterns::Double(0.)),
                            "List of stress exponents, $n_{\\text{diffusion}}$, for background mantle and compositional fields, "
@@ -285,14 +285,14 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\joule\\per\\mole}.");
+                           "Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Activation volumes for diffusion creep", "6e-6",
                            Patterns::List(Patterns::Double(0.)),
                            "List of activation volumes, $V_a$, for background mantle and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
 
         // Dislocation creep parameters
         prm.declare_entry ("Prefactors for dislocation creep", "1.1e-16",
@@ -301,7 +301,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\pascal}$^{-n_{\\text{dislocation}}}$\\si{\\per\\second}.");
+                           "Units: $\\text{Pa}$$^{-n_{\\text{dislocation}}}$$\\text{s}^{-1}$.");
         prm.declare_entry ("Stress exponents for dislocation creep", "3.5",
                            Patterns::List(Patterns::Double(0.)),
                            "List of stress exponents, $n_{\\text{dislocation}}$, for background mantle and compositional fields, "
@@ -314,14 +314,14 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\joule\\per\\mole}.");
+                           "Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Activation volumes for dislocation creep", "1.4e-5",
                            Patterns::List(Patterns::Double(0.)),
                            "List of activation volumes, $V_a$, for background mantle and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
 
         // Diffusion creep parameters
         Rheology::DiffusionCreep<dim>::declare_parameters(prm);

--- a/source/material_model/rheology/dislocation_creep.cc
+++ b/source/material_model/rheology/dislocation_creep.cc
@@ -185,7 +185,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\pascal}$^{-n_{\\text{dislocation}}}$ \\si{\\per\\second}.");
+                           "Units: $\\text{Pa}$$^{-n_{\\text{dislocation}}}$ $\\text{s}^{-1}$.");
         prm.declare_entry ("Stress exponents for dislocation creep", "3.5",
                            Patterns::Anything(),
                            "List of stress exponents, $n_{\\text{dislocation}}$, for background material and compositional fields, "
@@ -198,14 +198,14 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\joule\\per\\mole}.");
+                           "Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Activation volumes for dislocation creep", "1.4e-5",
                            Patterns::Anything(),
                            "List of activation volumes, $V_a$, for background material and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
       }
 
 

--- a/source/material_model/rheology/drucker_prager.cc
+++ b/source/material_model/rheology/drucker_prager.cc
@@ -284,7 +284,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from "
-                           "exceeding the yield stress. Units: \\si{\\pascal}.");
+                           "exceeding the yield stress. Units: $\\text{Pa}$.");
         prm.declare_entry ("Prefactors for yield stress", "1.0",
                            Patterns::Anything(),
                            "List of prefactors for the yield stress, for background material and compositional fields, "
@@ -298,7 +298,7 @@ namespace aspect
                            ", which limits the maximum value of the yield stress determined by the "
                            "Drucker-Prager plasticity parameters. Default value is chosen so this "
                            "is not automatically used. Values of 100e6--1000e6 $Pa$ have been used "
-                           "in previous models. Units: \\si{\\pascal}.");
+                           "in previous models. Units: $\\text{Pa}$.");
         prm.declare_entry ("Use plastic damper","false",
                            Patterns::Bool (),
                            "Whether to use a plastic damper when computing the Drucker-Prager "
@@ -307,7 +307,7 @@ namespace aspect
                            "sufficient resolutions.");
         prm.declare_entry ("Plastic damper viscosity", "0.0", Patterns::Double(0),
                            "Viscosity of the damper that acts in parallel with the plastic viscosity "
-                           "to produce mesh-independent behavior at sufficient resolutions. Units: \\si{\\pascal\\second}");
+                           "to produce mesh-independent behavior at sufficient resolutions. Units: $\\text{Pa}\\text{s}$");
       }
 
 

--- a/source/material_model/rheology/drucker_prager_power.cc
+++ b/source/material_model/rheology/drucker_prager_power.cc
@@ -164,15 +164,15 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "The extremely large default cohesion value (1e20 Pa) prevents the viscous stress from "
-                           "exceeding the yield stress. Units: \\si{\\pascal}.");
+                           "exceeding the yield stress. Units: $\\text{Pa}$.");
         prm.declare_entry ("Maximum yield stress", "1e12", Patterns::Double (0.),
                            "Limits the maximum value of the yield stress determined by the "
                            "Drucker-Prager plasticity parameters. Default value is chosen so this "
                            "is not automatically used. Values of 100e6--1000e6 $Pa$ have been used "
-                           "in previous models. Units: \\si{\\pascal}.");
+                           "in previous models. Units: $\\text{Pa}$.");
         prm.declare_entry ("Reference plastic strain rate", "1e-18", Patterns::Double (0.),
                            "Provides the strain rate at which the yield stress determined by the "
-                           "Drucker-Prager plasticity parameters apply. Units: \\si{\\per\\second}.");
+                           "Drucker-Prager plasticity parameters apply. Units: $\\text{s}^{-1}$.");
         prm.declare_entry ("Plastic stress exponent", "50", Patterns::Double (0.),
                            "Provides the stress exponent that modifies the yield stress according to "
                            "the strain rate. The default value is chosen to provide trade-off between "

--- a/source/material_model/rheology/friction_models.cc
+++ b/source/material_model/rheology/friction_models.cc
@@ -163,7 +163,7 @@ namespace aspect
                            "the static angle of internal friction is used. Around the dynamic characteristic "
                            "strain rate, there is a smooth gradient from the static to the dynamic angle "
                            "of internal friction. "
-                           "Units: \\si{\\per\\second}.");
+                           "Units: $\\text{s}^{-1}$.");
 
         prm.declare_entry ("Dynamic angles of internal friction", "2",
                            Patterns::List(Patterns::Double(0)),
@@ -172,7 +172,7 @@ namespace aspect
                            "those corresponding to chemical compositions. "
                            "Dynamic angles of friction are used as the current friction angle when the effective "
                            "strain rate is well above the 'dynamic characteristic strain rate'. "
-                           "Units: \\si{\\degree}.");
+                           "Units: $\\text{degree}$.");
 
         prm.declare_entry ("Dynamic friction smoothness exponent", "1",
                            Patterns::Double (0),

--- a/source/material_model/rheology/grain_boundary_sliding.cc
+++ b/source/material_model/rheology/grain_boundary_sliding.cc
@@ -142,7 +142,7 @@ namespace aspect
           prm.declare_entry ("Prefactors for grain boundary sliding", "6.2e-14",
                              Patterns::Anything(),
                              "Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. "
-                             "Units: \\si{\\pascal}$^{-n_{\\text{grain boundary sliding}}}$ \\si{\\meter}$^{m_{\\text{grain boundary sliding}}}$ \\si{\\per\\second}.");
+                             "Units: $\\text{Pa}$$^{-n_{\\text{grain boundary sliding}}}$ $\\text{m}$$^{m_{\\text{grain boundary sliding}}}$ $\\text{s}^{-1}$.");
           prm.declare_entry ("Stress exponents for grain boundary sliding", "1.8",
                              Patterns::List(Patterns::Double(0.)),
                              "Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. Units: None.");
@@ -152,14 +152,14 @@ namespace aspect
           prm.declare_entry ("Activation energies for grain boundary sliding", "49e3",
                              Patterns::Anything(),
                              "Here we use the default values for ice at T < 255 K as given in Goldsby & Kohlstedt, 2001. "
-                             "Units: \\si{\\joule\\per\\mole}.");
+                             "Units: $\\text{J}\\text{mol}^{-1}$.");
           prm.declare_entry ("Activation volumes for grain boundary sliding", "-13e-6",
                              Patterns::Anything(),
                              "Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. "
-                             "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                             "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
           prm.declare_entry ("Grain size", "26e-6", Patterns::Double (0.),
                              "Here we use the default values for ice as given in Goldsby & Kohlstedt, 2001. "
-                             "Units: \\si{\\meter}.");
+                             "Units: $\\text{m}$.");
           prm.leave_subsection();
         }
       }

--- a/source/material_model/rheology/peierls_creep.cc
+++ b/source/material_model/rheology/peierls_creep.cc
@@ -554,7 +554,7 @@ namespace aspect
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\pascal}$^{-n_{\\text{peierls}}}$ \\si{\\per\\second}");
+                           "Units: $\\text{Pa}$$^{-n_{\\text{peierls}}}$ $\\text{s}^{-1}$");
         prm.declare_entry ("Stress exponents for Peierls creep", "2.0",
                            Patterns::Anything(),
                            "List of stress exponents, $n_{\\text{peierls}}$, for background material and compositional "
@@ -566,21 +566,21 @@ namespace aspect
                            "List of activation energies, $E$, for background material and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
-                           "If only one value is given, then all use the same value. Units: \\si{\\joule\\per\\mole}.");
+                           "If only one value is given, then all use the same value. Units: $\\text{J}\\text{mol}^{-1}$.");
         prm.declare_entry ("Activation volumes for Peierls creep", "1.4e-5",
                            Patterns::Anything(),
                            "List of activation volumes, $V$, for background material and compositional fields, "
                            "for a total of N+1 values, where N is the number of all compositional fields or only "
                            "those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\meter\\cubed\\per\\mole}.");
+                           "Units: $\\text{m}^{3}\\text{mol}^{-1}$.");
         prm.declare_entry ("Peierls stresses", "5.e9",
                            Patterns::Anything(),
                            "List of stress limits for Peierls creep $\\sigma_{\\text{peierls}}$ for background "
                            "material and compositional fields, for a total of N+1 values, where N is the number "
                            "of all compositional fields or only those corresponding to chemical compositions. "
                            "If only one value is given, then all use the same value. "
-                           "Units: \\si{\\pascal}");
+                           "Units: $\\text{Pa}$");
         prm.declare_entry ("Peierls fitting parameters", "0.17",
                            Patterns::Anything(),
                            "List of fitting parameters $\\gamma$ between stress $\\sigma$ and the Peierls "
@@ -603,7 +603,7 @@ namespace aspect
         prm.declare_entry ("Cutoff stresses for Peierls creep", "0.0",
                            Patterns::Anything(),
                            "List of the Stress thresholds below which the strain rate is solved for as a quadratic "
-                           "function of stress to aid with convergence when stress exponent n=0. Units: \\si{\\pascal}");
+                           "function of stress to aid with convergence when stress exponent n=0. Units: $\\text{Pa}$");
         prm.declare_entry ("Apply strict stress cutoff for Peierls creep", "false", Patterns::Bool(),
                            "Whether the cutoff stresses for Peierls creep are used as the minimum "
                            "stresses in the Peierls rheology");

--- a/source/material_model/rheology/visco_plastic.cc
+++ b/source/material_model/rheology/visco_plastic.cc
@@ -649,9 +649,9 @@ namespace aspect
 
         // Reference and minimum/maximum values
         prm.declare_entry ("Minimum strain rate", "1.0e-20", Patterns::Double (0.),
-                           "Stabilizes strain dependent viscosity. Units: \\si{\\per\\second}.");
+                           "Stabilizes strain dependent viscosity. Units: $\\text{s}^{-1}$.");
         prm.declare_entry ("Reference strain rate","1.0e-15",Patterns::Double (0.),
-                           "Reference strain rate for first time step. Units: \\si{\\per\\second}.");
+                           "Reference strain rate for first time step. Units: $\\text{s}^{-1}$.");
         prm.declare_entry ("Minimum viscosity", "1e17", Patterns::Anything(),
                            "Lower cutoff for effective viscosity. Units: $\\text{Pa}\\text{s}$. "
                            "List with as many components as active "
@@ -758,7 +758,7 @@ namespace aspect
                            "is okay for the upper mantle, but is not really accurate for the lower mantle. "
                            "Using a pressure gradient of 32436 Pa/m, then a value of "
                            "0.3 K/km = 0.0003 K/m = 9.24e-09 K/Pa gives an earth-like adiabat."
-                           "Units: \\si{\\kelvin\\per\\pascal}.");
+                           "Units: $\\text{K}\\text{Pa}^{-1}$.");
       }
 
 

--- a/source/material_model/thermal_conductivity/tosi_stackhouse.cc
+++ b/source/material_model/thermal_conductivity/tosi_stackhouse.cc
@@ -71,7 +71,7 @@ namespace aspect
                            "A list of depth values that indicate where the transitions between "
                            "the different conductivity parameter sets should occur (in most cases, "
                            "these will be the depths of major phase transitions). "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Reference thermal conductivities", "2.47, 3.81, 3.52, 4.9",
                            Patterns::List(Patterns::Double (0.)),
                            "A list of base values of the thermal conductivity for each of the "
@@ -84,7 +84,7 @@ namespace aspect
                            Patterns::List(Patterns::Double ()),
                            "A list of values that determine the linear scaling of the "
                            "thermal conductivity with pressure. "
-                           "Units: \\si{\\watt\\per\\meter\\per\\kelvin\\per\\pascal}.");
+                           "Units: $\\text{W}\\text{m}^{-1}\\text{K}^{-1}\\text{Pa}^{-1}$.");
         prm.declare_entry ("Reference temperatures for thermal conductivity", "300, 300, 300, 1200",
                            Patterns::List(Patterns::Double (0.)),
                            "A list of values of reference temperatures used to determine "

--- a/source/material_model/utilities.cc
+++ b/source/material_model/utilities.cc
@@ -1633,20 +1633,20 @@ namespace aspect
                            Patterns::Anything(),
                            "A list of depths where phase transitions occur. Values must "
                            "monotonically increase. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Phase transition widths", "",
                            Patterns::Anything(),
                            "A list of widths for each phase transition, in terms of depth. The phase functions "
                            "are scaled with these values, leading to a jump between phases "
                            "for a value of zero and a gradual transition for larger values. "
                            "List must have the same number of entries as Phase transition depths. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
         prm.declare_entry ("Phase transition pressures", "",
                            Patterns::Anything(),
                            "A list of pressures where phase transitions occur. Values must "
                            "monotonically increase. Define transition by depth instead of "
                            "pressure must be set to false to use this parameter. "
-                           "Units: \\si{\\pascal}.");
+                           "Units: $\\text{Pa}$.");
         prm.declare_entry ("Phase transition pressure widths", "",
                            Patterns::Anything(),
                            "A list of widths for each phase transition, in terms of pressure. The phase functions "
@@ -1655,7 +1655,7 @@ namespace aspect
                            "List must have the same number of entries as Phase transition pressures. "
                            "Define transition by depth instead of pressure must be set to false "
                            "to use this parameter. "
-                           "Units: \\si{\\pascal}.");
+                           "Units: $\\text{Pa}$.");
         prm.declare_entry ("Define transition by depth instead of pressure", "true",
                            Patterns::Bool (),
                            "Whether to list phase transitions by depth or pressure. If this parameter is true, "
@@ -1670,7 +1670,7 @@ namespace aspect
                            "depths than given in Phase transition depths, depending on the "
                            "Clapeyron slope given in Phase transition Clapeyron slopes. "
                            "List must have the same number of entries as Phase transition depths. "
-                           "Units: \\si{\\kelvin}.");
+                           "Units: $\\text{K}$.");
         prm.declare_entry ("Phase transition temperature upper limits",
                            boost::lexical_cast<std::string>(std::numeric_limits<double>::max()),
                            Patterns::Anything(),
@@ -1683,7 +1683,7 @@ namespace aspect
                            "should be continuous in pressure-temperature space. "
                            "We recommend producing a phase diagram with "
                            "simple model setups to check the implementation as a starting point."
-                           "Units: \\si{\\kelvin}.");
+                           "Units: $\\text{K}$.");
         prm.declare_entry ("Phase transition temperature lower limits",
                            boost::lexical_cast<std::string>(std::numeric_limits<double>::lowest()),
                            Patterns::Anything(),
@@ -1696,7 +1696,7 @@ namespace aspect
                            "should be continuous in pressure-temperature space. "
                            "We recommend producing a phase diagram with "
                            "simple model setups to check the implementation as a starting point."
-                           "Units: \\si{\\kelvin}.");
+                           "Units: $\\text{K}$.");
         prm.declare_entry ("Phase transition Clapeyron slopes", "",
                            Patterns::Anything(),
                            "A list of Clapeyron slopes for each phase transition. A positive "
@@ -1706,7 +1706,7 @@ namespace aspect
                            "temperature is smaller than the one given in Phase transition temperatures. "
                            "For negative slopes the other way round. "
                            "List must have the same number of entries as Phase transition depths. "
-                           "Units: \\si{\\pascal\\per\\kelvin}.");
+                           "Units: $\\text{Pa}\\text{K}^{-1}$.");
       }
 
 

--- a/source/material_model/visco_plastic.cc
+++ b/source/material_model/visco_plastic.cc
@@ -378,7 +378,7 @@ namespace aspect
                              "for a total of N+1 values, where N is the number of all compositional fields or only "
                              "those corresponding to chemical compositions. "
                              "If only one value is given, then all use the same value.  "
-                             "Units: \\si{\\meter\\squared\\per\\second}.");
+                             "Units: $\\text{m}^{2}\\text{s}^{-1}$.");
           prm.declare_entry ("Define thermal conductivities","false",
                              Patterns::Bool (),
                              "Whether to directly define thermal conductivities for each compositional field "

--- a/source/mesh_deformation/diffusion.cc
+++ b/source/mesh_deformation/diffusion.cc
@@ -569,7 +569,7 @@ namespace aspect
                             "The hillslope transport coefficient $\\kappa$ used to "
                             "diffuse the free surface, either as a  "
                             "stabilization step or to mimic erosional "
-                            "and depositional processes. Units: $\\si{m^2/s}$. ");
+                            "and depositional processes. Units: $\\text{m}^2/\\text{s}$. ");
           prm.declare_entry("Time steps between diffusion", "1",
                             Patterns::Integer(0,std::numeric_limits<int>::max()),
                             "The number of time steps between each application of "

--- a/source/postprocess/visualization/density_anomaly.cc
+++ b/source/postprocess/visualization/density_anomaly.cc
@@ -227,7 +227,7 @@ namespace aspect
                                                   "``Number of depth slices''. In the ``reference profile'' scheme, the adiabatic density is used as the"
                                                   "average density."
                                                   "\n\n"
-                                                  "Physical units: \\si{\\kg/m^3}.")
+                                                  "Physical units: $\\text{kg}/\\text{m}^3$.")
     }
   }
 }

--- a/source/postprocess/visualization/depth_including_mesh_deformation.cc
+++ b/source/postprocess/visualization/depth_including_mesh_deformation.cc
@@ -88,7 +88,7 @@ namespace aspect
                                                   "determined by the current model surface. This plugin "
                                                   "will include changes to the surface from mesh deformation."
                                                   "\n\n"
-                                                  "Physical units: \\si{\\meter}.")
+                                                  "Physical units: $\\text{m}$.")
     }
   }
 }

--- a/source/postprocess/visualization/entropy_average.cc
+++ b/source/postprocess/visualization/entropy_average.cc
@@ -101,7 +101,7 @@ namespace aspect
                                                   "A visualization output object that generates output "
                                                   "for the averaged entropy of multiple components."
                                                   "\n\n"
-                                                  "Physical units: \\si{\\J/kg/K}.")
+                                                  "Physical units: $\\text{J/kg/K}$.")
     }
   }
 }

--- a/source/postprocess/visualization/heating.cc
+++ b/source/postprocess/visualization/heating.cc
@@ -182,7 +182,7 @@ namespace aspect
                                                   "A visualization output object that generates output "
                                                   "for all the heating terms used in the energy equation."
                                                   "\n\n"
-                                                  "Physical units: $\\frac{\\text{W}}{\\text{m}^3}$\\si{\\watt\\per\\cubic\\meter}.")
+                                                  "Physical units: $\\frac{\\text{W}}{\\text{m}^3}$.")
     }
   }
 }

--- a/source/postprocess/visualization/strain_rate_tensor.cc
+++ b/source/postprocess/visualization/strain_rate_tensor.cc
@@ -112,7 +112,7 @@ namespace aspect
                                                   "all components of the tensor because that is what the file format "
                                                   "requires."
                                                   "\n\n"
-                                                  "Physical units: \\si{\\per\\second}.")
+                                                  "Physical units: $\\text{s}^{-1}$.")
     }
   }
 }

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -696,7 +696,7 @@ namespace aspect
                            "More precisely, this length scale represents the square root of the "
                            "product of diffusivity and time in the diffusion equation, and controls "
                            "the distance over which features are diffused. "
-                           "Units: \\si{\\meter}.");
+                           "Units: $\\text{m}$.");
       }
       prm.leave_subsection ();
     }


### PR DESCRIPTION
While looking at the ASPECT user meeting doc, I noticed that I never fixed the `\si` unit instances in the manual :-(.

This PR replaces these instances with `.md`-compatible units. I also included the python script I used, mainly to make the review easier rather than looking at the individual file changes. There were some occurrences I fixed manually, e.g., `\\si{m}` or `\\si{meter}`, but the script caught almost all of them.

I reviewed all the individual file changes but only verified that the rendering looked correct for a subset of these changes.

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
