### PR TITLE
Support global-coarsening GMG for phi-periodic spherical shells

### DIFF
--- a/doc/modules/changes/20260709_FrancescoRadica_periodic_spherical_shell_gmg
+++ b/doc/modules/changes/20260709_FrancescoRadica_periodic_spherical_shell_gmg
@@ -1,0 +1,7 @@
+Fixed: The periodicity constraints of phi-periodic spherical shells were
+silently wrong for scalar fields such as the pressure of the matrix-free
+Stokes solvers, because the rotation matrix was misinterpreted as a face
+interpolation matrix. Forcing the GMG solver on periodic spherical shells
+used to produce wrong velocities near the periodic boundary.
+<br>
+(Francesco Radica, 2026/07/09)

--- a/doc/modules/changes/20260709_FrancescoRadica_periodic_spherical_shell_gmg_1
+++ b/doc/modules/changes/20260709_FrancescoRadica_periodic_spherical_shell_gmg_1
@@ -1,0 +1,7 @@
+New: The global coarsening GMG Stokes solver now supports periodic boundary
+conditions, including the rotational periodicity of spherical shells and
+hanging nodes on the periodic boundary. This solver must be selected
+explicitly by setting the Stokes solver type to `block GMG` and the Stokes
+GMG type to `global coarsening`.
+<br>
+(Francesco Radica, 2026/07/09)

--- a/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
+++ b/include/aspect/simulator/solver/stokes_matrix_free_global_coarsening.h
@@ -230,6 +230,24 @@ namespace aspect
 
       std::vector<std::shared_ptr<const Triangulation<dim, dim>>> trias;
 
+      /**
+       * Return a mapping that is valid on the (repartitioned copies of the)
+       * level triangulations of the global coarsening hierarchy. The
+       * simulator mapping can be a MappingQCache, which caches geometry
+       * information for the cells of the simulator triangulation only and
+       * must not be evaluated on other triangulations. In that case an
+       * equivalent manifold-based mapping is built (and stored in
+       * #level_triangulation_mapping); otherwise the simulator mapping is
+       * returned.
+       */
+      const Mapping<dim> &get_level_triangulation_mapping();
+
+      /**
+       * Storage for the mapping returned by
+       * get_level_triangulation_mapping().
+       */
+      std::unique_ptr<Mapping<dim>> level_triangulation_mapping;
+
       MGLevelObject<DoFHandler<dim>> dofhandlers_v;
       MGLevelObject<DoFHandler<dim>> dofhandlers_p;
       MGLevelObject<DoFHandler<dim>> dofhandlers_projection;

--- a/source/geometry_model/spherical_shell.cc
+++ b/source/geometry_model/spherical_shell.cc
@@ -903,11 +903,35 @@ namespace aspect
                                             /*direction*/ 1, matched_pairs,
                                             Tensor<1, dim>(), rotation_matrix);
 
-          DoFTools::make_periodicity_constraints<dim,dim,double>(matched_pairs,
-                                                                 constraints,
-                                                                 ComponentMask(),
-          {0},
-          1.);
+          if (dof_handler.get_fe().n_components() == 1)
+            {
+              // Scalar fields (for example the pressure DoFHandler of the
+              // matrix-free Stokes solvers) are invariant under the rotation
+              // that maps one periodic face onto the other. The rotation
+              // matrix is only needed to geometrically match the faces above.
+              // It must not be handed to make_periodicity_constraints():
+              // for scalar elements whose number of DoFs per face equals dim
+              // (e.g. Q1 in 2d) the dim x dim rotation matrix would be
+              // misinterpreted as a face interpolation matrix, silently
+              // producing wrong constraints that couple different DoFs of
+              // the same face.
+              for (auto &pair : matched_pairs)
+                pair.matrix = FullMatrix<double>();
+
+              DoFTools::make_periodicity_constraints<dim,dim,double>(matched_pairs,
+                                                                     constraints);
+            }
+          else
+            {
+              // Vector-valued case (velocity DoFHandler or the full coupled
+              // finite element system): rotate the vector components starting
+              // at component 0.
+              DoFTools::make_periodicity_constraints<dim,dim,double>(matched_pairs,
+                                                                     constraints,
+                                                                     ComponentMask(),
+              {0},
+              1.);
+            }
         }
     }
 

