### PR TITLE
Serialize the time stepping manager.

### DIFF
--- a/doc/modules/changes/20260723_bangerth
+++ b/doc/modules/changes/20260723_bangerth
@@ -1,0 +1,3 @@
+Fixed: We forgot to serialize the termination criteria and so they lose state between checkpointing and resuming. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2026/07/23)

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -188,6 +188,13 @@ namespace aspect
         void
         parse_parameters (ParameterHandler &prm) override;
 
+        template <class Archive>
+        void
+        serialize (Archive &ar, const unsigned int)
+        {
+          ar &termination_manager;
+        }
+
         /**
          * For the current plugin subsystem, write a connection graph of all of the
          * plugins we know about, in the format that the

--- a/source/simulator/checkpoint_restart.cc
+++ b/source/simulator/checkpoint_restart.cc
@@ -368,7 +368,7 @@ namespace aspect
       triangulation.save (checkpoint_path + "mesh");
     }
 
-    // save general information This calls the serialization functions on all
+    // Save general information. This calls the serialization functions on all
     // processes (so that they can take additional action, if necessary, see
     // the manual) but only writes to the restart file on process 0
     {
@@ -796,6 +796,8 @@ namespace aspect
 
     if (parameters.mesh_deformation_enabled)
       ar &(*mesh_deformation);
+
+    ar &time_stepping_manager;
 
     // We do not serialize the statistics_last_write_size and
     // statistics_last_hash variables on purpose. This way, upon


### PR DESCRIPTION
Some of the termination managers may carry state, and we need to serialize these. Discovered and fixed by Copilot.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [x] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.