### PR TITLE
Add reaction kinetics framework for solid-state phase transitions

### DIFF
--- a/doc/modules/changes/20260723_buchanankerswell
+++ b/doc/modules/changes/20260723_buchanankerswell
@@ -1,0 +1,4 @@
+Added: Implemented kinetic models are interface-controlled growth and
+eutectoid decomposition from Cahn (1956; https://doi.org/10.1016/0001-6160(56)90041-4).
+<br>
+(Buchanan Kerswell, 2026/07/23)

--- a/include/aspect/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.h
+++ b/include/aspect/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.h
@@ -1,0 +1,106 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_reaction_model_kinetics_cahn1956_eutectoid_decomposition_h
+#define _aspect_material_model_reaction_model_kinetics_cahn1956_eutectoid_decomposition_h
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      /**
+       * A kinetic model that computes the reaction rate of a phase transformation governed by 'eutectoid decomposition' kinetics. This describes
+       * phase transformations where a single reactant phase 'decomposes' into two product phases with an alternating lamellar structure. The
+       * kinetic model is derived from the site-saturated framework of Cahn (1956) and maximum lamellar spacing formulation of Zener (1946).
+       *
+       * Examples of this type of reaction include the ringwoodite -> bridgmanite + periclase ('postspinel') transformation (Kubo et al., 2002)
+       * and some alloys (Zener, 1946). In principle, the same functional form is applicable to any two-phase decomposition transformation for
+       * which short-range diffusion across alternating lamallae is rate-limiting.
+       *
+       * The net forward reaction rate dX_B/dt accounts for both the forward (A -> B) and reverse (B -> A) transformations, where X_A = 1 - X_B:
+       *
+       *                  ┌  Z * (-dG) * |dG| * exp(-Ea / (R * T)) * (1 - X_B) if dG < 0 (dX_B/dt is positive, A -> B)
+       *      dX_B/dt =  ─┤
+       *                  └  Z * (-dG) * |dG| * exp(-Ea / (R * T)) * X_B if dG > 0 (dX_B/dt is negative, B -> A)
+       *
+       * where X_B is the cumulative reaction progress (volume fraction of B; V_B / (V_A + V_B)), Z is a kinetic prefactor, Ea is the activation
+       * energy of diffusion, and dG is the Gibbs energy change of the forward reaction (dG < 0 favors product B; dG > 0 favors reactant A).
+       *
+       * This plugin can store parameters for multiple reactions.
+       *
+       * The formulation above comes from Equations (3) and (5) of Kubo et al. (2002), with modified notation to match the InterfaceControlledGrowth
+       * kinetic model (after Kerswell et al., 2026).
+       *
+       * Cahn, J. W. (1956). https://doi.org/10.1016/0001-6160(56)90041-4
+       * Zener, C. (1946). Kinetics of the decomposition of austenite. Trans. Aime, 167, 550--595.
+       * Kubo et al. (2002). https://doi.org/10.1016/S0031-9201(01)00270-9
+       * Kerswell et al. (2026). https://doi.org/10.1029/2026JB033781
+       *
+       * @ingroup ReactionModel
+       */
+      template <int dim>
+      class EutectoidDecomposition : public Cahn1956Interface<dim>
+      {
+        public:
+          /**
+           * Compute the net forward reaction rate dX_B/dt (units: 1/s, or 1/yr if the ``Use years instead of seconds'' global parameter is set),
+           * for the reaction at local index @p reaction_index, given the local temperature (K), pressure (Pa), Gibbs energy change of the forward
+           * reaction (A -> B; J/mol), and the cumulative forward reaction progress field from the Material Model.
+           *
+           * The sign of dX_B/dt is determined by delta_gibbs_energy:
+           * - If dG < 0 (favoring product assemblage B), the returned rate is positive (dX_B/dt > 0) and limited by X_A = 1 - X_B
+           * - If dG > 0 (favoring reactant A), the returned rate is negative (dX_B/dt < 0) and limited by X_B
+           */
+          double net_forward_reaction_rate(const double temperature,
+                                           const double pressure,
+                                           const double delta_forward_gibbs_energy,
+                                           const double cumulative_forward_reaction_progress,
+                                           const unsigned int reaction_index) const override;
+
+          /**
+           * Declare the parameters from the parameter file.
+           */
+          static void declare_parameters(ParameterHandler &prm);
+
+          /**
+           * Read the parameters from the parameter file.
+           */
+          void parse_parameters(ParameterHandler &prm, const unsigned int n_reactions) override;
+
+        private:
+          /**
+           * Kinetic prefactor Z, one per reaction using this model. Units: mol^2/J^2/s.
+           */
+          std::vector<double> kinetic_prefactors;
+
+          /**
+           * Activation energy Ea of diffusion, one per reaction using this model. Units: J/mol.
+           */
+          std::vector<double> activation_energies;
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/material_model/reaction_model/kinetics/cahn1956_interface.h
+++ b/include/aspect/material_model/reaction_model/kinetics/cahn1956_interface.h
@@ -1,0 +1,100 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_reaction_model_kinetics_cahn1956_interface_h
+#define _aspect_material_model_reaction_model_kinetics_cahn1956_interface_h
+
+#include <aspect/plugins.h>
+#include <aspect/simulator_access.h>
+#include <aspect/utilities.h>
+#include <deal.II/base/parameter_handler.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      /**
+       * Kinetic laws derived from Cahn (1956; https://doi.org/10.1016/0001-6160(56)90041-4) nucleation-and-growth theory in the limit of site
+       * saturation (all nucleation sites consumed early) with Avrami exponent n = 1 (interface-controlled growth on grain boundaries). In this
+       * limit the transformation kinetics reduce to a rate law that is first-order in the untransformed phase fraction and depends only on the
+       * instantaneous local thermodynamic driving force and temperature/pressure (no explicit time or nucleation-rate dependence is needed).
+       *
+       * @ingroup ReactionModel
+       */
+      template <int dim>
+      class Cahn1956Interface : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          /**
+           * Destructor.
+           */
+          virtual ~Cahn1956Interface() = default;
+
+          /**
+           * Net forward reaction rate dX_B/dt for the transformation A -> B at @p reaction_index.
+           */
+          virtual double
+          net_forward_reaction_rate(const double temperature,
+                                    const double pressure,
+                                    const double delta_forward_gibbs_energy,
+                                    const double cumulative_forward_reaction_progress,
+                                    const unsigned int reaction_index) const = 0;
+
+          /**
+           * Declare kinetic parameters (e.g., activation energy, kinetic prefactor).
+           */
+          static void declare_parameters(ParameterHandler &prm);
+
+          /**
+           * Read model-specific kinetic parameters for the @p n_reactions.
+           */
+          virtual void parse_parameters(ParameterHandler &prm, const unsigned int n_reactions) = 0;
+      };
+
+      /**
+       * Instantiate the reaction kinetics plugin named `model_name`.
+       */
+      template <int dim>
+      std::unique_ptr<Cahn1956Interface<dim>> create_reaction_model(const std::string &model_name);
+
+      template <int dim>
+      using ReactionModelPluginList = internal::Plugins::PluginList<Cahn1956Interface<dim>>;
+
+#define ASPECT_REGISTER_REACTION_MODEL(classname, name, description) \
+  template class classname<2>; \
+  template class classname<3>; \
+  namespace ASPECT_REGISTER_REACTION_MODEL_ ## classname \
+  { \
+    aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::ReactionModel::Cahn1956Interface<2>, classname<2>> \
+    dummy_ ## classname ## _2d(&aspect::MaterialModel::ReactionModel::ReactionModelPluginList<2>::register_plugin, name, description); \
+    aspect::internal::Plugins::RegisterHelper<aspect::MaterialModel::ReactionModel::Cahn1956Interface<3>, classname<3>> \
+    dummy_ ## classname ## _3d(&aspect::MaterialModel::ReactionModel::ReactionModelPluginList<3>::register_plugin, name, description); \
+  }
+    }
+  }
+}
+
+#endif