--- a/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
+++ b/source/simulator/solver/stokes_matrix_free_global_coarsening.cc
@@ -29,6 +29,8 @@
 #include <aspect/melt.h>
 #include <aspect/newton.h>
 
+#include <deal.II/fe/mapping_q.h>
+#include <deal.II/fe/mapping_q_cache.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <deal.II/matrix_free/tools.h>
@@ -368,7 +370,7 @@ namespace aspect
         AffineConstraints<double> cs;
         std::shared_ptr<MatrixFree<dim,double>>
         mf(new MatrixFree<dim,double>());
-        mf->reinit(this->get_mapping(), dofhandlers_projection[l], cs, QGauss<1>(degree+1));
+        mf->reinit(get_level_triangulation_mapping(), dofhandlers_projection[l], cs, QGauss<1>(degree+1));
         temp_ops[l].initialize(mf);
       }
 
@@ -1552,32 +1554,38 @@ namespace aspect
 
 
   template <int dim, int velocity_degree>
+  const Mapping<dim> &
+  StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::get_level_triangulation_mapping()
+  {
+    // Periodic spherical shells use a MappingQCache, which caches the geometry
+    // of the cells of the simulator triangulation. The level triangulations
+    // created by create_geometric_coarsening_sequence() are separate,
+    // repartitioned triangulations, on which evaluating that cache is invalid
+    // (and crashes once the partitions differ). For periodic geometries, build
+    // an equivalent manifold-based mapping of the same degree for them
+    // instead. The level triangulations inherit the manifolds of the simulator
+    // triangulation, so both mappings describe the same geometry.
+    if (const MappingQ<dim> *mapping_q = dynamic_cast<const MappingQ<dim>*>(&this->get_mapping()))
+      if (dynamic_cast<const MappingQCache<dim>*>(mapping_q) != nullptr &&
+          this->get_geometry_model().get_periodic_boundary_pairs().size() > 0)
+        {
+          if (level_triangulation_mapping.get() == nullptr)
+            level_triangulation_mapping = std::make_unique<MappingQ<dim>>(mapping_q->get_degree());
+          return *level_triangulation_mapping;
+        }
+
+    return this->get_mapping();
+  }
+
+
+
+  template <int dim, int velocity_degree>
   void StokesMatrixFreeHandlerGlobalCoarseningImplementation<dim, velocity_degree>::setup_dofs()
   {
-    // Periodic boundary conditions with hanging nodes on the boundary currently
-    // cause the GMG not to converge. We catch this case early to provide the
-    // user with a reasonable error message:
-    {
-      bool have_periodic_hanging_nodes = false;
-      for (const auto &cell : this->get_triangulation().active_cell_iterators())
-        if (cell->is_locally_owned())
-          for (const auto f : cell->face_indices())
-            {
-              if (cell->has_periodic_neighbor(f))
-                {
-                  const auto &neighbor = cell->periodic_neighbor(f);
-                  // This way, we can only detect the case where the neighbor is coarser,
-                  // but this is fine as the other owner covers that situation:
-                  if (neighbor->level()<cell->level())
-                    have_periodic_hanging_nodes = true;
-                }
-            }
-
-      have_periodic_hanging_nodes = (dealii::Utilities::MPI::max(have_periodic_hanging_nodes ? 1 : 0, this->get_mpi_communicator())) == 1;
-      AssertThrow(have_periodic_hanging_nodes==false, ExcNotImplemented());
-    }
-
-    const Mapping<dim> &mapping = this->get_mapping();
+    // Mapping used on the level triangulations of the multigrid hierarchy;
+    // see get_level_triangulation_mapping() for why this can differ from
+    // the simulator mapping.
+    const Mapping<dim> &mapping = get_level_triangulation_mapping();
 
     // This vector will be refilled with the new MatrixFree objects below:
     matrix_free_objects.clear();
@@ -1624,6 +1632,8 @@ namespace aspect
             constraint.reinit(locally_relevant_dofs);
 #endif
 
+            this->get_geometry_model().make_periodicity_constraints(dof_handler,
+                                                                    constraint);
 
             std::set<types::boundary_id> dirichlet_boundary = this->get_boundary_velocity_manager().get_zero_boundary_velocity_indicators();
             for (const auto boundary_id: this->get_boundary_velocity_manager().get_prescribed_boundary_velocity_indicators())
@@ -1734,6 +1744,9 @@ namespace aspect
 #else
             constraint.reinit(locally_relevant_dofs);
 #endif
+
+            this->get_geometry_model().make_periodicity_constraints(dof_handler,
+                                                                    constraint);
 
             DoFTools::make_hanging_node_constraints(dof_handler, constraint);
             constraint.close();

--- a/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
+++ b/source/simulator/solver/stokes_matrix_free_local_smoothing.cc
@@ -1622,7 +1622,13 @@ namespace aspect
 
       have_periodic_hanging_nodes = (Utilities::MPI::max(have_periodic_hanging_nodes ? 1 : 0,
                                                          this->get_mpi_communicator())) == 1;
-      AssertThrow(have_periodic_hanging_nodes==false, ExcNotImplemented());
+      AssertThrow(have_periodic_hanging_nodes==false,
+                  ExcMessage("The 'local smoothing' geometric multigrid solver does not "
+                             "support hanging nodes on periodic boundaries, which the "
+                             "adaptive mesh refinement has just created. Please set "
+                             "'Stokes GMG type = global coarsening' in subsection "
+                             "'Solver parameters/Stokes solver parameters' to use a "
+                             "multigrid variant that supports them."));
     }
 
     // This vector will be refilled with the new MatrixFree objects below:

