### PR TITLE
Cast consistently between integer and double in FastScape interface

### DIFF
--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -770,7 +770,7 @@ namespace aspect
                         // In local_aspect_values[1], we store integer indices even though the
                         // type of the left hand side is 'double'. We will have to cast back
                         // when we read from local_aspect_values[1].
-                        local_aspect_values[1].push_back(index-1);
+                        local_aspect_values[1].push_back(static_cast<double>(index-1));
 
                         for (unsigned int d=0; d<dim; ++d)
                           {
@@ -795,7 +795,7 @@ namespace aspect
     {
       for (unsigned int i=0; i<local_aspect_values[1].size(); ++i)
         {
-          // In get_aspect_values(), we store an integer value in local_aspect_values[1][...].
+          // In get_aspect_values(), we store an integer value as a double in local_aspect_values[1][...].
           // Explicitly cast it back.
           const unsigned int index = static_cast<unsigned int>(local_aspect_values[1][i]);
           elevation[index] = local_aspect_values[0][i];
@@ -831,9 +831,9 @@ namespace aspect
           // Now, place the numbers into the correct place based off the index.
           for (unsigned int i=0; i<local_aspect_values[1].size(); ++i)
             {
-              // In get_aspect_values(), we store an integer value in local_aspect_values[1][...].
+              // In get_aspect_values(), we store an integer value as a double in local_aspect_values[1][...].
               // Explicitly cast it back.
-              const unsigned int index = local_aspect_values[1][i];
+              const unsigned int index = static_cast<unsigned int>(local_aspect_values[1][i]);
               elevation[index] = local_aspect_values[0][i];
               velocity_x[index] = local_aspect_values[2][i];
               velocity_z[index] = local_aspect_values[dim+1][i];


### PR DESCRIPTION
fastscape.cc stores integers in a larger vector of a vector of doubles. These integers are currently not all cast to a double when storing and not all cast back to integer when being read. This gives compiler warnings:

```
In file included from /Users/admin/Applications/ASPECT/aspect/build_test/CMakeFiles/aspect.exe.release.dir/Unity/unity_21_cxx.cxx:16:
/Users/admin/Applications/ASPECT/aspect/source/mesh_deformation/fastscape.cc:836:42: warning: implicit conversion turns floating-point number into integer: 'value_type' (aka 'double') to
      'const unsigned int' [-Wfloat-conversion]
  836 |               const unsigned int index = local_aspect_values[1][i];
      |                                  ~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~
/Users/admin/Applications/ASPECT/aspect/source/mesh_deformation/fastscape.cc:836:42: warning: implicit conversion turns floating-point number into integer: 'value_type' (aka 'double') to
      'const unsigned int' [-Wfloat-conversion]
  836 |               const unsigned int index = local_aspect_values[1][i];
      |                                  ~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~
/Users/admin/Applications/ASPECT/aspect/source/mesh_deformation/fastscape.cc:2215:44: note: in instantiation of member function 'aspect::MeshDeformation::FastScape<2>::fill_fastscape_arrays'
      requested here
 2215 |     ASPECT_REGISTER_MESH_DEFORMATION_MODEL(FastScape,
      |                                            ^
/Users/admin/Applications/ASPECT/aspect/include/aspect/mesh_deformation/interface.h:764:18: note: expanded from macro 'ASPECT_REGISTER_MESH_DEFORMATION_MODEL'
  764 |   template class classname<2>; \
```

This PR consistently casts to double and back.

Locally 4 FastScape tests fail, but the fails seem unrelated for at least 3. I'm now running them in my local container to check the fails. No need to look at the PR yet.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