--- a/include/aspect/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.h
+++ b/include/aspect/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.h
@@ -1,0 +1,113 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_reaction_model_kinetics_cahn1956_interface_controlled_growth_h
+#define _aspect_material_model_reaction_model_kinetics_cahn1956_interface_controlled_growth_h
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      /**
+       * A kinetic model that computes the reaction rate of a phase transformation governed by `interface-controlled growth` kinetics. This
+       * describes phase transformations where a single product phase nucleates along grain boundaries of a single reactant phase, and then
+       * grows via grain-boundary migration at the expense of the reactant phase. The kinetic model is derived from the site-saturated
+       * framework of Cahn (1956) and with an interface-controlled growth rate after Fisher (1978; their Equation (11) ).
+       *
+       * Examples of this type of reaction include the olivine -> wadsleyite transformation (Hosoya et al., 2005), aragonite -> calcite,
+       * wadsleyite -> ringwoodite and coesite -> quartz. In principle, the same functional form is applicable to any transformation for
+       * which diffusionless grain-boundary migration is rate-limiting.
+       *
+       * The net forward reaction rate dX_B/dt accounts for both the forward (A -> B) and reverse (B -> A) transformations, where X_A = 1 - X_B:
+       *
+       *                  ┌  Z * T * exp(-(Ha+(P*Va))/(R*T)) * (1-exp(dG/(R*T))) * (1-X_B) if dG < 0 (dX_B/dt is positive, A -> B)
+       *      dX_B/dt =  ─┤
+       *                  └  Z * T * exp(-(Ha+(P*Va))/(R*T)) * (1-exp(dG/(R*T))) * X_B if dG > 0 (dX_B/dt is negative, B -> A)
+       *
+       * where X_B is the cumulative reaction progress (volume fraction of B; V_B / (V_A + V_B)), Z is a kinetic prefactor, Ha and Va are the
+       * activation enthalpy and volume of the reaction, and dG is the Gibbs energy change of the forward reaction (dG < 0 favors product B;
+       * dG > 0 favors reactant A).
+       *
+       * This plugin can store parameters for multiple reactions.
+       *
+       * The formulation above comes from Equations (1) and (2) of Hosoya et al. (2005), with modified notation to match the EutectoidDecomposition
+       * kinetic model (after Kerswell et al., 2026).
+       *
+       * Cahn, J. W. (1956). https://doi.org/10.1016/0001-6160(56)90041-4
+       * Fisher, G. W. (1978). https://doi.org/10.1016/0016-7037(78)90292-2
+       * Hosoya et al. (2002). https://doi.org/10.1029/2005GL023398
+       * Kerswell et al. (2026). https://doi.org/10.1029/2026JB033781
+       *
+       * @ingroup ReactionModel
+       */
+      template <int dim>
+      class InterfaceControlledGrowth : public Cahn1956Interface<dim>
+      {
+        public:
+          /**
+           * Compute the net forward reaction rate dX_B/dt (units: 1/s, or 1/yr if the ``Use years instead of seconds'' global parameter is set),
+           * for the reaction at local index @p reaction_index, given the local temperature (K), pressure (Pa), Gibbs energy change of the forward
+           * reaction (A -> B; J/mol), and the cumulative forward reaction progress field from the Material Model.
+           *
+           * The sign of dX_B/dt is determined by delta_gibbs_energy:
+           * - If dG < 0 (favoring product B), the returned rate is positive (dX_B/dt > 0) and limited by X_A = 1 - X_B
+           * - If dG > 0 (favoring reactant A), the returned rate is negative (dX_B/dt < 0) and limited by X_B
+           */
+          double net_forward_reaction_rate(const double temperature,
+                                           const double pressure,
+                                           const double delta_forward_gibbs_energy,
+                                           const double cumulative_forward_reaction_progress,
+                                           const unsigned int reaction_index) const override;
+
+          /**
+           * Declare the parameters from the parameter file.
+           */
+          static void declare_parameters(ParameterHandler &prm);
+
+          /**
+           * Read the parameters from the parameter file.
+           */
+          void parse_parameters(ParameterHandler &prm, const unsigned int n_reactions) override;
+
+        private:
+          /**
+           * Kinetic prefactor Z, one per reaction using this model. Units: 1/s/K.
+           */
+          std::vector<double> kinetic_prefactors;
+
+          /**
+           * Activation enthalpy Ha of the reaction, one per reaction using this model. Units: J/mol.
+           */
+          std::vector<double> activation_enthalpies;
+
+          /**
+           * Activation volume Va of the reaction, one per reaction using this model. Units: m^3/mol.
+           */
+          std::vector<double> activation_volumes;
+      };
+    }
+  }
+}
+
+#endif

--- a/include/aspect/material_model/reaction_model/reaction_chain.h
+++ b/include/aspect/material_model/reaction_model/reaction_chain.h
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _aspect_material_model_reaction_model_reaction_chain_h
+#define _aspect_material_model_reaction_model_reaction_chain_h
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface.h>
+#include <aspect/utilities.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      /**
+       * Stores the kinetics model for each reaction in a ReactionChain object. Each distinct reaction is referenced by a local index.
+       */
+      template <int dim>
+      struct ReactionStep
+      {
+        std::shared_ptr<Cahn1956Interface<dim>> kinetics;
+        unsigned int local_reaction_index = numbers::invalid_unsigned_int;
+      };
+
+      /**
+       * A linear chain of N phase transformations among N+1 phases, driven by N cumulative reaction progress fields with enforced ordering
+       *
+       *   1 >= xi_0 >= ... >= xi_{N-1} >= 0.
+       *
+       * N is set by the number of entries in "Reaction chain/Kinetic models" (see Cahn1956Interface).
+       *
+       * Independent linear chains only. Branching networks (a phase produced/consumed by more than one reaction) or competing back-reaction
+       * pathways need a stoichiometry-matrix mass balance and are out of scope here.
+       */
+      template <int dim>
+      class ReactionChain : public ::aspect::SimulatorAccess<dim>
+      {
+        public:
+          std::vector<ReactionStep<dim>> reactions;
+
+          void initialize();
+          unsigned int n_reactions() const;
+
+          std::vector<double> clamp_cumulative_progress(std::vector<double> reaction_progress_values) const;
+          std::vector<double> compute_phase_mass_fractions(const std::vector<double> &reaction_progress_values,
+                                                           const std::vector<double> &phase_densities) const;
+
+          double net_forward_reaction_rate(const double temperature,
+                                           const double pressure,
+                                           const double delta_forward_gibbs_energy,
+                                           const double cumulative_forward_reaction_progress,
+                                           const unsigned int reaction_index) const;
+
+          static void declare_parameters(ParameterHandler &prm);
+          void parse_parameters(ParameterHandler &prm);
+
+        private:
+          /**
+           * One entry per unique kinetics model name used in the chain.
+           */
+          std::vector<std::shared_ptr<Cahn1956Interface<dim>>> kinetics_models;
+
+          /**
+           * Allowed excursion/slack before a reaction progress value is considered unphysical or violates monotonicity ordering.
+           * Accepts values between [0, 1)
+           */
+          double tolerance_in_reaction_progress;
+      };
+    }
+  }
+}
+#endif

