### PR TITLE
Add mantle plume and slab flux statistics

### DIFF
--- a/doc/sphinx/parameters/Postprocess.md
+++ b/doc/sphinx/parameters/Postprocess.md
@@ -9,7 +9,7 @@
 :name: parameters:Postprocess/List_20of_20postprocessors
 **Default value:**
 
-**Pattern:** [MultipleSelection ODE statistics|Stokes residual|basic statistics|boundary densities|boundary pressures|boundary strain rate residual statistics|boundary velocity residual statistics|command|composition statistics|composition velocity statistics|core statistics|crystal preferred orientation|current surface|depth average|domain volume statistics|dynamic topography|entropy statistics|entropy viscosity statistics|fluid velocity statistics|geoid|global statistics|gravity calculation|heat flux densities|heat flux map|heat flux statistics|heating statistics|load balance statistics|mass flux statistics|material statistics|matrix statistics|maximum depth of field|melt statistics|memory statistics|mobility statistics|particle count statistics|particle distribution score|particle distribution statistics|particles|point values|pressure statistics|rotation statistics|sea level|spherical velocity statistics|temperature statistics|timing statistics|topography|velocity boundary statistics|velocity statistics|viscous dissipation statistics|visualization|volume of fluid statistics ]
+**Pattern:** [MultipleSelection ODE statistics|Stokes residual|basic statistics|boundary densities|boundary pressures|boundary strain rate residual statistics|boundary velocity residual statistics|command|composition statistics|composition velocity statistics|core statistics|crystal preferred orientation|current surface|depth average|domain volume statistics|dynamic topography|entropy statistics|entropy viscosity statistics|fluid velocity statistics|geoid|global statistics|gravity calculation|heat flux densities|heat flux map|heat flux statistics|heating statistics|load balance statistics|mantle flux statistics|mass flux statistics|material statistics|matrix statistics|maximum depth of field|melt statistics|memory statistics|mobility statistics|particle count statistics|particle distribution score|particle distribution statistics|particles|point values|pressure statistics|rotation statistics|sea level|spherical velocity statistics|temperature statistics|timing statistics|topography|velocity boundary statistics|velocity statistics|viscous dissipation statistics|visualization|volume of fluid statistics ]
 
 **Documentation:** A comma separated list of postprocessor objects that should be run at the end of each time step. Some of these postprocessors will declare their own parameters which may, for example, include that they will actually do something only every so many time steps or years. Alternatively, the text &lsquo;all&rsquo; indicates that all available postprocessors should be run after each time step.
 
@@ -83,6 +83,8 @@ The &ldquo;heat flux densities&rdquo; postprocessor computes the same quantity a
 &lsquo;heating statistics&rsquo;: A postprocessor that computes some statistics about heating, averaged by volume.
 
 &lsquo;load balance statistics&rsquo;: A postprocessor that computes statistics about the distribution of cells, and if present particles across subdomains. In particular, it computes maximal, average and minimal number of cells across all ranks. If there are particles it also computes the maximal, average, and minimum number of particles across all ranks, and maximal, average, and minimal ratio between local number of particles and local number of cells across all processes. All of these numbers can be useful to assess the load balance between different MPI ranks, as the difference between the minimal and maximal load should be as small as possible.
+
+&lsquo;mantle flux statistics&rsquo;: Measures hot outward flow (plumes) and cold inward flow (slabs) across layers at selected depths in spherical and Cartesian geometries. It reports volume flux, temperature-anomaly flux, thermal-buoyancy mass flux, thermal-buoyancy force rate, the number of detected structures, slab length, and plume radius. In two-dimensional models, fluxes are reported per unit length in the missing third direction. Rate units follow the global choice to use years or seconds in output.
 
 &lsquo;mass flux statistics&rsquo;: A postprocessor that computes some statistics about the mass flux across boundaries. For each boundary indicator (see your geometry description for which boundary indicators are used), the mass flux is computed in outward direction, i.e., from the domain to the outside, using the formula $\int_{\Gamma_i} \rho \mathbf v \cdot \mathbf n$ where $\Gamma_i$ is the part of the boundary with indicator $i$, $\rho$ is the density as reported by the material model, $\mathbf v$ is the velocity, and $\mathbf n$ is the outward normal.
 
@@ -774,6 +776,89 @@ all|temperature|composition|adiabatic temperature|adiabatic pressure|adiabatic d
 **Documentation:** The maximum number of time steps between each generation of gravity output files.
 ::::
 
