### PR TITLE
rename darcy field scheme

### DIFF
--- a/include/aspect/parameters.h
+++ b/include/aspect/parameters.h
@@ -216,7 +216,7 @@ namespace aspect
         volume_of_fluid,
         static_field,
         fem_melt_field,
-        fem_darcy_field,
+        fem_simple_darcy_field,
         prescribed_field,
         prescribed_field_with_diffusion
       };

--- a/source/postprocess/fluid_velocity_statistics.cc
+++ b/source/postprocess/fluid_velocity_statistics.cc
@@ -42,7 +42,7 @@ namespace aspect
       const unsigned int porosity_idx = this->introspection().compositional_index_for_name("porosity");
 
       AssertThrow(this->get_parameters().include_melt_transport ||
-                  this->get_parameters().compositional_field_methods[porosity_idx] == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field,
+                  this->get_parameters().compositional_field_methods[porosity_idx] == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field,
                   ExcMessage("The 'fluid velocity statistics' postprocessor requires advecting the 'porosity' compositional "
                              "field by either the darcy velocity or the melt velocity."));
 

--- a/source/simulator/assemblers/advection.cc
+++ b/source/simulator/assemblers/advection.cc
@@ -642,9 +642,9 @@ namespace aspect
       const AdvectionField advection_field = *scratch.advection_field;
 
       Assert(advection_field.advection_method(introspection)
-             == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field,
+             == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field,
              ExcMessage("The 'DarcySystem' assembler can only be executed for fields "
-                        "that use the advection method 'darcy field'."));
+                        "that use the advection method 'simple darcy field'."));
 
       const unsigned int n_q_points = scratch.finite_element_values.n_quadrature_points;
       const unsigned int advection_dofs_per_cell = data.local_dof_indices.size();
@@ -652,7 +652,7 @@ namespace aspect
       const bool use_supg = (this->get_parameters().advection_stabilization_method
                              == Parameters<dim>::AdvectionStabilizationMethod::supg);
       AssertThrow(use_supg == false,
-                  ExcMessage("The Darcy field advection method does not support the use of SUPG"));
+                  ExcMessage("The 'DarcySystem' advection method does not support the use of SUPG"));
 
       const bool   use_bdf2_scheme = (this->get_timestep_number() > 1);
       const double time_step = this->get_timestep();

--- a/source/simulator/assembly.cc
+++ b/source/simulator/assembly.cc
@@ -161,7 +161,7 @@ namespace aspect
             std::make_unique<aspect::Assemblers::DiffusionSystem<dim>>());
 
         // Add the darcy assemblers if we have fields that use this method