--- a/source/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.cc
+++ b/source/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.cc
@@ -1,0 +1,112 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.h>
+#include <aspect/global.h>
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/patterns.h>
+
+#include <cmath>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      template <int dim>
+      double EutectoidDecomposition<dim>::
+      net_forward_reaction_rate(const double temperature,
+                                const double /*pressure*/,
+                                const double delta_forward_gibbs_energy,
+                                const double cumulative_forward_reaction_progress,
+                                const unsigned int reaction_index) const
+      {
+        AssertIndexRange(reaction_index, kinetic_prefactors.size());
+
+        AssertThrow(temperature > 0.0,
+                    ExcMessage("Temperature must be strictly positive in net_forward_reaction_rate(), "
+                               "but received " + std::to_string(temperature) + " K."));
+
+        const double activation_energy = activation_energies[reaction_index];
+        AssertThrow(activation_energy >= 0.0,
+                    ExcMessage("Activation energy must be non-negative, "
+                               "but received " + std::to_string(activation_energy) + " J/mol."));
+
+        const double arrhenius_factor     = std::exp(-activation_energy / (constants::gas_constant * temperature));
+        const double thermodynamic_factor = -delta_forward_gibbs_energy * std::abs(delta_forward_gibbs_energy);
+        const double reaction_progress    = (delta_forward_gibbs_energy < 0.0) ?
+                                            (1.0 - cumulative_forward_reaction_progress) :
+                                            cumulative_forward_reaction_progress;
+
+        return kinetic_prefactors[reaction_index] * thermodynamic_factor * arrhenius_factor * reaction_progress;
+      }
+
+      template <int dim>
+      void EutectoidDecomposition<dim>::declare_parameters(ParameterHandler &prm)
+      {
+        prm.enter_subsection("Eutectoid decomposition");
+        {
+          prm.declare_entry("Kinetic prefactors",
+                            "2.7e-16",
+                            Patterns::List(Patterns::Double(0.0), 1, Patterns::List::max_int_value, "|"),
+                            "Kinetic prefactors Z, one '|'-separated entry per reaction assigned to this model. Units: mol^2/J^2/s");
+          prm.declare_entry("Activation energies",
+                            "355e3",
+                            Patterns::List(Patterns::Double(0.0), 1, Patterns::List::max_int_value, "|"),
+                            "Activation energies Ea of diffusion, one '|'-separated entry per reaction assigned to this model. Units: J/mol");
+        }
+        prm.leave_subsection();
+      }
+
+      template <int dim>
+      void EutectoidDecomposition<dim>::parse_parameters(ParameterHandler &prm, const unsigned int n_reactions)
+      {
+        prm.enter_subsection("Eutectoid decomposition");
+        {
+          kinetic_prefactors  = Utilities::string_to_double(Utilities::split_string_list(prm.get("Kinetic prefactors"), '|'));
+          activation_energies = Utilities::string_to_double(Utilities::split_string_list(prm.get("Activation energies"), '|'));
+
+          AssertThrow(kinetic_prefactors.size() == n_reactions && activation_energies.size() == n_reactions,
+                      ExcMessage("'Eutectoid decomposition' parameter lists must each have exactly " +
+                                 std::to_string(n_reactions) + " '|'-separated entries, matching the number of "
+                                 "reactions assigned to this kinetics model."));
+        }
+        prm.leave_subsection();
+      }
+    }
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      ASPECT_REGISTER_REACTION_MODEL(
+        EutectoidDecomposition,
+        "Eutectoid decomposition",
+        "Eutectoid decomposition kinetics following Cahn (1956; https://doi.org/10.1016/0001-6160(56)90041-4) and "
+        "Kubo et al. (2002; https://doi.org/10.1016/S0031-9201(01)00270-9)")
+    }
+  }
+}

--- a/source/material_model/reaction_model/kinetics/cahn1956_interface.cc
+++ b/source/material_model/reaction_model/kinetics/cahn1956_interface.cc
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface.h>
+#include <aspect/global.h>
+#include <deal.II/base/patterns.h>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      template <int dim>
+      std::unique_ptr<Cahn1956Interface<dim>> create_reaction_model(const std::string &model_name)
+      {
+        return std::unique_ptr<Cahn1956Interface<dim>>(ReactionModelPluginList<dim>::create_plugin(model_name, "Reaction kinetics model"));
+      }
+    }
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+#define INSTANTIATE(dim) \
+  template class Cahn1956Interface<dim>; \
+  template std::unique_ptr<Cahn1956Interface<dim>> create_reaction_model<dim>(const std::string &);
+      ASPECT_INSTANTIATE(INSTANTIATE)
+#undef INSTANTIATE
+    }
+  }
+}