+(parameters:Postprocess/Mantle_20flux_20statistics)=
+## **Subsection:** Postprocess / Mantle flux statistics
+::::{dropdown} __Parameter:__ {ref}`Cold temperature anomaly threshold<parameters:Postprocess/Mantle_20flux_20statistics/Cold_20temperature_20anomaly_20threshold>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Cold_20temperature_20anomaly_20threshold
+**Default value:** -200
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** A point colder than this value and moving inward is treated as slab material. Units: K.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Hot temperature anomaly threshold<parameters:Postprocess/Mantle_20flux_20statistics/Hot_20temperature_20anomaly_20threshold>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Hot_20temperature_20anomaly_20threshold
+**Default value:** 200
+
+**Pattern:** [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+
+**Documentation:** A point hotter than this value and moving outward is treated as plume material. Units: K.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Maximum point spacing<parameters:Postprocess/Mantle_20flux_20statistics/Maximum_20point_20spacing>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Maximum_20point_20spacing
+**Default value:** 80000
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Largest surface distance between neighboring cell centers that belong to the same plume or slab. Units: m.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Measurement depths<parameters:Postprocess/Mantle_20flux_20statistics/Measurement_20depths>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Measurement_20depths
+**Default value:** 440e3
+
+**Pattern:** [List of <[Double 0...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+
+**Documentation:** Depths below the surface where plume and slab fluxes are measured. Units: m.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Measurement layer half thickness<parameters:Postprocess/Mantle_20flux_20statistics/Measurement_20layer_20half_20thickness>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Measurement_20layer_20half_20thickness
+**Default value:** 20000
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Half the thickness of the layer sampled around each measurement depth. Units: m.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum points per structure<parameters:Postprocess/Mantle_20flux_20statistics/Minimum_20points_20per_20structure>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Minimum_20points_20per_20structure
+**Default value:** 5
+
+**Pattern:** [Integer range 1...2147483647 (inclusive)]
+
+**Documentation:** Smallest number of detected cell centers needed to count a plume or slab.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Minimum slab length<parameters:Postprocess/Mantle_20flux_20statistics/Minimum_20slab_20length>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Minimum_20slab_20length
+**Default value:** 0
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Do not count cold structures shorter than this surface distance. Units: m.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Time between cluster files<parameters:Postprocess/Mantle_20flux_20statistics/Time_20between_20cluster_20files>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Time_20between_20cluster_20files
+**Default value:** 0
+
+**Pattern:** [Double 0...MAX_DOUBLE (inclusive)]
+
+**Documentation:** Time between cluster files. Zero writes a file every time the postprocessor runs. Units: years when output uses years; seconds otherwise.
+::::
+
+::::{dropdown} __Parameter:__ {ref}`Write cluster files<parameters:Postprocess/Mantle_20flux_20statistics/Write_20cluster_20files>`
+:name: parameters:Postprocess/Mantle_20flux_20statistics/Write_20cluster_20files
+**Default value:** false
+
+**Pattern:** [Bool]
+
+**Documentation:** Write the cell centers assigned to each plume and slab to mantle_flux_clusters.NNNNN files.
+::::
+
 (parameters:Postprocess/Memory_20statistics)=
 ## **Subsection:** Postprocess / Memory statistics
 ::::{dropdown} __Parameter:__ {ref}`Output peak virtual memory (VmPeak)<parameters:Postprocess/Memory_20statistics/Output_20peak_20virtual_20memory_20_28VmPeak_29>`
@@ -1099,7 +1184,7 @@ Of course, activating this option also greatly increases the amount of data ASPE
 :name: parameters:Postprocess/Visualization/List_20of_20output_20variables
 **Default value:**
 
-**Pattern:** [MultipleSelection ISA rotation timescale|Vp anomaly|Vs anomaly|adiabat|artificial viscosity|artificial viscosity composition|boundary indicators|boundary strain rate residual|boundary velocity residual|compositional vector|darcy velocity|density anomaly|depth|depth including mesh deformation|dynamic topography|entropy average|error indicator|geoid|grain lag angle|gravity|heat flux map|heating|material properties|maximum horizontal compressive stress|melt fraction|melt material properties|named additional outputs|nonadiabatic pressure|nonadiabatic temperature|particle count|partition|prescribed solution|principal stress|shear stress|spd factor|spherical velocity components|strain rate|strain rate tensor|stress|stress residual|stress second invariant|surface dynamic topography|surface elevation|surface strain rate tensor|surface stress|temperature anomaly|vertical heat flux|volume of fluid values|volumetric strain rate ]
+**Pattern:** [MultipleSelection ISA rotation timescale|Vp anomaly|Vs anomaly|adiabat|artificial viscosity|artificial viscosity composition|boundary indicators|boundary strain rate residual|boundary velocity residual|compositional vector|darcy velocity|density anomaly|depth|depth including mesh deformation|dynamic topography|entropy average|error indicator|geoid|grain lag angle|gravity|heat flux map|heating|mantle flux|material properties|maximum horizontal compressive stress|melt fraction|melt material properties|named additional outputs|nonadiabatic pressure|nonadiabatic temperature|particle count|partition|prescribed solution|principal stress|shear stress|spd factor|spherical velocity components|strain rate|strain rate tensor|stress|stress residual|stress second invariant|surface dynamic topography|surface elevation|surface strain rate tensor|surface stress|temperature anomaly|vertical heat flux|volume of fluid values|volumetric strain rate ]
 
 **Documentation:** A comma separated list of visualization objects that should be run whenever writing graphical output. By default, the graphical output files will always contain the primary variables velocity, pressure, and temperature. However, one frequently wants to also visualize derived quantities, such as the thermodynamic phase that corresponds to a given temperature-pressure value, or the corresponding seismic wave speeds. The visualization objects do exactly this: they compute such derived quantities and place them into the output file. The current parameter is the place where you decide which of these additional output variables you want to have in your output file.
 
@@ -1198,6 +1283,8 @@ Physical units: $\frac{\text{W}}{\text{m}^2}$.
 &lsquo;heating&rsquo;: A visualization output object that generates output for all the heating terms used in the energy equation.
 
 Physical units: $\frac{\text{W}}{\text{m}^3}$\si{\watt\per\cubic\meter}.
+
+&lsquo;mantle flux&rsquo;: Writes four fields used by the mantle flux statistics postprocessor: the detected mantle structure, temperature-anomaly flux density, and the thermal-buoyancy mass-flux and force-rate densities. Radial velocity and nonadiabatic temperature are available through existing visualization postprocessors. The mantle structure field is 1 for plume material, -1 for slab material, and 0 for background mantle.
 
 &lsquo;material properties&rsquo;: A visualization output object that generates output for the material properties given by the material model. The current postprocessor allows to output a (potentially large) subset of all of the information provided by material models at once, with just a single material model evaluation per output point. Although individual properties can still be listed in the &ldquo;List of output variables&rdquo;, this visualization plugin is called internally to avoid duplicated evaluations of the material model.
 

--- a/include/aspect/postprocess/mantle_flux_statistics.h
+++ b/include/aspect/postprocess/mantle_flux_statistics.h
@@ -1,0 +1,133 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_postprocess_mantle_flux_statistics_h
+#define _aspect_postprocess_mantle_flux_statistics_h
+
+#include <aspect/postprocess/interface.h>
+#include <aspect/simulator_access.h>
+
+#include <limits>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    /**
+     * A postprocessor that measures hot upwellings and cold downwellings
+     * across layers at selected depths in a spherical model.
+     *
+     * @ingroup Postprocessing
+     */
+    template <int dim>
+    class MantleFluxStatistics : public Interface<dim>, public SimulatorAccess<dim>
+    {
+      public:
+        /**
+         * Values used to identify and visualize a plume or slab at one point.
+         */
+        struct PointDiagnostics
+        {
+          double outward_velocity = 0.0;
+          double temperature_anomaly = 0.0;
+          double temperature_flux_density = 0.0;
+          double buoyancy_mass_flux_density = 0.0;
+          double buoyancy_force_rate_density = 0.0;
+          int structure = 0;
+        };
+
+        /**
+         * Compute fluxes and measurements at all requested depths.
+         */
+        std::pair<std::string,std::string>
+        execute (TableHandler &statistics) override;
+
+        /**
+         * Return the local quantities used by this postprocessor. A structure
+         * value of 1 marks a plume, -1 marks a slab, and 0 marks background
+         * mantle.
+         */
+        PointDiagnostics
+        evaluate_point (const Point<dim> &position,
+                        const Tensor<1,dim> &velocity,
+                        const double temperature,
+                        const double density,
+                        const double thermal_expansivity,
+                        const Tensor<1,dim> &gravity) const;
+
+        /**
+         * Declare the parameters this postprocessor reads.
+         */
+        static void
+        declare_parameters (ParameterHandler &prm);
+
+        /**
+         * Read the parameters from the input file.
+         */
+        void
+        parse_parameters (ParameterHandler &prm) override;
+
+      private:
+        /**
+         * Join nearby points into separate mantle structures.
+         */
+        std::vector<std::vector<Point<dim>>>
+        find_clusters (const std::vector<Point<dim>> &points) const;
+
+        /**
+         * Return the largest surface distance between two points in a cluster.
+         */
+        double
+        cluster_length (const std::vector<Point<dim>> &points) const;
+
+        /**
+         * Return the mean surface distance from the cluster center.
+         */
+        double
+        cluster_radius (const std::vector<Point<dim>> &points) const;
+
+        /**
+         * Surface distance between two points in a spherical model.
+         */
+        double
+        surface_distance (const Point<dim> &first,
+                          const Point<dim> &second) const;
+
+        /**
+         * Write the centers of cells assigned to each plume and slab.
+         */
+        void
+        write_cluster_file (const std::string &content);
+
+        std::vector<double> measurement_depths;
+        double measurement_half_thickness = 20000.0;
+        double cold_temperature_threshold = -200.0;
+        double hot_temperature_threshold = 200.0;
+        double minimum_slab_length = 0.0;
+        double maximum_point_spacing = 80000.0;
+        unsigned int minimum_points_per_structure = 5;
+        bool write_cluster_files = false;
+        double cluster_file_interval = 0.0;
+        double last_output_time = std::numeric_limits<double>::quiet_NaN();
+    };
+  }
+}
+
+#endif

--- a/include/aspect/postprocess/visualization/mantle_flux.h
+++ b/include/aspect/postprocess/visualization/mantle_flux.h
@@ -42,8 +42,8 @@ namespace aspect
        */
       template <int dim>
       class MantleFlux : public DataPostprocessor<dim>,
-                         public SimulatorAccess<dim>,
-                         public Interface<dim>
+        public SimulatorAccess<dim>,
+        public Interface<dim>
       {
         public:
           /**

--- a/include/aspect/postprocess/visualization/mantle_flux.h
+++ b/include/aspect/postprocess/visualization/mantle_flux.h
@@ -1,0 +1,96 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_postprocess_visualization_mantle_flux_h
+#define _aspect_postprocess_visualization_mantle_flux_h
+
+#include <aspect/postprocess/visualization.h>
+#include <aspect/simulator_access.h>
+
+#include <deal.II/numerics/data_postprocessor.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      /**
+       * A visualization postprocessor that writes the local values used by
+       * the mantle flux statistics postprocessor. The structure field is 1
+       * in plumes, -1 in slabs, and 0 in the background mantle.
+       *
+       * @ingroup Postprocessing
+       * @ingroup Visualization
+       */
+      template <int dim>
+      class MantleFlux : public DataPostprocessor<dim>,
+                         public SimulatorAccess<dim>,
+                         public Interface<dim>
+      {
+        public:
+          /**
+           * Constructor.
+           */
+          MantleFlux ();
+
+          /**
+           * Return the names of the fields written to graphical output.
+           */
+          std::vector<std::string>
+          get_names () const override;
+
+          /**
+           * Mark every output field as a scalar.
+           */
+          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          get_data_component_interpretation () const override;
+
+          /**
+           * Return units that follow the global choice to use seconds or
+           * years in output.
+           */
+          std::string
+          get_physical_units () const override;
+
+          /**
+           * Request the solution information needed by the material model.
+           */
+          UpdateFlags
+          get_needed_update_flags () const override;
+
+          /**
+           * Compute plume, slab, and local flux values for graphical output.
+           */
+          void
+          evaluate_vector_field (const DataPostprocessorInputs::Vector<dim> &input_data,
+                                 std::vector<Vector<double>> &computed_quantities) const override;
+
+          /**
+           * Ensure that mantle flux statistics is active and available.
+           */
+          std::list<std::string>
+          required_other_postprocessors () const override;
+      };
+    }
+  }
+}
+
+#endif

--- a/source/postprocess/mantle_flux_statistics.cc
+++ b/source/postprocess/mantle_flux_statistics.cc
@@ -1,0 +1,619 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/postprocess/mantle_flux_statistics.h>
+
+#include <aspect/adiabatic_conditions/interface.h>
+#include <aspect/geometry_model/interface.h>
+#include <aspect/gravity_model/interface.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/utilities.h>
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <algorithm>
+#include <cmath>
+#include <queue>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    template <int dim>
+    typename MantleFluxStatistics<dim>::PointDiagnostics
+    MantleFluxStatistics<dim>::evaluate_point (const Point<dim> &position,
+                                               const Tensor<1,dim> &velocity,
+                                               const double temperature,
+                                               const double density,
+                                               const double thermal_expansivity,
+                                               const Tensor<1,dim> &gravity) const
+    {
+      PointDiagnostics result;
+      AssertThrow(gravity.norm() > 0.0,
+                  ExcMessage("The mantle flux statistics postprocessor requires "
+                             "a nonzero gravity vector."));
+      const Tensor<1,dim> outward_direction = -gravity / gravity.norm();
+
+      result.outward_velocity = velocity * outward_direction;
+      result.temperature_anomaly =
+        temperature - this->get_adiabatic_conditions().temperature(position);
+
+      // Hot outward flow is plume material; cold inward flow is slab material.
+      if (result.temperature_anomaly > hot_temperature_threshold &&
+          result.outward_velocity > 0.0)
+        result.structure = 1;
+      else if (result.temperature_anomaly < cold_temperature_threshold &&
+               result.outward_velocity < 0.0)
+        result.structure = -1;
+
+      if (result.structure != 0)
+        {
+          // Density and expansivity convert the temperature flux into the
+          // anomalous-mass flux commonly called buoyancy flux. Multiplication
+          // by gravity then gives the buoyancy force rate.
+          result.temperature_flux_density =
+            std::abs(result.temperature_anomaly * result.outward_velocity);
+          result.buoyancy_mass_flux_density =
+            density * thermal_expansivity * result.temperature_flux_density;
+          result.buoyancy_force_rate_density =
+            gravity.norm() * result.buoyancy_mass_flux_density;
+        }
+
+      return result;
+    }
+
+
+
+    template <int dim>
+    double
+    MantleFluxStatistics<dim>::surface_distance (const Point<dim> &first,
+                                                 const Point<dim> &second) const
+    {
+      if (this->get_geometry_model().natural_coordinate_system() ==
+          Utilities::Coordinates::CoordinateSystem::cartesian)
+        {
+          const auto first_coordinates =
+            this->get_geometry_model().cartesian_to_natural_coordinates(first);
+          const auto second_coordinates =
+            this->get_geometry_model().cartesian_to_natural_coordinates(second);
+
+          double distance_squared = 0.0;
+          for (unsigned int direction = 0; direction < dim-1; ++direction)
+            {
+              const double difference =
+                first_coordinates[direction] - second_coordinates[direction];
+              distance_squared += difference * difference;
+            }
+          return std::sqrt(distance_squared);
+        }
+
+      const double first_radius = first.norm();
+      const double second_radius = second.norm();
+      const double mean_radius = 0.5 * (first_radius + second_radius);
+      const double cosine = std::max(-1.0,
+                                     std::min(1.0,
+                                              (first * second) /
+                                              (first_radius * second_radius)));
+      return mean_radius * std::acos(cosine);
+    }
+
+
+
+    template <int dim>
+    std::vector<std::vector<Point<dim>>>
+    MantleFluxStatistics<dim>::find_clusters (const std::vector<Point<dim>> &points) const
+    {
+      std::vector<std::vector<Point<dim>>> clusters;
+      std::vector<bool> visited(points.size(), false);
+
+      for (unsigned int first_point = 0; first_point < points.size(); ++first_point)
+        {
+          if (visited[first_point])
+            continue;
+
+          std::queue<unsigned int> points_to_visit;
+          std::vector<Point<dim>> cluster;
+          points_to_visit.push(first_point);
+
+          while (!points_to_visit.empty())
+            {
+              const unsigned int current_point = points_to_visit.front();
+              points_to_visit.pop();
+
+              if (visited[current_point])
+                continue;
+
+              visited[current_point] = true;
+              cluster.push_back(points[current_point]);
+
+              for (unsigned int neighbor = 0; neighbor < points.size(); ++neighbor)
+                if (!visited[neighbor] &&
+                    surface_distance(points[current_point], points[neighbor]) <= maximum_point_spacing)
+                  points_to_visit.push(neighbor);
+            }
+
+          if (cluster.size() >= minimum_points_per_structure)
+            clusters.push_back(cluster);
+        }
+
+      return clusters;
+    }
+
+
+
+    template <int dim>
+    double
+    MantleFluxStatistics<dim>::cluster_length (const std::vector<Point<dim>> &points) const
+    {
+      double length = 0.0;
+      for (unsigned int first = 0; first < points.size(); ++first)
+        for (unsigned int second = first + 1; second < points.size(); ++second)
+          length = std::max(length, surface_distance(points[first], points[second]));
+      return length;
+    }
+
+
+
+    template <int dim>
+    double
+    MantleFluxStatistics<dim>::cluster_radius (const std::vector<Point<dim>> &points) const
+    {
+      Point<dim> center;
+      for (const Point<dim> &point : points)
+        center += point;
+      center /= points.size();
+
+      if (this->get_geometry_model().natural_coordinate_system() ==
+          Utilities::Coordinates::CoordinateSystem::spherical)
+        {
+          Point<dim> direction_center;
+          double mean_shell_radius = 0.0;
+          for (const Point<dim> &point : points)
+            {
+              direction_center += point / point.norm();
+              mean_shell_radius += point.norm();
+            }
+
+          mean_shell_radius /= points.size();
+          if (direction_center.norm() == 0.0)
+            return 0.0;
+          center = direction_center * (mean_shell_radius / direction_center.norm());
+        }
+
+      double radius = 0.0;
+      for (const Point<dim> &point : points)
+        radius += surface_distance(center, point);
+      return radius / points.size();
+    }
+
+
+
+    template <int dim>
+    void
+    MantleFluxStatistics<dim>::write_cluster_file (const std::string &content)
+    {
+      if (std::isnan(last_output_time))
+        last_output_time = this->get_time() - cluster_file_interval;
+
+      if (!write_cluster_files ||
+          ((this->get_time() < last_output_time + cluster_file_interval) &&
+           (this->get_timestep_number() != 0)))
+        return;
+
+      std::string filename = this->get_output_directory() +
+                             "mantle_flux_clusters." +
+                             Utilities::int_to_string(this->get_timestep_number(), 5);
+
+      if (this->get_parameters().run_postprocessors_on_nonlinear_iterations)
+        filename += "." + Utilities::int_to_string(this->get_nonlinear_iteration(), 4);
+
+      Utilities::collect_and_write_file_content(filename,
+                                                content,
+                                                this->get_mpi_communicator());
+
+      if (cluster_file_interval > 0.0)
+        {
+          const double adjustment = 1.0 + 2.0 * std::numeric_limits<double>::epsilon();
+          last_output_time +=
+            std::floor((this->get_time() - last_output_time) /
+                       cluster_file_interval * adjustment) *
+            cluster_file_interval / adjustment;
+        }
+    }
+
+
+
+    template <int dim>
+    std::pair<std::string,std::string>
+    MantleFluxStatistics<dim>::execute (TableHandler &statistics)
+    {
+      const auto coordinate_system =
+        this->get_geometry_model().natural_coordinate_system();
+      AssertThrow(coordinate_system == Utilities::Coordinates::CoordinateSystem::spherical ||
+                  coordinate_system == Utilities::Coordinates::CoordinateSystem::cartesian,
+                  ExcMessage("The mantle flux statistics postprocessor supports "
+                             "spherical and Cartesian geometry models."));
+
+      const MPI_Comm communicator = this->get_mpi_communicator();
+      const unsigned int rank = Utilities::MPI::this_mpi_process(communicator);
+      const Quadrature<dim> &quadrature = this->introspection().quadratures.velocities;
+      FEValues<dim> fe_values(this->get_mapping(),
+                              this->get_fe(),
+                              quadrature,
+                              update_values | update_gradients |
+                              update_quadrature_points | update_JxW_values);
+
+      MaterialModel::MaterialModelInputs<dim> material_inputs(quadrature.size(),
+                                                               this->n_compositional_fields());
+      MaterialModel::MaterialModelOutputs<dim> material_outputs(quadrature.size(),
+                                                                 this->n_compositional_fields());
+      material_inputs.requested_properties =
+        MaterialModel::MaterialProperties::density |
+        MaterialModel::MaterialProperties::thermal_expansion_coefficient;
+
+      std::ostringstream screen_output;
+      std::ostringstream cluster_output;
+
+      if (rank == 0)
+        {
+          cluster_output << "# ";
+          for (unsigned int direction = 0; direction < dim; ++direction)
+            cluster_output << static_cast<char>('x' + direction) << ' ';
+          cluster_output << "depth_km type cluster_id\n";
+        }
+
+      unsigned int next_cluster_id = 0;
+
+      enum FluxComponent
+        {
+          plume_volume_flux,
+          slab_volume_flux,
+          plume_temperature_flux,
+          slab_temperature_flux,
+          plume_buoyancy_mass_flux,
+          slab_buoyancy_mass_flux,
+          plume_buoyancy_force_rate,
+          slab_buoyancy_force_rate,
+          n_flux_components
+        };
+
+      for (const double requested_depth : measurement_depths)
+        {
+          std::vector<double> local_fluxes(n_flux_components, 0.0);
+          std::vector<Point<dim>> local_plume_points;
+          std::vector<Point<dim>> local_slab_points;
+
+          // Sample a thin layer around the requested depth. Dividing its
+          // volume by the layer thickness approximates a surface integral.
+          for (const auto &cell : this->get_dof_handler().active_cell_iterators())
+            if (cell->is_locally_owned())
+              {
+                fe_values.reinit(cell);
+                material_inputs.reinit(fe_values, cell, this->introspection(), this->get_solution());
+                this->get_material_model().evaluate(material_inputs, material_outputs);
+
+                bool cell_contains_plume = false;
+                bool cell_contains_slab = false;
+
+                for (unsigned int q = 0; q < quadrature.size(); ++q)
+                  {
+                    const Point<dim> &position = fe_values.quadrature_point(q);
+                    if (std::abs(this->get_geometry_model().depth(position) - requested_depth) >
+                        measurement_half_thickness)
+                      continue;
+
+                    const Tensor<1,dim> gravity =
+                      this->get_gravity_model().gravity_vector(position);
+                    const PointDiagnostics point =
+                      evaluate_point(position,
+                                     material_inputs.velocity[q],
+                                     material_inputs.temperature[q],
+                                     material_outputs.densities[q],
+                                     material_outputs.thermal_expansion_coefficients[q],
+                                     gravity);
+                    const double surface_measure =
+                      fe_values.JxW(q) / (2.0 * measurement_half_thickness);
+
+                    if (point.structure == 1)
+                      {
+                        local_fluxes[plume_volume_flux] +=
+                          point.outward_velocity * surface_measure;
+                        local_fluxes[plume_temperature_flux] +=
+                          point.temperature_flux_density * surface_measure;
+                        local_fluxes[plume_buoyancy_mass_flux] +=
+                          point.buoyancy_mass_flux_density * surface_measure;
+                        local_fluxes[plume_buoyancy_force_rate] +=
+                          point.buoyancy_force_rate_density * surface_measure;
+                        cell_contains_plume = true;
+                      }
+                    else if (point.structure == -1)
+                      {
+                        local_fluxes[slab_volume_flux] +=
+                          -point.outward_velocity * surface_measure;
+                        local_fluxes[slab_temperature_flux] +=
+                          point.temperature_flux_density * surface_measure;
+                        local_fluxes[slab_buoyancy_mass_flux] +=
+                          point.buoyancy_mass_flux_density * surface_measure;
+                        local_fluxes[slab_buoyancy_force_rate] +=
+                          point.buoyancy_force_rate_density * surface_measure;
+                        cell_contains_slab = true;
+                      }
+                  }
+
+                if (cell_contains_plume)
+                  local_plume_points.push_back(cell->center());
+                if (cell_contains_slab)
+                  local_slab_points.push_back(cell->center());
+              }
+
+          // Collect all integrated fluxes in one communication step.
+          std::vector<double> global_fluxes(n_flux_components);
+          Utilities::MPI::sum(local_fluxes, communicator, global_fluxes);
+
+          // Gather detected cell centers so that connected plumes and slabs
+          // can be counted consistently across MPI boundaries.
+          const std::vector<std::vector<Point<dim>>> gathered_plume_points =
+            Utilities::MPI::gather(communicator, local_plume_points);
+          const std::vector<std::vector<Point<dim>>> gathered_slab_points =
+            Utilities::MPI::gather(communicator, local_slab_points);
+
+          unsigned int plume_count = 0;
+          unsigned int slab_count = 0;
+          double total_slab_length = 0.0;
+          double mean_slab_length = 0.0;
+          double mean_plume_radius = 0.0;
+
+          if (rank == 0)
+            {
+              std::vector<Point<dim>> plume_points;
+              std::vector<Point<dim>> slab_points;
+              for (const auto &points : gathered_plume_points)
+                plume_points.insert(plume_points.end(), points.begin(), points.end());
+              for (const auto &points : gathered_slab_points)
+                slab_points.insert(slab_points.end(), points.begin(), points.end());
+
+              // Nearby points form one structure. Slabs shorter than the
+              // requested minimum length are left out of the reported count.
+              const auto plume_clusters = find_clusters(plume_points);
+              const auto possible_slab_clusters = find_clusters(slab_points);
+              std::vector<std::vector<Point<dim>>> slab_clusters;
+              for (const auto &cluster : possible_slab_clusters)
+                if (cluster_length(cluster) >= minimum_slab_length)
+                  slab_clusters.push_back(cluster);
+
+              plume_count = plume_clusters.size();
+              slab_count = slab_clusters.size();
+
+              for (const auto &cluster : plume_clusters)
+                {
+                  mean_plume_radius += cluster_radius(cluster);
+                  const unsigned int cluster_id = next_cluster_id++;
+                  for (const Point<dim> &point : cluster)
+                    {
+                      for (unsigned int direction = 0; direction < dim; ++direction)
+                        cluster_output << point[direction] << ' ';
+                      cluster_output << requested_depth / 1000.0 << " plume " << cluster_id << '\n';
+                    }
+                }
+
+              for (const auto &cluster : slab_clusters)
+                {
+                  total_slab_length += cluster_length(cluster);
+                  const unsigned int cluster_id = next_cluster_id++;
+                  for (const Point<dim> &point : cluster)
+                    {
+                      for (unsigned int direction = 0; direction < dim; ++direction)
+                        cluster_output << point[direction] << ' ';
+                      cluster_output << requested_depth / 1000.0 << " slab " << cluster_id << '\n';
+                    }
+                }
+
+              if (plume_count > 0)
+                mean_plume_radius /= plume_count;
+              if (slab_count > 0)
+                mean_slab_length = total_slab_length / slab_count;
+            }
+
+          plume_count = Utilities::MPI::broadcast(communicator, plume_count, 0);
+          slab_count = Utilities::MPI::broadcast(communicator, slab_count, 0);
+          total_slab_length = Utilities::MPI::broadcast(communicator, total_slab_length, 0);
+          mean_slab_length = Utilities::MPI::broadcast(communicator, mean_slab_length, 0);
+          mean_plume_radius = Utilities::MPI::broadcast(communicator, mean_plume_radius, 0);
+
+          // A 2D flux is per unit length in the missing direction; a 3D flux
+          // is a volume per time.
+          const bool output_in_years = this->convert_output_to_years();
+          const double time_conversion = output_in_years ? year_in_seconds : 1.0;
+          const std::string time_unit = output_in_years ? "yr" : "s";
+          const double volume_conversion = time_conversion / std::pow(1000.0, dim);
+          const std::string volume_unit =
+            (dim == 3 ? "km^3/" : "km^2/") + time_unit;
+          const std::string temperature_flux_unit =
+            (dim == 3 ? "K km^3/" : "K km^2/") + time_unit;
+          const std::string buoyancy_mass_flux_unit =
+            (dim == 3 ? "kg/" + time_unit : "kg/(m " + time_unit + ")");
+          const std::string buoyancy_unit =
+            (dim == 3 ? "N/" + time_unit : "N/(m " + time_unit + ")");
+          const std::string depth_label = Utilities::to_string(requested_depth / 1000.0) + " km";
+
+          const auto add_scientific_value = [&statistics](const std::string &name, const double value)
+          {
+            statistics.add_value(name, value);
+            statistics.set_precision(name, 8);
+            statistics.set_scientific(name, true);
+          };
+
+          add_scientific_value("Plume volume flux at " + depth_label + " (" + volume_unit + ")",
+                               global_fluxes[plume_volume_flux] * volume_conversion);
+          add_scientific_value("Slab volume flux at " + depth_label + " (" + volume_unit + ")",
+                               global_fluxes[slab_volume_flux] * volume_conversion);
+          add_scientific_value("Plume temperature anomaly flux at " + depth_label + " (" + temperature_flux_unit + ")",
+                               global_fluxes[plume_temperature_flux] * volume_conversion);
+          add_scientific_value("Slab temperature anomaly flux at " + depth_label + " (" + temperature_flux_unit + ")",
+                               global_fluxes[slab_temperature_flux] * volume_conversion);
+          add_scientific_value("Plume thermal buoyancy mass flux at " + depth_label + " (" + buoyancy_mass_flux_unit + ")",
+                               global_fluxes[plume_buoyancy_mass_flux] * time_conversion);
+          add_scientific_value("Slab thermal buoyancy mass flux at " + depth_label + " (" + buoyancy_mass_flux_unit + ")",
+                               global_fluxes[slab_buoyancy_mass_flux] * time_conversion);
+          add_scientific_value("Plume thermal buoyancy force rate at " + depth_label + " (" + buoyancy_unit + ")",
+                               global_fluxes[plume_buoyancy_force_rate] * time_conversion);
+          add_scientific_value("Slab thermal buoyancy force rate at " + depth_label + " (" + buoyancy_unit + ")",
+                               global_fluxes[slab_buoyancy_force_rate] * time_conversion);
+          statistics.add_value("Number of plumes at " + depth_label, plume_count);
+          statistics.add_value("Number of slabs at " + depth_label, slab_count);
+          add_scientific_value("Total slab length at " + depth_label + " (km)", total_slab_length / 1000.0);
+          add_scientific_value("Mean slab length at " + depth_label + " (km)", mean_slab_length / 1000.0);
+          add_scientific_value("Mean plume radius at " + depth_label + " (km)", mean_plume_radius / 1000.0);
+
+          screen_output << "Depth " << depth_label
+                        << ": plume flux="
+                        << global_fluxes[plume_volume_flux] * volume_conversion << ' ' << volume_unit
+                        << ", slab flux="
+                        << global_fluxes[slab_volume_flux] * volume_conversion << ' ' << volume_unit
+                        << ", plume temperature flux="
+                        << global_fluxes[plume_temperature_flux] * volume_conversion << ' '
+                        << temperature_flux_unit
+                        << ", slab temperature flux="
+                        << global_fluxes[slab_temperature_flux] * volume_conversion << ' '
+                        << temperature_flux_unit
+                        << ", plume buoyancy mass flux="
+                        << global_fluxes[plume_buoyancy_mass_flux] * time_conversion << ' '
+                        << buoyancy_mass_flux_unit
+                        << ", slab buoyancy mass flux="
+                        << global_fluxes[slab_buoyancy_mass_flux] * time_conversion << ' '
+                        << buoyancy_mass_flux_unit
+                        << ", plume buoyancy force rate="
+                        << global_fluxes[plume_buoyancy_force_rate] * time_conversion << ' ' << buoyancy_unit
+                        << ", slab buoyancy force rate="
+                        << global_fluxes[slab_buoyancy_force_rate] * time_conversion << ' ' << buoyancy_unit
+                        << ", plumes=" << plume_count
+                        << ", slabs=" << slab_count << ". ";
+        }
+
+      write_cluster_file(cluster_output.str());
+      return {"Mantle flux statistics:", screen_output.str()};
+    }
+
+
+
+    template <int dim>
+    void
+    MantleFluxStatistics<dim>::declare_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Mantle flux statistics");
+        {
+          prm.declare_entry("Measurement depths", "440e3",
+                            Patterns::List(Patterns::Double(0.0)),
+                            "Depths below the surface where plume and slab fluxes are measured. Units: m.");
+          prm.declare_entry("Measurement layer half thickness", "20000",
+                            Patterns::Double(0.0),
+                            "Half the thickness of the layer sampled around each measurement depth. Units: m.");
+          prm.declare_entry("Cold temperature anomaly threshold", "-200",
+                            Patterns::Double(),
+                            "A point colder than this value and moving inward is treated as slab material. Units: K.");
+          prm.declare_entry("Hot temperature anomaly threshold", "200",
+                            Patterns::Double(),
+                            "A point hotter than this value and moving outward is "
+                            "treated as plume material. Units: K.");
+          prm.declare_entry("Maximum point spacing", "80000",
+                            Patterns::Double(0.0),
+                            "Largest surface distance between neighboring cell centers "
+                            "that belong to the same plume or slab. Units: m.");
+          prm.declare_entry("Minimum points per structure", "5",
+                            Patterns::Integer(1),
+                            "Smallest number of detected cell centers needed to count a plume or slab.");
+          prm.declare_entry("Minimum slab length", "0",
+                            Patterns::Double(0.0),
+                            "Do not count cold structures shorter than this surface distance. Units: m.");
+          prm.declare_entry("Write cluster files", "false",
+                            Patterns::Bool(),
+                            "Write the cell centers assigned to each plume and slab "
+                            "to mantle_flux_clusters.NNNNN files.");
+          prm.declare_entry("Time between cluster files", "0",
+                            Patterns::Double(0.0),
+                            "Time between cluster files. Zero writes a file every time "
+                            "the postprocessor runs. Units: years when output uses years; "
+                            "seconds otherwise.");
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+    }
+
+
+
+    template <int dim>
+    void
+    MantleFluxStatistics<dim>::parse_parameters (ParameterHandler &prm)
+    {
+      prm.enter_subsection("Postprocess");
+      {
+        prm.enter_subsection("Mantle flux statistics");
+        {
+          measurement_depths = Utilities::string_to_double(
+            Utilities::split_string_list(prm.get("Measurement depths")));
+          measurement_half_thickness = prm.get_double("Measurement layer half thickness");
+          cold_temperature_threshold = prm.get_double("Cold temperature anomaly threshold");
+          hot_temperature_threshold = prm.get_double("Hot temperature anomaly threshold");
+          maximum_point_spacing = prm.get_double("Maximum point spacing");
+          minimum_points_per_structure = prm.get_integer("Minimum points per structure");
+          minimum_slab_length = prm.get_double("Minimum slab length");
+          write_cluster_files = prm.get_bool("Write cluster files");
+          cluster_file_interval = prm.get_double("Time between cluster files");
+          if (this->convert_output_to_years())
+            cluster_file_interval *= year_in_seconds;
+        }
+        prm.leave_subsection();
+      }
+      prm.leave_subsection();
+
+      AssertThrow(measurement_half_thickness > 0.0,
+                  ExcMessage("Measurement layer half thickness must be greater than zero."));
+      AssertThrow(cold_temperature_threshold < 0.0,
+                  ExcMessage("Cold temperature anomaly threshold must be negative."));
+      AssertThrow(hot_temperature_threshold > 0.0,
+                  ExcMessage("Hot temperature anomaly threshold must be positive."));
+      AssertThrow(maximum_point_spacing > 0.0,
+                  ExcMessage("Maximum point spacing must be greater than zero."));
+    }
+  }
+}
+
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    ASPECT_REGISTER_POSTPROCESSOR(MantleFluxStatistics,
+                                  "mantle flux statistics",
+                                  "Measures hot outward flow (plumes) and cold inward flow (slabs) "
+                                  "across layers at selected depths in spherical and Cartesian geometries. It reports "
+                                  "volume flux, temperature-anomaly flux, thermal-buoyancy mass flux, "
+                                  "thermal-buoyancy force rate, the "
+                                  "number of detected structures, slab length, and plume radius. In "
+                                  "two-dimensional models, fluxes are reported per unit length in the "
+                                  "missing third direction. Rate units follow the global choice to "
+                                  "use years or seconds in output.")
+  }
+}

--- a/source/postprocess/mantle_flux_statistics.cc
+++ b/source/postprocess/mantle_flux_statistics.cc
@@ -262,9 +262,9 @@ namespace aspect
                               update_quadrature_points | update_JxW_values);
 
       MaterialModel::MaterialModelInputs<dim> material_inputs(quadrature.size(),
-                                                               this->n_compositional_fields());
+                                                              this->n_compositional_fields());
       MaterialModel::MaterialModelOutputs<dim> material_outputs(quadrature.size(),
-                                                                 this->n_compositional_fields());
+                                                                this->n_compositional_fields());
       material_inputs.requested_properties =
         MaterialModel::MaterialProperties::density |
         MaterialModel::MaterialProperties::thermal_expansion_coefficient;
@@ -283,17 +283,17 @@ namespace aspect
       unsigned int next_cluster_id = 0;
 
       enum FluxComponent
-        {
-          plume_volume_flux,
-          slab_volume_flux,
-          plume_temperature_flux,
-          slab_temperature_flux,
-          plume_buoyancy_mass_flux,
-          slab_buoyancy_mass_flux,
-          plume_buoyancy_force_rate,
-          slab_buoyancy_force_rate,
-          n_flux_components
-        };
+      {
+        plume_volume_flux,
+        slab_volume_flux,
+        plume_temperature_flux,
+        slab_temperature_flux,
+        plume_buoyancy_mass_flux,
+        slab_buoyancy_mass_flux,
+        plume_buoyancy_force_rate,
+        slab_buoyancy_force_rate,
+        n_flux_components
+      };
 
       for (const double requested_depth : measurement_depths)
         {
@@ -571,7 +571,7 @@ namespace aspect
         prm.enter_subsection("Mantle flux statistics");
         {
           measurement_depths = Utilities::string_to_double(
-            Utilities::split_string_list(prm.get("Measurement depths")));
+                                 Utilities::split_string_list(prm.get("Measurement depths")));
           measurement_half_thickness = prm.get_double("Measurement layer half thickness");
           cold_temperature_threshold = prm.get_double("Cold temperature anomaly threshold");
           hot_temperature_threshold = prm.get_double("Hot temperature anomaly threshold");

--- a/source/postprocess/visualization/mantle_flux.cc
+++ b/source/postprocess/visualization/mantle_flux.cc
@@ -1,0 +1,170 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/postprocess/visualization/mantle_flux.h>
+
+#include <aspect/gravity_model/interface.h>
+#include <aspect/material_model/interface.h>
+#include <aspect/postprocess/mantle_flux_statistics.h>
+#include <aspect/simulator.h>
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      template <int dim>
+      MantleFlux<dim>::MantleFlux ()
+        :
+        DataPostprocessor<dim> (),
+        Interface<dim>("")
+      {}
+
+
+
+      template <int dim>
+      std::vector<std::string>
+      MantleFlux<dim>::get_names () const
+      {
+        return {"mantle_structure",
+                "temperature_anomaly_flux_density",
+                "thermal_buoyancy_mass_flux_density",
+                "thermal_buoyancy_force_rate_density"};
+      }
+
+
+
+      template <int dim>
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+      MantleFlux<dim>::get_data_component_interpretation () const
+      {
+        return std::vector<DataComponentInterpretation::DataComponentInterpretation>
+               (get_names().size(), DataComponentInterpretation::component_is_scalar);
+      }
+
+
+
+      template <int dim>
+      std::string
+      MantleFlux<dim>::get_physical_units () const
+      {
+        return this->convert_output_to_years()
+               ?
+               "-,K m/year,kg/(m^2 year),N/(m^2 year)"
+               :
+               "-,K m/s,kg/(m^2 s),N/(m^2 s)";
+      }
+
+
+
+      template <int dim>
+      UpdateFlags
+      MantleFlux<dim>::get_needed_update_flags () const
+      {
+        return update_gradients | update_values | update_quadrature_points;
+      }
+
+
+
+      template <int dim>
+      void
+      MantleFlux<dim>::evaluate_vector_field (
+        const DataPostprocessorInputs::Vector<dim> &input_data,
+        std::vector<Vector<double>> &computed_quantities) const
+      {
+        const unsigned int n_quadrature_points = input_data.solution_values.size();
+        Assert (computed_quantities.size() == n_quadrature_points,
+                ExcInternalError());
+        Assert (computed_quantities[0].size() == get_names().size(),
+                ExcInternalError());
+        Assert (input_data.solution_values[0].size() == this->introspection().n_components,
+                ExcInternalError());
+
+        MaterialModel::MaterialModelInputs<dim> material_inputs(input_data,
+                                                                 this->introspection());
+        MaterialModel::MaterialModelOutputs<dim> material_outputs(n_quadrature_points,
+                                                                   this->n_compositional_fields());
+        material_inputs.requested_properties =
+          MaterialModel::MaterialProperties::density |
+          MaterialModel::MaterialProperties::thermal_expansion_coefficient;
+        this->get_material_model().evaluate(material_inputs, material_outputs);
+
+        const auto &mantle_flux_statistics =
+          this->get_postprocess_manager().template
+          get_matching_active_plugin<Postprocess::MantleFluxStatistics<dim>>();
+
+        const double time_scaling =
+          this->convert_output_to_years() ? year_in_seconds : 1.0;
+
+        for (unsigned int q = 0; q < n_quadrature_points; ++q)
+          {
+            const Point<dim> &position = material_inputs.position[q];
+            const Tensor<1,dim> gravity =
+              this->get_gravity_model().gravity_vector(position);
+            const auto values = mantle_flux_statistics.evaluate_point(
+                                  position,
+                                  material_inputs.velocity[q],
+                                  material_inputs.temperature[q],
+                                  material_outputs.densities[q],
+                                  material_outputs.thermal_expansion_coefficients[q],
+                                  gravity);
+
+            computed_quantities[q][0] = values.structure;
+            computed_quantities[q][1] = values.temperature_flux_density * time_scaling;
+            computed_quantities[q][2] =
+              values.buoyancy_mass_flux_density * time_scaling;
+            computed_quantities[q][3] =
+              values.buoyancy_force_rate_density * time_scaling;
+          }
+      }
+
+
+
+      template <int dim>
+      std::list<std::string>
+      MantleFlux<dim>::required_other_postprocessors () const
+      {
+        return {"mantle flux statistics"};
+      }
+    }
+  }
+}
+
+
+
+namespace aspect
+{
+  namespace Postprocess
+  {
+    namespace VisualizationPostprocessors
+    {
+      ASPECT_REGISTER_VISUALIZATION_POSTPROCESSOR(
+        MantleFlux,
+        "mantle flux",
+        "Writes four fields used by the mantle flux statistics postprocessor: "
+        "the detected mantle structure, temperature-anomaly flux density, and "
+        "the thermal-buoyancy mass-flux and force-rate densities. Radial velocity and nonadiabatic "
+        "temperature are available through existing visualization postprocessors. "
+        "The mantle structure field is 1 for plume material, -1 for slab "
+        "material, and 0 for background mantle.")
+    }
+  }
+}

--- a/source/postprocess/visualization/mantle_flux.cc
+++ b/source/postprocess/visualization/mantle_flux.cc
@@ -47,7 +47,8 @@ namespace aspect
         return {"mantle_structure",
                 "temperature_anomaly_flux_density",
                 "thermal_buoyancy_mass_flux_density",
-                "thermal_buoyancy_force_rate_density"};
+                "thermal_buoyancy_force_rate_density"
+               };
       }
 
 
@@ -99,9 +100,9 @@ namespace aspect
                 ExcInternalError());
 
         MaterialModel::MaterialModelInputs<dim> material_inputs(input_data,
-                                                                 this->introspection());
+                                                                this->introspection());
         MaterialModel::MaterialModelOutputs<dim> material_outputs(n_quadrature_points,
-                                                                   this->n_compositional_fields());
+                                                                  this->n_compositional_fields());
         material_inputs.requested_properties =
           MaterialModel::MaterialProperties::density |
           MaterialModel::MaterialProperties::thermal_expansion_coefficient;

--- a/tests/mantle_flux_statistics_2d.prm
+++ b/tests/mantle_flux_statistics_2d.prm
@@ -1,0 +1,92 @@
+# A prescribed hot upwelling and cold downwelling in a 2D spherical shell.
+# The test checks the two-dimensional flux units, structure counts, and VTU fields.
+# MPI: 2
+
+set Dimension                         = 2
+set Use years instead of seconds      = false
+set End time                          = 0
+set Nonlinear solver scheme           = single Advection, no Stokes
+set Output directory                  = output-mantle_flux_statistics_2d
+
+subsection Geometry model
+  set Model name = spherical shell
+  subsection Spherical shell
+    set Inner radius  = 1e6
+    set Outer radius  = 2e6
+    set Opening angle = 360
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+subsection Adiabatic conditions model
+  set Model name = function
+  subsection Function
+    set Function expression = 1000; 0; 3300
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Variable names = x,y
+    set Function expression = 1000 + if(x/sqrt(x*x+y*y)>0.65,200,if(x/sqrt(x*x+y*y)<-0.65,-200,0))
+  end
+end
+
+subsection Prescribed Stokes solution
+  set Model name = function
+  subsection Velocity function
+    set Variable names = x,y
+    set Function expression = if(x/sqrt(x*x+y*y)>0.65,1,if(x/sqrt(x*x+y*y)<-0.65,-1,0))*x/sqrt(x*x+y*y); \
+                              if(x/sqrt(x*x+y*y)>0.65,1,if(x/sqrt(x*x+y*y)<-0.65,-1,0))*y/sqrt(x*x+y*y)
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators =
+end
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 3300
+    set Reference temperature         = 1000
+    set Thermal expansion coefficient = 4e-5
+    set Thermal conductivity          = 4
+    set Reference specific heat       = 1250
+    set Viscosity                     = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 2
+  set Initial adaptive refinement        = 0
+  set Time steps between mesh refinement = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = mantle flux statistics, visualization
+
+  subsection Mantle flux statistics
+    set Measurement depths                  = 500e3
+    set Measurement layer half thickness    = 150e3
+    set Cold temperature anomaly threshold  = -100
+    set Hot temperature anomaly threshold   = 100
+    set Maximum point spacing               = 600e3
+    set Minimum points per structure        = 2
+    set Minimum slab length                 = 0
+  end
+
+  subsection Visualization
+    set List of output variables            = mantle flux, nonadiabatic temperature, spherical velocity components
+    set Output format                       = vtu
+    set Time between graphical output       = 0
+    set Number of grouped files             = 0
+  end
+end

--- a/tests/mantle_flux_statistics_2d/screen-output
+++ b/tests/mantle_flux_statistics_2d/screen-output
@@ -1,0 +1,15 @@
+
+Number of active cells: 192 (on 3 levels)
+Number of degrees of freedom: 2,832 (1,728+240+864)
+
+*** Timestep 0:  t=0 seconds, dt=0 seconds
+   Solving temperature system... 0 iterations.
+
+   Postprocessing:
+     Mantle flux statistics:   Depth 500 km: plume flux=3.18893 km^2/s, slab flux=3.18893 km^2/s, plume temperature flux=640.278 K km^2/s, slab temperature flux=640.278 K km^2/s, plume buoyancy mass flux=8.38377e+07 kg/(m s), slab buoyancy mass flux=8.51957e+07 kg/(m s), plume buoyancy force rate=8.38377e+08 N/(m s), slab buoyancy force rate=8.51957e+08 N/(m s), plumes=1, slabs=1. 
+     Writing graphical output: output-mantle_flux_statistics_2d/solution/solution-00000
+
+Termination requested by criterion: end time
+
+
+ 

--- a/tests/mantle_flux_statistics_2d/statistics
+++ b/tests/mantle_flux_statistics_2d/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (seconds)
+# 3: Time step size (seconds)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Plume volume flux at 500 km (km^2/s)
+# 9: Slab volume flux at 500 km (km^2/s)
+# 10: Plume temperature anomaly flux at 500 km (K km^2/s)
+# 11: Slab temperature anomaly flux at 500 km (K km^2/s)
+# 12: Plume thermal buoyancy mass flux at 500 km (kg/(m s))
+# 13: Slab thermal buoyancy mass flux at 500 km (kg/(m s))
+# 14: Plume thermal buoyancy force rate at 500 km (N/(m s))
+# 15: Slab thermal buoyancy force rate at 500 km (N/(m s))
+# 16: Number of plumes at 500 km
+# 17: Number of slabs at 500 km
+# 18: Total slab length at 500 km (km)
+# 19: Mean slab length at 500 km (km)
+# 20: Mean plume radius at 500 km (km)
+# 21: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 192 1968 864 0 3.18893409e+00 3.18893409e+00 6.40278120e+02 6.40278120e+02 8.38377177e+07 8.51957060e+07 8.38377177e+08 8.51957060e+08 1 1 2.75933541e+03 2.75933541e+03 6.85751995e+02 output-mantle_flux_statistics_2d/solution/solution-00000 

--- a/tests/mantle_flux_statistics_3d.prm
+++ b/tests/mantle_flux_statistics_3d.prm
@@ -1,0 +1,93 @@
+# A prescribed hot upwelling and cold downwelling in a 3D spherical shell.
+# The test checks the three-dimensional flux units, structure counts, and VTU fields.
+# MPI: 2
+
+set Dimension                         = 3
+set Use years instead of seconds      = true
+set End time                          = 0
+set Nonlinear solver scheme           = single Advection, no Stokes
+set Output directory                  = output-mantle_flux_statistics_3d
+
+subsection Geometry model
+  set Model name = spherical shell
+  subsection Spherical shell
+    set Inner radius  = 1e6
+    set Outer radius  = 2e6
+    set Opening angle = 360
+  end
+end
+
+subsection Gravity model
+  set Model name = radial constant
+  subsection Radial constant
+    set Magnitude = 10
+  end
+end
+
+subsection Adiabatic conditions model
+  set Model name = function
+  subsection Function
+    set Function expression = 1000; 0; 3300
+  end
+end
+
+subsection Initial temperature model
+  set Model name = function
+  subsection Function
+    set Variable names = x,y,z
+    set Function expression = 1000 + if(x/sqrt(x*x+y*y+z*z)>0.65,200,if(x/sqrt(x*x+y*y+z*z)<-0.65,-200,0))
+  end
+end
+
+subsection Prescribed Stokes solution
+  set Model name = function
+  subsection Velocity function
+    set Variable names = x,y,z
+    set Function expression = if(x/sqrt(x*x+y*y+z*z)>0.65,1,if(x/sqrt(x*x+y*y+z*z)<-0.65,-1,0))*x/sqrt(x*x+y*y+z*z); \
+                              if(x/sqrt(x*x+y*y+z*z)>0.65,1,if(x/sqrt(x*x+y*y+z*z)<-0.65,-1,0))*y/sqrt(x*x+y*y+z*z); \
+                              if(x/sqrt(x*x+y*y+z*z)>0.65,1,if(x/sqrt(x*x+y*y+z*z)<-0.65,-1,0))*z/sqrt(x*x+y*y+z*z)
+  end
+end
+
+subsection Boundary temperature model
+  set Fixed temperature boundary indicators =
+end
+
+subsection Material model
+  set Model name = simple
+  subsection Simple model
+    set Reference density             = 3300
+    set Reference temperature         = 1000
+    set Thermal expansion coefficient = 4e-5
+    set Thermal conductivity          = 4
+    set Reference specific heat       = 1250
+    set Viscosity                     = 1e21
+  end
+end
+
+subsection Mesh refinement
+  set Initial global refinement          = 1
+  set Initial adaptive refinement        = 0
+  set Time steps between mesh refinement = 0
+end
+
+subsection Postprocess
+  set List of postprocessors = mantle flux statistics, visualization
+
+  subsection Mantle flux statistics
+    set Measurement depths                  = 500e3
+    set Measurement layer half thickness    = 150e3
+    set Cold temperature anomaly threshold  = -100
+    set Hot temperature anomaly threshold   = 100
+    set Maximum point spacing               = 600e3
+    set Minimum points per structure        = 2
+    set Minimum slab length                 = 0
+  end
+
+  subsection Visualization
+    set List of output variables            = mantle flux, nonadiabatic temperature, spherical velocity components
+    set Output format                       = vtu
+    set Time between graphical output       = 0
+    set Number of grouped files             = 0
+  end
+end

--- a/tests/mantle_flux_statistics_3d/screen-output
+++ b/tests/mantle_flux_statistics_3d/screen-output
@@ -1,0 +1,15 @@
+
+Number of active cells: 768 (on 2 levels)
+Number of degrees of freedom: 28,690 (20,790+970+6,930)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+
+   Postprocessing:
+     Mantle flux statistics:   Depth 500 km: plume flux=5705.65 km^3/yr, slab flux=5705.65 km^3/yr, plume temperature flux=1.12378e+06 K km^3/yr, slab temperature flux=1.12378e+06 K km^3/yr, plume buoyancy mass flux=1.47162e+14 kg/yr, slab buoyancy mass flux=1.49516e+14 kg/yr, plume buoyancy force rate=1.47162e+15 N/yr, slab buoyancy force rate=1.49516e+15 N/yr, plumes=1, slabs=1. 
+     Writing graphical output: output-mantle_flux_statistics_3d/solution/solution-00000
+
+Termination requested by criterion: end time
+
+
+ 

--- a/tests/mantle_flux_statistics_3d/statistics
+++ b/tests/mantle_flux_statistics_3d/statistics
@@ -1,0 +1,22 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Iterations for temperature solver
+# 8: Plume volume flux at 500 km (km^3/yr)
+# 9: Slab volume flux at 500 km (km^3/yr)
+# 10: Plume temperature anomaly flux at 500 km (K km^3/yr)
+# 11: Slab temperature anomaly flux at 500 km (K km^3/yr)
+# 12: Plume thermal buoyancy mass flux at 500 km (kg/yr)
+# 13: Slab thermal buoyancy mass flux at 500 km (kg/yr)
+# 14: Plume thermal buoyancy force rate at 500 km (N/yr)
+# 15: Slab thermal buoyancy force rate at 500 km (N/yr)
+# 16: Number of plumes at 500 km
+# 17: Number of slabs at 500 km
+# 18: Total slab length at 500 km (km)
+# 19: Mean slab length at 500 km (km)
+# 20: Mean plume radius at 500 km (km)
+# 21: Visualization file name
+0 0.000000000000e+00 0.000000000000e+00 768 21760 6930 0 5.70565490e+03 5.70565490e+03 1.12377906e+06 1.12377906e+06 1.47162094e+14 1.49515577e+14 1.47162094e+15 1.49515577e+15 1 1 2.86225431e+03 2.86225431e+03 9.20833613e+02 output-mantle_flux_statistics_3d/solution/solution-00000 


### PR DESCRIPTION
Hey everyone,

I wanted to add a postprocessor for measuring mantle plume and slab buoyancy flux at selected depths. Plumes and slabs are identified using their temperature anomaly relative to the adiabatic temperature and their direction of motion and it works for Cartesian and spherical geometries.

It estimates the volume flux, temperature-anomaly flux, thermal buoyancy mass flux, and buoyancy-force rate associated with the detected plumes and slabs.

I initially tried to reproduce the buoyancy-flux calculation used by [Li et al.](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2025JB032799). However, in their two-dimensional calculation assumes an out-of-plane plume width to obtain a result in $\mathrm{kg/s}$. Because this width cannot be determined from a 2-D model, the new postprocessor instead compute the kg/m.s in 2-D and, the integrated thermal buoyancy mass flux in In 3-D that is in kg/s (or in years if the output is in years defined from the prm).

I also tried to find a way to connected hot upwellings and cold downwellings, so we can estimate the number of plumes and slabs at each depth, the mean plume radius, and the total and mean slab lengths.

I also added a visualization postprocessor for the detected mantle structures, temperature-anomaly flux density, thermal buoyancy mass-flux density, and thermal buoyancy force-rate density. I ran several prescribed configurations of plumes and slabs models using annulus and box geometries with the features having different widths (images below).

Fig1 : Model geometry comparison slab and plumes numbers
<img width="3240" height="1980" alt="Revised mantle-flux fields and equations" src="https://github.com/user-attachments/assets/f2245c77-569e-4626-b211-72cc78bf8272" />

Fig 2:  fields visualisation for buoyancy fluxes 
<img width="2700" height="1800" alt="Revised geometry comparison" src="https://github.com/user-attachments/assets/b5bb0758-72aa-41fd-8b04-ce315853a876" />


 Additionaly, I added simple tests containing one prescribed hot upwelling and one prescribed cold downwelling in a spherical shell in two and three dimensions which verify the numbers of plumes and slabs and their their fluxes and if the new visualization fields are properly generated.

Cheers

P.S. I originally developed this postprocessor in MATLAB several years ago and later rewrote it in Python. I began the initial ASPECT implementation about a year ago, and used AI to helped me complete parts of the implementation, particularly the algorithms used to label and cluster connected plumes and slabs.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* I followed the [AI Policy](../blob/main/CONTRIBUTING.md#policy-on-usage-of-ai):
  - [x] Significant parts of this PR were written by AI (please add a sentence below).
  - [ ] AI has not been used in significant ways.

*If yes, please describe your usage of AI models in the creation of this pull request*

### For new features/models or changes of existing features:

* [x] I have tested my new feature locally to ensure it is correct.
* [x] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.