--- a/tests/spherical_shell_periodic_gmg.prm
+++ b/tests/spherical_shell_periodic_gmg.prm
@@ -1,0 +1,91 @@
+# Test that the global coarsening GMG solver works in a 2d spherical shell
+# with phi periodicity and adaptive refinement.
+
+# MPI: 2
+
+set Dimension                    = 2
+set End time                     = 1000
+set Output directory             = output-spherical_shell_periodic_gmg
+set Use years instead of seconds = true
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+    set Opening angle = 90
+    set Phi periodic  = true
+  end
+end
+
+subsection Material model
+  set Model name = simple
+  set Material averaging = harmonic average only viscosity
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = inner
+  set Tangential velocity boundary indicators = outer
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = inner, outer
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 4273
+    set Outer temperature = 973
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Coordinate system   = spherical
+    set Variable names      = r, phi
+    set Function constants  = r_inner=3481000, r_outer=6336000
+    set Function expression = 800 * sin(pi * (r - r_inner) / (r_outer - r_inner)) * exp(-((phi - 0.12) / 0.08)^2)
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 2
+  set Refinement fraction                = 0.3
+  set Coarsening fraction                = 0.03
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 1
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics
+
+  subsection Visualization
+    set List of output variables =
+    set Number of grouped files       = 1
+    set Output format                 = vtu
+    set Time between graphical output = 0
+  end
+end
+
+subsection Solver parameters
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Stokes GMG type    = global coarsening
+  end
+
+  subsection Matrix Free
+    set Output details = true
+  end
+end

