### PR TITLE
Fix MPI communication with empty FastScape data

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -613,7 +613,7 @@ namespace aspect
         // For ranks other than the root:
         {
           for (unsigned int i=0; i<local_aspect_values.size(); ++i)
-            MPI_Ssend(&local_aspect_values[i][0], local_aspect_values[i].size(), MPI_DOUBLE,
+            MPI_Ssend(&local_aspect_values[i].data(), local_aspect_values[i].size(), MPI_DOUBLE,
                       /* destination is root= */ 0,
                       /* tag= */ 42,
                       this->get_mpi_communicator());
@@ -823,7 +823,7 @@ namespace aspect
             }
 
           for (unsigned int i=0; i<local_aspect_values.size(); ++i)
-            MPI_Recv(&local_aspect_values[i][0], incoming_size, MPI_DOUBLE,
+            MPI_Recv(&local_aspect_values[i].data(), incoming_size, MPI_DOUBLE,
                      /* sender= */ p,
                      /* tag = */ 42,
                      this->get_mpi_communicator(), &status);


### PR DESCRIPTION
This PR fixes MPI communication in the FastScape mesh deformation plugin when an MPI process has no local data on the relevant surface boundary.

In this case, an entry of `local_aspect_values` can be empty. The existing code accesses the first element using `&local_aspect_values[i][0]`, which is invalid for an empty vector, even when the MPI message count is zero.

This PR replaces these expressions with `local_aspect_values[i].data()` in both `MPI_Ssend` and `MPI_Recv`. For non-empty vectors, `data()` points to the first element as before. For empty vectors, it can be passed to MPI together with a count of zero without accessing a nonexistent element. The zero-length MPI messages are still sent and received, preserving the existing communication sequence.

This addresses the same empty-vector MPI issue that was previously fixed in https://github.com/geodynamics/aspect/commit/2ad5365caba302208da2f3fab56b6e92220a6ccc, adapted to the current implementation by using `std::vector::data()`.

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better). 