### PR TITLE
Replace all log output from structured_data to pretty file name

### DIFF
--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -1041,7 +1041,7 @@ namespace aspect
           const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
 
           this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                            << pretty_name << '.' << std::endl << std::endl;
+                            << filename << '.' << std::endl << std::endl;
 
 
           AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
@@ -1066,11 +1066,10 @@ namespace aspect
                 current_file_number + 1;
 
               const std::string filename (create_filename (next_file_number, boundary_id));
-              const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
               if (Utilities::fexists(filename, this->get_mpi_communicator()))
                 {
                   this->get_pcout() << std::endl << "   Also loading next Ascii data boundary file "
-                                    << pretty_name << '.' << std::endl << std::endl;
+                                    << filename << '.' << std::endl << std::endl;
                   lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
                   lookups.find(boundary_id)->second->load_file(filename, this->get_mpi_communicator());
                 }
@@ -1229,9 +1228,8 @@ namespace aspect
       if (load_both_files)
         {
           const std::string filename (create_filename (current_file_number,boundary_id));
-          const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
           this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                            << pretty_name << '.' << std::endl << std::endl;
+                            << filename << '.' << std::endl << std::endl;
           if (Utilities::fexists(filename, this->get_mpi_communicator()))
             {
               lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
@@ -1251,9 +1249,8 @@ namespace aspect
         current_file_number + 1;
 
       const std::string filename (create_filename (next_file_number,boundary_id));
-      const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
       this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                        << pretty_name << '.' << std::endl << std::endl;
+                        << filename << '.' << std::endl << std::endl;
       if (Utilities::fexists(filename, this->get_mpi_communicator()))
         {
           lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
@@ -1735,7 +1732,7 @@ namespace aspect
       const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
 
       this->get_pcout() << std::endl << "   Loading Ascii data initial file "
-                        << pretty_name << '.' << std::endl << std::endl;
+                        << filename << '.' << std::endl << std::endl;
 
 
       AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),

--- a/source/structured_data.cc
+++ b/source/structured_data.cc
@@ -1038,15 +1038,16 @@ namespace aspect
           current_file_number = first_data_file_number;
 
           const std::string filename (create_filename (current_file_number, boundary_id));
+          const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
 
           this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                            << filename << '.' << std::endl << std::endl;
+                            << pretty_name << '.' << std::endl << std::endl;
 
 
           AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                       ExcMessage (std::string("Ascii data file <")
                                   +
-                                  filename
+                                  pretty_name
                                   +
                                   "> not found!"));
           lookups.find(boundary_id)->second->load_file(filename,this->get_mpi_communicator());
@@ -1065,10 +1066,11 @@ namespace aspect
                 current_file_number + 1;
 
               const std::string filename (create_filename (next_file_number, boundary_id));
+              const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
               if (Utilities::fexists(filename, this->get_mpi_communicator()))
                 {
                   this->get_pcout() << std::endl << "   Also loading next Ascii data boundary file "
-                                    << filename << '.' << std::endl << std::endl;
+                                    << pretty_name << '.' << std::endl << std::endl;
                   lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
                   lookups.find(boundary_id)->second->load_file(filename, this->get_mpi_communicator());
                 }
@@ -1227,8 +1229,9 @@ namespace aspect
       if (load_both_files)
         {
           const std::string filename (create_filename (current_file_number,boundary_id));
+          const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
           this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                            << filename << '.' << std::endl << std::endl;
+                            << pretty_name << '.' << std::endl << std::endl;
           if (Utilities::fexists(filename, this->get_mpi_communicator()))
             {
               lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
@@ -1248,8 +1251,9 @@ namespace aspect
         current_file_number + 1;
 
       const std::string filename (create_filename (next_file_number,boundary_id));
+      const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
       this->get_pcout() << std::endl << "   Loading Ascii data boundary file "
-                        << filename << '.' << std::endl << std::endl;
+                        << pretty_name << '.' << std::endl << std::endl;
       if (Utilities::fexists(filename, this->get_mpi_communicator()))
         {
           lookups.find(boundary_id)->second.swap(old_lookups.find(boundary_id)->second);
@@ -1591,10 +1595,11 @@ namespace aspect
       for (unsigned int i=0; i<number_of_layer_boundaries; ++i)
         {
           const std::string filename = this->data_directory + data_file_names[i];
+          const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
           AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                       ExcMessage (std::string("Ascii data file <")
                                   +
-                                  filename
+                                  pretty_name
                                   +
                                   "> not found!"));
 
@@ -1727,15 +1732,16 @@ namespace aspect
     AsciiDataInitial<dim>::initialize (const unsigned int n_components)
     {
       const std::string filename = this->data_directory + this->data_file_name;
+      const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
 
       this->get_pcout() << std::endl << "   Loading Ascii data initial file "
-                        << filename << '.' << std::endl << std::endl;
+                        << pretty_name << '.' << std::endl << std::endl;
 
 
       AssertThrow(Utilities::fexists(filename, this->get_mpi_communicator()) || filename_is_url(filename),
                   ExcMessage (std::string("Ascii data file <")
                               +
-                              filename
+                              pretty_name
                               +
                               "> not found!"));
 
@@ -1885,11 +1891,12 @@ namespace aspect
       lookup = std::make_unique<Utilities::StructuredDataLookup<1>> (this->scale_factor);
 
       const std::string filename = this->data_directory + this->data_file_name;
+      const std::string pretty_name = Utilities::replace_in_string(filename, ASPECT_SOURCE_DIR, "$ASPECT_SOURCE_DIR");
 
       AssertThrow(Utilities::fexists(filename, communicator) || filename_is_url(filename),
                   ExcMessage (std::string("Ascii data file <")
                               +
-                              filename
+                              pretty_name
                               +
                               "> not found!"));
       lookup->load_file(filename,communicator);

--- a/tests/ascii_data_fail_4/screen-output
+++ b/tests/ascii_data_fail_4/screen-output
@@ -9,7 +9,7 @@ synchronization (and subsequent output) will be skipped
 to avoid a possible deadlock.
 
 
-Exception 'ExcMessage (std::string("Ascii data file <") + filename + "> not found!")' on rank 0 on processing: 
+Exception 'ExcMessage (std::string("Ascii data file <") + pretty_name + "> not found!")' on rank 0 on processing: 
 
 An error occurred in file <structured_data.cc> in function
 (line in output replaced by default.sh script)


### PR DESCRIPTION
Follow-up on #7076: replace all filenames printed to log.txt with the pretty file name using $ASPECT_SOURCE_DIR instead of the absolute path.
The test ascii_data_fail_4 was still failing on other machines that have a different file path.
@tjhei 

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).
* [x] I have tested my new feature locally to ensure it is correct.