### PR TITLE
Removed deprecated code for deal.ii versions lower than 9.6

### DIFF
--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -717,7 +717,6 @@ namespace aspect
     // overall vector, so that they form a contiguous range starting
     // at zero. The assertion checks this, but this could easily be
     // generalized if the Stokes block were not starting at zero.
-#if DEAL_II_VERSION_GTE(9,6,0)
     Assert (introspection.block_indices.velocities == 0,
             ExcNotImplemented());
     if (parameters.use_direct_stokes_solver == false)
@@ -728,9 +727,6 @@ namespace aspect
     stokes_dofs.add_range (0, vec.size());
     const AffineConstraints<double> stokes_hanging_node_constraints
       = hanging_node_constraints.get_view (stokes_dofs);
-#else
-    const AffineConstraints<double> &stokes_hanging_node_constraints = hanging_node_constraints;
-#endif
 
     stokes_hanging_node_constraints.distribute(vec);
   }


### PR DESCRIPTION
Since deal.ii is now always required to be version 9.6 or above, the code path used for lower versions is never used.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [ ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
