### PR TITLE
Only ask FS for data when it has been set up, checkpoint empty data otherwise

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -1606,14 +1606,24 @@ namespace aspect
         {
           const unsigned int fastscape_array_size = fastscape_nx*fastscape_ny;
           elevation.resize(fastscape_array_size);
-          fastscape_copy_h_(elevation.data());
-
           basement.resize(fastscape_array_size);
-          fastscape_copy_basement_(basement.data());
-
           silt_fraction.resize(fastscape_array_size);
-          if (use_marine_component)
-            fastscape_copy_f_(silt_fraction.data());
+
+          // Only copy data from FastScape if Fastscape has been set up
+          // in the initialize_fastscape function, which happens at the beginning of timestep 1.
+          // We check against timestep 2, because checkpointing is done after advancing the timestep.
+          // Otherwise FastScape will return an error message and ASPECT will terminate.
+          if (this->get_timestep_number() >= 2)
+            {
+              fastscape_copy_h_(elevation.data());
+              fastscape_copy_basement_(basement.data());
+              if (use_marine_component)
+                fastscape_copy_f_(silt_fraction.data());
+            }
+          else
+            {
+              this->get_pcout() << "*** FastScape has not been set up yet, so checkpointed FastScape data is set to zero." << std::endl;
+            }
         }
 
       // Serialize into a stringstream. Put the following into a code

--- a/tests/fastscape_restart_basement_silt.prm
+++ b/tests/fastscape_restart_basement_silt.prm
@@ -27,11 +27,6 @@
 # of metres offshore, so the test guards the silt-fraction save independently
 # of the basement save.
 #
-# The checkpoint is placed at step 4 (Steps between checkpoint = 4), after
-# FastScape has been set up on its first execution step, to avoid the
-# "STOP CopyH - You need to run SetUp first" abort that a step-0/1 checkpoint
-# would trigger.
-#
 # Enable if: ASPECT_WITH_FASTSCAPE
 
 include $ASPECT_SOURCE_DIR/tests/fastscape_test_fixed_ghost_nodes.prm
@@ -40,7 +35,8 @@ set End time           = 1.2e5
 set Resume computation = false
 
 subsection Checkpointing
-  set Steps between checkpoint = 4
+  set Steps between checkpoint = 1
+  set Resume checkpoint = 2
 end
 
 subsection Mesh deformation


### PR DESCRIPTION
If the user requests checkpointing at every time step while FastScape is included, checkpointing at time step 0 will lead FastScape to crash as it is not initialised yet.

This PR only copies data from FastScape after time step 0, otherwise it just checkpoints zeroed data and gives a warning about it.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
