### PR TITLE
Re-markup units with \si{...}.

### DIFF
--- a/doc/sphinx/parameters/Gravity_20model.md
+++ b/doc/sphinx/parameters/Gravity_20model.md
@@ -103,7 +103,7 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Magnitude of the gravity vector in $m/s^2$. For positive values the direction is radially inward towards the center of the earth.
+**Documentation:** Magnitude of the gravity vector in $\si{\meter\per\second\squared}$. For positive values the direction is radially inward towards the center of the earth.
 ::::
 
 (parameters:Gravity_20model/Radial_20linear)=
@@ -134,5 +134,5 @@ If the function you are describing represents a vector-valued function with mult
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Value of the gravity vector in $m/s^2$ directed along negative y (2d) or z (3d) axis (if the magnitude is positive.
+**Documentation:** Value of the gravity vector in $\si{\meter\per\second\squared}$ directed along the negative $y$ (in 2d) or $z$ (in 3d) axis (if the magnitude is positive.
 ::::

--- a/source/gravity_model/radial_constant.cc
+++ b/source/gravity_model/radial_constant.cc
@@ -53,7 +53,8 @@ namespace aspect
         {
           prm.declare_entry ("Magnitude", "9.81",
                              Patterns::Double (),
-                             "Magnitude of the gravity vector in $m/s^2$. For positive values "
+                             "Magnitude of the gravity vector in $\\si{\\meter\\per\\second\\squared}$. "
+                             "For positive values "
                              "the direction is radially inward towards the center of the earth.");
         }
         prm.leave_subsection ();

--- a/source/gravity_model/vertical.cc
+++ b/source/gravity_model/vertical.cc
@@ -50,8 +50,8 @@ namespace aspect
         {
           prm.declare_entry ("Magnitude", "1.",
                              Patterns::Double (),
-                             "Value of the gravity vector in $m/s^2$ directed "
-                             "along negative y (2d) or z (3d) axis (if the magnitude "
+                             "Value of the gravity vector in $\\si{\\meter\\per\\second\\squared}$ directed "
+                             "along the negative $y$ (in 2d) or $z$ (in 3d) axis (if the magnitude "
                              "is positive.");
         }
         prm.leave_subsection ();


### PR DESCRIPTION
With #7041, we can go back to semantic mark-up. There are probably many places where one could do that, but these are two I happened to look at.