### PR TITLE
add pyroxenite melting model to reaction model and update melt fraction postprocessor

### DIFF
--- a/include/aspect/material_model/reaction_model/pyroxenite_melting.h
+++ b/include/aspect/material_model/reaction_model/pyroxenite_melting.h
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2024 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_reaction_model_pyroxenite_melting_h
+#define _aspect_material_model_reaction_model_pyroxenite_melting_h
+
+#include <aspect/material_model/interface.h>
+#include <aspect/simulator_access.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+
+      /**
+       * A melt model that calculates melt fraction and entropy change
+       * according to the melting model for dry peridotite of Katz, 2003.
+       * This also includes a computation of the latent heat of melting (if the latent heat
+       * heating model is active).
+       *
+       * These functions can be used in the calculation of melting and melt transport
+       * in the melt_simple material model and can be extended to other material models
+       *
+       * @ingroup ReactionModel
+       */
+      template <int dim>
+      class PyroxeniteMelting : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Declare the parameters this function takes through input files.
+           */
+          static
+          void
+          declare_parameters (ParameterHandler &prm);
+
+          /**
+           * Read the parameters from the parameter file.
+           */
+          void
+          parse_parameters (ParameterHandler &prm);
+
+          /**
+           * Percentage of material that is molten for a given @p temperature and
+           * @p pressure (assuming equilibrium conditions). Melting model after Katz,
+           * 2003, for dry peridotite.
+           */
+          double
+          melt_fraction (const double temperature,
+                         const double pressure) const;
+
+        private:
+          /**
+           * Parameters for melting of pyroxenite after Sobolev et al., 2011
+           */
+
+          // for the melting temperature
+          double D1;    // °C
+          double D2;  // °C/Pa
+          double D3; // °C/(Pa^2)
+
+          // for the melt-fraction dependence of productivity
+          double E1;
+          double E2;
+      };
+    }
+
+  }
+}
+
+#endif

--- a/include/aspect/postprocess/visualization/melt_fraction.h
+++ b/include/aspect/postprocess/visualization/melt_fraction.h
@@ -24,6 +24,8 @@
 
 #include <aspect/postprocess/visualization.h>
 #include <aspect/simulator_access.h>
+#include <aspect/material_model/reaction_model/katz2003_mantle_melting.h>
+#include <aspect/material_model/reaction_model/pyroxenite_melting.h>
 
 #include <deal.II/numerics/data_postprocessor.h>
 
@@ -69,45 +71,11 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
-          /**
-           * Parameters for anhydrous melting of peridotite after Katz, 2003
-           */
-
-          // for the solidus temperature
-          double A1;   // °C
-          double A2; // °C/Pa
-          double A3; // °C/(Pa^2)
-
-          // for the lherzolite liquidus temperature
-          double B1;   // °C
-          double B2;   // °C/Pa
-          double B3; // °C/(Pa^2)
-
-          // for the liquidus temperature
-          double C1;   // °C
-          double C2;  // °C/Pa
-          double C3; // °C/(Pa^2)
-
-          // for the reaction coefficient of pyroxene
-          double r1;     // cpx/melt
-          double r2;     // cpx/melt/GPa
-          double M_cpx;  // mass fraction of pyroxenite
-
-          // melt fraction exponent
-          double beta;
-
-          /**
-           * Parameters for melting of pyroxenite after Sobolev et al., 2011
-           */
-
-          // for the melting temperature
-          double D1;    // °C
-          double D2;  // °C/Pa
-          double D3; // °C/(Pa^2)
-
-          // for the melt-fraction dependence of productivity
-          double E1;
-          double E2;
+          /*
+          * Object for computing the melt parameters
+          */
+          MaterialModel::ReactionModel::Katz2003MantleMelting<dim> katz2003_model;
+          MaterialModel::ReactionModel::PyroxeniteMelting<dim> pyroxenite_model;
       };
     }
   }