--- a/tests/spherical_shell_periodic_gmg/screen-output
+++ b/tests/spherical_shell_periodic_gmg/screen-output
@@ -1,0 +1,80 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 48 (on 3 levels)
+Number of degrees of freedom: 740 (450+65+225)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 42, coarse size S: 8
+     GMG levels: 3
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 13+0 iterations.
+     Schur complement preconditioner: 14+0 iterations.
+     A block preconditioner: 14+0 iterations.
+
+Number of active cells: 84 (on 4 levels)
+Number of degrees of freedom: 1,371 (838+114+419)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 42, coarse size S: 8
+     GMG levels: 4
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 14+0 iterations.
+     Schur complement preconditioner: 15+0 iterations.
+     A block preconditioner: 15+0 iterations.
+
+Number of active cells: 120 (on 4 levels)
+Number of degrees of freedom: 1,810 (1,106+151+553)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 42, coarse size S: 8
+     GMG levels: 4
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 13+0 iterations.
+     Schur complement preconditioner: 14+0 iterations.
+     A block preconditioner: 14+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-spherical_shell_periodic_gmg/solution/solution-00000
+     RMS, max velocity:        0.0869 m/year, 0.271 m/year
+     Temperature min/avg/max:  -10.54 K, 160.8 K, 4273 K
+
+Number of active cells: 192 (on 5 levels)
+Number of degrees of freedom: 3,065 (1,878+248+939)
+
+*** Timestep 1:  t=1000 years, dt=1000 years
+   Solving temperature system... 11 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 42, coarse size S: 8
+     GMG levels: 5
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 10+0 iterations.
+     Schur complement preconditioner: 11+0 iterations.
+     A block preconditioner: 11+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-spherical_shell_periodic_gmg/solution/solution-00001
+     RMS, max velocity:        0.0869 m/year, 0.271 m/year
+     Temperature min/avg/max:  -10.55 K, 160.8 K, 4273 K
+
+Number of active cells: 246 (on 5 levels)
+Number of degrees of freedom: 3,726 (2,282+303+1,141)
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/spherical_shell_periodic_gmg/statistics
+++ b/tests/spherical_shell_periodic_gmg/statistics
@@ -1,0 +1,19 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 120 1257 553  0 13 14 14 output-spherical_shell_periodic_gmg/solution/solution-00000 8.68630030e-02 2.71337560e-01 -1.05399225e+01 1.60806316e+02 4.27300000e+03 5.19231026e-02 
+1 1.000000000000e+03 1.000000000000e+03 192 2126 939 11 10 11 11 output-spherical_shell_periodic_gmg/solution/solution-00001 8.68569698e-02 2.71111973e-01 -1.05468129e+01 1.60807995e+02 4.27300000e+03 5.19256993e-02 

--- a/tests/spherical_shell_periodic_gmg_180.prm
+++ b/tests/spherical_shell_periodic_gmg_180.prm
@@ -1,0 +1,92 @@
+# Test that the GMG global coarsening solver works in a 2d spherical shell
+# with 180 degree opening angle, phi periodicity and adaptive refinement
+# (including hanging nodes on the periodic boundary).
+
+# MPI: 2
+
+set Dimension                    = 2
+set End time                     = 1000
+set Output directory             = output-spherical_shell_periodic_gmg_180
+set Use years instead of seconds = true
+
+subsection Geometry model
+  set Model name = spherical shell
+
+  subsection Spherical shell
+    set Inner radius  = 3481000
+    set Outer radius  = 6336000
+    set Opening angle = 180
+    set Phi periodic  = true
+  end
+end
+
+subsection Material model
+  set Model name = simple
+  set Material averaging = harmonic average only viscosity
+
+  subsection Simple model
+    set Thermal expansion coefficient = 4e-5
+    set Viscosity                     = 1e22
+  end
+end
+
+subsection Boundary velocity model
+  set Zero velocity boundary indicators       = inner
+  set Tangential velocity boundary indicators = outer
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators = inner, outer
+  set List of model names = spherical constant
+
+  subsection Spherical constant
+    set Inner temperature = 4273
+    set Outer temperature = 973
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+
+  subsection Function
+    set Coordinate system   = spherical
+    set Variable names      = r, phi
+    set Function constants  = r_inner=3481000, r_outer=6336000
+    set Function expression = 800 * sin(pi * (r - r_inner) / (r_outer - r_inner)) * exp(-((phi - 0.12) / 0.08)^2)
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 2
+  set Refinement fraction                = 0.3
+  set Coarsening fraction                = 0.03
+  set Strategy                           = temperature
+  set Time steps between mesh refinement = 1
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization, velocity statistics, temperature statistics
+
+  subsection Visualization
+    set List of output variables =
+    set Number of grouped files       = 1
+    set Output format                 = vtu
+    set Time between graphical output = 0
+  end
+end
+
+subsection Solver parameters
+  subsection Matrix Free
+    set Output details = true
+  end
+
+  subsection Stokes solver parameters
+    set Stokes solver type = block GMG
+    set Stokes GMG type    = global coarsening
+  end
+end