--- a/source/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.cc
+++ b/source/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.cc
@@ -1,0 +1,120 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.h>
+#include <aspect/global.h>
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/patterns.h>
+
+#include <cmath>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      template <int dim>
+      double InterfaceControlledGrowth<dim>::
+      net_forward_reaction_rate(const double temperature,
+                                const double pressure,
+                                const double delta_forward_gibbs_energy,
+                                const double cumulative_forward_reaction_progress,
+                                const unsigned int reaction_index) const
+      {
+        AssertIndexRange(reaction_index, kinetic_prefactors.size());
+
+        AssertThrow(temperature > 0.0,
+                    ExcMessage("Temperature must be strictly positive in net_forward_reaction_rate(), "
+                               "but received " + std::to_string(temperature) + " K."));
+
+        const double activation_enthalpy = activation_enthalpies[reaction_index];
+        const double activation_volume   = activation_volumes[reaction_index];
+        AssertThrow(activation_enthalpy >= 0.0,
+                    ExcMessage("Activation enthalpy must be non-negative, "
+                               "but received " + std::to_string(activation_enthalpy) + " J/mol."));
+
+        const double arrhenius_factor     = std::exp(-(activation_enthalpy + (pressure * activation_volume)) / (constants::gas_constant * temperature));
+        const double magnitude            = 1.0 - std::exp(-std::abs(delta_forward_gibbs_energy) / (constants::gas_constant * temperature));
+        const double thermodynamic_factor = -std::copysign(1.0, delta_forward_gibbs_energy) * magnitude;
+        const double reaction_progress    = (delta_forward_gibbs_energy < 0.0) ?
+                                            (1.0 - cumulative_forward_reaction_progress) :
+                                            cumulative_forward_reaction_progress;
+
+        return kinetic_prefactors[reaction_index] * temperature * arrhenius_factor * thermodynamic_factor * reaction_progress;
+      }
+
+      template <int dim>
+      void InterfaceControlledGrowth<dim>::declare_parameters(ParameterHandler &prm)
+      {
+        prm.enter_subsection("Interface controlled growth");
+        {
+          prm.declare_entry("Kinetic prefactors",
+                            "7.0e7",
+                            Patterns::List(Patterns::Double(0.0), 1, Patterns::List::max_int_value, "|"),
+                            "Kinetic prefactors Z, one '|'-separated entry per reaction assigned to this model. Units: 1/s/K");
+          prm.declare_entry("Activation enthalpies",
+                            "274e3",
+                            Patterns::List(Patterns::Double(0.0), 1, Patterns::List::max_int_value, "|"),
+                            "Activation enthalpies Ha, one '|'-separated entry per reaction assigned to this model. Units: J/mol");
+          prm.declare_entry("Activation volumes",
+                            "3.3e-6",
+                            Patterns::List(Patterns::Double(0.0), 1, Patterns::List::max_int_value, "|"),
+                            "Activation volumes Va, one '|'-separated entry per reaction assigned to this model. Units: m^3/mol");
+        }
+        prm.leave_subsection();
+      }
+
+      template <int dim>
+      void InterfaceControlledGrowth<dim>::parse_parameters(ParameterHandler &prm, const unsigned int n_reactions)
+      {
+        prm.enter_subsection("Interface controlled growth");
+        {
+          kinetic_prefactors    = Utilities::string_to_double(Utilities::split_string_list(prm.get("Kinetic prefactors"), '|'));
+          activation_enthalpies = Utilities::string_to_double(Utilities::split_string_list(prm.get("Activation enthalpies"), '|'));
+          activation_volumes    = Utilities::string_to_double(Utilities::split_string_list(prm.get("Activation volumes"), '|'));
+
+          AssertThrow(kinetic_prefactors.size() == n_reactions && activation_enthalpies.size() == n_reactions &&
+                      activation_volumes.size() == n_reactions,
+                      ExcMessage("'Interface controlled growth' parameter lists must each have exactly " +
+                                 std::to_string(n_reactions) + " '|'-separated entries, matching the number of "
+                                 "reactions assigned to this kinetics model."));
+        }
+        prm.leave_subsection();
+      }
+    }
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      ASPECT_REGISTER_REACTION_MODEL(
+        InterfaceControlledGrowth,
+        "Interface controlled growth",
+        "Interface-controlled growth kinetics following Cahn (1956; https://doi.org/10.1016/0001-6160(56)90041-4) and "
+        "Hosoya et al. (2005; https://doi.org/10.1029/2005GL023398)")
+    }
+  }
+}