--- a/source/material_model/reaction_model/pyroxenite_melting.cc
+++ b/source/material_model/reaction_model/pyroxenite_melting.cc
@@ -1,0 +1,133 @@
+/*
+  Copyright (C) 2024 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+
+
+#include <aspect/material_model/reaction_model/pyroxenite_melting.h>
+#include <aspect/utilities.h>
+#include <aspect/adiabatic_conditions/interface.h>
+#include <deal.II/base/parameter_handler.h>
+
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      // melting of pyroxenite after Sobolev et al., 2011. 
+      // Originally implemented in melt fraction postprocessor.
+      template <int dim>
+      double
+      PyroxeniteMelting<dim>::
+      melt_fraction (const double temperature,
+                     const double pressure) const
+      {
+        const double T_melting = D1 + 273.15
+                                  + D2 * pressure
+                                  + D3 * pressure * pressure;
+
+        const double discriminant = E1*E1/(E2*E2*4) + (temperature-T_melting)/E2;
+
+        double pyroxenite_melt_fraction;
+        if (temperature < T_melting || pressure > 1.3e10)
+          pyroxenite_melt_fraction = 0.0;
+        else if (discriminant < 0)
+          pyroxenite_melt_fraction = 0.5429;
+        else
+          pyroxenite_melt_fraction = -E1/(2*E2) - std::sqrt(discriminant);
+
+        return pyroxenite_melt_fraction;
+      }
+
+
+      template <int dim>
+      void
+      PyroxeniteMelting<dim>::declare_parameters (ParameterHandler &prm)
+      {
+        prm.declare_entry ("D1", "976.0",
+                            Patterns::Double (),
+                            "Constant parameter in the quadratic "
+                            "function that approximates the solidus "
+                            "of pyroxenite. "
+                            "Units: $^\\circ\\text{C}$.");
+        prm.declare_entry ("D2", "1.329e-7",
+                            Patterns::Double (),
+                            "Prefactor of the linear pressure term "
+                            "in the quadratic function that approximates "
+                            "the solidus of pyroxenite. "
+                            "Note that this factor is different from the "
+                            "value given in Sobolev, 2011, because they use "
+                            "the potential temperature whereas we use the "
+                            "absolute temperature. "
+                            "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
+        prm.declare_entry ("D3", "-5.1e-18",
+                            Patterns::Double (),
+                            "Prefactor of the quadratic pressure term "
+                            "in the quadratic function that approximates "
+                            "the solidus of pyroxenite. "
+                            "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
+        prm.declare_entry ("E1", "663.8",
+                            Patterns::Double (),
+                            "Prefactor of the linear depletion term "
+                            "in the quadratic function that approximates "
+                            "the melt fraction of pyroxenite. "
+                            "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
+        prm.declare_entry ("E2", "-611.4",
+                            Patterns::Double (),
+                            "Prefactor of the quadratic depletion term "
+                            "in the quadratic function that approximates "
+                            "the melt fraction of pyroxenite. "
+                            "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
+
+
+      }
+
+
+      template <int dim>
+      void
+      PyroxeniteMelting<dim>::parse_parameters (ParameterHandler &prm)
+      {
+        D1              = prm.get_double ("D1");
+        D2              = prm.get_double ("D2");
+        D3              = prm.get_double ("D3");
+        E1              = prm.get_double ("E1");
+        E2              = prm.get_double ("E2");
+      }
+    }
+  }
+}
+
+
+// explicit instantiations
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+#define INSTANTIATE(dim) \
+  template class PyroxeniteMelting<dim>;
+
+      ASPECT_INSTANTIATE(INSTANTIATE)
+#undef INSTANTIATE
+    }
+  }
+}

--- a/source/postprocess/visualization/melt_fraction.cc
+++ b/source/postprocess/visualization/melt_fraction.cc
@@ -21,6 +21,8 @@
 
 #include <aspect/postprocess/visualization/melt_fraction.h>
 #include <aspect/melt.h>
+#include <aspect/material_model/reaction_model/pyroxenite_melting.h>
+#include <aspect/material_model/reaction_model/katz2003_mantle_melting.h>
 
 #include <deal.II/base/parameter_handler.h>
 
@@ -82,57 +84,18 @@ namespace aspect
               for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
                 composition[c] = input_data.solution_values[q][this->introspection().component_indices.compositional_fields[c]];
 
-              // anhydrous melting of peridotite after Katz, 2003
-              const double T_solidus  = A1 + 273.15
-                                        + A2 * pressure
-                                        + A3 * pressure * pressure;
-              const double T_lherz_liquidus = B1 + 273.15
-                                              + B2 * pressure
-                                              + B3 * pressure * pressure;
-              const double T_liquidus = C1 + 273.15
-                                        + C2 * pressure
-                                        + C3 * pressure * pressure;
+              // melting model 1: anhydrous melting of peridotite after Katz, 2003
+              double peridotite_melt_fraction = katz2003_model.melt_fraction(temperature, pressure);
 
-              // melt fraction for peridotite with clinopyroxene
-              double peridotite_melt_fraction;
-              if (temperature < T_solidus || pressure > 1.3e10)
-                peridotite_melt_fraction = 0.0;
-              else if (temperature > T_lherz_liquidus)
-                peridotite_melt_fraction = 1.0;
-              else
-                peridotite_melt_fraction = std::pow((temperature - T_solidus) / (T_lherz_liquidus - T_solidus),beta);
-
-              // melt fraction after melting of all clinopyroxene
-              const double R_cpx = r1 + r2 * std::max(0.0, pressure);
-              const double F_max = M_cpx / R_cpx;
-
-              if (peridotite_melt_fraction > F_max && temperature < T_liquidus)
-                {
-                  const double T_max = std::pow(F_max,1/beta) * (T_lherz_liquidus - T_solidus) + T_solidus;
-                  peridotite_melt_fraction = F_max + (1 - F_max) * std::pow((temperature - T_max) / (T_liquidus - T_max),beta);
-                }
-
-              // melting of pyroxenite after Sobolev et al., 2011
-              const double T_melting = D1 + 273.15
-                                       + D2 * pressure
-                                       + D3 * pressure * pressure;
-
-              const double discriminant = E1*E1/(E2*E2*4) + (temperature-T_melting)/E2;
-
-              double pyroxenite_melt_fraction;
-              if (temperature < T_melting || pressure > 1.3e10)
-                pyroxenite_melt_fraction = 0.0;
-              else if (discriminant < 0)
-                pyroxenite_melt_fraction = 0.5429;
-              else
-                pyroxenite_melt_fraction = -E1/(2*E2) - std::sqrt(discriminant);
-
+              // melting model 2: melting of pyroxenite after Sobolev et al., 2011 here. 
+              // Can be replaced by any other melting model that is implemented in ASPECT with a "melt_fraction" function.
+              double comp_2_melt_fraction = pyroxenite_model.melt_fraction(temperature, pressure);
               double melt_fraction;
-              if (this->introspection().compositional_name_exists("pyroxenite"))
+              if (this->introspection().compositional_name_exists("composition_2"))
                 {
-                  const unsigned int pyroxenite_index = this->introspection().compositional_index_for_name("pyroxenite");
-                  melt_fraction = composition[pyroxenite_index] * pyroxenite_melt_fraction +
-                                  (1-composition[pyroxenite_index]) * peridotite_melt_fraction;
+                  const unsigned int comp_2_index = this->introspection().compositional_index_for_name("composition_2");
+                  melt_fraction = composition[comp_2_index] * comp_2_melt_fraction +
+                                  (1-composition[comp_2_index]) * peridotite_melt_fraction;
                 }
               else
                 melt_fraction = peridotite_melt_fraction;
@@ -153,121 +116,8 @@ namespace aspect
           {
             prm.enter_subsection("Melt fraction");
             {
-              prm.declare_entry ("A1", "1085.7",
-                                 Patterns::Double (),
-                                 "Constant parameter in the quadratic "
-                                 "function that approximates the solidus "
-                                 "of peridotite. "
-                                 "Units: $^\\circ\\text{C}$.");
-              prm.declare_entry ("A2", "1.329e-7",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the solidus of peridotite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
-              prm.declare_entry ("A3", "-5.1e-18",
-                                 Patterns::Double (),
-                                 "Prefactor of the quadratic pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the solidus of peridotite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
-              prm.declare_entry ("B1", "1475.0",
-                                 Patterns::Double (),
-                                 "Constant parameter in the quadratic "
-                                 "function that approximates the lherzolite "
-                                 "liquidus used for calculating the fraction "
-                                 "of peridotite-derived melt. "
-                                 "Units: $^\\circ\\text{C}$.");
-              prm.declare_entry ("B2", "8.0e-8",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the  lherzolite liquidus used for "
-                                 "calculating the fraction of peridotite-"
-                                 "derived melt. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
-              prm.declare_entry ("B3", "-3.2e-18",
-                                 Patterns::Double (),
-                                 "Prefactor of the quadratic pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the  lherzolite liquidus used for "
-                                 "calculating the fraction of peridotite-"
-                                 "derived melt. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
-              prm.declare_entry ("C1", "1780.0",
-                                 Patterns::Double (),
-                                 "Constant parameter in the quadratic "
-                                 "function that approximates the liquidus "
-                                 "of peridotite. "
-                                 "Units: $^\\circ\\text{C}$.");
-              prm.declare_entry ("C2", "4.50e-8",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the liquidus of peridotite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
-              prm.declare_entry ("C3", "-2.0e-18",
-                                 Patterns::Double (),
-                                 "Prefactor of the quadratic pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the liquidus of peridotite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
-              prm.declare_entry ("r1", "0.5",
-                                 Patterns::Double (),
-                                 "Constant in the linear function that "
-                                 "approximates the clinopyroxene reaction "
-                                 "coefficient. "
-                                 "Units: non-dimensional.");
-              prm.declare_entry ("r2", "8e-11",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear pressure term "
-                                 "in the linear function that approximates "
-                                 "the clinopyroxene reaction coefficient. "
-                                 "Units: $\\frac{1}{\\text{Pa}}$.");
-              prm.declare_entry ("beta", "1.5",
-                                 Patterns::Double (),
-                                 "Exponent of the melting temperature in "
-                                 "the melt fraction calculation. "
-                                 "Units: non-dimensional.");
-              prm.declare_entry ("Mass fraction cpx", "0.15",
-                                 Patterns::Double (),
-                                 "Mass fraction of clinopyroxene in the "
-                                 "peridotite to be molten. "
-                                 "Units: non-dimensional.");
-              prm.declare_entry ("D1", "976.0",
-                                 Patterns::Double (),
-                                 "Constant parameter in the quadratic "
-                                 "function that approximates the solidus "
-                                 "of pyroxenite. "
-                                 "Units: $^\\circ\\text{C}$.");
-              prm.declare_entry ("D2", "1.329e-7",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the solidus of pyroxenite. "
-                                 "Note that this factor is different from the "
-                                 "value given in Sobolev, 2011, because they use "
-                                 "the potential temperature whereas we use the "
-                                 "absolute temperature. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
-              prm.declare_entry ("D3", "-5.1e-18",
-                                 Patterns::Double (),
-                                 "Prefactor of the quadratic pressure term "
-                                 "in the quadratic function that approximates "
-                                 "the solidus of pyroxenite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
-              prm.declare_entry ("E1", "663.8",
-                                 Patterns::Double (),
-                                 "Prefactor of the linear depletion term "
-                                 "in the quadratic function that approximates "
-                                 "the melt fraction of pyroxenite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}}$.");
-              prm.declare_entry ("E2", "-611.4",
-                                 Patterns::Double (),
-                                 "Prefactor of the quadratic depletion term "
-                                 "in the quadratic function that approximates "
-                                 "the melt fraction of pyroxenite. "
-                                 "$\\frac{^\\circ\\text{C}}{\\text{Pa}^2}$.");
+              MaterialModel::ReactionModel::Katz2003MantleMelting<dim>::declare_parameters(prm);
+              MaterialModel::ReactionModel::PyroxeniteMelting<dim>::declare_parameters(prm);
             }
             prm.leave_subsection();
           }
@@ -286,24 +136,13 @@ namespace aspect
           {
             prm.enter_subsection("Melt fraction");
             {
-              A1              = prm.get_double ("A1");
-              A2              = prm.get_double ("A2");
-              A3              = prm.get_double ("A3");
-              B1              = prm.get_double ("B1");
-              B2              = prm.get_double ("B2");
-              B3              = prm.get_double ("B3");
-              C1              = prm.get_double ("C1");
-              C2              = prm.get_double ("C2");
-              C3              = prm.get_double ("C3");
-              r1              = prm.get_double ("r1");
-              r2              = prm.get_double ("r2");
-              beta            = prm.get_double ("beta");
-              M_cpx           = prm.get_double ("Mass fraction cpx");
-              D1              = prm.get_double ("D1");
-              D2              = prm.get_double ("D2");
-              D3              = prm.get_double ("D3");
-              E1              = prm.get_double ("E1");
-              E2              = prm.get_double ("E2");
+              // initialize simulator access of the katz2003_mantle_melting and pyroxenite_melting model
+              katz2003_model.initialize_simulator(this->get_simulator());
+              pyroxenite_model.initialize_simulator(this->get_simulator());
+              
+              // call parse_parameters of the katz2003_mantle_melting model and pyroxenite_melting to get the solidus and melt fraction parameters
+              katz2003_model.parse_parameters(prm);
+              pyroxenite_model.parse_parameters(prm);
             }
             prm.leave_subsection();
           }
@@ -332,10 +171,10 @@ namespace aspect
                                                   "Otherwise, a specific parametrization for batch melting "
                                                   "(as described in the following) will be used. "
                                                   "It does not take into account latent heat. "
-                                                  "If there are no compositional fields, or no fields called 'pyroxenite', "
+                                                  "If there are no compositional fields, or no fields called 'composition_2', "
                                                   " this postprocessor will visualize the melt fraction of peridotite "
                                                   "(calculated using the anhydrous model of Katz, 2003). "
-                                                  "If there is a compositional field called 'pyroxenite', the "
+                                                  "If there is a compositional field called 'composition_2', the "
                                                   "postprocessor assumes that this compositional "
                                                   "field is the content of pyroxenite, and will visualize "
                                                   "the melt fraction for a mixture of peridotite and pyroxenite "
@@ -344,7 +183,7 @@ namespace aspect
                                                   "can be changed in the input file, the most relevant maybe "
                                                   "being the mass fraction of Cpx in peridotite in the Katz "
                                                   "melting model (Mass fraction cpx), which right now has a "
-                                                  "default of 15\\%. "
+                                                  "default of 15\\%."
                                                   "The corresponding $p$-$T$-diagrams can be generated by running "
                                                   "the tests melt\\_postprocessor\\_peridotite and "
                                                   "melt\\_postprocessor\\_pyroxenite."

--- a/tests/melt_postprocessor_pyroxenite.prm
+++ b/tests/melt_postprocessor_pyroxenite.prm
@@ -41,7 +41,7 @@ end
 
 subsection Compositional fields
   set Number of fields = 1
-  set Names of fields = pyroxenite
+  set Names of fields = composition_2
 end
 
 # The next section deals with the initial conditions for the


### PR DESCRIPTION
I add the pyroxenite melting model currently implemented in melt_fraction postprocessor to material_model/reaction_model/pyroxenite_melting.cc as a reaction model.

I update how melt_fraction postprocessor computes melt fraction for models that do not have melting by calling "melt_fraction" function in the reaction models instead of having the repetitive lines in the postprocess/visualization/melt_fraction.cc.

Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [ ] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [ ] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
