### PR TITLE
Set bedrock diffusivity in tests to something very small instead of -1

### DIFF
--- a/tests/fastscape_kf_function.prm
+++ b/tests/fastscape_kf_function.prm
@@ -78,7 +78,7 @@ subsection Mesh deformation
       set Function expression = if(t<=250e3, 1e-6, if(x>25e3,1e-4, 1e-6))
     end
      set Sediment river incision rate = 1e-5
-     set Bedrock diffusivity = -1    
+     set Bedrock diffusivity = 1e-10
      set Sediment diffusivity = -1
    end
   end

--- a/tests/fastscape_kf_function_in_seconds.prm
+++ b/tests/fastscape_kf_function_in_seconds.prm
@@ -23,7 +23,7 @@ subsection Mesh deformation
       set Function expression = if(t<=250e3*year_in_seconds, 1e-6/year_in_seconds, if(x>25e3,1e-4/year_in_seconds, 1e-6/year_in_seconds))
     end
      set Sediment river incision rate = 3.16887385e-13
-     set Bedrock diffusivity = -1    
+     set Bedrock diffusivity = 3.16887385e-18
      set Sediment diffusivity = -1
    end
   end

--- a/tests/fastscape_sea_level_function.prm
+++ b/tests/fastscape_sea_level_function.prm
@@ -72,7 +72,7 @@ subsection Mesh deformation
    subsection Erosional parameters
     set Bedrock river incision rate = 1e-5
      set Sediment river incision rate = 1e-5
-     set Bedrock diffusivity = -1    
+     set Bedrock diffusivity = 1e-10
      set Sediment diffusivity = -1
    end
 


### PR DESCRIPTION
A` bedrock diffusivity` of -1 does not make sense. However, for `sediment diffusivity `a value of -1 is allowed, as it indicates to FastScape that the same diffusivity should be used for the sediment as for the bedrock.

I will update the test output files once I've run them locally in docker after #6996, #6994 and #6995 have been merged.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
