### PR TITLE
Set convert unit to big endian for FastScape

### DIFF
--- a/contrib/docker/tester/Dockerfile
+++ b/contrib/docker/tester/Dockerfile
@@ -40,6 +40,7 @@ RUN cd /opt && \
 ENV PATH="/opt/astyle-2.04:/opt/cmake-3.26.4-linux-x86_64/bin:$PATH"
 ENV DEAL_II_DIR=/opt/deal.II-master
 ENV FASTSCAPE_DIR=/opt/fastscapelib-fortran/build
+ENV GFORTRAN_CONVERT_UNIT='big_endian'
 ENV NETCDF_DIR=/opt/netcdf-4.7.4
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 ENV OMPI_MCA_mpi_yield_when_idle=1


### PR DESCRIPTION
This PR sets an environment variable in the Dockerfile from which the dealii-master tester image is built. The GFORTRAN_CONVERT_UNIT setting is needed to get correct VTU output from FastScape (see https://github.com/fastscape-lem/fastscapelib-fortran/issues/49). Without it, the output is not readible in ParaView. Although this is not so important for the tester, I would like to include it for completion and in case someone uses the image. Also, the FastScape tests do produce VTU output, but I don't think that is compared.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
