### PR TITLE
Avoid test failure by giving test own cc file

### DIFF
--- a/tests/prescribed_field_temperature_max_isotherm.cc
+++ b/tests/prescribed_field_temperature_max_isotherm.cc
@@ -1,0 +1,21 @@
+/*
+  Copyright (C) 2011 - 2023 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include "prescribed_temperature_in_field.cc"

--- a/tests/prescribed_field_temperature_max_isotherm.prm
+++ b/tests/prescribed_field_temperature_max_isotherm.prm
@@ -1,4 +1,4 @@
-set Additional shared libraries = ./libprescribed_temperature_in_field.so
+set Additional shared libraries = ./libprescribed_field_temperature_max_isotherm.so
 
 include $ASPECT_SOURCE_DIR/tests/prescribed_temperature_in_field.prm
 

--- a/tests/prescribed_field_temperature_max_isotherm/screen-output
+++ b/tests/prescribed_field_temperature_max_isotherm/screen-output
@@ -1,5 +1,5 @@
 
-Loading shared library <./libprescribed_temperature_in_field.debug.so>
+Loading shared library <./libprescribed_field_temperature_max_isotherm.debug.so>
 
 Number of active cells: 256 (on 5 levels)
 Number of degrees of freedom: 5,734 (2,178+289+1,089+1,089+1,089)


### PR DESCRIPTION
When running all tests in a local Docker container from the v9.6 Docker Hub image, the test `prescribed_field_temperature_max_isotherm` fails. It includes a shared library from another test. The shared libs are only built upon running their respective test. The included .so file is from the test `prescribed_temperature_in_field`, which comes later alphabetically. Therefore its shared lib isn't available when running `prescribed_field_temperature_max_isotherm`.

This PR creates `prescribed_field_temperature_max_isotherm.cc`, which just includes `prescribed_temperature_in_field.cc`, and replaces the message about loading the shared lib in `screen-output`.


* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
