### PR TITLE
testsuite: fix occasional test failure due to blank lines

### DIFF
--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -2355,7 +2355,7 @@ namespace aspect
     // Provide output about the resources used during the computation, but only
     // if the model run is longer than our test cases. This ensures the
     // additional empty lines do not confuse our test system.
-    if (resource_usage > 0.2)
+    if (resource_usage > 1.0)
       resource_output << "\n-- Approximate resource usage including restarts:             "
                       << resource_usage
                       << " core hours"


### PR DESCRIPTION
It turns out that the energy resource display triggers for runs that use more than 12 minutes of CPU time, which sometimes happens during CI on Github Actions. The display itself is filtered by normalize.pl but two empty lines remain.
Fix this by bumping the minimum time to 60 minutes.
