### PR TITLE
Serialize the particle generator classes.

### DIFF
--- a/doc/modules/changes/20260723_bangerth3
+++ b/doc/modules/changes/20260723_bangerth3
@@ -1,0 +1,3 @@
+Fixed: Some of the particle generator plugins had no means of serializing themselves. As a consequence, they lose state between checkpointing and resuming. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2026/07/23)

--- a/include/aspect/particle/generator/interface.h
+++ b/include/aspect/particle/generator/interface.h
@@ -71,6 +71,12 @@ namespace aspect
           void
           initialize () override;
 
+          void
+          save (std::map<std::string, std::string> &status_strings) const override;
+
+          void
+          load (const std::map<std::string, std::string> &status_strings) override;
+
           /**
            * Generate particles. Every derived class
            * has to decide on the method and number of particles to generate,

--- a/source/particle/generator/interface.cc
+++ b/source/particle/generator/interface.cc
@@ -42,6 +42,32 @@ namespace aspect
 
 
       template <int dim>
+      void
+      Interface<dim>::save (std::map<std::string, std::string> &status_strings) const
+      {
+        std::ostringstream os;
+        os << random_number_generator;
+        status_strings["ParticleGenerator"] = os.str();
+      }
+
+
+
+      template <int dim>
+      void
+      Interface<dim>::load (const std::map<std::string, std::string> &status_strings)
+      {
+        const auto saved_state = status_strings.find("ParticleGenerator");
+        if (saved_state != status_strings.end())
+          {
+            std::istringstream is (saved_state->second);
+            is >> random_number_generator;
+            AssertThrow(!is.fail(), ExcMessage("Could not restore the particle generator random number generator."));
+          }
+      }
+
+
+
+      template <int dim>
       std::pair<Particles::internal::LevelInd,Particle<dim>>
       Interface<dim>::generate_particle(const Point<dim> &position,
                                         const types::particle_index id) const


### PR DESCRIPTION
The particle generator base class is stateful in that it has a random number generator that we will want to serialize. This patch does that.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
