### PR TITLE
Fix nsinker_gmg_gc test

### DIFF
--- a/tests/spherical_nsinker_gmg_gc/screen-output
+++ b/tests/spherical_nsinker_gmg_gc/screen-output
@@ -37,3 +37,5 @@ Termination requested by criterion: end time
 
 
 
+
+


### PR DESCRIPTION
This test is failing on the tester for other PRs and after looking at #7022 it seems that the issue is just a difference in the number of empty lines? We'll see if the test passes here, not sure what could have caused this discrepancy.