### PR TITLE
Remove unused code in mesh deformation interface

### DIFF
--- a/source/mesh_deformation/interface.cc
+++ b/source/mesh_deformation/interface.cc
@@ -655,12 +655,8 @@ namespace aspect
 
       // Now construct the mesh displacement constraints
       mesh_velocity_constraints.clear();
-#if DEAL_II_VERSION_GTE(9,6,0)
       mesh_velocity_constraints.reinit(mesh_deformation_dof_handler.locally_owned_dofs(),
                                        mesh_locally_relevant);
-#else
-      mesh_velocity_constraints.reinit(mesh_locally_relevant);
-#endif
       // mesh_velocity_constraints can use the same hanging node
       // information that was used for mesh_vertex constraints.
       mesh_velocity_constraints.merge(mesh_vertex_constraints);


### PR DESCRIPTION
Removing the code in mesh deformation interface that is not used any more as dealii version check is not needed.