### PR TITLE
Convert \si and \SI before running them through sphinx.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -4,6 +4,8 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -46,6 +48,171 @@ myst_enable_extensions = [
     "dollarmath",
     "amsmath",
 ]
+
+
+# Map units used by the LaTeX 'siunitx' package to text that
+# can directly be used in LaTeX formulas:
+_siunitx_symbols = {
+    "degree": r"^\circ",
+    "J": "J",
+    "joule": "J",
+    "K": "K",
+    "kelvin": "K",
+    "kg": "kg",
+    "kilogram": "kg",
+    "m": "m",
+    "meter": "m",
+    "metre": "m",
+    "mol": "mol",
+    "mole": "mol",
+    "Pa": "Pa",
+    "pascal": "Pa",
+    "s": "s",
+    "second": "s",
+    "W": "W",
+    "watt": "W",
+}
+
+_siunitx_prefixes = {
+    "kilo": "k",
+    "mega": "M",
+    "giga": "G",
+    "milli": "m",
+    "micro": r"\mu",
+    "nano": "n",
+}
+
+
+# Read the text of a brace-enclosed LaTeX macro, allowing for nested
+# braces:
+def _read_braced_argument(text, position):
+    """Return the braced argument at position and the following position."""
+    if position == len(text) or text[position] != "{":
+        return None, position
+
+    depth = 1
+    end = position + 1
+    while end < len(text) and depth:
+        if text[end] == "{":
+            depth += 1
+        elif text[end] == "}":
+            depth -= 1
+        end += 1
+
+    if depth:
+        return None, position
+
+    return text[position + 1:end - 1], end
+
+
+def _format_siunitx_unit(unit):
+    """Convert the subset of siunitx unit syntax used in this manual to LaTeX."""
+    components = []
+    denominator = False
+    prefix = ""
+    next_power = 1
+    tokens = re.findall(r"\\[A-Za-z]+|[A-Za-z]+|[0-9]+|[*/^]", unit)
+    position = 0
+
+    def set_last_power(power):
+        if components:
+            components[-1][1] = -power if components[-1][1] < 0 else power
+
+    while position < len(tokens):
+        token = tokens[position]
+        name = token[1:] if token.startswith("\\") else token
+
+        if name == "per" or token == "/":
+            denominator = True
+        elif name == "squared":
+            set_last_power(2)
+        elif name == "cubed":
+            set_last_power(3)
+        elif name == "cubic":
+            next_power = 3
+        elif name in _siunitx_prefixes:
+            prefix += _siunitx_prefixes[name]
+        elif token == "^" and position + 1 < len(tokens):
+            position += 1
+            if tokens[position].isdigit():
+                set_last_power(int(tokens[position]))
+        elif token != "*":
+            symbol = _siunitx_symbols.get(name, name)
+            components.append([prefix + symbol,
+                               -next_power if denominator else next_power])
+            prefix = ""
+            next_power = 1
+
+        position += 1
+
+    formatted = []
+    for symbol, power in components:
+        if symbol == r"^\circ" :
+            factor = symbol
+        else :
+            factor = r"\mathrm{" + symbol + "}"
+        if power != 1:
+            factor += "^{" + str(power) + "}"
+        formatted.append(factor)
+
+    return r"\,".join(formatted)
+
+
+def _is_inside_math(text, position):
+    """Determine whether position occurs between matching dollar delimiters."""
+    delimiter = None
+    for match in re.finditer(r"(?<!\\)\${1,2}", text[:position]):
+        value = match.group()
+        if delimiter == value:
+            delimiter = None
+        elif delimiter is None:
+            delimiter = value
+    return delimiter is not None
+
+
+def _convert_siunitx_commands(app, docname, source):
+    """Replace legacy siunitx commands with inline LaTeX math."""
+    text = source[0]
+    result = []
+    position = 0
+
+    while position < len(text):
+        match = re.search(r"\\(si|SI)\s*", text[position:])
+        if match is None:
+            result.append(text[position:])
+            break
+
+        start = position + match.start()
+        command_end = position + match.end()
+        first_argument, argument_end = _read_braced_argument(text, command_end)
+        if first_argument is None:
+            result.append(text[position:command_end])
+            position = command_end
+            continue
+
+        if match.group(1) == "SI":
+            while argument_end < len(text) and text[argument_end].isspace():
+                argument_end += 1
+            second_argument, end = _read_braced_argument(text, argument_end)
+            if second_argument is None:
+                result.append(text[position:argument_end])
+                position = argument_end
+                continue
+            formula = first_argument + r"\," + _format_siunitx_unit(second_argument)
+        else:
+            end = argument_end
+            formula = _format_siunitx_unit(first_argument)
+
+        result.append(text[position:start])
+        result.append(formula if _is_inside_math(text, start) else "$" + formula + "$")
+        position = end
+
+    source[0] = "".join(result)
+
+
+def setup(app):
+    app.connect("source-read", _convert_siunitx_commands)
+
 
 tikz_proc_suite = "GhostScript"
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This patch perhaps supersedes #6992 (@alarshi and @danieldouglas92 FYI). We have spent a lot of effort in marking up units via `\si` and `\SI`, and it's a bit of a shame to get rid of that work again as @alarshi does in #6992 just because sphinx doesn't understand these commands. It's also a lot of work.

I think a better way is to create a custom script that when seeing these commands, converts them into something that sphinx can understand. I asked copilot to write such a function for me, and this is what it came up with (plus a few of my own comments in reading through it). Perhaps that allows us to retain the semantic markup we currently have.

I don't have sphinx locally set up, so I can't see the output, but I think that one of the CI checks creates output that we can look at.


*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
