### PR TITLE
Also allow using 'year' in \si.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -71,6 +71,11 @@ _siunitx_symbols = {
     "second": "s",
     "W": "W",
     "watt": "W",
+    "hour": "h",
+    "hours": "h",
+    "year": "yr",
+    "years": "yr",
+    "yr": "yr",
 }
 
 _siunitx_prefixes = {


### PR DESCRIPTION
Another follow-up to #7041: Allow using 'year' in `\si` commands. Apparently we're also using 'hours' somewhere, so Copilot also added that.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
