### PR TITLE
Update maintainers for tester

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,9 +58,11 @@ pipeline {
               not {changeRequest authorEmail: "ja3170@columbia.edu"}
               not {changeRequest authorEmail: "jbnaliboff@ucdavis.edu"}
               not {changeRequest authorEmail: "menno.fraters@tutanota.com"}
-              not {changeRequest authorEmail: "a.c.glerum@uu.nl"}
+              not {changeRequest authorEmail: "acglerum@gfz.de"}
               not {changeRequest authorEmail: "myhill.bob@gmail.com"}
               not {changeRequest authorEmail: "ljhwang@ucdavis.edu"}
+              not {changeRequest authorEmail: "saxena.arushi314@gmail.com"}
+              not {changeRequest authorEmail: "daniel.douglas@bc.edu"}
             }
           }
           steps {


### PR DESCRIPTION
Update the identities of the people whose PRs are automatically tested. Anne's case is a bit weird, because her commits still appear under her old address, but the tester doesnt seem to recognize that, and I suspect it is because her github address has changed. Hopefully this resolves the issue.

@tjhei FYI.