--- a/tests/spherical_shell_periodic_gmg_180/screen-output
+++ b/tests/spherical_shell_periodic_gmg_180/screen-output
@@ -1,0 +1,80 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 96 (on 3 levels)
+Number of degrees of freedom: 1,448 (882+125+441)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 78, coarse size S: 14
+     GMG levels: 3
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 15+0 iterations.
+     Schur complement preconditioner: 16+0 iterations.
+     A block preconditioner: 16+0 iterations.
+
+Number of active cells: 171 (on 4 levels)
+Number of degrees of freedom: 2,752 (1,684+226+842)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 78, coarse size S: 14
+     GMG levels: 4
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 15+0 iterations.
+     Schur complement preconditioner: 16+0 iterations.
+     A block preconditioner: 16+0 iterations.
+
+Number of active cells: 249 (on 5 levels)
+Number of degrees of freedom: 3,737 (2,286+308+1,143)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 78, coarse size S: 14
+     GMG levels: 5
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 15+0 iterations.
+     Schur complement preconditioner: 16+0 iterations.
+     A block preconditioner: 16+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-spherical_shell_periodic_gmg_180/solution/solution-00000
+     RMS, max velocity:        0.0615 m/year, 0.272 m/year
+     Temperature min/avg/max:  -509.7 K, 136.9 K, 4273 K
+
+Number of active cells: 219 (on 5 levels)
+Number of degrees of freedom: 3,451 (2,110+286+1,055)
+
+*** Timestep 1:  t=1000 years, dt=1000 years
+   Solving temperature system... 12 iterations.
+   Solving Stokes system (GMG-GC)... 
+     GMG coarse size A: 78, coarse size S: 14
+     GMG levels: 5
+     Viscosity range: 1e+22 - 1e+22
+     Stokes solver (GMRES): 12+0 iterations.
+     Schur complement preconditioner: 13+0 iterations.
+     A block preconditioner: 13+0 iterations.
+
+   Postprocessing:
+     Writing graphical output: output-spherical_shell_periodic_gmg_180/solution/solution-00001
+     RMS, max velocity:        0.0615 m/year, 0.271 m/year
+     Temperature min/avg/max:  -536.8 K, 136.9 K, 4273 K
+
+Number of active cells: 330 (on 5 levels)
+Number of degrees of freedom: 5,219 (3,198+422+1,599)
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/spherical_shell_periodic_gmg_180/statistics
+++ b/tests/spherical_shell_periodic_gmg_180/statistics
@@ -1,0 +1,19 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Iterations for Stokes solver
+# 9: Velocity iterations in Stokes preconditioner
+# 10: Schur complement iterations in Stokes preconditioner
+# 11: Visualization file name
+# 12: RMS velocity (m/year)
+# 13: Max. velocity (m/year)
+# 14: Minimal temperature (K)
+# 15: Average temperature (K)
+# 16: Maximal temperature (K)
+# 17: Average nondimensional temperature (K)
+0 0.000000000000e+00 0.000000000000e+00 249 2594 1143  0 15 16 16 output-spherical_shell_periodic_gmg_180/solution/solution-00000 6.15144196e-02 2.71636165e-01 -5.09687218e+02 1.36930183e+02 4.27300000e+03 1.95944667e-01 
+1 1.000000000000e+03 1.000000000000e+03 219 2396 1055 12 12 13 13 output-spherical_shell_periodic_gmg_180/solution/solution-00001 6.14861121e-02 2.71431910e-01 -5.36846515e+02 1.36931050e+02 4.27300000e+03 2.04175019e-01 


### PR DESCRIPTION
## Summary

This PR enables the matrix-free global-coarsening GMG Stokes solver for two-dimensional phi-periodic spherical shells. It covers both quarter shells (90 degrees) and half shells (180 degrees), including adaptive refinement and hanging nodes on periodic faces.

This PR does not change the default Stokes solver selection. Global-coarsening GMG must be selected explicitly for periodic spherical shells.

## What changed

1. **Correct periodicity constraints for scalar fields.** Scalar DoFs, such as the pressure DoFHandler, are invariant under the spherical-shell rotation. The rotation matrix is therefore used for geometric face matching but is not passed as a component transformation for scalar elements. This avoids silently coupling unrelated scalar DoFs on periodic faces.

2. **Support periodic constraints on every global-coarsening level.** The global-coarsening hierarchy now builds the geometry-model periodicity constraints on each level before adding hanging-node constraints. This removes the previous limitation for periodic hanging nodes in the global-coarsening solver.

3. **Use a valid mapping on repartitioned level triangulations.** Global coarsening can create level triangulations with partitions different from the simulator triangulation. When the simulator uses `MappingQCache`, the solver constructs an equivalent manifold-based `MappingQ` for those level triangulations instead of evaluating a cache on the wrong triangulation.

