### PR TITLE
add cmcrameri to env-py_aspect.yml

### DIFF
--- a/contrib/python/env-py_aspect.yml
+++ b/contrib/python/env-py_aspect.yml
@@ -8,3 +8,4 @@ dependencies:
   - pandas
   - matplotlib
   - libnetcdf
+  - cmcrameri


### PR DESCRIPTION
This is a follow up to #7005 , I forgot to include the cmcrameri color maps package in the environment file. This isn't needed for any of the scripts in the repository right now but is used in the scripts that Chris is writing to generate the figures for the cookbook documentation.