### PR TITLE
make velocity angle a variable in crust litho formation particle model

### DIFF
--- a/doc/modules/changes/20260727_ranpengli
+++ b/doc/modules/changes/20260727_ranpengli
@@ -1,4 +1,4 @@
-Changed: In the crust and lithosphere formation reaction model, the upwelling angle has been changed from a hardcoded value (30 degrees from the horizontal direction) to a user-defined input input parameter.
+Changed: In the crust and lithosphere formation reaction model, the upwelling angle has been changed from a hardcoded value (30 degrees from the horizontal direction) to a user-defined input parameter.
 Added: An option to select whether the harzburgite profile in the lithosphere is constant or decreases linearly with depth.
 <br>
 (Ranpeng Li 2026/07/27)

--- a/doc/modules/changes/20260727_ranpengli
+++ b/doc/modules/changes/20260727_ranpengli
@@ -1,0 +1,4 @@
+Changed: In the crust and lithosphere formation reaction model, the upwelling angle has been changed from a hardcoded value (30 degrees from the horizontal direction) to a user-defined input input parameter.
+Added: An option to select whether the harzburgite profile in the lithosphere is constant or decreases linearly with depth.
+<br>
+(Ranpeng Li 2026/07/27)

--- a/doc/sphinx/parameters/Particles.md
+++ b/doc/sphinx/parameters/Particles.md
@@ -377,13 +377,22 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 (parameters:Particles/Crust_20and_20lithosphere_20formation)=
 ## **Subsection:** Particles / Crust and lithosphere formation
-::::{dropdown} __Parameter:__ {ref}`Crustal thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Crustal_20thickness>`
-:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Crustal_20thickness
+::::{dropdown} __Parameter:__ {ref}`Crust thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Crust_20thickness>`
+:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Crust_20thickness
 **Default value:** 7000
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the crustal layer generated at the surface.Units: \si{\meter}.
+**Documentation:** Thickness of the crustal layer generated at the surface. Units: \si{\meter}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Harzburgite profile in lithosphere<parameters:Particles/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere>`
+:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere
+**Default value:** constant
+
+**Pattern:** [Selection constant|linear ]
+
+**Documentation:** Choose the profile used for the harzburgite fraction within the lithosphere. If set to constant, the harzburgite fraction is 100\% everywhere except where basalt is present. If set to linear, the harzburgite fraction is 100\% at the top of the lithosphere and decreases linearly to 0\% at the bottom of the lithosphere.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithosphere thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Lithosphere_20thickness>`
@@ -392,7 +401,25 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: \si{\meter}.
+**Documentation:** Thickness of the lithosphere layer generated below the crust. Units: \si{\meter}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum upwelling angle for crust formation<parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation>`
+:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation
+**Default value:** 30
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The minimum upwelling angle required for a particle to be converted into crustal material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into crust (basalt). Units: \si{\degree}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum upwelling angle for lithosphere formation<parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation>`
+:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation
+**Default value:** 30
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
 ::::
 
 (parameters:Particles/Crystal_20Preferred_20Orientation)=

--- a/doc/sphinx/parameters/Particles.md
+++ b/doc/sphinx/parameters/Particles.md
@@ -377,8 +377,8 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 (parameters:Particles/Crust_20and_20lithosphere_20formation)=
 ## **Subsection:** Particles / Crust and lithosphere formation
-::::{dropdown} __Parameter:__ {ref}`Crust thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Crust_20thickness>`
-:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Crust_20thickness
+::::{dropdown} __Parameter:__ {ref}`Crustal thickness<parameters:Particles/Crust_20and_20lithosphere_20formation/Crustal_20thickness>`
+:name: parameters:Particles/Crust_20and_20lithosphere_20formation/Crustal_20thickness
 **Default value:** 7000
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
@@ -388,7 +388,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 ::::{dropdown} __Parameter:__ {ref}`Harzburgite profile in lithosphere<parameters:Particles/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere>`
 :name: parameters:Particles/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere
-**Default value:** constant
+**Default value:** linear
 
 **Pattern:** [Selection constant|linear ]
 
