### PR TITLE
Only run expensive tests when the label ready to test is set.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
       - 'aspect-*'
   pull_request:
+      types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
 
 concurrency:
@@ -22,6 +26,7 @@ env:
 
 jobs:
   linux-nounity:
+    if: contains(github.event.pull_request.labels.*.name, 'ready to test')
     #linux build with unity/precompiled headers disabled
     name: no-unity-build
     runs-on: [ubuntu-22.04]
@@ -110,6 +115,7 @@ jobs:
         git diff --exit-code
 
   tests:
+    if: contains(github.event.pull_request.labels.*.name, 'ready to test')
     #linux build including tests
     name: tests
     runs-on: [ubuntu-22.04]


### PR DESCRIPTION
We had a discussion about whether there was a way to disable the expensive tests for work in progress pull request. In the end I decided to go for reusing the `ready to test` label and do not distinguish between maintainers an non maintainers. This adds a step for maintainers, having to add the label ready to test, but it give more finegrain control over when the tester is run (which can be useful, especially during hackathons). If there are strong preferences, I could also check specifically for a `do not test` label, but I have a slight preference for using the ready to test label.