--- a/source/material_model/reaction_model/reaction_chain.cc
+++ b/source/material_model/reaction_model/reaction_chain.cc
@@ -1,0 +1,246 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include <aspect/material_model/reaction_model/reaction_chain.h>
+#include <aspect/global.h>
+#include <algorithm>
+#include <map>
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+      template <int dim>
+      void
+      ReactionChain<dim>::initialize()
+      {
+        for (auto &kinetics : kinetics_models)
+          {
+            kinetics->initialize_simulator(this->get_simulator());
+          }
+      }
+
+      template <int dim>
+      unsigned int
+      ReactionChain<dim>::n_reactions() const
+      {
+        return reactions.size();
+      }
+
+      template <int dim>
+      std::vector<double>
+      ReactionChain<dim>::clamp_cumulative_progress(std::vector<double> reaction_progress_values) const
+      {
+        AssertThrow(reaction_progress_values.size() == reactions.size(),
+                    ExcMessage("Size of 'reaction_progress_values' (" + std::to_string(reaction_progress_values.size()) +
+                               ") does not match number of reactions (" + std::to_string(reactions.size()) + ")."));
+
+        // Sanity check: reaction progress values should be close to [0, 1]
+        for (unsigned int i = 0; i < reaction_progress_values.size(); ++i)
+          {
+            const double val = reaction_progress_values[i];
+
+            AssertThrow(std::isfinite(val),
+                        ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " + std::to_string(val) +
+                                   " is not finite (NaN or Inf)."));
+
+            AssertThrow(val > -tolerance_in_reaction_progress && val < 1.0 + tolerance_in_reaction_progress,
+                        ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " + std::to_string(val) +
+                                   " is too far outside the physical range [0, 1] (allowed excursion is " +
+                                   std::to_string(tolerance_in_reaction_progress) + ")."));
+          }
+
+        // Sanity check: reaction progress values should be close to monotonic
+        for (unsigned int i = 1; i < reaction_progress_values.size(); ++i)
+          AssertThrow(reaction_progress_values[i] < reaction_progress_values[i-1] + tolerance_in_reaction_progress,
+                      ExcMessage("'reaction_progress_values[" + std::to_string(i) + "]' = " +
+                                 std::to_string(reaction_progress_values[i]) + " exceeds "
+                                 "'reaction_progress_values[" + std::to_string(i-1) + "]' = " +
+                                 std::to_string(reaction_progress_values[i-1]) + " by more than the "
+                                 "allowed excursion (" + std::to_string(tolerance_in_reaction_progress) + "). Reaction " +
+                                 std::to_string(i) + " should not have progressed further than reaction " +
+                                 std::to_string(i-1) + " in a sequential chain."));
+
+        if (!reaction_progress_values.empty())
+          reaction_progress_values[0] = std::clamp(reaction_progress_values[0], 0.0, 1.0);
+
+        for (unsigned int i = 1; i < reaction_progress_values.size(); ++i)
+          {
+            reaction_progress_values[i] = std::clamp(reaction_progress_values[i], 0.0, 1.0);  // Clamp to valid physical range [0, 1]
+            reaction_progress_values[i] = std::min(reaction_progress_values[i], reaction_progress_values[i-1]);  // Enforce monotonicity xi[i] <= xi[i-1]
+          }
+
+        return reaction_progress_values;
+      }
+
+      template <int dim>
+      std::vector<double>
+      ReactionChain<dim>::compute_phase_mass_fractions(const std::vector<double> &reaction_progress_values, const std::vector<double> &phase_densities) const
+      {
+        AssertThrow(!reaction_progress_values.empty(),
+                    ExcMessage("'reaction_progress_values' cannot be empty."));
+        AssertThrow(reaction_progress_values.size() == reactions.size(),
+                    ExcMessage("Size of 'reaction_progress_values' (" + std::to_string(reaction_progress_values.size()) +
+                               ") does not match number of reactions (" + std::to_string(reactions.size()) + ")."));
+        AssertThrow(phase_densities.size() == reactions.size() + 1,
+                    ExcMessage("Size of 'phase_densities' (" + std::to_string(phase_densities.size()) +
+                               ") must be equal to reactions + 1 (" + std::to_string(reactions.size() + 1) + ")."));
+
+        for (unsigned int p = 0; p < phase_densities.size(); ++p)
+          AssertThrow(phase_densities[p] > 0.0 && std::isfinite(phase_densities[p]),
+                      ExcMessage("Phase density at index " + std::to_string(p) + " must be strictly positive and finite."));
+
+        std::vector<double> volume_fraction_values(phase_densities.size());
+        std::vector<double> mass_fraction_values(phase_densities.size(), 0.0);
+
+        // Guarantee bounds and monotonicity of reaction sequence
+        const std::vector<double> reaction_progress_values_clamped = clamp_cumulative_progress(reaction_progress_values);
+
+        // Derive (N+1) volume fractions from (N) cumulative reaction progress fields
+        volume_fraction_values[0] = 1.0 - reaction_progress_values_clamped[0];
+        for (unsigned int i = 1; i < reaction_progress_values_clamped.size(); ++i)
+          volume_fraction_values[i] = std::max(0.0, reaction_progress_values_clamped[i-1] - reaction_progress_values_clamped[i]);
+        volume_fraction_values.back() = std::max(0.0, reaction_progress_values_clamped.back());
+
+        // Sanity check: by construction these should sum to 1 and be non-negative
+        const double volume_fraction_sum = std::accumulate(volume_fraction_values.begin(), volume_fraction_values.end(), 0.0);
+        AssertThrow(std::abs(volume_fraction_sum - 1.0) < 1e-10,
+                    ExcMessage("Computed phase volume fractions sum to " + std::to_string(volume_fraction_sum) + " instead of 1."));
+
+        // Compute bulk density of phase mixture
+        double bulk_density = 0.0;
+        for (unsigned int p = 0; p < phase_densities.size(); ++p)
+          bulk_density += phase_densities[p] * volume_fraction_values[p];
+
+        // Convert (N+1) phase volume fractions to (N+1) phase mass fractions
+        if (bulk_density > 0.0)
+          for (unsigned int p = 0; p < phase_densities.size(); ++p)
+            mass_fraction_values[p] = (phase_densities[p] * volume_fraction_values[p]) / bulk_density;
+
+        return mass_fraction_values;
+      }
+
+      template <int dim>
+      double
+      ReactionChain<dim>::net_forward_reaction_rate(const double temperature,
+                                                    const double pressure,
+                                                    const double delta_forward_gibbs_energy,
+                                                    const double cumulative_forward_reaction_progress,
+                                                    const unsigned int reaction_index) const
+      {
+        AssertIndexRange(reaction_index, reactions.size());
+        const ReactionStep<dim> &reaction = reactions[reaction_index];
+        return reaction.kinetics->net_forward_reaction_rate(temperature, pressure,
+                                                            delta_forward_gibbs_energy,
+                                                            cumulative_forward_reaction_progress,
+                                                            reaction.local_reaction_index);
+      }
+
+      template <int dim>
+      void
+      ReactionChain<dim>::declare_parameters(ParameterHandler &prm)
+      {
+        prm.enter_subsection("Reaction chain");
+        {
+          prm.declare_entry("Kinetic models",
+                            "Interface controlled growth",
+                            Patterns::List(Patterns::Selection(ReactionModelPluginList<dim>::get_pattern_of_names()),
+                                           1, Patterns::List::max_int_value, "|"),
+                            "'|'-separated list of registered reaction kinetics model names, one per reaction in the chain. The number of entries "
+                            "sets the number of reactions N, which must equal the number of compositional fields tracking reaction progress.");
+
+          prm.declare_entry("Tolerance in reaction progress",
+                            "0.1",
+                            Patterns::Double(0.0),
+                            "Allowed excursion before a reaction progress value outside [0, 1] is considered unphysical.");
+
+          // One subsection per registered kinetics model (not per reaction).
+          ReactionModelPluginList<dim>::declare_parameters(prm);
+        }
+        prm.leave_subsection();
+      }
+
+      template <int dim>
+      void
+      ReactionChain<dim>::parse_parameters(ParameterHandler &prm)
+      {
+        prm.enter_subsection("Reaction chain");
+        {
+          tolerance_in_reaction_progress = prm.get_double("Tolerance in reaction progress");
+
+          AssertThrow(tolerance_in_reaction_progress >= 0.0 && tolerance_in_reaction_progress < 1.0,
+                      ExcMessage("The 'Tolerance in reaction progress' must be between [0, 1), "
+                                 "but was set to " + std::to_string(tolerance_in_reaction_progress) + "."));
+
+          const std::vector<std::string> kinetic_model_names = Utilities::split_string_list(prm.get("Kinetic models"), '|');
+          const unsigned int n_reactions = kinetic_model_names.size();
+
+          AssertThrow(n_reactions > 0, ExcMessage("'Reaction chain/Kinetic models' must contain at least one entry."));
+
+          reactions.resize(n_reactions);
+          kinetics_models.clear();
+
+          // Group global reaction indices by model name, preserving first-appearance order, so reactions sharing a model name get consecutive
+          // local indices matching the order that name appears in Kinetic models.
+          std::vector<std::string> unique_model_names;
+          std::map<std::string, std::vector<unsigned int>> global_indices_by_model;
+          for (unsigned int global_index = 0; global_index < n_reactions; ++global_index)
+            {
+              const std::string &model_name = kinetic_model_names[global_index];
+              if (global_indices_by_model.find(model_name) == global_indices_by_model.end())
+                unique_model_names.push_back(model_name);
+              global_indices_by_model[model_name].push_back(global_index);
+            }
+
+          for (const std::string &model_name : unique_model_names)
+            {
+              const std::vector<unsigned int> &global_indices = global_indices_by_model[model_name];
+
+              std::shared_ptr<Cahn1956Interface<dim>> kinetics(create_reaction_model<dim>(model_name).release());
+              kinetics->parse_parameters(prm, global_indices.size());
+              kinetics_models.push_back(kinetics);
+
+              for (unsigned int local_index = 0; local_index < global_indices.size(); ++local_index)
+                {
+                  reactions[global_indices[local_index]].kinetics             = kinetics;
+                  reactions[global_indices[local_index]].local_reaction_index = local_index;
+                }
+            }
+        }
+        prm.leave_subsection();
+      }
+    }
+  }
+}
+
+namespace aspect
+{
+  namespace MaterialModel
+  {
+    namespace ReactionModel
+    {
+#define INSTANTIATE(dim) template struct ReactionStep<dim>; template class ReactionChain<dim>;
+      ASPECT_INSTANTIATE(INSTANTIATE)
+#undef INSTANTIATE
+    }
+  }
+}