@@ -408,7 +408,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 :name: parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation
 **Default value:** 30
 
-**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+**Pattern:** [Double 0...90 (inclusive)]
 
 **Documentation:** The minimum upwelling angle required for a particle to be converted into crustal material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into crust (basalt). Units: \si{\degree}.
 ::::
@@ -417,9 +417,9 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 :name: parameters:Particles/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation
 **Default value:** 30
 
-**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+**Pattern:** [Double 0...90 (inclusive)]
 
-**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
+**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles (except for particles with a basaltic composition) are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles (except for particles with a basaltic composition) moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
 ::::
 
 (parameters:Particles/Crystal_20Preferred_20Orientation)=

--- a/doc/sphinx/parameters/Particles_202.md
+++ b/doc/sphinx/parameters/Particles_202.md
@@ -368,8 +368,8 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 (parameters:Particles_202/Crust_20and_20lithosphere_20formation)=
 ## **Subsection:** Particles 2 / Crust and lithosphere formation
-::::{dropdown} __Parameter:__ {ref}`Crust thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crust_20thickness>`
-:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crust_20thickness
+::::{dropdown} __Parameter:__ {ref}`Crustal thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crustal_20thickness>`
+:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crustal_20thickness
 **Default value:** 7000
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
@@ -379,7 +379,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 ::::{dropdown} __Parameter:__ {ref}`Harzburgite profile in lithosphere<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere>`
 :name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere
-**Default value:** constant
+**Default value:** linear
 
 **Pattern:** [Selection constant|linear ]
 
@@ -399,7 +399,7 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 :name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation
 **Default value:** 30
 
-**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+**Pattern:** [Double 0...90 (inclusive)]
 
 **Documentation:** The minimum upwelling angle required for a particle to be converted into crustal material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into crust (basalt). Units: \si{\degree}.
 ::::
@@ -408,9 +408,9 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 :name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation
 **Default value:** 30
 
-**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+**Pattern:** [Double 0...90 (inclusive)]
 
-**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
+**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles (except for particles with a basaltic composition) are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles (except for particles with a basaltic composition) moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
 ::::
 
 (parameters:Particles_202/Crystal_20Preferred_20Orientation)=

--- a/doc/sphinx/parameters/Particles_202.md
+++ b/doc/sphinx/parameters/Particles_202.md
@@ -368,13 +368,22 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 (parameters:Particles_202/Crust_20and_20lithosphere_20formation)=
 ## **Subsection:** Particles 2 / Crust and lithosphere formation