-        if (i>0 && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field)
+        if (i>0 && parameters.compositional_field_methods[i-1] == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field)
           assemblers->advection_system[i].push_back(
             std::make_unique<aspect::Assemblers::DarcySystem<dim>>());
 

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -945,7 +945,7 @@ namespace aspect
         {
           case Parameters<dim>::AdvectionFieldMethod::fem_field:
           case Parameters<dim>::AdvectionFieldMethod::fem_melt_field:
-          case Parameters<dim>::AdvectionFieldMethod::fem_darcy_field:
+          case Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field:
           case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
             return true;
           case Parameters<dim>::AdvectionFieldMethod::particles:

--- a/source/simulator/entropy_viscosity.cc
+++ b/source/simulator/entropy_viscosity.cc
@@ -163,7 +163,7 @@ namespace aspect
 
     std::vector<Tensor<1,dim>> old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
     std::vector<Tensor<1,dim>> old_old_fluid_velocity_values(scratch.finite_element_values.n_quadrature_points);
-    const bool use_darcy_velocity = (advection_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field);
+    const bool use_darcy_velocity = (advection_field.advection_method(introspection) == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field);
 
     std::shared_ptr<const MaterialModel::MeltOutputs<dim>> melt_outputs;
     if (use_darcy_velocity)

--- a/source/simulator/helper_functions.cc
+++ b/source/simulator/helper_functions.cc
@@ -2208,7 +2208,7 @@ namespace aspect
     // transport is included).
     if (is_composition)
       {
-        if (introspection.compositional_field_methods[composition_index] == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field)
+        if (introspection.compositional_field_methods[composition_index] == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field)
           {
             consider_darcy_velocity = true;
             porosity_idx = introspection.find_composition_type(CompositionalFieldDescription::porosity);

--- a/source/simulator/parameters.cc
+++ b/source/simulator/parameters.cc
@@ -1415,7 +1415,7 @@ namespace aspect
                          "the user's responsibility to check that the chosen material model "
                          "and other plugins interpret the compositional fields as intended.");
       prm.declare_entry ("Compositional field methods", "",
-                         Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|darcy field|prescribed field|prescribed field with diffusion")),
+                         Patterns::List (Patterns::Selection("field|particles|volume of fluid|static|melt field|simple darcy field|prescribed field|prescribed field with diffusion")),
                          "A comma separated list denoting the solution method of each "
                          "compositional field. Each entry of the list must be "
                          "one of the currently implemented field methods."
@@ -2262,8 +2262,8 @@ namespace aspect
             compositional_field_methods[i] = AdvectionFieldMethod::static_field;
           else if (x_compositional_field_methods[i] == "melt field")
             compositional_field_methods[i] = AdvectionFieldMethod::fem_melt_field;
-          else if (x_compositional_field_methods[i] == "darcy field")
-            compositional_field_methods[i] = AdvectionFieldMethod::fem_darcy_field;
+          else if (x_compositional_field_methods[i] == "simple darcy field")
+            compositional_field_methods[i] = AdvectionFieldMethod::fem_simple_darcy_field;
           else if (x_compositional_field_methods[i] == "prescribed field")
             compositional_field_methods[i] = AdvectionFieldMethod::prescribed_field;
           else if (x_compositional_field_methods[i] == "prescribed field with diffusion")
@@ -2295,14 +2295,14 @@ namespace aspect
                    ExcMessage ("The list of names for the mapped particle property fields needs to either be empty or have a length equal to "
                                "the number of compositional fields that are interpolated from particle properties."));
 
-      if (std::find(compositional_field_methods.begin(), compositional_field_methods.end(), AdvectionFieldMethod::fem_darcy_field)
+      if (std::find(compositional_field_methods.begin(), compositional_field_methods.end(), AdvectionFieldMethod::fem_simple_darcy_field)
           != compositional_field_methods.end())
         {
           const unsigned int porosity_idx = std::find(names_of_compositional_fields.begin(), names_of_compositional_fields.end(), "porosity")
                                             - names_of_compositional_fields.begin();
           AssertThrow (porosity_idx != n_compositional_fields,
                        ExcMessage ("The Darcy advection field method only works if there is a compositional field named 'porosity'"));
-          AssertThrow (compositional_field_methods[porosity_idx] == AdvectionFieldMethod::fem_darcy_field,
+          AssertThrow (compositional_field_methods[porosity_idx] == AdvectionFieldMethod::fem_simple_darcy_field,
                        ExcMessage ("When using the Darcy advection field method, the porosity field must be advected with the Darcy method."));
         }
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -271,7 +271,7 @@ namespace aspect
             case Parameters<dim>::AdvectionFieldMethod::fem_field:
             case Parameters<dim>::AdvectionFieldMethod::fem_melt_field:
             case Parameters<dim>::AdvectionFieldMethod::prescribed_field_with_diffusion:
-            case Parameters<dim>::AdvectionFieldMethod::fem_darcy_field:
+            case Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field:
             {
               // if this is a prescribed field with diffusion, we first have to copy the material model
               // outputs into the prescribed field before we assemble and solve the equation

--- a/source/time_stepping/convection_time_step.cc
+++ b/source/time_stepping/convection_time_step.cc
@@ -39,7 +39,7 @@ namespace aspect
       if (this->introspection().composition_type_exists(CompositionalFieldDescription::porosity))
         {
           porosity_idx = this->introspection().find_composition_type(CompositionalFieldDescription::porosity);
-          if (this->get_parameters().compositional_field_methods[porosity_idx] == Parameters<dim>::AdvectionFieldMethod::fem_darcy_field)
+          if (this->get_parameters().compositional_field_methods[porosity_idx] == Parameters<dim>::AdvectionFieldMethod::fem_simple_darcy_field)
             consider_darcy_timestep = true;
         }
 

--- a/tests/darcy_convection_step.prm
+++ b/tests/darcy_convection_step.prm
@@ -1,7 +1,7 @@
 #########################################################
 # This is a test for limiting the time step when advecting
-# a field with the 'darcy field' method without setting
-# Include melt transport = true. With the 'darcy field'
+# a field with the 'simple darcy field' method without setting
+# Include melt transport = true. With the 'simple darcy field'
 # advection method, the field is advected using the Darcy
 # velocity, which is expressed as:
 #
@@ -89,12 +89,12 @@ end
 
 # porosity and bound_fluid are required compositional fields when
 # using the reactive fluid transport. Set the porosity field method
-# to 'darcy field' so that the fluid is adveted with the Darcy
+# to 'simple darcy field' so that the fluid is advected with the Darcy
 # velocity.
 subsection Compositional fields
   set Number of fields = 2
   set Names of fields = porosity, bound_fluid
-  set Compositional field methods = darcy field, field
+  set Compositional field methods = simple darcy field, field
 end
 
 # Initialize a porosity of 2% (0.02) everywhere.

--- a/tests/darcy_field_diffusion.prm
+++ b/tests/darcy_field_diffusion.prm
@@ -1,7 +1,7 @@
 #########################################################
 # This test is built off of the darcy convection step test, but increases the 
 # stabilization parameters to show that the diffusion of the porosity with the 
-# "darcy field" advection method works.
+# "simple darcy field" advection method works.
 #########################################################
 
 include $ASPECT_SOURCE_DIR/tests/darcy_convection_step.prm

--- a/tests/darcy_outflow.prm
+++ b/tests/darcy_outflow.prm
@@ -2,7 +2,7 @@
 # Because the porosity composition is less dense than the solid, the porosity will rise to the 
 # surface of the model and flow out of the top of the box. This tests the implementation of 
 # composition dependent outflow boundary conditions for when a composition is advected with the 
-# Darcy field advection method.
+# simple Darcy field advection method.
 set Dimension                              = 2
 set Use years instead of seconds           = true
 set End time                               = 50
@@ -90,7 +90,7 @@ end
 subsection Compositional fields
   set Number of fields            = 3
   set Names of fields             = porosity, bound_fluid, solid_phase
-  set Compositional field methods = darcy field, field, field
+  set Compositional field methods = simple darcy field, field, field
 end
 
 subsection Melt settings

--- a/tests/darcy_velocity.prm
+++ b/tests/darcy_velocity.prm
@@ -88,7 +88,7 @@ end
 subsection Compositional fields
   set Number of fields = 2
   set Names of fields = porosity, fluid
-  set Compositional field methods = darcy field, darcy field
+  set Compositional field methods = simple darcy field, simple darcy field
   set Types of fields = porosity, generic
 end
 

--- a/tests/tian_water_mass_conservation.prm
+++ b/tests/tian_water_mass_conservation.prm
@@ -37,9 +37,9 @@ include $ASPECT_SOURCE_DIR/tests/tian_peridotite.prm
 set End time                               = 1e2
 set Maximum time step                      = 1e2
 
-# Set the advection method to be darcy field
+# Set the advection method to be a simple darcy field
 subsection Compositional fields
-  set Compositional field methods = darcy field, field, field, field, field, field
+  set Compositional field methods = simple darcy field, field, field, field, field, field
 end
 
 # Change the Reaction solver type to fixed step, so that we know how to scale the

--- a/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab.prm
+++ b/tests/uncoupled_two_phase_tian_parameterization_kinematic_slab.prm
@@ -16,7 +16,7 @@ subsection Mesh refinement
 end
 
 subsection Compositional fields
-  set Compositional field methods = darcy field, field, field, field, field, field
+  set Compositional field methods = simple darcy field, field, field, field, field, field
 end
 
 # Slightly change composition model to ensure that there is bound_fluid


### PR DESCRIPTION
Rename the "darcy field" advection method to "simple darcy field". This will be required for adding a new darcy advection darcy field advection method which uses the pressure gradient instead of just using the density differences