### PR TITLE
Place file path on new line in error message to avoid test failure

### DIFF
--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -541,14 +541,14 @@ namespace aspect
           while (in >> temp_data);
 
           AssertThrow(in.eof(),
-                      ExcMessage ("While reading the data file '" + filename + "' the ascii data "
+                      ExcMessage ("While reading the data file\n'" + filename + "'\nthe ascii data "
                                   "plugin has encountered an error before the end of the file. "
                                   "Please check for malformed data values (e.g. NaN) or superfluous "
                                   "lines at the end of the data file."));
 
           const std::size_t n_expected_data_entries = (n_components + dim) * data_table.n_elements();
           AssertThrow(read_data_entries == n_expected_data_entries,
-                      ExcMessage ("While reading the data file '" + filename + "' the ascii data "
+                      ExcMessage ("While reading the data file\n'" + filename + "'\nthe ascii data "
                                   "plugin has reached the end of the file, but has not found the "
                                   "expected number of data values considering the spatial dimension, "
                                   "data columns, and number of lines prescribed by the POINTS header "

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -392,7 +392,7 @@ namespace aspect
             {
               AssertThrow(new_points_per_direction[i] != 0,
                           ExcMessage("Could not successfully read in the file header of the "
-                                     "ascii data file <" + filename + ">. One header line has to "
+                                     "ascii data file\n<" + filename + ">.\nOne header line has to "
                                      "be of the format: '#POINTS: N1 [N2] [N3]', where N1 and "
                                      "potentially N2 and N3 have to be the number of data points "
                                      "in their respective dimension. Check for typos in this line "
@@ -427,8 +427,8 @@ namespace aspect
                   else if (name_column_index != 0)
                     AssertThrow (n_components+dim == name_column_index,
                                  ExcMessage("The number of expected data columns and the "
-                                            "list of column names at the beginning of the data file "
-                                            + filename + " do not match. The file should contain "
+                                            "list of column names at the beginning of the data file\n"
+                                            + filename + "\ndo not match. The file should contain "
                                             + Utilities::int_to_string(name_column_index) + " column "
                                             "names (one for each dimension and one per data column), "
                                             "but it only has " + Utilities::int_to_string(n_components+dim) +
@@ -448,7 +448,7 @@ namespace aspect
                       AssertThrow(std::find(column_names.begin(),column_names.end(),column_name_or_data)
                                   == column_names.end(),
                                   ExcMessage("There are multiple fields named " + column_name_or_data +
-                                             " in the data file " + filename + ". Please remove duplication to "
+                                             " in the data file\n" + filename + ".\nPlease remove duplication to "
                                              "allow for unique association between column and name."));
 
                       column_names.push_back(column_name_or_data);
@@ -463,7 +463,7 @@ namespace aspect
           Table<dim,double> data_table;
           data_table.TableBase<dim,double>::reinit(new_points_per_direction);
           AssertThrow (n_components != numbers::invalid_unsigned_int,
-                       ExcMessage("ERROR: number of n_components in " + filename + " could not be "
+                       ExcMessage("ERROR: number of n_components in\n" + filename + "\ncould not be "
                                   "determined automatically. Either add a header with column "
                                   "names or pass the number of columns in the StructuredData "
                                   "constructor."));
@@ -494,8 +494,8 @@ namespace aspect
             number_of_entries += 1;
 
           AssertThrow ((number_of_entries) == column_names.size()+dim,
-                       ExcMessage("ERROR: The number of columns in the data file " + filename +
-                                  " is incorrect. It needs to have " + Utilities::int_to_string(column_names.size()+dim) +
+                       ExcMessage("ERROR: The number of columns in the data file\n" + filename +
+                                  "\nis incorrect. It needs to have " + Utilities::int_to_string(column_names.size()+dim) +
                                   " columns, but the first row has " + Utilities::int_to_string(number_of_entries) +
                                   " columns."));
 
@@ -521,7 +521,7 @@ namespace aspect
                               ExcMessage("Invalid coordinate in column "
                                          + Utilities::int_to_string(column_num) + " in row "
                                          + Utilities::int_to_string(row_num)
-                                         + " in file " + filename +
+                                         + " in file\n" + filename +
                                          "\nThis class expects the coordinates to be structured, meaning "
                                          "the coordinate values in each coordinate direction repeat exactly "
                                          "each time. This also means each row in the data file has to have "
@@ -1043,11 +1043,11 @@ namespace aspect
 
 
           AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
-                      ExcMessage (std::string("Ascii data file <")
+                      ExcMessage (std::string("Ascii data file\n<")
                                   +
                                   filename
                                   +
-                                  "> not found!"));
+                                  ">\nnot found!"));
           lookups.find(boundary_id)->second->load_file(filename,this->get_mpi_communicator());
 
           if (time_dependent == true)
@@ -1591,11 +1591,11 @@ namespace aspect
         {
           const std::string filename = this->data_directory + data_file_names[i];
           AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
-                      ExcMessage (std::string("Ascii data file <")
+                      ExcMessage (std::string("Ascii data file\n<")
                                   +
                                   filename
                                   +
-                                  "> not found!"));
+                                  ">\nnot found!"));
 
           lookups.push_back(std::make_unique<Utilities::StructuredDataLookup<dim-1>> (n_components,
                                                                                        this->scale_factor));
@@ -1732,11 +1732,11 @@ namespace aspect
 
 
       AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
-                  ExcMessage (std::string("Ascii data file <")
+                  ExcMessage (std::string("Ascii data file\n<")
                               +
                               filename
                               +
-                              "> not found!"));
+                              ">\nnot found!"));
 
       if (slice_data == true)
         {
@@ -1886,11 +1886,11 @@ namespace aspect
       const std::string filename = this->data_directory + this->data_file_name;
 
       AssertThrow(Utilities::fexists(filename, communicator) || filename_is_url(filename),
-                  ExcMessage (std::string("Ascii data file <")
+                  ExcMessage (std::string("Ascii data file\n<")
                               +
                               filename
                               +
-                              "> not found!"));
+                              ">\nnot found!"));
       lookup->load_file(filename,communicator);
     }
 

--- a/tests/ascii_data_fail_1/screen-output
+++ b/tests/ascii_data_fail_1/screen-output
@@ -9,7 +9,7 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage ("While reading the data file '" + filename + "' the ascii data " "plugin has encountered an error before the end of the file. " "Please check for malformed data values (e.g. NaN) or superfluous " "lines at the end of the data file.")' on rank 0 on processing: 
+Exception 'ExcMessage ("While reading the data file\n'" + filename + "'\nthe ascii data " "plugin has encountered an error before the end of the file. " "Please check for malformed data values (e.g. NaN) or superfluous " "lines at the end of the data file.")' on rank 0 on processing: 
 
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/ascii_data_fail_2/screen-output
+++ b/tests/ascii_data_fail_2/screen-output
@@ -9,7 +9,7 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage ("While reading the data file '" + filename + "' the ascii data " "plugin has reached the end of the file, but has not found the " "expected number of data values considering the spatial dimension, " "data columns, and number of lines prescribed by the POINTS header " "of the file. Please check the number of data " "lines against the POINTS header in the file.")' on rank 0 on processing: 
+Exception 'ExcMessage ("While reading the data file\n'" + filename + "'\nthe ascii data " "plugin has reached the end of the file, but has not found the " "expected number of data values considering the spatial dimension, " "data columns, and number of lines prescribed by the POINTS header " "of the file. Please check the number of data " "lines against the POINTS header in the file.")' on rank 0 on processing: 
 
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/ascii_data_fail_3/screen-output
+++ b/tests/ascii_data_fail_3/screen-output
@@ -9,7 +9,7 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage ("While reading the data file '" + filename + "' the ascii data " "plugin has reached the end of the file, but has not found the " "expected number of data values considering the spatial dimension, " "data columns, and number of lines prescribed by the POINTS header " "of the file. Please check the number of data " "lines against the POINTS header in the file.")' on rank 0 on processing: 
+Exception 'ExcMessage ("While reading the data file\n'" + filename + "'\nthe ascii data " "plugin has reached the end of the file, but has not found the " "expected number of data values considering the spatial dimension, " "data columns, and number of lines prescribed by the POINTS header " "of the file. Please check the number of data " "lines against the POINTS header in the file.")' on rank 0 on processing: 
 
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)

--- a/tests/ascii_data_fail_4/screen-output
+++ b/tests/ascii_data_fail_4/screen-output
@@ -17,8 +17,8 @@ The violated condition was:
     Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename)
 Additional information: 
     Ascii data file
-    <ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_4.txt>
-    not found!
+    <ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_4.txt> not
+    found!
 
 Stacktrace:
 (rest of the output replaced by default.sh script)

--- a/tests/ascii_data_fail_4/screen-output
+++ b/tests/ascii_data_fail_4/screen-output
@@ -9,7 +9,7 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (std::string("Ascii data file <") + filename + "> not found!")' on rank 0 on processing: 
+Exception 'ExcMessage (std::string("Ascii data file\n<") + filename + ">\nnot found!")' on rank 0 on processing: 
 
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)
@@ -17,8 +17,8 @@ The violated condition was:
     Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename)
 Additional information: 
     Ascii data file
-    <ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_4.txt> not
-    found!
+    <ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_4.txt>
+    not found!
 
 Stacktrace:
 (rest of the output replaced by default.sh script)


### PR DESCRIPTION
When running all tests in the deal-v9.6 image from Docker Hub on my machine, the `ascii_data_fail_*` tests fail when comparing the error message. The first diff is:
```
##20      <==     'ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_1.txt'
##20      ==>     'ASPECT_DIR/data/boundary-velocity/ascii-data/test/fail_1.txt' the

```
What I think happens is that the error message is written with the absolute path, which is then partly replaced with `ASPECT_DIR` before comparison. The addition of `the` in the first line of the generated test output is however not corrected, so the comparison fails.

This PR places the file path in the output message on its own line, to avoid having a different number of additional words after the file path depending on the file path length.

It could be that the output of more tests needs to be updated.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
