### PR TITLE
added unit test for euler angle conversions

### DIFF
--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -2311,3 +2311,46 @@ TEST_CASE("LPO elastic tensor decomposition")
       }
   }
 }
+
+TEST_CASE("Utilities Euler Angles to and from Rotation matrix")
+{
+  const std::vector<double> approval_tests;
+
+  // note, this is only testing consistency (can it convert back and forth) and
+  // it only works for rotation matrices which are defined in the same way (z-x-z).
+  {
+    auto rot1 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(-85,340,56);
+    auto ea1 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot1);
+    auto rot2 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea1[0],ea1[1],ea1[2]);
+    compare_rotation_matrices_approx(rot2, rot1);
+    auto ea2 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot2);
+    compare_3d_arrays_approx(ea2,ea1);
+    auto rot3 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea2[0],ea2[1],ea2[2]);
+    compare_rotation_matrices_approx(rot3, rot2);
+  }
+
+  {
+    auto rot1 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(90,180,270);
+    auto ea1 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot1);
+    auto rot2 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea1[0],ea1[1],ea1[2]);
+    compare_rotation_matrices_approx(rot2, rot1);
+    auto ea2 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot2);
+    compare_3d_arrays_approx(ea2,ea1);
+    auto rot3 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea2[0],ea2[1],ea2[2]);
+    compare_rotation_matrices_approx(rot3, rot2);
+  }
+
+  {
+    const std::array<double,3> ea0 = {{20,30,40}};
+    auto rot0 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(20,30,40);
+    auto ea1 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot0);
+    compare_3d_arrays_approx(ea1,ea0);
+    auto rot2 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea1[0],ea1[1],ea1[2]);
+    compare_rotation_matrices_approx(rot2, rot0);
+    auto ea2 = aspect::Utilities::zxz_euler_angles_from_rotation_matrix(rot2);
+    compare_3d_arrays_approx(ea2,ea1);
+    auto rot3 = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(ea2[0],ea2[1],ea2[2]);
+    compare_rotation_matrices_approx(rot3, rot2);
+  }
+
+}

--- a/unit_tests/crystal_preferred_orientation.cc
+++ b/unit_tests/crystal_preferred_orientation.cc
@@ -2314,8 +2314,6 @@ TEST_CASE("LPO elastic tensor decomposition")
 
 TEST_CASE("Utilities Euler Angles to and from Rotation matrix")
 {
-  const std::vector<double> approval_tests;
-
   // note, this is only testing consistency (can it convert back and forth) and
   // it only works for rotation matrices which are defined in the same way (z-x-z).
   {


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

I added a unit test for the functions aspect::Utilities::zxz_euler_angles_to_rotation_matrix and aspect::Utilities::zxz_euler_angles_from_rotation_matrix. 
The test is located in unit_tests/crystal_preferred_orientation and consists of going back and forth between euler angles and rotation matrices. It is exactly the same test as implemented in World builder 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