4. **Improve the local-smoothing diagnostic.** The periodic-hanging-node check remains in the local-smoothing implementation, where ASPECT now reports an actionable error explaining how to select global coarsening.

## Solver configuration

The solver is selected explicitly:

```text
subsection Solver parameters
  subsection Stokes solver parameters
    set Stokes solver type = block GMG
    set Stokes GMG type    = global coarsening
  end
end
```

## Tests

The PR adds two tests:

- `spherical_shell_periodic_gmg`: 90-degree phi-periodic spherical shell with explicit global-coarsening GMG and adaptive refinement.
- `spherical_shell_periodic_gmg_180`: 180-degree phi-periodic spherical shell with explicit global-coarsening GMG, adaptive refinement, and periodic hanging nodes.

Validation performed after addressing the review feedback:

```text
cmake --build build -j20                         PASS
ctest --test-dir build \
  -R '^spherical_shell_periodic_gmg(_180)?$' \
  -j2 --output-on-failure                        2/2 PASS
```

## Production-like benchmark

The supplementary benchmark uses an optimized ASPECT build with 64 MPI ranks, a 2D Steinberger spherical-shell model with phi-periodicity, LLSVP and dynamic-core physics, and sequential GMG/AMG runs. The GMG logs confirm that the global-coarsening variant is used.

The `mesh levels` column is taken from the ASPECT log line `Number of active cells ... (on N levels)`. The speedup is defined as `T_AMG / T_GMG`: values above 1 mean GMG is faster, while values below 1 mean AMG is faster for that case.

| Resolution | Opening angle | Target time | Active cells | Mesh levels (log) | GMG wall time | AMG wall time | AMG/GMG | Faster |
|---:|---:|---:|---:|---:|---:|---:|---:|---|
| 7 | 90°  | 4.5 Gyr | 49,152 | 8 | 4:09:34 | 7:49:50 | 1.88× | GMG |
| 7 | 180° | 0.5 Gyr | 98,304 | 8 | 1:01:52 | 5:05:00 | 4.93× | GMG |
| 6 | 90°  | 4.5 Gyr | 12,288 | 7 | 0:56:41.62 | 1:11:48 | 1.27× | GMG |
| 6 | 180° | 4.5 Gyr | 24,576 | 7 | 1:56:29 | 3:35:39 | 1.85× | GMG |
| 5 | 90°  | 4.5 Gyr | 3,072 | 6 | 0:42:16.49 | 0:24:47.94 | 0.59× | AMG |
| 5 | 180° | 4.5 Gyr | 6,144 | 6 | 1:15:33 | 0:50:46.98 | 0.67× | AMG |

All twelve runs in this table reached their requested end time with exit status 0. Resolution level 4 was intentionally stopped after a coarse-resolution advection instability and is not used as evidence for this PR.

## Comparison videos

The six videos show GMG on the left and AMG on the right. Each frame includes the solver name, simulated time, benchmark resolution, mesh-level count from the log, opening angle, and an external LLSVP colorbar.

The videos are stored as supplementary assets in a separate branch of the contributor fork, so they do not become part of the ASPECT source-tree diff.

- [Resolution 7, 90 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level7_90deg_gmg_left_amg_right.mp4)
- [Resolution 7, 180 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level7_180deg_gmg_left_amg_right.mp4)
- [Resolution 6, 90 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level6_90deg_gmg_left_amg_right.mp4)
- [Resolution 6, 180 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level6_180deg_gmg_left_amg_right.mp4)
- [Resolution 5, 90 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level5_90deg_gmg_left_amg_right.mp4)
- [Resolution 5, 180 degrees](https://github.com/Francyrad/aspect_dynamic_core_fixes/raw/refs/heads/pr-periodic-shell-gmg-video-assets/pr-assets/periodic-shell-gmg/llsvp_level5_180deg_gmg_left_amg_right.mp4)

## Scope

This change is intentionally limited to explicitly selected global-coarsening GMG for phi-periodic spherical shells. It does not change the default solver behavior.

General periodic-box support, in particular adaptive refinement with periodic hanging nodes, remains outside the scope of this PR and should be handled in a separate follow-up with focused tests.
