### PR TITLE
Make treatment of %d more secure in gplates filename expansion.

### DIFF
--- a/doc/sphinx/parameters/Boundary_20velocity_20model.md
+++ b/doc/sphinx/parameters/Boundary_20velocity_20model.md
@@ -268,5 +268,5 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Anything]
 
-**Documentation:** The file name of the material data. Provide file in format: (Velocity file name).\%d.gpml where \%d is any sprintf integer qualifier, specifying the format of the current file number.
+**Documentation:** The file name of the material data. Provide file in format: some_file_name.\%d.gpml where \%d will be replaced by the current file number. (Only \%d is allowed here, not any of the other printf-style format specifiers.)
 ::::

--- a/source/boundary_velocity/gplates.cc
+++ b/source/boundary_velocity/gplates.cc
@@ -29,6 +29,8 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <regex>
+
 
 namespace aspect
 {
@@ -582,12 +584,31 @@ namespace aspect
     std::string
     GPlates<dim>::create_filename (const int timestep) const
     {
-      std::string templ = data_directory+velocity_file_name;
-      const int size = templ.length();
-      std::vector<char> buffer(size+10);
-      std::snprintf (buffer.data(), size + 10, templ.c_str(), timestep);
-      std::string str_filename (buffer.data());
-      return str_filename;
+      // We allow regexes of the form '%[dui]' as well as '%0N[dui]' where
+      // in the latter case, the number N is used to pad the timestep with
+      // leading zeros. Start with the first form:
+      std::string text = std::regex_replace(velocity_file_name, std::regex("%[dui]"),
+                                            std::to_string(timestep));
+
+      // The second form is a bit more complicated, as we need to extract the number of zeros to pad with:
+      const std::regex regex("%0(\\d+)[dui]");
+      std::smatch match;
+      while (std::regex_search(text, match, regex))
+        {
+          std::string padded_timestep = Utilities::to_string(timestep);
+
+          const unsigned int n_zeros = std::stoi(match[1].str());
+          while (padded_timestep.length() < n_zeros)
+            padded_timestep.insert(/*position=*/0, /*count=*/1, '0');
+
+          // Replace the matched substring with the padded timestep.
+          // In fact, this will replace all occurrences of the regex
+          // in the string (not just the one found in 'match'), which
+          // is what we want.
+          text = std::regex_replace(text, regex, padded_timestep);
+        }
+
+      return (data_directory + text);
     }
 
 
@@ -761,8 +782,9 @@ namespace aspect
           prm.declare_entry ("Velocity file name", "phi.%d",
                              Patterns::Anything (),
                              "The file name of the material data. Provide file in format: "
-                             "(Velocity file name).\\%d.gpml where \\%d is any sprintf integer "
-                             "qualifier, specifying the format of the current file number.");
+                             "some_file_name.\\%d.gpml where \\%d will be replaced by the "
+                             "current file number. (Only \\%d is allowed here, not any of the "
+                             "other printf-style format specifiers.)");
           prm.declare_entry ("First data file model time", "0.",
                              Patterns::Double (0.),
                              "Time from which on the velocity file with number 'First velocity "


### PR DESCRIPTION
The current scheme whereby we expand `%d` using the time step number is not very secure. That's because we use `printf`-style functions *assuming* that the user had a single `%d` in the file name template, but the whole thing fails if a user puts *multiple* `%d` into the file name template, or even worse if there are other `%` type specifiers because all we do is pass in one integer. If you did, say, `%f` you'd likely get memory access violations or worse.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