-::::{dropdown} __Parameter:__ {ref}`Crustal thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crustal_20thickness>`
-:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crustal_20thickness
+::::{dropdown} __Parameter:__ {ref}`Crust thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crust_20thickness>`
+:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Crust_20thickness
 **Default value:** 7000
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the crustal layer generated at the surface.Units: \si{\meter}.
+**Documentation:** Thickness of the crustal layer generated at the surface. Units: \si{\meter}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Harzburgite profile in lithosphere<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere>`
+:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Harzburgite_20profile_20in_20lithosphere
+**Default value:** constant
+
+**Pattern:** [Selection constant|linear ]
+
+**Documentation:** Choose the profile used for the harzburgite fraction within the lithosphere. If set to constant, the harzburgite fraction is 100\% everywhere except where basalt is present. If set to linear, the harzburgite fraction is 100\% at the top of the lithosphere and decreases linearly to 0\% at the bottom of the lithosphere.
 ::::
 
 ::::{dropdown} __Parameter:__ {ref}`Lithosphere thickness<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Lithosphere_20thickness>`
@@ -383,7 +392,25 @@ A typical example would be to set this runtime parameter to &lsquo;pi=3.14159265
 
 **Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
 
-**Documentation:** Thickness of the lithosphere layer generated below the crust.Units: \si{\meter}.
+**Documentation:** Thickness of the lithosphere layer generated below the crust. Units: \si{\meter}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum upwelling angle for crust formation<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation>`
+:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20crust_20formation
+**Default value:** 30
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The minimum upwelling angle required for a particle to be converted into crustal material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into crust (basalt). Units: \si{\degree}.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum upwelling angle for lithosphere formation<parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation>`
+:name: parameters:Particles_202/Crust_20and_20lithosphere_20formation/Minimum_20upwelling_20angle_20for_20lithosphere_20formation
+**Default value:** 30
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** The minimum upwelling angle required for a particle to be converted into lithospheric material. This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). Units: \si{\degree}.
 ::::
 
 (parameters:Particles_202/Crystal_20Preferred_20Orientation)=

--- a/include/aspect/material_model/reaction_model/crust_and_lithosphere_formation.h
+++ b/include/aspect/material_model/reaction_model/crust_and_lithosphere_formation.h
@@ -82,11 +82,44 @@ namespace aspect
            *
            * This variable is read from the parameter file through a parameter called 'Crustal thickness'.
            */
-          double crustal_thickness;
+          double crust_thickness;
+
           /**
            *  This variable is read from the parameter file through a parameter called 'Lithosphere thickness'.
            */
           double lithosphere_thickness;
+
+          /**
+           * The minimum upwelling angle required for a particle to be converted into crust.
+           *
+           * This variable is read from the parameter file through parameters called 'Minimum upwelling angle for crust formation'
+           */
+          double minimum_upwelling_angle_for_crust;
+
+          /**
+           * The minimum upwelling angle required for a particle to be converted into lithosphere.
+           *
+           * This variable is read from the parameter file through parameters called 'Minimum upwelling angle for lithosphere formation'.
+           */
+
+          double minimum_upwelling_angle_for_lithosphere;
+
+          /**
+           * An enum describing the different options to compute the harzburgite profile
+           * within the lithosphere.
+           *
+           * The selection is made from the parameter file through a parameter called 'Harzburgite profile in lithosphere'.
+           */
+          enum HarzburgiteProfile
+          {
+            linear,
+            constant
+          };
+
+          /**
+          * Selected option to compute the reference profile for composition.
+          */
+          HarzburgiteProfile harzburgite_profile;
 
           /**
            * The indices of the compositional fields that store the basalt and

--- a/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
+++ b/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
@@ -50,10 +50,16 @@ namespace aspect
                 if (gravity_norm > 0.0)
                   vertically_up /= gravity_norm;
 
-                // angle of 30 degrees upward
-                const bool upward_flow = in.velocity[i] * vertically_up > in.velocity[i].norm() * 0.5;
-                const bool within_crust = depth < crustal_thickness && upward_flow;
-                const bool within_lithosphere = depth < crustal_thickness + lithosphere_thickness && upward_flow;
+                // We only convert material to crust and lithosphere if its upwelling angle is above a certain value.
+                // The upwelling angle is defined as the angle between the horizontal and the velocity vector.
+                const double crustal_angle = std::sin(minimum_upwelling_angle_for_crust);
+                const double lithospheric_angle = std::sin(minimum_upwelling_angle_for_lithosphere);
+
+                const bool upward_flow_crust = in.velocity[i] * vertically_up > in.velocity[i].norm() * crustal_angle;
+                const bool upward_flow_lithosphere = in.velocity[i] * vertically_up > in.velocity[i].norm() * lithospheric_angle;
+
+                const bool within_crust = depth < crust_thickness && upward_flow_crust;
+                const bool within_lithosphere = depth < crust_thickness + lithosphere_thickness && upward_flow_lithosphere;
 
                 // In the crust, we convert every material to basalt.
                 if (within_crust)
@@ -74,8 +80,15 @@ namespace aspect
                       {
                         // Lithosphere composition changes linearly with depth, but only background mantle
                         // is converted (whereas basalt is not).
-                        const double harzburgite_change = (crustal_thickness + lithosphere_thickness - depth) / lithosphere_thickness
-                                                          * (1.0 - in.composition[i][basalt_index]);
+
+                        double harzburgite_change = std::numeric_limits<double>::signaling_NaN();
+                        if (harzburgite_profile == linear)
+                          harzburgite_change = (crust_thickness + lithosphere_thickness - depth) / lithosphere_thickness
+                                               * (1.0 - in.composition[i][basalt_index]);
+
+                        else if (harzburgite_profile == constant)
+                          harzburgite_change = 1.0 - in.composition[i][basalt_index];
+
                         // If we already have more harzburgite than the change, we do not change it.
                         if (in.composition[i][c] >= harzburgite_change)
                           out.reaction_terms[i][c] = 0.0;
@@ -99,16 +112,36 @@ namespace aspect
         // TODO: In the future, we could make these depths depend on the solidus
         // and the temperature. However, note that technically this would affect
         // the composition of the generated melt and residual as well.
-        prm.declare_entry ("Crustal thickness", "7000",
+        prm.declare_entry ("Crust thickness", "7000",
                            Patterns::Double (),
                            "Thickness of the crustal layer generated "
-                           "at the surface."
+                           "at the surface. "
                            "Units: \\si{\\meter}.");
         prm.declare_entry ("Lithosphere thickness", "63000",
                            Patterns::Double (),
                            "Thickness of the lithosphere layer generated "
-                           "below the crust."
+                           "below the crust. "
                            "Units: \\si{\\meter}.");
+        prm.declare_entry ("Minimum upwelling angle for crust formation", "30",
+                           Patterns::Double (),
+                           "The minimum upwelling angle required for a particle to be converted into crustal material. "
+                           "This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. "
+                           "A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. "
+                           "A value of 90 means that only particles moving vertically upward are converted into crust (basalt). "
+                           "Units: \\si{\\degree}.");
+        prm.declare_entry ("Minimum upwelling angle for lithosphere formation", "30",
+                           Patterns::Double (),
+                           "The minimum upwelling angle required for a particle to be converted into lithospheric material. "
+                           "This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. "
+                           "A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. "
+                           "A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). "
+                           "Units: \\si{\\degree}.");
+        prm.declare_entry ("Harzburgite profile in lithosphere", "constant",
+                           Patterns::Selection ("constant|linear"),
+                           "Choose the profile used for the harzburgite fraction within the lithosphere. "
+                           "If set to constant, the harzburgite fraction is 100\\% everywhere except where basalt is present. "
+                           "If set to linear, the harzburgite fraction is 100\\% at the top of the lithosphere "
+                           "and decreases linearly to 0\\% at the bottom of the lithosphere.");
       }
 
 
@@ -117,8 +150,24 @@ namespace aspect
       void
       CrustLithosphereFormation<dim>::parse_parameters (ParameterHandler &prm)
       {
-        crustal_thickness     = prm.get_double ("Crustal thickness");
+        crust_thickness     = prm.get_double ("Crust thickness");
         lithosphere_thickness = prm.get_double ("Lithosphere thickness");
+        minimum_upwelling_angle_for_crust = prm.get_double ("Minimum upwelling angle for crust formation")* constants::degree_to_radians;
+        minimum_upwelling_angle_for_lithosphere = prm.get_double ("Minimum upwelling angle for lithosphere formation")* constants::degree_to_radians;
+
+        AssertThrow(minimum_upwelling_angle_for_crust >= 0.0 && minimum_upwelling_angle_for_crust <= 90.0,
+                    ExcMessage("The minimum upwelling angle for crust formation must be between 0 and 90 degrees."));
+
+        AssertThrow(minimum_upwelling_angle_for_lithosphere >= 0.0 && minimum_upwelling_angle_for_lithosphere <= 90.0,
+                    ExcMessage("The minimum upwelling angle for lithosphere formation must be between 0 and 90 degrees."));
+
+        const std::string harzburgite_profile_selection = prm.get ("Harzburgite profile in lithosphere");
+        if (harzburgite_profile_selection == "constant")
+          harzburgite_profile = constant;
+        else if (harzburgite_profile_selection == "linear")
+          harzburgite_profile = linear;
+        else
+          AssertThrow(false, ExcNotImplemented("The selected harzburgite profile calculation method does not exist."));
 
         AssertThrow(this->introspection().compositional_name_exists("basalt") &&
                     this->introspection().compositional_name_exists("harzburgite"),

--- a/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
+++ b/source/material_model/reaction_model/crust_and_lithosphere_formation.cc
@@ -78,8 +78,7 @@ namespace aspect
                       out.reaction_terms[i][c] = 0.0;
                     else if (c == harzburgite_index)
                       {
-                        // Lithosphere composition changes linearly with depth, but only background mantle
-                        // is converted (whereas basalt is not).
+                        // Only background mantle is converted, whereas basalt is not.
 
                         double harzburgite_change = std::numeric_limits<double>::signaling_NaN();
                         if (harzburgite_profile == linear)
@@ -112,7 +111,7 @@ namespace aspect
         // TODO: In the future, we could make these depths depend on the solidus
         // and the temperature. However, note that technically this would affect
         // the composition of the generated melt and residual as well.
-        prm.declare_entry ("Crust thickness", "7000",
+        prm.declare_entry ("Crustal thickness", "7000",
                            Patterns::Double (),
                            "Thickness of the crustal layer generated "
                            "at the surface. "
@@ -123,20 +122,20 @@ namespace aspect
                            "below the crust. "
                            "Units: \\si{\\meter}.");
         prm.declare_entry ("Minimum upwelling angle for crust formation", "30",
-                           Patterns::Double (),
+                           Patterns::Double (0,90),
                            "The minimum upwelling angle required for a particle to be converted into crustal material. "
                            "This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. "
                            "A value of 0 means that all particles are converted into crust (basalt) as soon as they reach the required depth. "
                            "A value of 90 means that only particles moving vertically upward are converted into crust (basalt). "
                            "Units: \\si{\\degree}.");
         prm.declare_entry ("Minimum upwelling angle for lithosphere formation", "30",
-                           Patterns::Double (),
+                           Patterns::Double (0,90),
                            "The minimum upwelling angle required for a particle to be converted into lithospheric material. "
                            "This angle is measured between the horizontal direction and the particle velocity vector and ranges from 0 to 90 degrees. "
-                           "A value of 0 means that all particles are converted into lithosphere (harzburgite) as soon as they reach the required depth. "
-                           "A value of 90 means that only particles moving vertically upward are converted into lithosphere (harzburgite). "
+                           "A value of 0 means that all particles (except for particles with a basaltic composition) are converted into lithosphere (harzburgite) as soon as they reach the required depth. "
+                           "A value of 90 means that only particles (except for particles with a basaltic composition) moving vertically upward are converted into lithosphere (harzburgite). "
                            "Units: \\si{\\degree}.");
-        prm.declare_entry ("Harzburgite profile in lithosphere", "constant",
+        prm.declare_entry ("Harzburgite profile in lithosphere", "linear",
                            Patterns::Selection ("constant|linear"),
                            "Choose the profile used for the harzburgite fraction within the lithosphere. "
                            "If set to constant, the harzburgite fraction is 100\\% everywhere except where basalt is present. "
@@ -150,16 +149,10 @@ namespace aspect
       void
       CrustLithosphereFormation<dim>::parse_parameters (ParameterHandler &prm)
       {
-        crust_thickness     = prm.get_double ("Crust thickness");
+        crust_thickness     = prm.get_double ("Crustal thickness");
         lithosphere_thickness = prm.get_double ("Lithosphere thickness");
         minimum_upwelling_angle_for_crust = prm.get_double ("Minimum upwelling angle for crust formation")* constants::degree_to_radians;
         minimum_upwelling_angle_for_lithosphere = prm.get_double ("Minimum upwelling angle for lithosphere formation")* constants::degree_to_radians;
-
-        AssertThrow(minimum_upwelling_angle_for_crust >= 0.0 && minimum_upwelling_angle_for_crust <= 90.0,
-                    ExcMessage("The minimum upwelling angle for crust formation must be between 0 and 90 degrees."));
-
-        AssertThrow(minimum_upwelling_angle_for_lithosphere >= 0.0 && minimum_upwelling_angle_for_lithosphere <= 90.0,
-                    ExcMessage("The minimum upwelling angle for lithosphere formation must be between 0 and 90 degrees."));
 
         const std::string harzburgite_profile_selection = prm.get ("Harzburgite profile in lithosphere");
         if (harzburgite_profile_selection == "constant")

--- a/tests/crustal_formation_particles.prm
+++ b/tests/crustal_formation_particles.prm
@@ -141,7 +141,7 @@ subsection Particles
     set Update ghost particles = true
 
     subsection Crust and lithosphere formation
-      set Crust thickness                             = 70000
+      set Crustal thickness                             = 70000
       set Lithosphere thickness                         = 700000
       set Harzburgite profile in lithosphere = linear
     end

--- a/tests/crustal_formation_particles_upwell_angle.prm
+++ b/tests/crustal_formation_particles_upwell_angle.prm
@@ -141,7 +141,7 @@ subsection Particles
     set Update ghost particles = true
 
     subsection Crust and lithosphere formation
-      set Crust thickness                             = 70000
+      set Crustal thickness                             = 70000
       set Lithosphere thickness                         = 700000
       set Harzburgite profile in lithosphere = constant
       set Minimum upwelling angle for crust formation = 0

--- a/tests/crustal_formation_particles_upwell_angle.prm
+++ b/tests/crustal_formation_particles_upwell_angle.prm
@@ -143,7 +143,9 @@ subsection Particles
     subsection Crust and lithosphere formation
       set Crust thickness                             = 70000
       set Lithosphere thickness                         = 700000
-      set Harzburgite profile in lithosphere = linear
+      set Harzburgite profile in lithosphere = constant
+      set Minimum upwelling angle for crust formation = 0
+      set Minimum upwelling angle for lithosphere formation = 0
     end
 
     subsection Generator

--- a/tests/crustal_formation_particles_upwell_angle/log.txt
+++ b/tests/crustal_formation_particles_upwell_angle/log.txt
@@ -1,0 +1,87 @@
+-----------------------------------------------------------------------------
+--                             This is ASPECT                              --
+-- The Advanced Solver for Planetary Evolution, Convection, and Tectonics. --
+-----------------------------------------------------------------------------
+--     . version 3.1.0-pre (modify-litho-formation-plugin, 29d6b02a1)
+--     . using deal.II 9.6.0
+--     .       with 32 bit indices
+--     .       with vectorization level 1 (SSE2, 2 doubles, 128 bits)
+--     . using Trilinos 14.4.0
+--     . using p4est 2.3.6
+--     . using Geodynamic World Builder 1.1.0
+--     . running in DEBUG mode
+--     . running with 1 MPI process
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=3.1.0-pre&particles=1&sha=29d6b02a1&src=code
+-----------------------------------------------------------------------------
+Number of active cells: 768 (on 5 levels)
+Number of degrees of freedom: 16,838 (6,402+833+3,201+3,201+3,201)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 37+0 iterations.
+
+Number of active cells: 1,488 (on 6 levels)
+Number of degrees of freedom: 33,549 (12,758+1,654+6,379+6,379+6,379)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Advecting particles...  done.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system (AMG)... 40+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-crustal_formation_particles_upwell_angle/solution/solution-00000
+     Compositions min/max/mass: 0/0.25/1.976e+11 // 0/0.5412/3.053e+11
+     Writing particle output:   output-crustal_formation_particles_upwell_angle/particles/particles-00000
+
+*** Timestep 1:  t=1e+06 years, dt=1e+06 years
+   Solving temperature system... 8 iterations.
+   Advecting particles...  done.
+   Solving Stokes system (AMG)... 29+0 iterations.
+
+   Postprocessing:
+     Writing graphical output:  output-crustal_formation_particles_upwell_angle/solution/solution-00001
+     Compositions min/max/mass: 0/0.9526/5.22e+11 // 0/1/3.352e+12
+     Writing particle output:   output-crustal_formation_particles_upwell_angle/particles/particles-00001
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start     |      99.5s |            |
+|                                              |            |            |
+| Section                          | no. calls |  wall time | % of total |
++----------------------------------+-----------+------------+------------+
+| Assemble Stokes system           |         3 |      5.69s |       5.7% |
+| Assemble temperature system      |         3 |      11.7s |        12% |
+| Build Stokes preconditioner      |         2 |      4.04s |       4.1% |
+| Build temperature preconditioner |         3 |    0.0277s |         0% |
+| Initialization                   |         1 |       1.2s |       1.2% |
+| Particles: Advect                |         4 |      6.15s |       6.2% |
+| Particles: Copy                  |         3 |    0.0499s |         0% |
+| Particles: Generate              |         2 |      1.97s |         2% |
+| Particles: Initialization        |         1 |  0.000503s |         0% |
+| Particles: Initialize properties |         2 |     0.912s |      0.92% |
+| Particles: Interpolate           |         3 |      5.83s |       5.9% |
+| Particles: Sort                  |         4 |      17.3s |        17% |
+| Particles: Update properties     |         2 |      11.7s |        12% |
+| Postprocessing                   |         2 |      4.76s |       4.8% |
+| Refine mesh structure, part 1    |         1 |      1.29s |       1.3% |
+| Refine mesh structure, part 2    |         1 |      6.85s |       6.9% |
+| Setup dof systems                |         2 |     0.545s |      0.55% |
+| Setup initial conditions         |         2 |      7.79s |       7.8% |
+| Setup matrices                   |         2 |      2.73s |       2.7% |
+| Solve Stokes system              |         3 |      7.79s |       7.8% |
+| Solve temperature system         |         3 |    0.0268s |         0% |
++----------------------------------+-----------+------------+------------+
+
+-- Total wallclock time elapsed including restarts: 99s
+-----------------------------------------------------------------------------
+-- For information on how to cite ASPECT, see:
+--   https://aspect.geodynamics.org/citing.html?ver=3.1.0-pre&particles=1&sha=29d6b02a1&src=code
+-----------------------------------------------------------------------------

--- a/tests/crustal_formation_particles_upwell_angle/statistics
+++ b/tests/crustal_formation_particles_upwell_angle/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for Stokes solver
+# 10: Velocity iterations in Stokes preconditioner
+# 11: Schur complement iterations in Stokes preconditioner
+# 12: Visualization file name
+# 13: Minimal value for composition basalt
+# 14: Maximal value for composition basalt
+# 15: Global mass for composition basalt
+# 16: Minimal value for composition harzburgite
+# 17: Maximal value for composition harzburgite
+# 18: Global mass for composition harzburgite
+# 19: Number of advected particles
+# 20: Particle file name
+0 0.000000000000e+00 0.000000000000e+00 1488 14412 6379 12758 0 40 40 192 output-crustal_formation_particles_upwell_angle/solution/solution-00000 0.00000000e+00 2.50000000e-01 1.97628443e+11 0.00000000e+00 5.41158301e-01 3.05268278e+11 148800 output-crustal_formation_particles_upwell_angle/particles/particles-00000 
+1 1.000000000000e+06 1.000000000000e+06 1488 14412 6379 12758 8 29 29 142 output-crustal_formation_particles_upwell_angle/solution/solution-00001 0.00000000e+00 9.52635802e-01 5.21961510e+11 0.00000000e+00 1.00000000e+00 3.35180705e+12 148800 output-crustal_formation_particles_upwell_angle/particles/particles-00001 


### PR DESCRIPTION
I changed the upwelling angle in the crust and lithosphere formation from a hardcoded value (30 degrees from the horizontal direction) to a user-defined input input parameter.
I also added an option to select whether the harzburgite profile in the lithosphere is constant or decreases linearly with depth. I added a new test case to test the new implementation. The particle properties are correctly generated as the figure shows. In the upwelling area, all particles at depth < 77000 m are converted to 100% harzburgite, except for an original basalt layer.

<img width="1846" height="948" alt="image (2)" src="https://github.com/user-attachments/assets/c029d466-3aa0-47cd-8129-719acf7bd570" />

I asked ChatGPT to suggest parameter names and to correct grammar mistake in documentation.
### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
