### PR TITLE
[WIP] Update FastScape visualization function

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -349,6 +349,12 @@ namespace aspect
         mutable double last_output_time;
 
         /**
+         * Consecutively counted number indicating the how-manyth time we will
+         * create output the next time we get to it.
+         */
+        mutable unsigned int output_file_number;
+
+        /**
          * @name Fastscape boundary conditions
          * @{
          */
@@ -656,6 +662,7 @@ namespace aspect
          * Flag to use orographic controls.
          */
         bool use_orographic_controls;
+        
         /**
          * @}
          */

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -662,7 +662,6 @@ namespace aspect
          * Flag to use orographic controls.
          */
         bool use_orographic_controls;
-        
         /**
          * @}
          */

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -151,7 +151,12 @@ namespace aspect
                                 const double *vexp,
                                 unsigned int *astep,
                                 const char *c,
-                                const unsigned int *length);
+                                const unsigned int *length,
+                                const double *model_height,
+                                const unsigned int *model_dim,
+                                const double *adjustment,
+                                const double *time);
+
 #endif
 
       /**
@@ -301,6 +306,17 @@ namespace aspect
                                    false);
 
       last_output_time = 0;
+      output_file_number = 0;
+
+      if (!this->get_parameters().resume_computation
+          && Utilities::MPI::this_mpi_process(this->get_mpi_communicator()) == 0)
+        {
+          const std::string dir = this->get_output_directory() + "fastscape/";
+          std::filesystem::remove(dir + ".pvd_index");
+          std::filesystem::remove(dir + "Topography.pvd");
+          std::filesystem::remove(dir + "SeaLevel.pvd");
+          std::filesystem::remove(dir + "Basement.pvd");
+        }
     }
 
 
@@ -950,11 +966,18 @@ namespace aspect
 
       // Because on the first timestep we will create an initial VTK file before running FastScape
       // and a second after, we first set the visualization step to zero.
-      unsigned int visualization_step = 0;
       const unsigned int current_timestep = this->get_timestep_number ();
       const std::string dirname = (this->get_output_directory() + "fastscape/");
       const char *dirname_char=dirname.c_str();
       const unsigned int dirname_length = dirname.length();
+      const GeometryModel::Box<dim> &geometry =
+            Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model());
+
+      // This is used so that the FastScape visualization defaults to showing
+      // up slightly above the ASPECT surface.
+      const double model_height = geometry.get_extents()[dim-1];
+      const unsigned model_dim = dim;
+      const double ghost_node_adjustment = fastscape_dx*use_ghost_nodes;
 
       // Set time step
       fastscape_set_dt_(&fastscape_timestep_in_years);
@@ -965,20 +988,29 @@ namespace aspect
           {
 #ifdef ASPECT_HAVE_FASTSCAPE_NAMED_VTK
             this->get_pcout() << "      Writing initial VTK..." << std::endl;
+
+            const double time_in_years_or_seconds = 0;
+            unsigned int initial_file_number = 0;
+
             // FastScape by default visualizes a field called HHHHH,
             // and the parameter this shows will be whatever is given as the first
             // position. extra_vtk_field is set to the river incision rate by default.
             fastscape_named_vtk_(extra_vtk_field.data(),
                                  &vexp,
-                                 &visualization_step,
+                                 &initial_file_number,
                                  dirname_char,
-                                 &dirname_length);
+                                 &dirname_length,
+                                 &model_height,
+                                 &model_dim,
+                                 &ghost_node_adjustment,
+                                 &time_in_years_or_seconds);
 #else
             (void)extra_vtk_field;
             (void)vexp;
-            (void)visualization_step;
             (void)dirname_char;
             (void)dirname_length;
+            (void)model_height;
+            (void)model_dim;
 
             this->get_pcout() << "      Not writing initial VTK because the FastScape library does not support this functionality."
                               << std::endl;
@@ -1042,7 +1074,20 @@ namespace aspect
           {
 #ifdef ASPECT_HAVE_FASTSCAPE_NAMED_VTK
             this->get_pcout() << "      Writing FastScape VTK..." << std::endl;
-            visualization_step = current_timestep;
+
+            const double time_in_years_or_seconds = (this->convert_output_to_years() ?
+                                         this->get_time() / year_in_seconds :
+                                         this->get_time());
+
+            // up the counter of the number of the file by one, but not in
+            // the very first output step. if we run postprocessors on all
+            // iterations, only increase file number in the first nonlinear iteration
+            const bool increase_file_number = (this->get_nonlinear_iteration() == 0) || (!this->get_parameters().run_postprocessors_on_nonlinear_iterations);
+            if (output_file_number == numbers::invalid_unsigned_int)
+              output_file_number = 0;
+            else if (increase_file_number)
+              ++output_file_number;
+
             // Get the output directory name and name length again
             // to avoid Fortran error that the dirname has length -1,
             // eventhough dirname_length passes the correct length.
@@ -1051,15 +1096,20 @@ namespace aspect
             const unsigned int dirname_length = dirname.length();
             fastscape_named_vtk_(extra_vtk_field.data(),
                                  &vexp,
-                                 &visualization_step,
+                                 &output_file_number,
                                  dirname_char,
-                                 &dirname_length);
+                                 &dirname_length,
+                                 &model_height,
+                                 &model_dim,
+                                 &ghost_node_adjustment,
+                                 &time_in_years_or_seconds);                              
 #else
             (void)extra_vtk_field;
             (void)vexp;
-            (void)visualization_step;
             (void)dirname_char;
             (void)dirname_length;
+            (void)model_height;
+            (void)model_dim;
 
             this->get_pcout() << "      Not writing FastScape VTK because the FastScape library does not support this functionality."
                               << std::endl;
@@ -1581,7 +1631,8 @@ namespace aspect
     template <class Archive>
     void FastScape<dim>::serialize (Archive &ar, const unsigned int)
     {
-      ar &last_output_time;
+      ar &last_output_time
+      & output_file_number;
     }
 
 

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -156,7 +156,6 @@ namespace aspect
                                 const unsigned int *model_dim,
                                 const double *adjustment,
                                 const double *time);
-
 #endif
 
       /**

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -970,7 +970,7 @@ namespace aspect
       const char *dirname_char=dirname.c_str();
       const unsigned int dirname_length = dirname.length();
       const GeometryModel::Box<dim> &geometry =
-            Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model());
+        Plugins::get_plugin_as_type<const GeometryModel::Box<dim>>(this->get_geometry_model());
 
       // This is used so that the FastScape visualization defaults to showing
       // up slightly above the ASPECT surface.
@@ -1075,8 +1075,8 @@ namespace aspect
             this->get_pcout() << "      Writing FastScape VTK..." << std::endl;
 
             const double time_in_years_or_seconds = (this->convert_output_to_years() ?
-                                         this->get_time() / year_in_seconds :
-                                         this->get_time());
+                                                     this->get_time() / year_in_seconds :
+                                                     this->get_time());
 
             // up the counter of the number of the file by one, but not in
             // the very first output step. if we run postprocessors on all
@@ -1101,7 +1101,7 @@ namespace aspect
                                  &model_height,
                                  &model_dim,
                                  &ghost_node_adjustment,
-                                 &time_in_years_or_seconds);                              
+                                 &time_in_years_or_seconds);
 #else
             (void)extra_vtk_field;
             (void)vexp;


### PR DESCRIPTION
This pull request updates the fastscape coupling to call an updated function for fastscape visualization. This new function does a few things:

1) Writes to .vts files instead of .vtk

2) Writes .pvd files that contain the timings from ASPECT so that in paraview they can directly be opened together without needing to use a conversion script.

3) Small changes so that whether in 2D or 3D, the FastScape surface is set in a way that it will appear at the top surface of ASPECT and adjust to whether or not ghost nodes are set.

4) The numbering on FastScape visualizations has been fixed to increase incrementally instead of using the timestep of visualization.

The conversion to write .vtk instead of .vts and the .pvd files was done using Claude. As the function replaced the old one, and requires new inputs, this would require the new version to compile. The pull request for adding the updated named_vtk, at least to my fastscape repository, is here: 

https://github.com/Djneu/fastscapelib-fortran/pull/7

(A reminder to myself that I also would need to remove the HHHH field from FastScape and extra_vtk_field from ASPECT since we now output all fields we could copy by default, though we could potentially visualize things like e.g. provenance once we find how to calculate it). Attached is also an image to show an example of the default position of FastScape loaded with a 2D ASPECT model (using ghost nodes).

<img width="701" height="344" alt="image" src="https://github.com/user-attachments/assets/90787e73-a796-4136-8dde-fd5b17f26e0e" />


@anne-glerum 
