### PR TITLE
Composition-dependent bedrock erosion parameters in fastscape

### DIFF
--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -148,6 +148,8 @@ namespace aspect
         void fill_fastscape_arrays(std::vector<double> &elevation,
                                    std::vector<double> &bedrock_transport_coefficient_array,
                                    std::vector<double> &bedrock_river_incision_rate_array,
+                                   std::vector<double> &sand_transport_coefficient,
+                                   std::vector<double> &silt_transport_coefficient,
                                    std::vector<double> &velocity_x,
                                    std::vector<double> &velocity_y,
                                    std::vector<double> &velocity_z,
@@ -475,7 +477,7 @@ namespace aspect
          * otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$. Then a time scale factor will be applied to
          * convert it into  ${m^(1-2drainage_area_exponent)/yr}$ for Fastscape.
          */
-        double constant_bedrock_river_incision_rate;
+        std::vector<double> constant_bedrock_river_incision_rate;
 
         /**
          * Sediment river incision rate for the stream power law.
@@ -509,7 +511,7 @@ namespace aspect
          * convert it into  ${m^2/yr}$ for Fastscape.
          * This function is only used only if use_kf_distribution_function is false.
          */
-        double constant_bedrock_transport_coefficient;
+        std::vector<double> constant_bedrock_transport_coefficient;
 
         /**
          * Sediment transport coefficient for hillslope diffusion.
@@ -595,14 +597,20 @@ namespace aspect
         double sand_silt_averaging_depth;
 
         /**
+         * Submarine diffusion decay coefficient for the exponential decay of the marine diffusion coefficient with depth. Units: 1/m.
+         */
+        double lambda_decay_coefficient;
+
+        /**
          * Sand marine transport coefficient. (marine diffusion, m^2/yr.)
          */
-        double sand_transport_coefficient;
+        std::vector<double> sand_transport_coefficient
+        ;
 
         /**
          * Silt marine transport coefficient. (marine diffusion, m^2/yr.)
          */
-        double silt_transport_coefficient;
+        std::vector<double> silt_transport_coefficient;
 
         /**
          * Flag to use the marine component of FastScape.

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -454,6 +454,11 @@ namespace aspect
         double sediment_deposition_g;
 
         /**
+         * Flag for allowing chemical compositions to have different erosional parameters for bedrock
+         */
+        bool use_compositional_erosion_bedrock;
+
+        /**
          * Function of bedrock river incision rate (kf) for the stream power law.
          * Represents the parameter `kf` in the FastScape landscape evolution equation.
          * Units: ${m^(1-2drainage_area_exponent)/yr}$ if "Use years instead of seconds in output" is true;

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -148,8 +148,6 @@ namespace aspect
         void fill_fastscape_arrays(std::vector<double> &elevation,
                                    std::vector<double> &bedrock_transport_coefficient_array,
                                    std::vector<double> &bedrock_river_incision_rate_array,
-                                   std::vector<double> &sand_transport_coefficient,
-                                   std::vector<double> &silt_transport_coefficient,
                                    std::vector<double> &velocity_x,
                                    std::vector<double> &velocity_y,
                                    std::vector<double> &velocity_z,
@@ -597,20 +595,14 @@ namespace aspect
         double sand_silt_averaging_depth;
 
         /**
-         * Submarine diffusion decay coefficient for the exponential decay of the marine diffusion coefficient with depth. Units: 1/m.
-         */
-        double lambda_decay_coefficient;
-
-        /**
          * Sand marine transport coefficient. (marine diffusion, m^2/yr.)
          */
-        std::vector<double> sand_transport_coefficient
-        ;
+        double sand_transport_coefficient;
 
         /**
          * Silt marine transport coefficient. (marine diffusion, m^2/yr.)
          */
-        std::vector<double> silt_transport_coefficient;
+        double silt_transport_coefficient;
 
         /**
          * Flag to use the marine component of FastScape.

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -352,11 +352,15 @@ namespace aspect
           std::vector<double> velocity_z(fastscape_array_size);
           std::vector<double> bedrock_river_incision_rate_array(fastscape_array_size);
           std::vector<double> bedrock_transport_coefficient_array(fastscape_array_size);
+          std::vector<double> sand_transport_coefficient_array(fastscape_array_size);
+          std::vector<double> silt_transport_coefficient_array(fastscape_array_size);
           std::vector<double> elevation_old(fastscape_array_size);
 
           fill_fastscape_arrays(elevation,
                                 bedrock_transport_coefficient_array,
                                 bedrock_river_incision_rate_array,
+                                sand_transport_coefficient_array,
+                                silt_transport_coefficient_array,
                                 velocity_x,
                                 velocity_y,
                                 velocity_z,
@@ -496,8 +500,8 @@ namespace aspect
                                              &sand_efold_depth,
                                              &incoming_silt_fraction,
                                              &sand_silt_averaging_depth,
-                                             &silt_transport_coefficient,
-                                             &sand_transport_coefficient);
+                                             sand_transport_coefficient_array.data(),
+                                             silt_transport_coefficient_array.data());
 
           // Generate a combined array for kf and kd both onshore and offshore.
           // Onshore, kf and kd can have different values for bedrock and
@@ -561,7 +565,7 @@ namespace aspect
                   // The combined marine diffusion coefficient is an approximation
                   // of the actual diffusion, which is solved for both sediment
                   // types separately in Fastscape.
-                  const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient + (1. - silt_fraction[i]) * sand_transport_coefficient;
+                  const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient_array[i] + (1. - silt_fraction[i]) * sand_transport_coefficient_array[i];
                   combined_kd[i] = marine_diffusion_coefficient;
                 }
               else
@@ -685,8 +689,15 @@ namespace aspect
     FastScape<dim>::get_aspect_values() const
     {
 
+      // Get the number of chemical compositions and their names to access their erosion parameters.
+      const unsigned int n_chemical_composition_fields = this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition);
+      AssertThrow(n_chemical_composition_fields <= this->n_compositional_fields(),
+                  ExcMessage("n_chemical_composition_fields exceeds n_compositional_fields."));
+      std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
+
+
       const types::boundary_id relevant_boundary = this->get_geometry_model().translate_symbolic_boundary_name_to_id ("top");
-      std::vector<std::vector<double>> local_aspect_values(dim+2, std::vector<double>());
+      std::vector<std::vector<double>> local_aspect_values(dim+6, std::vector<double>());
 
       // Get a quadrature rule that exists only on the corners, and increase the refinement if specified.
       const QIterated<dim-1> face_corners (QTrapezoid<1>(),
@@ -710,6 +721,27 @@ namespace aspect
                 fe_face_values.reinit(cell, face_no);
                 fe_face_values[this->introspection().extractors.velocities].get_function_values(this->get_solution(), vel);
 
+                // Get compositional erosional parameters from compositional values.
+                std::vector<std::vector<double>> composition_values_array(this->n_compositional_fields(), std::vector<double>(fe_face_values.n_quadrature_points));
+                std::vector<double> composition_values;
+                double volume_fraction_sum = 0.0;
+                // Go through all compositions, only get the compositional values when the type is chemical composition
+                for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+                  {
+                    if (this->introspection().get_composition_descriptions()[c].type == CompositionalFieldDescription::chemical_composition)
+                      {
+                        this->introspection().extractors.compositional_fields[c];
+                        fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(), composition_values_array[c]);
+                        AssertThrow(c < composition_values_array.size(),
+                                    ExcMessage("composition_values_array too small"));
+                        AssertThrow(composition_values_array[c].size() > 0,
+                                    ExcMessage("composition_values_array[c] empty"));
+
+                        composition_values.push_back(composition_values_array[c][0]);
+                        volume_fraction_sum += composition_values_array[c][0];
+                      }
+                  }
+                
                 for (unsigned int corner = 0; corner < face_corners.size(); ++corner)
                   {
                     const Point<dim> vertex = fe_face_values.quadrature_point(corner);
@@ -741,7 +773,7 @@ namespace aspect
                             const double index = std::round(indx)+fastscape_nx*ys;
 
                             local_aspect_values[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);
-
+                            
                             // In local_aspect_values[1], we store integer indices even though the
                             // type of the left hand side is 'double'. We will have to cast back
                             // when we read from local_aspect_values[1].
@@ -752,6 +784,15 @@ namespace aspect
                                 // Always convert to m/yr for FastScape
                                 local_aspect_values[2+d].push_back(vel[corner][d]*year_in_seconds);
                               }
+
+                            double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
+                            double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                            double sand_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, sand_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                            double silt_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, silt_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                            local_aspect_values[2+dim].push_back(bedrock_river_incision_rate_at_point);
+                            local_aspect_values[3+dim].push_back(bedrock_transport_coefficient_at_point);
+                            local_aspect_values[4+dim].push_back(sand_transport_coefficient_at_point);
+                            local_aspect_values[5+dim].push_back(silt_transport_coefficient_at_point);
                           }
                       }
                     // 3D case
@@ -776,6 +817,15 @@ namespace aspect
                           {
                             local_aspect_values[2+d].push_back(vel[corner][d]*year_in_seconds);
                           }
+
+                        double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
+                        double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                        double sand_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, sand_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                        double silt_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, silt_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                        local_aspect_values[2+dim].push_back(bedrock_river_incision_rate_at_point);
+                        local_aspect_values[3+dim].push_back(bedrock_transport_coefficient_at_point);
+                        local_aspect_values[4+dim].push_back(sand_transport_coefficient_at_point);
+                        local_aspect_values[5+dim].push_back(silt_transport_coefficient_at_point);
                       }
                   }
               }
@@ -788,11 +838,18 @@ namespace aspect
     void FastScape<dim>::fill_fastscape_arrays(std::vector<double> &elevation,
                                                std::vector<double> &bedrock_transport_coefficient_array,
                                                std::vector<double> &bedrock_river_incision_rate_array,
+                                               std::vector<double> &sand_transport_coefficient_array,
+                                               std::vector<double> &silt_transport_coefficient_array,
                                                std::vector<double> &velocity_x,
                                                std::vector<double> &velocity_y,
                                                std::vector<double> &velocity_z,
                                                std::vector<std::vector<double>> &local_aspect_values) const
     {
+      double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
+      const double current_sea_level = use_sea_level_function
+                                       ? sea_level_function.value(Point<1>())
+                                       : sea_level_constant_value;
+
       for (unsigned int i=0; i<local_aspect_values[1].size(); ++i)
         {
           // In get_aspect_values(), we store an integer value in local_aspect_values[1][...].
@@ -806,6 +863,11 @@ namespace aspect
             velocity_y[index] = 0;
           else
             velocity_y[index] = local_aspect_values[3][i];
+
+          bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[2+dim][i];
+          bedrock_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[3+dim][i];
+          sand_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[4+dim][i];
+          silt_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[5+dim][i];
         }
 
       for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
@@ -843,14 +905,31 @@ namespace aspect
                 velocity_y[index] = 0;
               else
                 velocity_y[index] = local_aspect_values[3][i];
+
+              bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[2+dim][i];
+              bedrock_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[3+dim][i];
+              sand_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[4+dim][i];
+              silt_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[5+dim][i];
             }
         }
 
+      bool fastscape_mesh_filled = true;
+
+      std::vector<int> global_to_local(bedrock_transport_coefficient_array.size(),-1);
+      for (unsigned int i = 0; i < local_aspect_values[1].size(); ++i)
+      {
+        const int global_index = local_aspect_values[1][i];
+        AssertThrow(static_cast<std::size_t>(global_index) < global_to_local.size(),
+                    ExcMessage("global_index out of range for global_to_local"));
+        global_to_local[global_index] = i;
+      }
+      this->get_pcout() << "   Updating FastScape erodibility parameters from distribution functions..." << std::endl;
+      
       // Initialize the bedrock river incision rate and transport coefficient,
       // and check that there are no empty mesh points due to
       // an improperly set maximum_surface_refinement_level, additional_refinement_levels,
       // and surface_refinement_difference
-      bool fastscape_mesh_filled = true;
+
       const unsigned int fastscape_array_size = fastscape_nx*fastscape_ny;
       for (unsigned int i=0; i<fastscape_array_size; ++i)
         {
@@ -862,35 +941,49 @@ namespace aspect
           const double x = grid_extent[0].first + (ix - use_ghost_nodes) * fastscape_dx;
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
-          // Set the time scaling factor based on the unit of time, as Fastscape always
-          // expects units in years, not seconds. Therefore, the factor is used to scale
-          // the quantities when "Use years instead of seconds" in ASPECT is set to false.
-          // In that case the transport coefficient has units ${m^2/s}$, and the river
-          // incision rate units of $m^(1-2drainage_area_exponent)/s}$, so we multiply
-          // with a year in seconds.
-          const double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
-          // Set bedrock transport coefficient kd either from a function or a constant.
-          bedrock_transport_coefficient_array[i] =
-            (use_kd_distribution_function
-             ?
-             time_scaling_factor * kd_distribution_function.value(Point<2>(x, y))
-             :
-             time_scaling_factor * constant_bedrock_transport_coefficient);
-
-          // Set bedrock river incision rate kf either from a function or a constant.
+          const int index = global_to_local[i];
+          double bedrock_river_incision_rate_local = constant_bedrock_river_incision_rate[0];
+          double bedrock_transport_coefficient_local = constant_bedrock_transport_coefficient[0];
+          double sand_transport_coefficient_local = sand_transport_coefficient[0];
+          double silt_transport_coefficient_local = silt_transport_coefficient[0];
+          if (index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
+            {
+              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
+              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index]; 
+              sand_transport_coefficient_local = time_scaling_factor * local_aspect_values[4+dim][index];
+              silt_transport_coefficient_local = time_scaling_factor * local_aspect_values[5+dim][index];             
+            }
+          
           bedrock_river_incision_rate_array[i] =
             (use_kf_distribution_function)
-            ?
+            ?  // update with time scaling
             time_scaling_factor * kf_distribution_function.value(Point<2>(x, y))
             :
-            time_scaling_factor * constant_bedrock_river_incision_rate;
+            bedrock_river_incision_rate_local;
+          bedrock_transport_coefficient_array[i] =
+            (use_kd_distribution_function)
+            ?  // update with time scaling
+            time_scaling_factor * kd_distribution_function.value(Point<2>(x, y))
+            :
+            bedrock_transport_coefficient_local;
+          // If the elevation is above sea level, we set the marine diffusion coefficients to signaling NaN to indicate that they are not used.
+          sand_transport_coefficient_array[i] = 0;
+          silt_transport_coefficient_array[i] = 0;
+          
+          // If the elevation is below sea level, we set the marine diffusion coefficients to depend on water depth with a exponential decay. The deeper the water, the smaller the diffusion coefficients.
+          if (elevation[i] < current_sea_level)
+            {
+              sand_transport_coefficient_array[i] = std::exp(-lambda_decay_coefficient * (current_sea_level - elevation[i]))*sand_transport_coefficient_local;
+              silt_transport_coefficient_array[i] = std::exp(-lambda_decay_coefficient * (current_sea_level - elevation[i]))*silt_transport_coefficient_local;
+            }
 
-
-          // If this is a boundary node that is a ghost node then ignore that it
-          // has not filled yet as the ghost nodes haven't been set.
           if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false))
-            fastscape_mesh_filled = false;
+            {
+              fastscape_mesh_filled = false;
+            }
+            
         }
+      
 
       fastscape_mesh_filled = Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);
       AssertThrow (fastscape_mesh_filled == true,
@@ -1844,10 +1937,10 @@ namespace aspect
                               "the parameter ``Bedrock river incision rate''. Units: ${m^(1-2drainage_area_exponent)/yr}$ "
                               "if ``Use years instead of seconds'' is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.");
             prm.declare_entry("Bedrock river incision rate", "1e-5",
-                              Patterns::Double(),
+                              Patterns::List(Patterns::Double(0.)),
                               "River incision rate for bedrock in the Stream Power Law. "
-                              "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds'' is true; "
-                              "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.");
+                              "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; "
+                              "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$");
             prm.enter_subsection ("kf distribution function");
             {
               Functions::ParsedFunction<2>::declare_parameters(prm, 2);
@@ -1867,8 +1960,8 @@ namespace aspect
                               "``Bedrock diffusivity''. Units: ${m^2/yr}$ if ``Use years instead of seconds'' "
                               "is true; otherwise, the units are ${m^2/s}$.");
             prm.declare_entry("Bedrock diffusivity", "1e-2",
-                              Patterns::Double(),
-                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds'' "
+                              Patterns::List(Patterns::Double(0.)),
+                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds in output'' "
                               "is true; otherwise, the units are ${m^2/s}$.");
             prm.enter_subsection ("kd distribution function");
             {
@@ -1962,11 +2055,14 @@ namespace aspect
             prm.declare_entry("Depth averaging thickness", "1e2",
                               Patterns::Double(),
                               "Depth averaging for the sand-silt equation. Units: ${m}$");
-            prm.declare_entry("Sand transport coefficient", "5e2",
+            prm.declare_entry("Submarine diffusion decay coefficient", "5e-4",
                               Patterns::Double(),
+                              "The decay coefficient to compute depth-dependent sand and silt transport coefficient. Units: ${m}$");
+            prm.declare_entry("Sand transport coefficient", "5e2",
+                              Patterns::List(Patterns::Double(0.)),
                               "Transport coefficient (diffusivity) for sand. Units: ${m^2/yr}$");
             prm.declare_entry("Silt transport coefficient", "2.5e2",
-                              Patterns::Double(),
+                              Patterns::List(Patterns::Double(0.)),
                               "Transport coefficient (diffusivity) for silt. Units: ${m^2/yr}$ ");
           }
           prm.leave_subsection();
@@ -2070,8 +2166,13 @@ namespace aspect
             // with a year in seconds. The bedrock values are scaled when filling the FastScape
             // arrays.
             const double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
+
             sediment_river_incision_rate = time_scaling_factor * prm.get_double("Sediment river incision rate");
             // kf
+            // Make options file for parsing maps to double arrays for bedrock river incision rate and bedrock transport coefficient
+            std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+            Utilities::MapParsing::Options options(chemical_field_names, "Bedrock river incision rate");
+            options.list_of_allowed_keys = chemical_field_names;
             use_kf_distribution_function = prm.get_bool("Use kf distribution function");
             if (use_kf_distribution_function)
               {
@@ -2083,11 +2184,14 @@ namespace aspect
                 // If using the function description for the kf, no parts of the code
                 // base should use the constant_bedrock_river_incision_rate variable. Poison it to
                 // make sure it really isn't used anywhere:
-                constant_bedrock_river_incision_rate = numbers::signaling_nan<double>();
+                constant_bedrock_river_incision_rate.assign(
+                  constant_bedrock_river_incision_rate.size(),
+                  numbers::signaling_nan<double>()
+                );
               }
             else
               {
-                constant_bedrock_river_incision_rate = prm.get_double("Bedrock river incision rate");
+                constant_bedrock_river_incision_rate = Utilities::MapParsing::parse_map_to_double_array(prm.get("Bedrock river incision rate"), options);
               }
             sediment_transport_coefficient = time_scaling_factor * prm.get_double("Sediment diffusivity");
             // kd
@@ -2102,11 +2206,15 @@ namespace aspect
                 // If using the function description for the kd, no parts of the code
                 // base should use the constant_bedrock_river_incision_rate variable. Poison it to
                 // make sure it really isn't used anywhere:
-                constant_bedrock_transport_coefficient = numbers::signaling_nan<double>();
+                constant_bedrock_transport_coefficient.assign(
+                  constant_bedrock_transport_coefficient.size(),
+                  numbers::signaling_nan<double>()
+                );
               }
             else
               {
-                constant_bedrock_transport_coefficient = prm.get_double("Bedrock diffusivity");
+                options.property_name = "Bedrock diffusivity";
+                constant_bedrock_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Bedrock diffusivity"), options);
               }
             bedrock_deposition_g = prm.get_double("Bedrock deposition coefficient");
             sediment_deposition_g = prm.get_double("Sediment deposition coefficient");
@@ -2166,14 +2274,14 @@ namespace aspect
             silt_efold_depth = prm.get_double("Silt e-folding depth");
             incoming_silt_fraction = prm.get_double("Silt fraction");
             sand_silt_averaging_depth = prm.get_double("Depth averaging thickness");
-            sand_transport_coefficient = prm.get_double("Sand transport coefficient");
-            silt_transport_coefficient = prm.get_double("Silt transport coefficient");
-
-            if (!this->convert_output_to_years())
-              {
-                sand_transport_coefficient *= year_in_seconds;
-                silt_transport_coefficient *= year_in_seconds;
-              }
+            lambda_decay_coefficient = prm.get_double("Submarine diffusion decay coefficient");
+            // Make options file for parsing maps to double arrays for marine sand and silt transport coefficients. Scaling of these parameters also happens when filling aspect arrays.
+            std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
+            Utilities::MapParsing::Options options(chemical_field_names, "Sand transport coefficient");
+            options.property_name = "Sand transport coefficient";
+            sand_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Sand transport coefficient"), options);
+            options.property_name = "Silt transport coefficient";
+            silt_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Silt transport coefficient"), options);
           }
           prm.leave_subsection();
         }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -741,7 +741,7 @@ namespace aspect
                         volume_fraction_sum += composition_values_array[c][0];
                       }
                   }
-                
+
                 for (unsigned int corner = 0; corner < face_corners.size(); ++corner)
                   {
                     const Point<dim> vertex = fe_face_values.quadrature_point(corner);
@@ -773,7 +773,7 @@ namespace aspect
                             const double index = std::round(indx)+fastscape_nx*ys;
 
                             local_aspect_values[0].push_back(vertex(dim-1) - grid_extent[dim-1].second);
-                            
+
                             // In local_aspect_values[1], we store integer indices even though the
                             // type of the left hand side is 'double'. We will have to cast back
                             // when we read from local_aspect_values[1].
@@ -917,14 +917,14 @@ namespace aspect
 
       std::vector<int> global_to_local(bedrock_transport_coefficient_array.size(),-1);
       for (unsigned int i = 0; i < local_aspect_values[1].size(); ++i)
-      {
-        const int global_index = local_aspect_values[1][i];
-        AssertThrow(static_cast<std::size_t>(global_index) < global_to_local.size(),
-                    ExcMessage("global_index out of range for global_to_local"));
-        global_to_local[global_index] = i;
-      }
+        {
+          const int global_index = local_aspect_values[1][i];
+          AssertThrow(static_cast<std::size_t>(global_index) < global_to_local.size(),
+                      ExcMessage("global_index out of range for global_to_local"));
+          global_to_local[global_index] = i;
+        }
       this->get_pcout() << "   Updating FastScape erodibility parameters from distribution functions..." << std::endl;
-      
+
       // Initialize the bedrock river incision rate and transport coefficient,
       // and check that there are no empty mesh points due to
       // an improperly set maximum_surface_refinement_level, additional_refinement_levels,
@@ -949,11 +949,11 @@ namespace aspect
           if (index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
             {
               bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
-              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index]; 
+              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
               sand_transport_coefficient_local = time_scaling_factor * local_aspect_values[4+dim][index];
-              silt_transport_coefficient_local = time_scaling_factor * local_aspect_values[5+dim][index];             
+              silt_transport_coefficient_local = time_scaling_factor * local_aspect_values[5+dim][index];
             }
-          
+
           bedrock_river_incision_rate_array[i] =
             (use_kf_distribution_function)
             ?  // update with time scaling
@@ -969,7 +969,7 @@ namespace aspect
           // If the elevation is above sea level, we set the marine diffusion coefficients to signaling NaN to indicate that they are not used.
           sand_transport_coefficient_array[i] = 0;
           silt_transport_coefficient_array[i] = 0;
-          
+
           // If the elevation is below sea level, we set the marine diffusion coefficients to depend on water depth with a exponential decay. The deeper the water, the smaller the diffusion coefficients.
           if (elevation[i] < current_sea_level)
             {
@@ -981,9 +981,9 @@ namespace aspect
             {
               fastscape_mesh_filled = false;
             }
-            
+
         }
-      
+
 
       fastscape_mesh_filled = Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);
       AssertThrow (fastscape_mesh_filled == true,

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -352,15 +352,11 @@ namespace aspect
           std::vector<double> velocity_z(fastscape_array_size);
           std::vector<double> bedrock_river_incision_rate_array(fastscape_array_size);
           std::vector<double> bedrock_transport_coefficient_array(fastscape_array_size);
-          std::vector<double> sand_transport_coefficient_array(fastscape_array_size);
-          std::vector<double> silt_transport_coefficient_array(fastscape_array_size);
           std::vector<double> elevation_old(fastscape_array_size);
 
           fill_fastscape_arrays(elevation,
                                 bedrock_transport_coefficient_array,
                                 bedrock_river_incision_rate_array,
-                                sand_transport_coefficient_array,
-                                silt_transport_coefficient_array,
                                 velocity_x,
                                 velocity_y,
                                 velocity_z,
@@ -500,8 +496,8 @@ namespace aspect
                                              &sand_efold_depth,
                                              &incoming_silt_fraction,
                                              &sand_silt_averaging_depth,
-                                             sand_transport_coefficient_array.data(),
-                                             silt_transport_coefficient_array.data());
+                                             &silt_transport_coefficient,
+                                             &sand_transport_coefficient);
 
           // Generate a combined array for kf and kd both onshore and offshore.
           // Onshore, kf and kd can have different values for bedrock and
@@ -565,7 +561,7 @@ namespace aspect
                   // The combined marine diffusion coefficient is an approximation
                   // of the actual diffusion, which is solved for both sediment
                   // types separately in Fastscape.
-                  const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient_array[i] + (1. - silt_fraction[i]) * sand_transport_coefficient_array[i];
+                  const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient + (1. - silt_fraction[i]) * sand_transport_coefficient;
                   combined_kd[i] = marine_diffusion_coefficient;
                 }
               else
@@ -697,7 +693,7 @@ namespace aspect
 
 
       const types::boundary_id relevant_boundary = this->get_geometry_model().translate_symbolic_boundary_name_to_id ("top");
-      std::vector<std::vector<double>> local_aspect_values(dim+6, std::vector<double>());
+      std::vector<std::vector<double>> local_aspect_values(dim+4, std::vector<double>());
 
       // Get a quadrature rule that exists only on the corners, and increase the refinement if specified.
       const QIterated<dim-1> face_corners (QTrapezoid<1>(),
@@ -787,12 +783,8 @@ namespace aspect
 
                             double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
                             double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                            double sand_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, sand_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                            double silt_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, silt_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                            local_aspect_values[2+dim].push_back(bedrock_river_incision_rate_at_point);
-                            local_aspect_values[3+dim].push_back(bedrock_transport_coefficient_at_point);
-                            local_aspect_values[4+dim].push_back(sand_transport_coefficient_at_point);
-                            local_aspect_values[5+dim].push_back(silt_transport_coefficient_at_point);
+                            local_aspect_values[dim+2].push_back(bedrock_river_incision_rate_at_point);
+                            local_aspect_values[dim+3].push_back(bedrock_transport_coefficient_at_point);
                           }
                       }
                     // 3D case
@@ -820,12 +812,8 @@ namespace aspect
 
                         double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
                         double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                        double sand_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, sand_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                        double silt_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, silt_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                        local_aspect_values[2+dim].push_back(bedrock_river_incision_rate_at_point);
-                        local_aspect_values[3+dim].push_back(bedrock_transport_coefficient_at_point);
-                        local_aspect_values[4+dim].push_back(sand_transport_coefficient_at_point);
-                        local_aspect_values[5+dim].push_back(silt_transport_coefficient_at_point);
+                        local_aspect_values[dim+2].push_back(bedrock_river_incision_rate_at_point);
+                        local_aspect_values[dim+3].push_back(bedrock_transport_coefficient_at_point);
                       }
                   }
               }
@@ -838,17 +826,12 @@ namespace aspect
     void FastScape<dim>::fill_fastscape_arrays(std::vector<double> &elevation,
                                                std::vector<double> &bedrock_transport_coefficient_array,
                                                std::vector<double> &bedrock_river_incision_rate_array,
-                                               std::vector<double> &sand_transport_coefficient_array,
-                                               std::vector<double> &silt_transport_coefficient_array,
                                                std::vector<double> &velocity_x,
                                                std::vector<double> &velocity_y,
                                                std::vector<double> &velocity_z,
                                                std::vector<std::vector<double>> &local_aspect_values) const
     {
-      double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
-      const double current_sea_level = use_sea_level_function
-                                       ? sea_level_function.value(Point<1>())
-                                       : sea_level_constant_value;
+      const double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
 
       for (unsigned int i=0; i<local_aspect_values[1].size(); ++i)
         {
@@ -864,10 +847,8 @@ namespace aspect
           else
             velocity_y[index] = local_aspect_values[3][i];
 
-          bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[2+dim][i];
-          bedrock_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[3+dim][i];
-          sand_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[4+dim][i];
-          silt_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[5+dim][i];
+          bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
+          bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
         }
 
       for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
@@ -906,10 +887,8 @@ namespace aspect
               else
                 velocity_y[index] = local_aspect_values[3][i];
 
-              bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[2+dim][i];
-              bedrock_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[3+dim][i];
-              sand_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[4+dim][i];
-              silt_transport_coefficient_array[index] = time_scaling_factor *local_aspect_values[5+dim][i];
+              bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
+              bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
             }
         }
 
@@ -919,8 +898,8 @@ namespace aspect
       for (unsigned int i = 0; i < local_aspect_values[1].size(); ++i)
         {
           const int global_index = local_aspect_values[1][i];
-          AssertThrow(static_cast<std::size_t>(global_index) < global_to_local.size(),
-                      ExcMessage("global_index out of range for global_to_local"));
+          Assert(static_cast<std::size_t>(global_index) < global_to_local.size(),
+                 ExcMessage("The index for filling fastscape arrays is out of bounds. This index array is constructed in get_aspect_values() and should contain values only within the bounds of the FastScape mesh. This error may be caused by an improperly set maximum_surface_refinement_level, additional_refinement_levels, and surface_refinement_difference."));
           global_to_local[global_index] = i;
         }
       this->get_pcout() << "   Updating FastScape erodibility parameters from distribution functions..." << std::endl;
@@ -942,16 +921,12 @@ namespace aspect
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
           const int index = global_to_local[i];
-          double bedrock_river_incision_rate_local = constant_bedrock_river_incision_rate[0];
-          double bedrock_transport_coefficient_local = constant_bedrock_transport_coefficient[0];
-          double sand_transport_coefficient_local = sand_transport_coefficient[0];
-          double silt_transport_coefficient_local = silt_transport_coefficient[0];
+          double bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
+          double bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
           if (index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
             {
               bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
               bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
-              sand_transport_coefficient_local = time_scaling_factor * local_aspect_values[4+dim][index];
-              silt_transport_coefficient_local = time_scaling_factor * local_aspect_values[5+dim][index];
             }
 
           bedrock_river_incision_rate_array[i] =
@@ -966,25 +941,15 @@ namespace aspect
             time_scaling_factor * kd_distribution_function.value(Point<2>(x, y))
             :
             bedrock_transport_coefficient_local;
-          // If the elevation is above sea level, we set the marine diffusion coefficients to signaling NaN to indicate that they are not used.
-          sand_transport_coefficient_array[i] = 0;
-          silt_transport_coefficient_array[i] = 0;
-
-          // If the elevation is below sea level, we set the marine diffusion coefficients to depend on water depth with a exponential decay. The deeper the water, the smaller the diffusion coefficients.
-          if (elevation[i] < current_sea_level)
-            {
-              sand_transport_coefficient_array[i] = std::exp(-lambda_decay_coefficient * (current_sea_level - elevation[i]))*sand_transport_coefficient_local;
-              silt_transport_coefficient_array[i] = std::exp(-lambda_decay_coefficient * (current_sea_level - elevation[i]))*silt_transport_coefficient_local;
-            }
 
           if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false))
             {
               fastscape_mesh_filled = false;
             }
-
         }
-
-
+      
+      // If this is a boundary node that is a ghost node then ignore that it
+      // has not filled yet as the ghost nodes haven't been set.
       fastscape_mesh_filled = Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);
       AssertThrow (fastscape_mesh_filled == true,
                    ExcMessage("The FastScape mesh is missing data. A likely cause for this is that the "
@@ -1939,8 +1904,8 @@ namespace aspect
             prm.declare_entry("Bedrock river incision rate", "1e-5",
                               Patterns::List(Patterns::Double(0.)),
                               "River incision rate for bedrock in the Stream Power Law. "
-                              "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds in output'' is true; "
-                              "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$");
+                              "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds'' is true; "
+                              "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.");
             prm.enter_subsection ("kf distribution function");
             {
               Functions::ParsedFunction<2>::declare_parameters(prm, 2);
@@ -1961,7 +1926,7 @@ namespace aspect
                               "is true; otherwise, the units are ${m^2/s}$.");
             prm.declare_entry("Bedrock diffusivity", "1e-2",
                               Patterns::List(Patterns::Double(0.)),
-                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds in output'' "
+                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds'' "
                               "is true; otherwise, the units are ${m^2/s}$.");
             prm.enter_subsection ("kd distribution function");
             {
@@ -2055,14 +2020,11 @@ namespace aspect
             prm.declare_entry("Depth averaging thickness", "1e2",
                               Patterns::Double(),
                               "Depth averaging for the sand-silt equation. Units: ${m}$");
-            prm.declare_entry("Submarine diffusion decay coefficient", "5e-4",
+            prm.declare_entry("Sand transport coefficient", "2.5e2",
                               Patterns::Double(),
-                              "The decay coefficient to compute depth-dependent sand and silt transport coefficient. Units: ${m}$");
-            prm.declare_entry("Sand transport coefficient", "5e2",
-                              Patterns::List(Patterns::Double(0.)),
                               "Transport coefficient (diffusivity) for sand. Units: ${m^2/yr}$");
             prm.declare_entry("Silt transport coefficient", "2.5e2",
-                              Patterns::List(Patterns::Double(0.)),
+                              Patterns::Double(),
                               "Transport coefficient (diffusivity) for silt. Units: ${m^2/yr}$ ");
           }
           prm.leave_subsection();
@@ -2274,14 +2236,8 @@ namespace aspect
             silt_efold_depth = prm.get_double("Silt e-folding depth");
             incoming_silt_fraction = prm.get_double("Silt fraction");
             sand_silt_averaging_depth = prm.get_double("Depth averaging thickness");
-            lambda_decay_coefficient = prm.get_double("Submarine diffusion decay coefficient");
-            // Make options file for parsing maps to double arrays for marine sand and silt transport coefficients. Scaling of these parameters also happens when filling aspect arrays.
-            std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
-            Utilities::MapParsing::Options options(chemical_field_names, "Sand transport coefficient");
-            options.property_name = "Sand transport coefficient";
-            sand_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Sand transport coefficient"), options);
-            options.property_name = "Silt transport coefficient";
-            silt_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Silt transport coefficient"), options);
+            sand_transport_coefficient = prm.get_double("Sand transport coefficient");
+            silt_transport_coefficient = prm.get_double("Silt transport coefficient");
           }
           prm.leave_subsection();
         }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -738,8 +738,8 @@ namespace aspect
 
                     // Find what x point we're at. Add 1 or 2 depending on if ghost nodes are used.
                     // Subtract the origin point so that it corresponds to an origin of 0,0 in FastScape.
-                    const double indx = 1+use_ghost_nodes+(vertex(0) - grid_extent[0].first)/fastscape_dx;                   
-
+                    const double indx = 1+use_ghost_nodes+(vertex(0) - grid_extent[0].first)/fastscape_dx;
+                    
                     // The quadrature rule is created so that there are enough interpolation points in the
                     // lowest resolved ASPECT surface cell to fill out the FastScape mesh. However, as the
                     // same rule is used for all cell sizes, higher resolution areas will have interpolation
@@ -748,7 +748,6 @@ namespace aspect
                     if (std::abs(indx - std::round(indx)) >= node_tolerance)
                       continue;
 
-                    // Initialize the bedrock river incision rate and diffusivity to be the first value in the input array
                     double bedrock_river_incision_rate_at_point = numbers::signaling_nan<double>();
                     double bedrock_transport_coefficient_at_point = numbers::signaling_nan<double>();
                     if (use_compositional_erosion_bedrock)

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -685,12 +685,9 @@ namespace aspect
     FastScape<dim>::get_aspect_values() const
     {
 
-      // Get the number of chemical compositions and their names to access their erosion parameters.
-      const unsigned int n_chemical_composition_fields = this->introspection().get_number_of_fields_of_type(CompositionalFieldDescription::chemical_composition);
-      AssertThrow(n_chemical_composition_fields <= this->n_compositional_fields(),
-                  ExcMessage("n_chemical_composition_fields exceeds n_compositional_fields."));
       std::vector<std::string> compositional_field_names = this->introspection().get_composition_names();
-
+      const std::vector<unsigned int> chemical_composition_idx = this->introspection().chemical_composition_field_indices();
+      const unsigned int n_chemical_compositional_fields = chemical_composition_idx.size();
 
       const types::boundary_id relevant_boundary = this->get_geometry_model().translate_symbolic_boundary_name_to_id ("top");
       std::vector<std::vector<double>> local_aspect_values(dim+4, std::vector<double>());
@@ -713,28 +710,19 @@ namespace aspect
                 if ( cell->face(face_no)->boundary_id() != relevant_boundary)
                   continue;
 
+                std::vector<std::vector<double>> composition_values_array(n_chemical_compositional_fields, std::vector<double>(face_corners.size()));
                 std::vector<Tensor<1,dim>> vel(face_corners.size());
                 fe_face_values.reinit(cell, face_no);
                 fe_face_values[this->introspection().extractors.velocities].get_function_values(this->get_solution(), vel);
 
-                // Get compositional erosional parameters from compositional values.
-                std::vector<std::vector<double>> composition_values_array(this->n_compositional_fields(), std::vector<double>(fe_face_values.n_quadrature_points));
-                std::vector<double> composition_values;
-                double volume_fraction_sum = 0.0;
-                // Go through all compositions, only get the compositional values when the type is chemical composition
-                for (unsigned int c=0; c<this->n_compositional_fields(); ++c)
+                if (use_compositional_erosion_bedrock)
                   {
-                    if (this->introspection().get_composition_descriptions()[c].type == CompositionalFieldDescription::chemical_composition)
+                    // Get compositional erosional parameters from compositional values, for chemical compositions + background mantle
+                    for (unsigned int c=0; c<n_chemical_compositional_fields; ++c)
                       {
-                        this->introspection().extractors.compositional_fields[c];
-                        fe_face_values[this->introspection().extractors.compositional_fields[c]].get_function_values(this->get_solution(), composition_values_array[c]);
-                        AssertThrow(c < composition_values_array.size(),
-                                    ExcMessage("composition_values_array too small"));
-                        AssertThrow(composition_values_array[c].size() > 0,
-                                    ExcMessage("composition_values_array[c] empty"));
-
-                        composition_values.push_back(composition_values_array[c][0]);
-                        volume_fraction_sum += composition_values_array[c][0];
+                        fe_face_values[this->introspection().extractors.compositional_fields[chemical_composition_idx[c]]].get_function_values(this->get_solution(), composition_values_array[c]);
+                        Assert(composition_values_array[c].size() > 0,
+                               ExcMessage("Composition_values_array[c] is empty"));
                       }
                   }
 
@@ -754,6 +742,25 @@ namespace aspect
                     if (std::abs(indx - std::round(indx)) >= node_tolerance)
                       continue;
 
+                    // Initialize the bedrock river incision rate and diffusivity to be the first value in the input array
+                    double bedrock_river_incision_rate_at_point = constant_bedrock_river_incision_rate[0];
+                    double bedrock_transport_coefficient_at_point = constant_bedrock_transport_coefficient[0];
+                    // If we allow compositional erosional parameters for bedrock, update them with the average
+                    // taken from all chemical compositions + background mantle
+                    std::vector<double> composition_values(this->introspection().chemical_composition_field_indices().size());
+                    if (use_compositional_erosion_bedrock)
+                      {
+                        double volume_fraction_sum = 0;
+                        for (unsigned int c=0; c < n_chemical_compositional_fields; ++c)
+                          {
+                            composition_values[c] = composition_values_array[c][corner];
+                            volume_fraction_sum = volume_fraction_sum + composition_values_array[c][corner];
+                          }
+                        // Add background material fraction at the beginning
+                        composition_values.insert(composition_values.begin(), 1.0 - volume_fraction_sum);
+                        bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
+                        bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
+                      }
 
                     // If we're in 2D, we want to take the values and apply them to every row of X points.
                     if (dim == 2)
@@ -781,8 +788,6 @@ namespace aspect
                                 local_aspect_values[2+d].push_back(vel[corner][d]*year_in_seconds);
                               }
 
-                            double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
-                            double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
                             local_aspect_values[dim+2].push_back(bedrock_river_incision_rate_at_point);
                             local_aspect_values[dim+3].push_back(bedrock_transport_coefficient_at_point);
                           }
@@ -810,8 +815,6 @@ namespace aspect
                             local_aspect_values[2+d].push_back(vel[corner][d]*year_in_seconds);
                           }
 
-                        double bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
-                        double bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
                         local_aspect_values[dim+2].push_back(bedrock_river_incision_rate_at_point);
                         local_aspect_values[dim+3].push_back(bedrock_transport_coefficient_at_point);
                       }
@@ -929,6 +932,7 @@ namespace aspect
               bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
             }
 
+          // Set bedrock river incision rate kf either from a function or a constant.
           bedrock_river_incision_rate_array[i] =
             (use_kf_distribution_function)
             ?  // update with time scaling
@@ -1895,6 +1899,10 @@ namespace aspect
                               Patterns::Double(),
                               "Deposition coefficient for sediment. A value smaller than 0 sets this to the same as the bedrock deposition coefficient.");
             // Define Bedrock river incision rate (Kf) as a constant value or a time-dependent user-defined function
+            prm.declare_entry("Allow compositional erosion for bedrock", "false",
+                              Patterns::Bool (),
+                              "Whether to allow chemical compositions to have different erosional parameters for bedrock, "
+                              "including river incision rate and diffusivity.");
             prm.declare_entry("Use kf distribution function", "false",
                               Patterns::Bool(),
                               "Whether to define bedrock river incision rate using a distribution function. "
@@ -1903,7 +1911,8 @@ namespace aspect
                               "if ``Use years instead of seconds'' is true; otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.");
             prm.declare_entry("Bedrock river incision rate", "1e-5",
                               Patterns::List(Patterns::Double(0.)),
-                              "River incision rate for bedrock in the Stream Power Law. "
+                              "A list of river incision rate for bedrock in the Stream Power Law, for background mantle and chemical "
+                              "composition fields, for a total of N+1 values, where N is the number of chemical composition fields. "
                               "Units: ${m^(1-2drainage_area_exponent)/yr}$ if ``Use years instead of seconds'' is true; "
                               "otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$.");
             prm.enter_subsection ("kf distribution function");
@@ -1926,8 +1935,9 @@ namespace aspect
                               "is true; otherwise, the units are ${m^2/s}$.");
             prm.declare_entry("Bedrock diffusivity", "1e-2",
                               Patterns::List(Patterns::Double(0.)),
-                              "Transport coefficient (diffusivity) for bedrock. Units: ${m^2/yr}$ if ``Use years instead of seconds'' "
-                              "is true; otherwise, the units are ${m^2/s}$.");
+                              "A list of transport coefficient (diffusivity) for bedrock, for background mantle and chemical "
+                              "composition fields, for a total of N+1 values, where N is the number of chemical composition fields. "
+                              " Units: ${m^2/yr}$ if ``Use years instead of seconds'' is true; otherwise, the units are ${m^2/s}$.");
             prm.enter_subsection ("kd distribution function");
             {
               Functions::ParsedFunction<2>::declare_parameters(prm, 2);
@@ -2130,11 +2140,15 @@ namespace aspect
             const double time_scaling_factor = (this->convert_output_to_years() ? 1.0 : year_in_seconds);
 
             sediment_river_incision_rate = time_scaling_factor * prm.get_double("Sediment river incision rate");
+            use_compositional_erosion_bedrock = prm.get_bool("Allow compositional erosion for bedrock");
             // kf
             // Make options file for parsing maps to double arrays for bedrock river incision rate and bedrock transport coefficient
             std::vector<std::string> chemical_field_names = this->introspection().chemical_composition_field_names();
-            Utilities::MapParsing::Options options(chemical_field_names, "Bedrock river incision rate");
+            // Establish that a background field is required here
+            chemical_field_names.insert(chemical_field_names.begin(),"background");
+            Utilities::MapParsing::Options options(chemical_field_names, "");
             options.list_of_allowed_keys = chemical_field_names;
+            options.property_name = "Bedrock river incision rate";
             use_kf_distribution_function = prm.get_bool("Use kf distribution function");
             if (use_kf_distribution_function)
               {
@@ -2153,7 +2167,7 @@ namespace aspect
               }
             else
               {
-                constant_bedrock_river_incision_rate = Utilities::MapParsing::parse_map_to_double_array(prm.get("Bedrock river incision rate"), options);
+                constant_bedrock_river_incision_rate = Utilities::MapParsing::parse_map_to_double_array(prm.get(options.property_name), options);
               }
             sediment_transport_coefficient = time_scaling_factor * prm.get_double("Sediment diffusivity");
             // kd
@@ -2176,8 +2190,15 @@ namespace aspect
             else
               {
                 options.property_name = "Bedrock diffusivity";
-                constant_bedrock_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get("Bedrock diffusivity"), options);
+                constant_bedrock_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get(options.property_name), options);
               }
+            // this->get_pcout() << "Bedrock river incision rate:" << std::endl;
+            // for (unsigned int i = 0; i < chemical_field_names.size(); ++i)
+            //   this->get_pcout() << "  "
+            //                     << chemical_field_names[i]
+            //                     << " : "
+            //                     << constant_bedrock_river_incision_rate[i]
+            //                     << std::endl;
             bedrock_deposition_g = prm.get_double("Bedrock deposition coefficient");
             sediment_deposition_g = prm.get_double("Sediment deposition coefficient");
             slope_exponent_p = prm.get_double("Multi-direction slope exponent");
@@ -2238,6 +2259,11 @@ namespace aspect
             sand_silt_averaging_depth = prm.get_double("Depth averaging thickness");
             sand_transport_coefficient = prm.get_double("Sand transport coefficient");
             silt_transport_coefficient = prm.get_double("Silt transport coefficient");
+            if (!this->convert_output_to_years())
+              {
+                sand_transport_coefficient *= year_in_seconds;
+                silt_transport_coefficient *= year_in_seconds;
+              }
           }
           prm.leave_subsection();
         }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -564,13 +564,8 @@ namespace aspect
                   const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient + (1. - silt_fraction[i]) * sand_transport_coefficient;
                   combined_kd[i] = marine_diffusion_coefficient;
                 }
-              else if (elevation[i] < current_sea_level && !use_marine_component)
-                std::cout<<"Below sea level and not use marine component"<<std::endl;
               else
                 {
-                  std::cout<<"elevation[i]: "<<elevation[i]<<std::endl;
-                  std::cout<<"current_sea_level: "<<current_sea_level<<std::endl;
-                  std::cout<<"use_marine_component: "<<use_marine_component<<std::endl;
                   AssertThrow (false, ExcMessage ("Unexpected conditions reached while filling the kf and kd arrays in the FastScape interface."));
                 }
             }
@@ -852,6 +847,12 @@ namespace aspect
             velocity_y[index] = 0;
           else
             velocity_y[index] = local_aspect_values[3][i];
+
+          if (use_compositional_erosion_bedrock)
+            {
+              bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
+              bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
+            }
         }
 
       for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
@@ -890,17 +891,16 @@ namespace aspect
               else
                 velocity_y[index] = local_aspect_values[3][i];
 
+              if (use_compositional_erosion_bedrock)
+                {
+                  bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
+                  bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
+                }
+
             }
         }
 
       bool fastscape_mesh_filled = true;
-
-      std::vector<int> global_to_local(bedrock_transport_coefficient_array.size(),-1);
-      for (unsigned int i = 0; i < local_aspect_values[1].size(); ++i)
-        {
-          const int global_index = local_aspect_values[1][i];
-          global_to_local[global_index] = i;
-        }
 
       // Initialize the bedrock river incision rate and transport coefficient,
       // and check that there are no empty mesh points due to
@@ -918,35 +918,18 @@ namespace aspect
           const double x = grid_extent[0].first + (ix - use_ghost_nodes) * fastscape_dx;
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
-          const int idx = global_to_local[i];
-          double bedrock_river_incision_rate_local = numbers::signaling_nan<double>();
-          double bedrock_transport_coefficient_local = numbers::signaling_nan<double>();
-          if (use_compositional_erosion_bedrock)
+          if (!use_kf_distribution_function)
             {
-              AssertThrow(idx >= 0,
-                          ExcMessage("Missing data from ASPECT for fastscape mesh"));
-              AssertThrow(static_cast<unsigned int>(idx) < local_aspect_values[dim+2].size(),
-                          ExcMessage("ASPECT data out of bounds for fastscape mesh"));
-              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][idx];
-              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][idx];
+              bedrock_river_incision_rate_array[i] = time_scaling_factor * constant_bedrock_river_incision_rate[0];
             }
           else
+            bedrock_river_incision_rate_array[i] = time_scaling_factor * kf_distribution_function.value(Point<2>(x, y));
+          if (!use_kd_distribution_function)
             {
-              if (!use_kf_distribution_function)
-                {
-                  bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
-                }
-              else
-                bedrock_river_incision_rate_local = time_scaling_factor * kf_distribution_function.value(Point<2>(x, y));
-              if (!use_kd_distribution_function)
-                {
-                  bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
-                }
-              else
-                bedrock_transport_coefficient_local = time_scaling_factor * kd_distribution_function.value(Point<2>(x, y));
+              bedrock_transport_coefficient_array[i] = time_scaling_factor * constant_bedrock_transport_coefficient[0];
             }
-          bedrock_river_incision_rate_array[i] = bedrock_river_incision_rate_local;
-          bedrock_transport_coefficient_array[i] = bedrock_transport_coefficient_local;
+          else
+            bedrock_transport_coefficient_array[i] = time_scaling_factor * kd_distribution_function.value(Point<2>(x, y));
 
           if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false) || std::isnan(elevation[i]))
             {

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -738,7 +738,7 @@ namespace aspect
 
                     // Find what x point we're at. Add 1 or 2 depending on if ghost nodes are used.
                     // Subtract the origin point so that it corresponds to an origin of 0,0 in FastScape.
-                    const double indx = 1+use_ghost_nodes+(vertex(0) - grid_extent[0].first)/fastscape_dx;
+                    const double indx = 1+use_ghost_nodes+(vertex(0) - grid_extent[0].first)/fastscape_dx;                   
 
                     // The quadrature rule is created so that there are enough interpolation points in the
                     // lowest resolved ASPECT surface cell to fill out the FastScape mesh. However, as the
@@ -853,9 +853,6 @@ namespace aspect
             velocity_y[index] = 0;
           else
             velocity_y[index] = local_aspect_values[3][i];
-
-          bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
-          bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
         }
 
       for (unsigned int p=1; p<Utilities::MPI::n_mpi_processes(this->get_mpi_communicator()); ++p)
@@ -894,8 +891,6 @@ namespace aspect
               else
                 velocity_y[index] = local_aspect_values[3][i];
 
-              bedrock_river_incision_rate_array[index] = time_scaling_factor * local_aspect_values[dim+2][i];
-              bedrock_transport_coefficient_array[index] = time_scaling_factor * local_aspect_values[dim+3][i];
             }
         }
 
@@ -924,26 +919,30 @@ namespace aspect
           const double x = grid_extent[0].first + (ix - use_ghost_nodes) * fastscape_dx;
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
-          const int index = global_to_local[i];
-
+          const int idx = global_to_local[i];
           double bedrock_river_incision_rate_local = numbers::signaling_nan<double>();
           double bedrock_transport_coefficient_local = numbers::signaling_nan<double>();
-
           if (use_compositional_erosion_bedrock)
             {
-              AssertThrow(index>=0,
-                          ExcMessage("No local aspect data was found for a FastScape mesh node."));
-              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
-              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
+              AssertThrow(idx >= 0,
+                          ExcMessage("Missing data from ASPECT for fastscape mesh"));
+              AssertThrow(static_cast<unsigned int>(idx) < local_aspect_values[dim+2].size(),
+                          ExcMessage("ASPECT data out of bounds for fastscape mesh"));
+              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][idx];
+              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][idx];
             }
           else
             {
               if (!use_kf_distribution_function)
-                bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
+                {
+                  bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
+                }
               else
                 bedrock_river_incision_rate_local = time_scaling_factor * kf_distribution_function.value(Point<2>(x, y));
               if (!use_kd_distribution_function)
-                bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
+                {
+                  bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
+                }
               else
                 bedrock_transport_coefficient_local = time_scaling_factor * kd_distribution_function.value(Point<2>(x, y));
             }

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -947,7 +947,7 @@ namespace aspect
               fastscape_mesh_filled = false;
             }
         }
-      
+
       // If this is a boundary node that is a ghost node then ignore that it
       // has not filled yet as the ghost nodes haven't been set.
       fastscape_mesh_filled = Utilities::MPI::broadcast(this->get_mpi_communicator(), fastscape_mesh_filled, 0);

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -727,11 +727,11 @@ namespace aspect
                       {
                         const unsigned int field = chemical_composition_idx[c];
                         fe_face_values[this->introspection().extractors.compositional_fields[field]].get_function_values(this->get_solution(), composition_values_array[field]);
-                        Assert(composition_values_array[c].size() > 0,
+                        Assert(composition_values_array[field].size() > 0,
                                ExcMessage("Composition_values_array[c] is empty"));
                       }
                   }
-                
+
                 for (unsigned int corner = 0; corner < face_corners.size(); ++corner)
                   {
                     const Point<dim> vertex = fe_face_values.quadrature_point(corner);
@@ -764,7 +764,7 @@ namespace aspect
                         composition_values.insert(composition_values.begin(), std::max(0.0, 1.0 - volume_fraction_sum));
                         bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
                         bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                      }                    
+                      }
 
                     // If we're in 2D, we want to take the values and apply them to every row of X points.
                     if (dim == 2)
@@ -905,8 +905,6 @@ namespace aspect
       for (unsigned int i = 0; i < local_aspect_values[1].size(); ++i)
         {
           const int global_index = local_aspect_values[1][i];
-          Assert(static_cast<std::size_t>(global_index) < global_to_local.size(),
-                 ExcMessage("The index for filling fastscape arrays is out of bounds. This index array is constructed in get_aspect_values() and should contain values only within the bounds of the FastScape mesh. This error may be caused by an improperly set maximum_surface_refinement_level, additional_refinement_levels, and surface_refinement_difference."));
           global_to_local[global_index] = i;
         }
 
@@ -927,32 +925,30 @@ namespace aspect
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
           const int index = global_to_local[i];
-          
+
           double bedrock_river_incision_rate_local = numbers::signaling_nan<double>();
           double bedrock_transport_coefficient_local = numbers::signaling_nan<double>();
 
-          if (use_compositional_erosion_bedrock && index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
-          {
-            bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
-            bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
-          }
-          if (!use_kf_distribution_function)
-            bedrock_river_incision_rate_local = constant_bedrock_river_incision_rate[0];
-          if (!use_kd_distribution_function)
-            bedrock_transport_coefficient_local = constant_bedrock_transport_coefficient[0];
-
-          bedrock_river_incision_rate_array[i] =
-            (use_kf_distribution_function)
-            ?  // update with time scaling
-            time_scaling_factor * kf_distribution_function.value(Point<2>(x, y))
-            :
-            bedrock_river_incision_rate_local;
-          bedrock_transport_coefficient_array[i] =
-            (use_kd_distribution_function)
-            ?  // update with time scaling
-            time_scaling_factor * kd_distribution_function.value(Point<2>(x, y))
-            :
-            bedrock_transport_coefficient_local;
+          if (use_compositional_erosion_bedrock)
+            {
+              AssertThrow(index>=0,
+                          ExcMessage("No local aspect data was found for a FastScape mesh node."));
+              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
+              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
+            }
+          else
+            {
+              if (!use_kf_distribution_function)
+                bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
+              else
+                bedrock_river_incision_rate_local = time_scaling_factor * kf_distribution_function.value(Point<2>(x, y));
+              if (!use_kd_distribution_function)
+                bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
+              else
+                bedrock_transport_coefficient_local = time_scaling_factor * kd_distribution_function.value(Point<2>(x, y));
+            }
+          bedrock_river_incision_rate_array[i] = bedrock_river_incision_rate_local;
+          bedrock_transport_coefficient_array[i] = bedrock_transport_coefficient_local;
 
           if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false) || std::isnan(elevation[i]))
             {
@@ -2201,8 +2197,8 @@ namespace aspect
                 constant_bedrock_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get(options.property_name), options);
               }
             AssertThrow(!(use_compositional_erosion_bedrock &&
-              (use_kf_distribution_function || use_kd_distribution_function)),
-            ExcMessage("Compositional erosion for bedrock cannot be used together with kf or kd distribution functions."));
+                          (use_kf_distribution_function || use_kd_distribution_function)),
+                        ExcMessage("Compositional erosion for bedrock cannot be used together with kf or kd distribution functions."));
             bedrock_deposition_g = prm.get_double("Bedrock deposition coefficient");
             sediment_deposition_g = prm.get_double("Sediment deposition coefficient");
             slope_exponent_p = prm.get_double("Multi-direction slope exponent");

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -739,7 +739,7 @@ namespace aspect
                     // Find what x point we're at. Add 1 or 2 depending on if ghost nodes are used.
                     // Subtract the origin point so that it corresponds to an origin of 0,0 in FastScape.
                     const double indx = 1+use_ghost_nodes+(vertex(0) - grid_extent[0].first)/fastscape_dx;
-                    
+
                     // The quadrature rule is created so that there are enough interpolation points in the
                     // lowest resolved ASPECT surface cell to fill out the FastScape mesh. However, as the
                     // same rule is used for all cell sizes, higher resolution areas will have interpolation

--- a/source/mesh_deformation/fastscape.cc
+++ b/source/mesh_deformation/fastscape.cc
@@ -526,7 +526,7 @@ namespace aspect
                   // (by default -1). If a different rate is set for sediment and
                   // bedrock, the sediment rate is only used for sediment layers
                   // at least 1 m thick.
-                  if (sediment_river_incision_rate < 0. || sediment_thickness <= 1.)
+                  if (sediment_river_incision_rate < 0. || sediment_thickness <= 1. || std::isnan(sediment_thickness))
                     combined_kf[i] = bedrock_river_incision_rate_array[i];
                   else if (sediment_river_incision_rate >= 0. && sediment_thickness > 1.)
                     combined_kf[i] = sediment_river_incision_rate;
@@ -540,7 +540,7 @@ namespace aspect
                   // (by default -1). If a different rate is set for sediment and bedrock,
                   // the sediment coefficient is only used for sediment layers
                   // at least 1 m thick.
-                  if (sediment_transport_coefficient < 0 || sediment_thickness <= 1.)
+                  if (sediment_transport_coefficient < 0 || sediment_thickness <= 1. || std::isnan(sediment_thickness))
                     combined_kd[i] = bedrock_transport_coefficient_array[i];
                   else if (sediment_transport_coefficient >= 0. && sediment_thickness > 1.)
                     combined_kd[i] = sediment_transport_coefficient;
@@ -564,8 +564,13 @@ namespace aspect
                   const double marine_diffusion_coefficient = silt_fraction[i] * silt_transport_coefficient + (1. - silt_fraction[i]) * sand_transport_coefficient;
                   combined_kd[i] = marine_diffusion_coefficient;
                 }
+              else if (elevation[i] < current_sea_level && !use_marine_component)
+                std::cout<<"Below sea level and not use marine component"<<std::endl;
               else
                 {
+                  std::cout<<"elevation[i]: "<<elevation[i]<<std::endl;
+                  std::cout<<"current_sea_level: "<<current_sea_level<<std::endl;
+                  std::cout<<"use_marine_component: "<<use_marine_component<<std::endl;
                   AssertThrow (false, ExcMessage ("Unexpected conditions reached while filling the kf and kd arrays in the FastScape interface."));
                 }
             }
@@ -710,7 +715,7 @@ namespace aspect
                 if ( cell->face(face_no)->boundary_id() != relevant_boundary)
                   continue;
 
-                std::vector<std::vector<double>> composition_values_array(n_chemical_compositional_fields, std::vector<double>(face_corners.size()));
+                std::vector<std::vector<double>> composition_values_array(this->n_compositional_fields(), std::vector<double>(face_corners.size()));
                 std::vector<Tensor<1,dim>> vel(face_corners.size());
                 fe_face_values.reinit(cell, face_no);
                 fe_face_values[this->introspection().extractors.velocities].get_function_values(this->get_solution(), vel);
@@ -720,12 +725,13 @@ namespace aspect
                     // Get compositional erosional parameters from compositional values, for chemical compositions + background mantle
                     for (unsigned int c=0; c<n_chemical_compositional_fields; ++c)
                       {
-                        fe_face_values[this->introspection().extractors.compositional_fields[chemical_composition_idx[c]]].get_function_values(this->get_solution(), composition_values_array[c]);
+                        const unsigned int field = chemical_composition_idx[c];
+                        fe_face_values[this->introspection().extractors.compositional_fields[field]].get_function_values(this->get_solution(), composition_values_array[field]);
                         Assert(composition_values_array[c].size() > 0,
                                ExcMessage("Composition_values_array[c] is empty"));
                       }
                   }
-
+                
                 for (unsigned int corner = 0; corner < face_corners.size(); ++corner)
                   {
                     const Point<dim> vertex = fe_face_values.quadrature_point(corner);
@@ -743,24 +749,22 @@ namespace aspect
                       continue;
 
                     // Initialize the bedrock river incision rate and diffusivity to be the first value in the input array
-                    double bedrock_river_incision_rate_at_point = constant_bedrock_river_incision_rate[0];
-                    double bedrock_transport_coefficient_at_point = constant_bedrock_transport_coefficient[0];
-                    // If we allow compositional erosional parameters for bedrock, update them with the average
-                    // taken from all chemical compositions + background mantle
-                    std::vector<double> composition_values(this->introspection().chemical_composition_field_indices().size());
+                    double bedrock_river_incision_rate_at_point = numbers::signaling_nan<double>();
+                    double bedrock_transport_coefficient_at_point = numbers::signaling_nan<double>();
                     if (use_compositional_erosion_bedrock)
                       {
+                        std::vector<double> composition_values(n_chemical_compositional_fields);
                         double volume_fraction_sum = 0;
                         for (unsigned int c=0; c < n_chemical_compositional_fields; ++c)
                           {
-                            composition_values[c] = composition_values_array[c][corner];
-                            volume_fraction_sum = volume_fraction_sum + composition_values_array[c][corner];
+                            composition_values[c] = composition_values_array[chemical_composition_idx[c]][corner];
+                            volume_fraction_sum = volume_fraction_sum + composition_values_array[chemical_composition_idx[c]][corner];
                           }
                         // Add background material fraction at the beginning
-                        composition_values.insert(composition_values.begin(), 1.0 - volume_fraction_sum);
+                        composition_values.insert(composition_values.begin(), std::max(0.0, 1.0 - volume_fraction_sum));
                         bedrock_river_incision_rate_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_river_incision_rate, MaterialModel::MaterialUtilities::arithmetic);
                         bedrock_transport_coefficient_at_point = MaterialModel::MaterialUtilities::average_value (composition_values, constant_bedrock_transport_coefficient, MaterialModel::MaterialUtilities::arithmetic);
-                      }
+                      }                    
 
                     // If we're in 2D, we want to take the values and apply them to every row of X points.
                     if (dim == 2)
@@ -905,7 +909,6 @@ namespace aspect
                  ExcMessage("The index for filling fastscape arrays is out of bounds. This index array is constructed in get_aspect_values() and should contain values only within the bounds of the FastScape mesh. This error may be caused by an improperly set maximum_surface_refinement_level, additional_refinement_levels, and surface_refinement_difference."));
           global_to_local[global_index] = i;
         }
-      this->get_pcout() << "   Updating FastScape erodibility parameters from distribution functions..." << std::endl;
 
       // Initialize the bedrock river incision rate and transport coefficient,
       // and check that there are no empty mesh points due to
@@ -924,15 +927,20 @@ namespace aspect
           const double y = grid_extent[1].first + (iy - use_ghost_nodes) * fastscape_dy;
 
           const int index = global_to_local[i];
-          double bedrock_river_incision_rate_local = time_scaling_factor * constant_bedrock_river_incision_rate[0];
-          double bedrock_transport_coefficient_local = time_scaling_factor * constant_bedrock_transport_coefficient[0];
-          if (index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
-            {
-              bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
-              bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
-            }
+          
+          double bedrock_river_incision_rate_local = numbers::signaling_nan<double>();
+          double bedrock_transport_coefficient_local = numbers::signaling_nan<double>();
 
-          // Set bedrock river incision rate kf either from a function or a constant.
+          if (use_compositional_erosion_bedrock && index >= 0 && static_cast<std::size_t>(index) < local_aspect_values[dim+3].size())
+          {
+            bedrock_river_incision_rate_local = time_scaling_factor * local_aspect_values[dim+2][index];
+            bedrock_transport_coefficient_local = time_scaling_factor * local_aspect_values[dim+3][index];
+          }
+          if (!use_kf_distribution_function)
+            bedrock_river_incision_rate_local = constant_bedrock_river_incision_rate[0];
+          if (!use_kd_distribution_function)
+            bedrock_transport_coefficient_local = constant_bedrock_transport_coefficient[0];
+
           bedrock_river_incision_rate_array[i] =
             (use_kf_distribution_function)
             ?  // update with time scaling
@@ -946,7 +954,7 @@ namespace aspect
             :
             bedrock_transport_coefficient_local;
 
-          if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false))
+          if (elevation[i] == std::numeric_limits<double>::max() && !is_ghost_node(i,false) || std::isnan(elevation[i]))
             {
               fastscape_mesh_filled = false;
             }
@@ -2192,13 +2200,9 @@ namespace aspect
                 options.property_name = "Bedrock diffusivity";
                 constant_bedrock_transport_coefficient = Utilities::MapParsing::parse_map_to_double_array(prm.get(options.property_name), options);
               }
-            // this->get_pcout() << "Bedrock river incision rate:" << std::endl;
-            // for (unsigned int i = 0; i < chemical_field_names.size(); ++i)
-            //   this->get_pcout() << "  "
-            //                     << chemical_field_names[i]
-            //                     << " : "
-            //                     << constant_bedrock_river_incision_rate[i]
-            //                     << std::endl;
+            AssertThrow(!(use_compositional_erosion_bedrock &&
+              (use_kf_distribution_function || use_kd_distribution_function)),
+            ExcMessage("Compositional erosion for bedrock cannot be used together with kf or kd distribution functions."));
             bedrock_deposition_g = prm.get_double("Bedrock deposition coefficient");
             sediment_deposition_g = prm.get_double("Sediment deposition coefficient");
             slope_exponent_p = prm.get_double("Multi-direction slope exponent");


### PR DESCRIPTION
I implemented one Fastscape feature:
1. Allows the bedrock erosion parameters (river incision rate and transport coefficient) to vary for different compositions.
(The marine part of this PR will move to another new PR)