--- a/unit_tests/reaction_model_kinetics.cc
+++ b/unit_tests/reaction_model_kinetics.cc
@@ -1,0 +1,449 @@
+/*
+  Copyright (C) 2011 - 2026 by the authors of the ASPECT code.
+
+  This file is part of ASPECT.
+
+  ASPECT is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2, or (at your option)
+  any later version.
+
+  ASPECT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ASPECT; see the file LICENSE.  If not see
+  <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_eutectoid_decomposition.h>
+#include <aspect/material_model/reaction_model/kinetics/cahn1956_interface_controlled_growth.h>
+#include <aspect/material_model/reaction_model/reaction_chain.h>
+
+#include <deal.II/base/parameter_handler.h>
+#include <cmath>
+
+TEST_CASE("Eutectoid Decomposition Kinetics")
+{
+  using namespace aspect::MaterialModel::ReactionModel;
+
+  EutectoidDecomposition<2> kinetics;
+  dealii::ParameterHandler prm;
+
+  kinetics.declare_parameters(prm);
+
+  prm.enter_subsection("Eutectoid decomposition");
+  {
+    prm.set("Kinetic prefactors", "2.0e-16");
+    prm.set("Activation energies", "300000.0");
+  }
+  prm.leave_subsection();
+
+  kinetics.parse_parameters(prm, 1);
+
+  const double temperature = 1500.0; // K
+  const double pressure = 1.0e9;     // Pa
+  const double R = aspect::constants::gas_constant;
+
+  SECTION("Net forward reaction rate calculation")
+  {
+    const double arrhenius = std::exp(-300000.0 / (R * temperature));
+
+    SECTION("Forward reaction (dG < 0)")
+    {
+      const double dG_forward = -2000.0;
+      const double forward_reaction_progress = 0.2;
+      const double reaction_progress = 1.0 - forward_reaction_progress;
+      const double therm_factor = -dG_forward * std::abs(dG_forward); // 4.0e6
+      const double expected_rate = 2.0e-16 * therm_factor * arrhenius * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_forward, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Forward reaction (dG < 0) from pure reactant")
+    {
+      const double dG_forward = -2000.0;
+      const double forward_reaction_progress = 0.0;
+      const double reaction_progress = 1.0 - forward_reaction_progress;
+      const double therm_factor = -dG_forward * std::abs(dG_forward); // 4.0e6
+      const double expected_rate = 2.0e-16 * therm_factor * arrhenius * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_forward, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Reverse reaction (dG > 0)")
+    {
+      const double dG_reverse = 2000.0;
+      const double forward_reaction_progress = 0.2;
+      const double reaction_progress = forward_reaction_progress;
+      const double therm_factor = -dG_reverse * std::abs(dG_reverse); // -4.0e6
+      const double expected_rate = 2.0e-16 * therm_factor * arrhenius * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_reverse, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Equilibrium (dG = 0)")
+    {
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, 0.0, 0.5, 0);
+      CHECK(computed_rate == Approx(0.0));
+    }
+  }
+}
+
+TEST_CASE("Interface Controlled Growth Kinetics")
+{
+  using namespace aspect::MaterialModel::ReactionModel;
+
+  InterfaceControlledGrowth<2> kinetics;
+  dealii::ParameterHandler prm;
+
+  kinetics.declare_parameters(prm);
+
+  prm.enter_subsection("Interface controlled growth");
+  {
+    prm.set("Kinetic prefactors", "1.0e8");
+    prm.set("Activation enthalpies", "200000.0");
+    prm.set("Activation volumes", "2.0e-6");
+  }
+  prm.leave_subsection();
+
+  kinetics.parse_parameters(prm, 1);
+
+  const double temperature = 1600.0; // K
+  const double pressure = 2.0e9;     // Pa
+  const double R = aspect::constants::gas_constant;
+
+  SECTION("Net forward reaction rate calculation")
+  {
+    const double arrhenius = std::exp(-(200000.0 + pressure * 2.0e-6) / (R * temperature));
+
+    SECTION("Forward reaction (dG < 0)")
+    {
+      const double dG_forward = -1500.0;
+      const double forward_reaction_progress = 0.5;
+      const double reaction_progress = 1.0 - forward_reaction_progress;
+      const double therm_factor = 1.0 - std::exp(-std::abs(dG_forward) / (R * temperature));
+      const double expected_rate = 1.0e8 * temperature * arrhenius * therm_factor * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_forward, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Forward reaction (dG < 0) from pure reactant")
+    {
+      const double dG_forward = -1500.0;
+      const double forward_reaction_progress = 0.0;
+      const double reaction_progress = 1.0 - forward_reaction_progress;
+      const double therm_factor = 1.0 - std::exp(-std::abs(dG_forward) / (R * temperature));
+      const double expected_rate = 1.0e8 * temperature * arrhenius * therm_factor * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_forward, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Reverse reaction (dG > 0)")
+    {
+      const double dG_reverse = 1500.0;
+      const double forward_reaction_progress = 0.5;
+      const double reaction_progress = forward_reaction_progress;
+      const double therm_factor = -(1.0 - std::exp(-std::abs(dG_reverse) / (R * temperature)));
+      const double expected_rate = 1.0e8 * temperature * arrhenius * therm_factor * reaction_progress;
+
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG_reverse, forward_reaction_progress, 0);
+      CHECK(computed_rate == Approx(expected_rate));
+    }
+
+    SECTION("Equilibrium (dG = 0)")
+    {
+      const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, 0.0, 0.5, 0);
+      CHECK(computed_rate == Approx(0.0));
+    }
+  }
+}
+
+TEST_CASE("Multiple Reactions Sharing One Kinetics Instance")
+{
+  using namespace aspect::MaterialModel::ReactionModel;
+
+  InterfaceControlledGrowth<2> kinetics;
+  dealii::ParameterHandler prm;
+
+  kinetics.declare_parameters(prm);
+
+  prm.enter_subsection("Interface controlled growth");
+  {
+    prm.set("Kinetic prefactors", "1.0e8|2.0e8");
+    prm.set("Activation enthalpies", "200000.0|250000.0");
+    prm.set("Activation volumes", "2.0e-6|3.0e-6");
+  }
+  prm.leave_subsection();
+
+  kinetics.parse_parameters(prm, 2);
+
+  const double temperature = 1600.0; // K
+  const double pressure = 2.0e9;     // Pa
+  const double dG = -1500.0;
+  const double forward_reaction_progress = 0.5;
+  const double R = aspect::constants::gas_constant;
+
+  SECTION("Local index 0 uses the first entry of each list")
+  {
+    const double arrhenius = std::exp(-(200000.0 + pressure * 2.0e-6) / (R * temperature));
+    const double therm_factor = 1.0 - std::exp(-std::abs(dG) / (R * temperature));
+    const double expected_rate = 1.0e8 * temperature * arrhenius * therm_factor * forward_reaction_progress;
+
+    const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG, forward_reaction_progress, 0);
+    CHECK(computed_rate == Approx(expected_rate));
+  }
+
+  SECTION("Local index 1 uses the second entry of each list")
+  {
+    const double arrhenius = std::exp(-(250000.0 + pressure * 3.0e-6) / (R * temperature));
+    const double therm_factor = 1.0 - std::exp(-std::abs(dG) / (R * temperature));
+    const double expected_rate = 2.0e8 * temperature * arrhenius * therm_factor * forward_reaction_progress;
+
+    const double computed_rate = kinetics.net_forward_reaction_rate(temperature, pressure, dG, forward_reaction_progress, 1);
+    CHECK(computed_rate == Approx(expected_rate));
+  }
+}
+
+TEST_CASE("Reaction Chain Processing")
+{
+  using namespace aspect::MaterialModel::ReactionModel;
+
+  dealii::ParameterHandler prm;
+  ReactionChain<2> reaction_chain;
+  ReactionChain<2>::declare_parameters(prm);
+
+  prm.enter_subsection("Reaction chain");
+  {
+    prm.set("Kinetic models", "Interface controlled growth|Eutectoid decomposition|Interface controlled growth");
+    prm.set("Tolerance in reaction progress", "0.05");
+
+    prm.enter_subsection("Interface controlled growth");
+    {
+      prm.set("Kinetic prefactors", "7.0e7|7.0e7");
+      prm.set("Activation enthalpies", "274e3|274e3");
+      prm.set("Activation volumes", "3.3e-6|3.3e-6");
+    }
+    prm.leave_subsection();
+
+    prm.enter_subsection("Eutectoid decomposition");
+    {
+      prm.set("Kinetic prefactors", "2.7e-16");
+      prm.set("Activation energies", "355e3");
+    }
+    prm.leave_subsection();
+  }
+  prm.leave_subsection();
+
+  reaction_chain.parse_parameters(prm);
+
+  SECTION("Clamping cumulative reaction progress within custom tolerance")
+  {
+    const std::vector<double> xi_raw = {1.04, 0.85, -0.04};
+    const std::vector<double> xi_clamped = reaction_chain.clamp_cumulative_progress(xi_raw);
+
+    const std::vector<double> expected = {1.0, 0.85, 0.0};
+    compare_vectors_approx(xi_clamped, expected);
+  }
+
+  SECTION("Clamping throws on non-physical bounds exceeding tolerance")
+  {
+    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({1.06, 0.5, 0.1}), dealii::ExceptionBase);
+    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({0.8, 0.5, -0.06}), dealii::ExceptionBase);
+  }
+
+  SECTION("Clamping throws on non-monotonic values exceeding tolerance")
+  {
+    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({0.80, 0.87, 0.1}), dealii::ExceptionBase);
+  }
+
+  SECTION("Clamping throws on NaN or Inf input")
+  {
+    const double nan_val = std::numeric_limits<double>::quiet_NaN();
+    const double inf_val = std::numeric_limits<double>::infinity();
+
+    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({0.8, nan_val, 0.2}), dealii::ExceptionBase);
+    CHECK_THROWS_AS(reaction_chain.clamp_cumulative_progress({inf_val, 0.5, 0.2}), dealii::ExceptionBase);
+  }
+
+  SECTION("Phase mass fraction extraction from cumulative progress")
+  {
+    SECTION("Uniform phase densities (equal volume and mass fractions)")
+    {
+      // xi = {1.0, 1.0, 0.4}
+      // Volume fractions:
+      // Phase 0: 1 - 1 = 0.0
+      // Phase 1: 1 - 1 = 0.0
+      // Phase 2: 1 - 0.4 = 0.6
+      // Phase 3: 0.4
+      const std::vector<double> xi = {1.0, 1.0, 0.4};
+      const std::vector<double> densities = {3300.0, 3300.0, 3300.0, 3300.0};
+      const std::vector<double> expected_X = {0.0, 0.0, 0.6, 0.4};
+
+      const std::vector<double> computed_X = reaction_chain.compute_phase_mass_fractions(xi, densities);
+      compare_vectors_approx(computed_X, expected_X);
+    }
+
+    SECTION("Variable phase densities")
+    {
+      // xi = {0.8, 0.5, 0.1}
+      // Volume fractions: phi = {0.2, 0.3, 0.4, 0.1}
+      // Densities: rho = {3200, 3500, 3700, 4100} kg/m^3
+      // Mass = {640, 1050, 1480, 410} -> Bulk density = 3580 kg/m^3
+      const std::vector<double> xi = {0.8, 0.5, 0.1};
+      const std::vector<double> densities = {3200.0, 3500.0, 3700.0, 4100.0};
+
+      const double bulk_density = 0.2 * 3200.0 + 0.3 * 3500.0 + 0.4 * 3700.0 + 0.1 * 4100.0;
+      const std::vector<double> expected_X =
+      {
+        (0.2 * 3200.0) / bulk_density,
+        (0.3 * 3500.0) / bulk_density,
+        (0.4 * 3700.0) / bulk_density,
+        (0.1 * 4100.0) / bulk_density
+      };
+
+      const std::vector<double> computed_X = reaction_chain.compute_phase_mass_fractions(xi, densities);
+      compare_vectors_approx(computed_X, expected_X);
+    }
+
+    SECTION("Single phase boundary limit")
+    {
+      dealii::ParameterHandler single_prm;
+      ReactionChain<2> single_reaction_chain;
+      ReactionChain<2>::declare_parameters(single_prm);
+
+      single_reaction_chain.parse_parameters(single_prm); // 1 default reaction
+
+      const std::vector<double> xi = {0.3};
+      const std::vector<double> densities = {3000.0, 3000.0};
+      const std::vector<double> expected_X = {0.7, 0.3};
+
+      const std::vector<double> computed_X = single_reaction_chain.compute_phase_mass_fractions(xi, densities);
+      compare_vectors_approx(computed_X, expected_X);
+    }
+
+    SECTION("Asserts throw on invalid inputs")
+    {
+      const std::vector<double> valid_xi = {0.8, 0.5, 0.1};
+      const std::vector<double> valid_densities = {3200.0, 3500.0, 3700.0, 4100.0};
+
+      // Empty reaction progress values
+      CHECK_THROWS_AS(reaction_chain.compute_phase_mass_fractions({}, valid_densities), dealii::ExceptionBase);
+
+      // Non-positive phase density
+      const std::vector<double> zero_density = {3200.0, 0.0, 3700.0, 4100.0};
+      CHECK_THROWS_AS(reaction_chain.compute_phase_mass_fractions(valid_xi, zero_density), dealii::ExceptionBase);
+
+      // Non-finite (Inf/NaN) phase density
+      const std::vector<double> inf_density = {3200.0, std::numeric_limits<double>::infinity(), 3700.0, 4100.0};
+      CHECK_THROWS_AS(reaction_chain.compute_phase_mass_fractions(valid_xi, inf_density), dealii::ExceptionBase);
+    }
+  }
+}
+
+TEST_CASE("Reaction Chain Kinetic Models Parsing")
+{
+  using namespace aspect::MaterialModel::ReactionModel;
+
+  SECTION("Number of reactions matches the number of entries in 'Kinetic models'")
+  {
+    dealii::ParameterHandler prm;
+    ReactionChain<2> reaction_chain;
+
+    ReactionChain<2>::declare_parameters(prm);
+
+    prm.enter_subsection("Reaction chain");
+    {
+      prm.set("Kinetic models", "Interface controlled growth|Eutectoid decomposition");
+    }
+    prm.leave_subsection();
+
+    reaction_chain.parse_parameters(prm);
+
+    REQUIRE(reaction_chain.n_reactions() == 2);
+    REQUIRE(reaction_chain.reactions.size() == 2);
+    CHECK(reaction_chain.reactions[0].kinetics != nullptr);
+    CHECK(reaction_chain.reactions[1].kinetics != nullptr);
+    // Distinct model names -> distinct kinetics instances, each the sole (local index 0) user of its instance.
+    CHECK(reaction_chain.reactions[0].kinetics != reaction_chain.reactions[1].kinetics);
+    CHECK(reaction_chain.reactions[0].local_reaction_index == 0);
+    CHECK(reaction_chain.reactions[1].local_reaction_index == 0);
+  }
+
+  SECTION("Repeated model name shares one kinetics instance across local indices")
+  {
+    dealii::ParameterHandler prm;
+    ReactionChain<2> reaction_chain;
+
+    ReactionChain<2>::declare_parameters(prm);
+
+    prm.enter_subsection("Reaction chain");
+    {
+      prm.set("Kinetic models", "Interface controlled growth|Interface controlled growth|Eutectoid decomposition");
+      prm.enter_subsection("Interface controlled growth");
+      {
+        prm.set("Kinetic prefactors", "1.4e4|1.4e4");
+        prm.set("Activation enthalpies", "274e3|274e3");
+        prm.set("Activation volumes", "3.3e-6|3.3e-6");
+      }
+      prm.leave_subsection();
+      prm.enter_subsection("Eutectoid decomposition");
+      {
+        prm.set("Kinetic prefactors", "1.6e-3");
+        prm.set("Activation energies", "355e3");
+      }
+      prm.leave_subsection();
+    }
+    prm.leave_subsection();
+
+    reaction_chain.parse_parameters(prm);
+
+    REQUIRE(reaction_chain.n_reactions() == 3);
+    // The two "Interface controlled growth" reactions share one instance, with consecutive local indices.
+    CHECK(reaction_chain.reactions[0].kinetics == reaction_chain.reactions[1].kinetics);
+    CHECK(reaction_chain.reactions[0].local_reaction_index == 0);
+    CHECK(reaction_chain.reactions[1].local_reaction_index == 1);
+    // The "Eutectoid decomposition" reaction gets its own instance.
+    CHECK(reaction_chain.reactions[2].kinetics != reaction_chain.reactions[0].kinetics);
+    CHECK(reaction_chain.reactions[2].local_reaction_index == 0);
+  }
+
+  SECTION("Default 'Kinetic models' declared in parameters")
+  {
+    dealii::ParameterHandler prm;
+    ReactionChain<2>::declare_parameters(prm);
+
+    prm.enter_subsection("Reaction chain");
+    const std::string parsed_default = prm.get("Kinetic models");
+    prm.leave_subsection();
+
+    CHECK(parsed_default == "Interface controlled growth");
+  }
+
+  SECTION("Parsing throws on invalid 'Tolerance in reaction progress'")
+  {
+    SECTION("Tolerance >= 1.0 throws")
+    {
+      dealii::ParameterHandler prm;
+      ReactionChain<2> reaction_chain;
+      ReactionChain<2>::declare_parameters(prm);
+
+      prm.enter_subsection("Reaction chain");
+      {
+        prm.set("Tolerance in reaction progress", "1.0");
+      }
+      prm.leave_subsection();
+
+      CHECK_THROWS_AS(reaction_chain.parse_parameters(prm), dealii::ExceptionBase);
+    }
+  }
+}


### PR DESCRIPTION
Pull Request Checklist. Please read and check each box with an X. Delete any part not applicable. Ask on the [forum](https://community.geodynamics.org/c/aspect) if you need help with any step.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [X] I have tested my new feature locally to ensure it is correct.
* [X] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.

## Summary

This PR introduces an extensible reaction kinetics framework for modeling solid-state phase transitions in ASPECT.

The framework handles kinetic models (rate laws), reaction sequencing, and mass conservation based on local pressure-temperature conditions. It is designed to operate with compositional fields representing *cumulative reaction progress* (one field per reaction).

> **Note:** This is the **first PR in a series** that will connect this framework directly to existing material models. This PR focuses on establishing the core architecture, parameter parsing, and fundamental kinetic models.

## Architecture Overview

### Extensible Plugin Interface

The base class `Interface` (`material_model/reaction_model/solid_state/cahn1956/site_saturated_n1/interface`) defines a uniform plugin architecture for kinetics models based on the Cahn (1956) site-saturated nucleation and growth formulation.

* **Modular Kinetics:** Abstracting kinetic rate formulations into dedicated interfaces allows new kinetic models to be added as plugins without altering the downstream reaction manager.
* **Separation of Concerns:** Individual kinetic models (such as `EutectoidDecomposition` and `InterfaceControlledGrowth`) are solely responsible for computing reaction rates based on their unique reaction pathways.

### Sequencing Independent Reaction Steps via `ReactionChain`

The `ReactionChain` class (`material_model/reaction_model/solid_state/reaction_chain`) manages sequences of solid-state reactions (e.g., olivine $\rightarrow$ wadsleyite $\rightarrow$ ringwoodite $\rightarrow$ postspinel).

The plugin interface wires kinetic models into reaction chains as follows:

1. **Reaction Evaluation:** For a given local PT state and current compositional field state, the `ReactionChain` queries the active `Interface` kinetics model assigned to each independent reaction step.
2. **Sequential Progress & Mass Balance:** The chain tracks cumulative reaction progress ($\xi_i$) for each reaction step and enforces non-negative mass conservation constraints across the phase sequence:

$$X_0 = 1 - \xi_0, \quad X_i = \xi_{i-1} - \xi_i, \quad X_N = \xi_{N-1}$$


3. **Bounding:** The system provides built-in state clamping (`clamp_cumulative_progress`) to guarantee physically valid bounds ($1 \ge \xi_0 \ge \xi_1 \ge \dots \ge 0$).

## Parameter File (`.prm`) Configuration

Reaction chains are configured within the parameter file inside the chosen material model subsection. Users specify phase names, independent reaction steps, and the kinetic model governing the progress of each reaction step.

```prm
subsection Material model
  set Model name = arbitrary reaction model

  subsection Arbitrary reaction model
    ...
    
    set Phase names = olivine, wadsleyite, ringwoodite, postspinel

    subsection Reaction chain
      subsection olivine wadsleyite
        set Enable transformation = true
        set Data directory        = data/
        set Data file name        = olivine-wadsleyite-profile-Mg100.tsv
        set Kinetics model        = Interface controlled growth

        subsection Interface controlled growth
          set Kinetic factor      = 1.4e+04
          set Activation enthalpy = 274e+03
          set Activation volume   = 3.3e-06
        end
      end

      subsection wadsleyite ringwoodite
        set Enable transformation = true
        set Data directory        = data/
        set Data file name        = wadsleyite-ringwoodite-profile-Mg100.tsv
        set Kinetics model        = Interface controlled growth

        subsection Interface controlled growth
          set Kinetic factor      = 1.4e+04
          set Activation enthalpy = 274e+03
          set Activation volume   = 3.3e-06
        end
      end

      subsection ringwoodite postspinel
        set Enable transformation = true
        set Data directory        = data/
        set Data file name        = ringwoodite-postspinel-profile-Mg100.tsv
        set Kinetics model        = Eutectoid decomposition

        subsection Eutectoid decomposition
          set Kinetic factor      = 1.6e-03
          set Activation energy   = 355e+03
        end
      end
    end

  ...

  end
end

```

---

## Notes for Reviewers

* **Unit Testing:** All kinetic models and core utility methods are tested in `unit_tests/reaction_model.cc` (e.g., driving force sign conventions, temperature-pressure dependencies, cumulative-to-phase fraction conversions, and bounds enforcement).
* **Zero Overhead when Unused:** If no reaction steps are enabled, `ReactionChain::any_enabled()` evaluates to `false`, allowing material models to bypass kinetics computations entirely.
* **Mass Balance Safety:** Mass fractions are unconditionally guaranteed to be non-negative and sum to 1.0 across all phases because `compute_phase_mass_fractions` automatically clamps cumulative progress fields ($\xi$) to valid bounds ($1 \ge \xi_0 \ge \dots \ge \xi_{N-1} \ge 0$) before evaluating phase fractions.
* **Future Scope:** In subsequent PRs, material models will consume the phase mass fractions ($X_i$) calculated here to evaluate composite material properties (density, viscosity, thermal conductivity) via their internal averaging schemes. In addition, this initial PR focuses specifically on the Cahn1956::SiteSaturatedN1 kinetic family (`material_model/reaction_model/solid_state/cahn1956/site_saturated_n1`). Other kinetic families (e.g., JMAK or non-site-saturated models) will be added in future PRs via variants/templates.
* **Future Cookbook Example:** In a separate subsequent PR, a provided cookbook will demonstrate how to use this framework for simulating metastable reactions in cold slabs moving through the mantle transition zone.