### PR TITLE
Properly serialize particle managers and generators.

### DIFF
--- a/doc/modules/changes/20260723_bangerth4
+++ b/doc/modules/changes/20260723_bangerth4
@@ -1,0 +1,3 @@
+Fixed: The particle manager only serialized some data that describes the state of the simulation, but not all. In particular, it did not save the particle generator state, the particle property state, and the state of a random number generator. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2026/07/23)

--- a/include/aspect/particle/manager.h
+++ b/include/aspect/particle/manager.h
@@ -534,12 +534,82 @@ namespace aspect
     template <class Archive>
     void Manager<dim>::serialize (Archive &ar, const unsigned int)
     {
-      // Note that although Boost claims to handle serialization of pointers
+      // Although Boost claims to handle serialization of pointers
       // correctly, at least for the case of unique_ptr it seems to not work.
       // It works correctly when archiving the content of the pointer instead.
       ar
       &(*particle_handler)
       ;
+
+      std::vector<std::string> rank_states;
+
+      // Save the state of the particle manager, generator,
+      // and random number generator to a string stream on every rank,
+      // and gather the strings on all ranks to the root rank. This is
+      // the right approach because we only save the state of the
+      // particle manager on the root rank (see the create_snapshot() function
+      // in checkpoint_restart.cc). Usually that's good enough because
+      // the state of plugins should be the same on all ranks. However,
+      // if the state of plugins is different on different ranks (for example
+      // if plugins use random number generators), this approach will not
+      // work. In that case, we need to save the state of plugins on all
+      // ranks, transfer the state to the root rank, and then save it to the
+      // checkpoint file. This is what we do here.
+      if constexpr (Archive::is_saving::value)
+        {
+          std::ostringstream os;
+          {
+            aspect::oarchive oa (os);
+            property_manager->save(oa, 0);
+
+            std::map<std::string, std::string> generator_state;
+            generator->save(generator_state);
+            oa << generator_state;
+
+            std::ostringstream random_number_generator_state;
+            random_number_generator_state << random_number_generator;
+            oa << random_number_generator_state.str();
+          }
+
+          const std::string local_state = os.str();
+          rank_states
+            = Utilities::MPI::gather(this->get_mpi_communicator(), local_state);
+        }
+
+      // Now serialize the vector of strings on the root rank.
+      ar &rank_states;
+
+      // If we are loading, we need to restore the state of the particle manager, generator,
+      // and random number generator from the string stream on the root rank. We
+      // read the serialized data on all processes, so we don't have to distribute the
+      // data from the root rank to all other ranks.
+      if constexpr (Archive::is_loading::value)
+        {
+          const unsigned int n_processes
+            = Utilities::MPI::n_mpi_processes(this->get_mpi_communicator());
+          const unsigned int my_rank
+            = Utilities::MPI::this_mpi_process(this->get_mpi_communicator());
+
+          AssertThrow(rank_states.size() == n_processes,
+                      ExcMessage("The number of MPI processes used to resume the "
+                                 "particle checkpoint does not match the number used "
+                                 "to create it."));
+
+          std::istringstream is (rank_states[my_rank]);
+          aspect::iarchive ia (is);
+          property_manager->load(ia, 0);
+
+          std::map<std::string, std::string> generator_state;
+          ia >> generator_state;
+          generator->load(generator_state);
+
+          std::string random_number_generator_state;
+          ia >> random_number_generator_state;
+          std::istringstream random_number_generator_stream(random_number_generator_state);
+          random_number_generator_stream >> random_number_generator;
+          AssertThrow(!random_number_generator_stream.fail(),
+                      ExcMessage("Could not restore the particle manager random number generator."));
+        }
     }
   }
 }


### PR DESCRIPTION
This is a difficult one, and it took me quite a lot of tokens to find and fix, and then brainpower to understand and revise. The key issue here is that the particle manager only saves the `ParticleHandler` class during serialization. But it doesn't save the following:
* Its own state in the form of a random number generator
* The particle generators
* The particle property manager.
This patch addresses this, but the underlying issue is actually more complicated.

At its root, the issue is that we call the serialization functionality on all processes, but we only store the information on process zero. I don't recall the exact thought processes that led to this design decision, but I *think* that fundamentally it was about this:

1. We assume that the state of a plugin is the same across all processes, and so saving on one rank is enough.
2. We of course still have to restore on all processes, but that can be the information saved on rank zero.
3. We want to be able to resume on a different number of processes than what we saved.

All of this gets in trouble if you have a random number generator, for example for particle generation. In fact, the particle generation base class already provides a random number generator for all of its derived classes to use (see also #7097). The issue here is that on different ranks, we may be calling the random number generator a different number of times, and so the *state* of the RNG may be different on different ranks. If we really want to save the state of the simulator, we have to save the state *from all ranks*. That's what Copilot came up with: It collects the state from all ranks to rank zero, and saves that whole array. When we resume, each process picks its state out of the array and restores from that.

I'm not excited about this approach. I think memory is ok, since if we have many processes, we also have many solution vector elements to store and the addition of the state of an RNG per rank isn't going to make a difference. But it destroys our ability to restart with a different number of processes. This is in conflict with our goal that a resumed process results in exactly the same answer as the original process (which requires saving the state from all processes).

I can see two solutions here, neither of which is implemented in the current patch:

* If the number of restart processes is different than the number of checkpointed processes, then simply reset all RNGs to the default seed. That's not unreasonable because in that case there has never been an expectation that the resumed computation is binary identical to the original one. If so, we can as well reset RNGs. But if we restart with the exact same number of processes, we do want to restart with the checkpointed numbers.
* We could try and avoid checkpointing all RNGs to begin with, and only checkpoint from rank zero as we do with all data. This would requiring restoring the assumption that the same plugin has the same state across all ranks. A way to achieve that would be to make sure that at the beginning of every time step, each rank's RNG is exactly the same; for example, rank 0 could send its RNG state to all other ranks and they then set their own RNG state to that of rank zero.

Thoughts?


### Before your first pull request:

* [X] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [X] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [X] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
