### PR TITLE
Add and test rotate kelvin tensor

### DIFF
--- a/include/aspect/utilities.h
+++ b/include/aspect/utilities.h
@@ -33,6 +33,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/component_mask.h>
 #include <deal.II/lac/solver_control.h>
+#include <deal.II/physics/notation.h>
 
 #include <aspect/coordinate_systems.h>
 #include <aspect/structured_data.h>
@@ -1333,6 +1334,12 @@ namespace aspect
        */
       SymmetricTensor<2,6>
       rotate_voigt_stiffness_matrix(const Tensor<2,3> &rotation_tensor, const SymmetricTensor<2,6> &input_tensor);
+
+      /**
+       * Rotate a symmetric 6x6 tensor in kelvin notation
+       */
+      SymmetricTensor<2,6>
+      rotate_kelvin_tensor(const Tensor<2,3> &rotation_tensor, const SymmetricTensor<2,6> &input_tensor);
 
       /**
        * Transform a 4th order full stiffness tensor into a 6x6 Voigt stiffness matrix.

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -3097,6 +3097,60 @@ namespace aspect
         return symmetrize((rotation_matrix*input_tensor)*rotation_matrix_transposed);
       }
 
+      SymmetricTensor<2,6>
+      rotate_kelvin_tensor(const Tensor<2,3> &rotation_tensor, const SymmetricTensor<2,6> &input_tensor)
+      {
+        // rotating a 4th order tensor represented as a matrix in kelvin notation
+        // by computing $C'=MCM^T$ and using the same principle as in (Carcione, J. M. (2007).
+        // Wave Fields in Real Media: Wave Propagation in Anisotropic, Anelastic,
+        // Porous and Electromagnetic Media. Netherlands: Elsevier Science. Pages 8-9).
+        // though this time using kelvin notation
+
+        Tensor<2,6> rotation_matrix;
+        rotation_matrix[0][0] = Utilities::fixed_power<2>(rotation_tensor[0][0]);
+        rotation_matrix[0][1] = Utilities::fixed_power<2>(rotation_tensor[0][1]);
+        rotation_matrix[0][2] = Utilities::fixed_power<2>(rotation_tensor[0][2]);
+        rotation_matrix[0][3] = numbers::SQRT2*rotation_tensor[0][1]*rotation_tensor[0][2];
+        rotation_matrix[0][4] = numbers::SQRT2*rotation_tensor[0][0]*rotation_tensor[0][2];
+        rotation_matrix[0][5] = numbers::SQRT2*rotation_tensor[0][0]*rotation_tensor[0][1];
+
+        rotation_matrix[1][0] = Utilities::fixed_power<2>(rotation_tensor[1][0]);
+        rotation_matrix[1][1] = Utilities::fixed_power<2>(rotation_tensor[1][1]);
+        rotation_matrix[1][2] = Utilities::fixed_power<2>(rotation_tensor[1][2]);
+        rotation_matrix[1][3] = numbers::SQRT2*rotation_tensor[1][1]*rotation_tensor[1][2];
+        rotation_matrix[1][4] = numbers::SQRT2*rotation_tensor[1][0]*rotation_tensor[1][2];
+        rotation_matrix[1][5] = numbers::SQRT2*rotation_tensor[1][0]*rotation_tensor[1][1];
+
+        rotation_matrix[2][0] = Utilities::fixed_power<2>(rotation_tensor[2][0]);
+        rotation_matrix[2][1] = Utilities::fixed_power<2>(rotation_tensor[2][1]);
+        rotation_matrix[2][2] = Utilities::fixed_power<2>(rotation_tensor[2][2]);
+        rotation_matrix[2][3] = numbers::SQRT2*rotation_tensor[2][1]*rotation_tensor[2][2];
+        rotation_matrix[2][4] = numbers::SQRT2*rotation_tensor[2][0]*rotation_tensor[2][2];
+        rotation_matrix[2][5] = numbers::SQRT2*rotation_tensor[2][0]*rotation_tensor[2][1];
+
+        rotation_matrix[3][0] = numbers::SQRT2*rotation_tensor[1][0]*rotation_tensor[2][0];
+        rotation_matrix[3][1] = numbers::SQRT2*rotation_tensor[1][1]*rotation_tensor[2][1];
+        rotation_matrix[3][2] = numbers::SQRT2*rotation_tensor[1][2]*rotation_tensor[2][2];
+        rotation_matrix[3][3] = rotation_tensor[1][1]*rotation_tensor[2][2]+rotation_tensor[1][2]*rotation_tensor[2][1];
+        rotation_matrix[3][4] = rotation_tensor[1][0]*rotation_tensor[2][2]+rotation_tensor[1][2]*rotation_tensor[2][0];
+        rotation_matrix[3][5] = rotation_tensor[1][0]*rotation_tensor[2][1]+rotation_tensor[1][1]*rotation_tensor[2][0];
+
+        rotation_matrix[4][0] = numbers::SQRT2*rotation_tensor[0][0]*rotation_tensor[2][0];
+        rotation_matrix[4][1] = numbers::SQRT2*rotation_tensor[0][1]*rotation_tensor[2][1];
+        rotation_matrix[4][2] = numbers::SQRT2*rotation_tensor[0][2]*rotation_tensor[2][2];
+        rotation_matrix[4][3] = rotation_tensor[0][1]*rotation_tensor[2][2]+rotation_tensor[0][2]*rotation_tensor[2][1];
+        rotation_matrix[4][4] = rotation_tensor[0][0]*rotation_tensor[2][2]+rotation_tensor[0][2]*rotation_tensor[2][0];
+        rotation_matrix[4][5] = rotation_tensor[0][0]*rotation_tensor[2][1]+rotation_tensor[0][1]*rotation_tensor[2][0];
+
+        rotation_matrix[5][0] = numbers::SQRT2*rotation_tensor[0][0]*rotation_tensor[1][0];
+        rotation_matrix[5][1] = numbers::SQRT2*rotation_tensor[0][1]*rotation_tensor[1][1];
+        rotation_matrix[5][2] = numbers::SQRT2*rotation_tensor[0][2]*rotation_tensor[1][2];
+        rotation_matrix[5][3] = rotation_tensor[0][1]*rotation_tensor[1][2]+rotation_tensor[0][2]*rotation_tensor[1][1];
+        rotation_matrix[5][4] = rotation_tensor[0][0]*rotation_tensor[1][2]+rotation_tensor[0][2]*rotation_tensor[1][0];
+        rotation_matrix[5][5] = rotation_tensor[0][0]*rotation_tensor[1][1]+rotation_tensor[0][1]*rotation_tensor[1][0];
+
+        return symmetrize((rotation_matrix*input_tensor)*transpose(rotation_matrix));
+      }
 
 
       SymmetricTensor<2,6>

--- a/unit_tests/utilities.cc
+++ b/unit_tests/utilities.cc
@@ -626,3 +626,58 @@ TEST_CASE("Utilities::string_to_unsigned_int")
   CHECK(aspect::Utilities::string_to_unsigned_int(std::vector<std::string>({}))
         == std::vector<unsigned int>());
 }
+
+TEST_CASE("Rotate Kelvin Tensor")
+{
+  // define a random rotation
+  std::vector<double> EA = {13, 21, 34};
+  dealii::Tensor<2,3> rotation = aspect::Utilities::zxz_euler_angles_to_rotation_matrix(EA[0], EA[1], EA[1]);
+
+  // generate an symmetric tensor in kelvin notation
+  // full matrix necessary for dealii::Physics::Notation::Kelvin::to_tensor
+  dealii::FullMatrix<double> kelvin_tensor_fm(6,6);
+  dealii::SymmetricTensor<2,6> kelvin_tensor;
+  for (unsigned short int i1 = 0; i1 < 6; ++i1)
+    {
+      for (unsigned short int i2 = i1; i2 < 6; ++i2)
+        {
+          kelvin_tensor_fm[i1][i2] = kelvin_tensor_fm[i2][i1] = 2.5*i1 + 3.4*i2 + 3.0;
+          kelvin_tensor[i1][i2]    = kelvin_tensor_fm[i1][i2];
+        }
+    }
+
+  dealii::SymmetricTensor<4,3> full_tensor;
+  dealii::Physics::Notation::Kelvin::to_tensor(kelvin_tensor_fm, full_tensor);
+
+  // rotating using rotate full stiffness tensor (checked and tested)
+  dealii::SymmetricTensor<4,3> rotated_full_tensor = aspect::Utilities::Tensors::rotate_full_stiffness_tensor(rotation, full_tensor);
+
+  // rotation using rotate kelvin tensor
+  dealii::SymmetricTensor<2,6> rotated_kelvin_tensor = aspect::Utilities::Tensors::rotate_kelvin_tensor(rotation, kelvin_tensor);
+
+  // painstakingly use dealii::Physics::Notation::Kelvin::to_tensor
+  dealii::FullMatrix<double> rotated_kelvin_tensor_fm(6,6);
+  for (unsigned int ai=0; ai<6; ++ai)
+    for (unsigned int aj=0; aj<6; ++aj)
+      rotated_kelvin_tensor_fm[ai][aj] = rotated_kelvin_tensor[ai][aj];
+
+  dealii::SymmetricTensor<4,3> rotated_full_tensor_new;
+  dealii::Physics::Notation::Kelvin::to_tensor(rotated_kelvin_tensor_fm, rotated_full_tensor_new);
+
+  // check that every component is the same
+  for (unsigned int i1=0; i1<3; ++i1)
+    {
+      for (unsigned int i2=0; i2<3; ++i2)
+        {
+          for (unsigned int i3=0; i3<3; ++i3)
+            {
+              for (unsigned int i4=0; i4<3; ++i4)
+                {
+                  INFO("array index i,j,k,l=" << i1 << ',' << i2 << ',' << i3 << ',' << i4 << ',' << ": ");
+                  CHECK(rotated_full_tensor_new[i1][i2][i3][i4] == Approx(rotated_full_tensor[i1][i2][i3][i4]));
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

I added the function aspect::Utilities::Tensors::rotate_kelvin_tensor and implemented a minimal unit test to ensure it is working as expected. Any rank four tensor $G_{ijkl}$ can be rotated with a rotation matrix $R_{ij}$ by computing 
$G_{ijkl}' = R_{iq}R_{jp}R_{kr}R_{ls}G_{qprs}$.
This is already implemented and tested as aspect::Utilities::Tensors::rotate_full_stiffness_matrix and is applicable to any rank 4 tensor. If the tensor $G_{ijkl}$ has certain symmetries it can be written in Kelvin notation (also known as Mandel Notation) as a rank 2 tensor $G_{ij}$ and the rotation can be computed using, $G_{ij}' = M_{ik}G_{kl}M_{lj}^T$ , where  $M_{ij}$ is the 4th order tensor $R_{ij}R_{kl}$ written in Kelvin notation. (see for example this [github page](https://jfbarthelemy.github.io/echoes/99_appendices/tensor_algebra.html#eq-rot6) )

The reason for the change is that rotation of a tensor in kelvin notation like this is already being done in the CPO_AV_3D material model plugin, but it was not tested before. This test compares the rotation using aspect::Utilities::Tensors::rotate_full_stiffness_matrix to a rotation computed with the new functionality.

More tests such as rotating back and forth or adding functions to convert into kelvin or from kelvin notation in aspect not using dealii::Physics::Notation::Kelvin::to_tensor can be implemented. 

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
