### PR TITLE
Link variable documentation to the input parameters they are read from.

### DIFF
--- a/doc/modules/changes/20260724_bangerth
+++ b/doc/modules/changes/20260724_bangerth
@@ -1,0 +1,3 @@
+New: In nearly a thousand places, the declaration of member variables of plugin classes are now annotated with the run-time parameter from the input file they are initialized with.
+<br>
+(Wolfgang Bangerth, 2026/07/24)

--- a/include/aspect/adiabatic_conditions/compute_entropy_profile.h
+++ b/include/aspect/adiabatic_conditions/compute_entropy_profile.h
@@ -109,11 +109,14 @@ namespace aspect
 
         /**
          * Number of points at which we compute the adiabatic values.
+         * This variable is read from the parameter file through a parameter called 'Number of points'.
          */
         unsigned int n_points;
 
         /**
          * Starting entropy for the profile.
+         *
+         * This variable is read from the parameter file through a parameter called 'Surface entropy'.
          */
         double surface_entropy;
 

--- a/include/aspect/adiabatic_conditions/compute_profile.h
+++ b/include/aspect/adiabatic_conditions/compute_profile.h
@@ -123,6 +123,7 @@ namespace aspect
 
         /**
          * Number of points at which we compute the adiabatic values.
+         * This variable is read from the parameter file through a parameter called 'Number of points'.
          */
         unsigned int n_points;
 
@@ -167,6 +168,8 @@ namespace aspect
          * conditions, or the adiabatic_surface_temperature and surface_pressure
          * parameters. If this is set to true the reference profile is updated
          * every timestep.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use surface condition function'.
          */
         bool use_surface_condition_function;
 

--- a/include/aspect/boundary_composition/box.h
+++ b/include/aspect/boundary_composition/box.h
@@ -74,6 +74,10 @@ namespace aspect
         /**
          * The values of the various composition variables on each of the
          * 2*dim boundaries of the box.
+         *
+         * This variable is read from the parameter file through parameters called 'Left composition',
+         * 'Right composition', 'Bottom composition', 'Top composition',
+         * 'Front composition', and 'Back composition'.
          */
         std::vector<double> composition_values[2*dim];
     };

--- a/include/aspect/boundary_composition/function.h
+++ b/include/aspect/boundary_composition/function.h
@@ -78,6 +78,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/boundary_composition/initial_composition.h
+++ b/include/aspect/boundary_composition/initial_composition.h
@@ -95,8 +95,15 @@ namespace aspect
       private:
         /**
          * Compositions at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Minimal composition'.
          */
         double min_composition;
+
+        /**
+         * Compositions at the inner and outer boundaries.
+         *
+         * This variable is read from the parameter file through a parameter called 'Maximal composition'.
+         */
         double max_composition;
 
         /**

--- a/include/aspect/boundary_composition/spherical_constant.h
+++ b/include/aspect/boundary_composition/spherical_constant.h
@@ -78,8 +78,15 @@ namespace aspect
       private:
         /**
          * Compositions at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Inner composition'.
          */
         std::vector<double> inner_composition;
+
+        /**
+         * Compositions at the inner and outer boundaries.
+         *
+         * This variable is read from the parameter file through a parameter called 'Outer composition'.
+         */
         std::vector<double> outer_composition;
 
         /**

--- a/include/aspect/boundary_composition/two_merged_boxes.h
+++ b/include/aspect/boundary_composition/two_merged_boxes.h
@@ -74,6 +74,11 @@ namespace aspect
         /**
          * The values of the various composition variables on each of the
          * 2*dim+2*(dim-1) boundaries of the box.
+         *
+         * This variable is read from the parameter file through parameters called 'Left composition',
+         * 'Right composition', 'Bottom composition', 'Top composition',
+         * 'Front composition', and 'Back composition', as well as 'Left composition lithosphere',
+         * 'Right composition lithosphere', 'Front composition lithosphere', and 'Back composition lithosphere'.
          */
         std::vector<double> composition_values[2*dim+2*(dim-1)];
     };

--- a/include/aspect/boundary_convective_heating/function.h
+++ b/include/aspect/boundary_convective_heating/function.h
@@ -88,6 +88,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/boundary_convective_heating/interface.h
+++ b/include/aspect/boundary_convective_heating/interface.h
@@ -221,11 +221,14 @@ namespace aspect
 
         /**
         * Names of temperature plugins.
+        * This variable is read from the parameter file through a parameter called 'List of boundary temperature model names'.
         */
         std::vector<std::string> temperature_plugin_names;
 
         /**
          * Names of heat flux plugins.
+         *
+         * This variable is read from the parameter file through a parameter called 'List of boundary heat flux model names'.
          */
         std::vector<std::string> heat_flux_plugin_names;
 

--- a/include/aspect/boundary_heat_flux/function.h
+++ b/include/aspect/boundary_heat_flux/function.h
@@ -81,6 +81,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/boundary_temperature/box.h
+++ b/include/aspect/boundary_temperature/box.h
@@ -82,6 +82,13 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * The values of the various temperature variables on each of the boundaries of the box.
+         *
+         * This variable is read from the parameter file through parameters called 'Left composition',
+         * 'Right composition', 'Bottom composition', 'Top composition',
+         * 'Front composition', and 'Back composition'.
+         */
         double temperature_[2*dim];
     };
   }

--- a/include/aspect/boundary_temperature/dynamic_core.h
+++ b/include/aspect/boundary_temperature/dynamic_core.h
@@ -218,11 +218,13 @@ namespace aspect
 
         /**
          * Temperature at the inner boundary.
+         * This variable is read from the parameter file through a parameter called 'Inner temperature'.
          */
         double inner_temperature;
 
         /**
          * Temperatures at the outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Outer temperature'.
          */
         double outer_temperature;
 
@@ -234,16 +236,19 @@ namespace aspect
 
         /**
          * Initial CMB temperature changing rate
+         * This variable is read from the parameter file through a parameter called 'dT over dt'.
          */
         double init_dT_dt;
 
         /**
          * Initial inner core radius changing rate
+         * This variable is read from the parameter file through a parameter called 'dR over dt'.
          */
         double init_dR_dt;
 
         /**
          * Initial light composition changing rate
+         * This variable is read from the parameter file through a parameter called 'dX over dt'.
          */
         double init_dX_dt;
 
@@ -259,16 +264,19 @@ namespace aspect
 
         /**
          * Initial light composition concentration
+         * This variable is read from the parameter file through a parameter called 'Initial light composition'.
          */
         double X_init;
 
         /**
          * Partition coefficient of the light element
+         * This variable is read from the parameter file through a parameter called 'Delta'.
          */
         double Delta;
 
         /**
          * Pressure at the core mantle boundary
+         * This variable is read from the parameter file through a parameter called 'CMB pressure'.
          */
         double P_CMB;
 
@@ -278,81 +286,113 @@ namespace aspect
          *   Tm(p)= Tm0*(1-Theta)*(1+Tm1*p+Tm2*p^2)
          * if depend on composition X
          *   Tm(p)= Tm0*(1-Theta*X)*(1+Tm1*p+Tm2*p^2)
+         * This variable is read from the parameter file through a parameter called 'Tm0'.
          */
         double Tm0;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Tm1'.
+         */
         double Tm1;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Tm2'.
+         */
         double Tm2;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Theta'.
+         */
         double Theta;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Composition dependency'.
+         */
         bool composition_dependency;
 
         /**
          * If using the Fe-FeS system solidus from Buono & Walker (2011) instead.
+         * This variable is read from the parameter file through a parameter called 'Use BW11'.
          */
         bool use_bw11;
 
-        //Variables for formulation of \cite NPB+04
         /**
+         * Variables for formulation of \cite NPB+04
+         *
          * Compressibility at zero pressure
+         * This variable is read from the parameter file through a parameter called 'K0'.
          */
         double K0;
 
         /**
          * Thermal expansivity
+         * This variable is read from the parameter file through a parameter called 'Alpha'.
          */
         double Alpha;
 
         /**
          * Density at zero pressure
+         * This variable is read from the parameter file through a parameter called 'Rho0'.
          */
         double Rho_0;
 
         /**
          * Density at the center of the planet
+         * This variable is read from the parameter file through a parameter called 'Core density'.
          */
         double Rho_cen;
 
         /**
          * Latent heat of fusion
+         * This variable is read from the parameter file through a parameter called 'Lh'.
          */
         double Lh;
 
         /**
          * Heat of reaction
+         * This variable is read from the parameter file through a parameter called 'Rh'.
          */
         double Rh;
 
         /**
          * Compositional expansion coefficient
+         * This variable is read from the parameter file through a parameter called 'Beta composition'.
          */
         double Beta_c;
 
         /**
          * Heat conductivity of the core
+         * This variable is read from the parameter file through a parameter called 'Core conductivity'.
          */
         double k_c;
 
         /**
          * Heat capacity
+         * This variable is read from the parameter file through a parameter called 'Core heat capacity'.
          */
         double Cp;
 
         /**
          * Number of radioheating element in core
+         * This variable is read from the parameter file through a parameter called 'Number of radioactive heating elements'.
          */
         unsigned int n_radioheating_elements;
 
         /**
          * Heating rates of different elements
+         * This variable is read from the parameter file through a parameter called 'Heating rates'.
          */
         std::vector<double> heating_rate;
 
         /**
          * Half life of different elements
+         * This variable is read from the parameter file through a parameter called 'Half life times'.
          */
         std::vector<double> half_life;
 
         /**
          * Initial concentration of different elements
+         * This variable is read from the parameter file through a parameter called 'Initial concentrations'.
          */
         std::vector<double> initial_concentration;
 
@@ -369,6 +409,7 @@ namespace aspect
 
         /**
          * Max iterations for the core energy balance solver.
+         * This variable is read from the parameter file through a parameter called 'Max iteration'.
          */
         unsigned int max_steps;
 
@@ -379,6 +420,8 @@ namespace aspect
 
         /**
          * Other energy source into the core, e.g. the mechanical stirring of the moon.
+         *
+         * This variable is read from the parameter file through a parameter called 'File name'.
          */
         std::string name_OES;
         struct str_data_OES

--- a/include/aspect/boundary_temperature/function.h
+++ b/include/aspect/boundary_temperature/function.h
@@ -104,13 +104,21 @@ namespace aspect
 
         /**
          * Temperatures at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Minimal temperature'.
          */
         double min_temperature;
+
+        /**
+         * Temperatures at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Maximal temperature'.
+         */
         double max_temperature;
 
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/boundary_temperature/initial_temperature.h
+++ b/include/aspect/boundary_temperature/initial_temperature.h
@@ -96,8 +96,15 @@ namespace aspect
       private:
         /**
          * Temperatures at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Minimal temperature'.
          */
         double min_temperature;
+
+        /**
+         * Temperatures at the inner and outer boundaries.
+         *
+         * This variable is read from the parameter file through a parameter called 'Maximal temperature'.
+         */
         double max_temperature;
 
         /**

--- a/include/aspect/boundary_temperature/interface.h
+++ b/include/aspect/boundary_temperature/interface.h
@@ -286,6 +286,8 @@ namespace aspect
         /**
          * Whether we allow the temperature to be fixed on parts of the boundary
          * where material flows out of the domain.
+         *
+         * This variable is read from the parameter file through a parameter called 'Allow fixed temperature on outflow boundaries'.
          */
         bool allow_fixed_temperature_on_outflow_boundaries;
     };

--- a/include/aspect/boundary_temperature/spherical_constant.h
+++ b/include/aspect/boundary_temperature/spherical_constant.h
@@ -92,8 +92,15 @@ namespace aspect
       private:
         /**
          * Temperatures at the inner and outer boundaries.
+         * This variable is read from the parameter file through a parameter called 'Inner temperature'.
          */
         double inner_temperature;
+
+        /**
+         * Temperatures at the inner and outer boundaries.
+         *
+         * This variable is read from the parameter file through a parameter called 'Outer temperature'.
+         */
         double outer_temperature;
 
         /**

--- a/include/aspect/boundary_temperature/two_merged_boxes.h
+++ b/include/aspect/boundary_temperature/two_merged_boxes.h
@@ -86,6 +86,11 @@ namespace aspect
         /**
          * The values of the various temperature variables on each of the
          * 2*dim+2*(dim-1) boundaries of the box.
+         *
+         * This variable is read from the parameter file through parameters called 'Left composition',
+         * 'Right composition', 'Bottom composition', 'Top composition',
+         * 'Front composition', and 'Back composition', as well as 'Left composition lithosphere',
+         * 'Right composition lithosphere', 'Front composition lithosphere', and 'Back composition lithosphere'.
          */
         double temperature_values[2*dim+2*(dim-1)];
     };

--- a/include/aspect/boundary_traction/ascii_data.h
+++ b/include/aspect/boundary_traction/ascii_data.h
@@ -113,12 +113,15 @@ namespace aspect
         /**
          * Whether to specify traction in x, y, z components, or
          * r, phi, theta components.
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
 
         /**
         * Whether to prescribe pressure (default: true) or full traction vector (false)
         * at the boundary. If true, only 1 component will be used for the boundary condition.
+        *
+        * This variable is read from the parameter file through a parameter called 'Prescribe pressure instead of full traction'.
         */
         bool prescribe_pressure_instead_of_full_traction;
 

--- a/include/aspect/boundary_traction/function.h
+++ b/include/aspect/boundary_traction/function.h
@@ -88,12 +88,15 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 
         /**
          * Whether to specify traction in x, y, z components, or
          * r, phi, theta components.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
     };

--- a/include/aspect/boundary_traction/initial_lithostatic_pressure.h
+++ b/include/aspect/boundary_traction/initial_lithostatic_pressure.h
@@ -79,6 +79,8 @@ namespace aspect
 
         /**
          * The number of integration points.
+         *
+         * This variable is read from the parameter file through a parameter called 'Number of integration points'.
          */
         unsigned int n_points;
 

--- a/include/aspect/boundary_velocity/ascii_data.h
+++ b/include/aspect/boundary_velocity/ascii_data.h
@@ -94,6 +94,8 @@ namespace aspect
         /**
          * Whether to specify velocity in x, y, z components, or
          * r, phi, theta components.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
     };

--- a/include/aspect/boundary_velocity/function.h
+++ b/include/aspect/boundary_velocity/function.h
@@ -87,12 +87,15 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 
         /**
          * Whether to specify velocity in x, y, z components, or
          * r, phi, theta components.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
     };

--- a/include/aspect/boundary_velocity/gplates.h
+++ b/include/aspect/boundary_velocity/gplates.h
@@ -222,12 +222,14 @@ namespace aspect
          * returned for every field. Depending on the setting of the global
          * 'Use years instead of seconds' flag in the input file,
          * this number is either interpreted as seconds or as years."
+         * This variable is read from the parameter file through a parameter called 'First data file model time'.
          */
         double first_data_file_model_time;
 
         /**
          * Number of the first data file to be loaded when the model time is
          * larger than 'First data file model time'.
+         * This variable is read from the parameter file through a parameter called 'First data file number'.
          */
         int first_data_file_number;
 
@@ -236,12 +238,14 @@ namespace aspect
          * in decreasing order (e.g. 'Ma BP'). If this flag is set to 'True'
          * the plugin will first load the file with the number 'First data
          * file number' and decrease the file number during the model run.
+         * This variable is read from the parameter file through a parameter called 'Decreasing file order'.
          */
         bool decreasing_file_order;
 
         /**
          * Time in model units (depends on other model inputs) between two
          * velocity files.
+         * This variable is read from the parameter file through a parameter called 'Data file time step'.
          */
         double data_file_time_step;
 
@@ -260,6 +264,7 @@ namespace aspect
 
         /**
          * Directory in which the gplates velocity files are present.
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string data_directory;
 
@@ -267,11 +272,13 @@ namespace aspect
          * First part of filename of velocity files. The files have to have
          * the pattern velocity_file_name.n.gpml where n is the number of the
          * current timestep (starts from 0).
+         * This variable is read from the parameter file through a parameter called 'Velocity file name'.
          */
         std::string velocity_file_name;
 
         /**
          * Scale the velocity boundary condition by a scalar factor.
+         * This variable is read from the parameter file through a parameter called 'Scale factor'.
          */
         double velocity_scaling_factor;
 
@@ -281,8 +288,13 @@ namespace aspect
          * as if the model is lying in this plane although no actual model
          * coordinate is changed. The strings need to have the format "a,b"
          * where a and b are doubles and define theta and phi on a sphere.
+         * This variable is read from the parameter file through a parameter called 'Point one'.
          */
         std::string point1;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Point two'.
+         */
         std::string point2;
 
         /**
@@ -297,6 +309,8 @@ namespace aspect
          * in the whole lithosphere. At every side boundary point with a depth
          * smaller than this value (and thus being located in the lithosphere),
          * the surface velocity will be described.
+         *
+         * This variable is read from the parameter file through a parameter called 'Lithosphere thickness'.
          */
         double lithosphere_thickness;
 

--- a/include/aspect/geometry_model/box.h
+++ b/include/aspect/geometry_model/box.h
@@ -223,21 +223,30 @@ namespace aspect
 
         /**
          * Extent of the box in x-, y-, and z-direction (in 3d).
+         * This variable is read from the parameter file through parameters called
+         * 'X extent', 'Y extent', and 'Z extent'.
          */
         Point<dim> extents;
 
         /**
          * Origin of the box in x, y, and z (in 3d) coordinates.
+         * This variable is read from the parameter file through parameters called
+         * 'Box origin X coordinate', 'Box origin Y coordinate', and 'Box origin Z coordinate'.
          */
         Point<dim> box_origin;
 
         /**
          * Flag whether the box is periodic in the x-, y-, and z-direction.
+         * This variable is read from the parameter file through parameters called
+         * 'X periodic', 'Y periodic', 'Z periodic'.
          */
         std::array<bool, dim> periodic;
 
         /**
          * The number of cells in each coordinate direction.
+         *
+         * This variable is read from the parameter file through parameters called
+         * 'X repetitions', 'Y repetitions', and 'Z repetitions'.
          */
         std::array<unsigned int, dim> repetitions;
     };

--- a/include/aspect/geometry_model/chunk.h
+++ b/include/aspect/geometry_model/chunk.h
@@ -380,19 +380,24 @@ namespace aspect
 
       private:
         /**
-         * Minimum longitude-depth or
-         * longitude-latitude-depth point
+         * Minimum longitude-depth or longitude-latitude-depth point.
+         * This variable is read from the parameter file through parameters called
+         * 'Chunk inner radius', 'Chunk minimum longitude', and 'Chunk minimum latitude'.
          */
         Point<dim> point1;
 
         /**
-         * Maximum longitude-depth or
-         * longitude-latitude-depth point
+         * Maximum longitude-depth or longitude-latitude-depth point
+         * This variable is read from the parameter file through parameters called
+         * 'Chunk outer radius', 'Chunk maximum longitude', and 'Chunk maximum latitude'.
          */
         Point<dim> point2;
 
         /**
          * The number of cells in each coordinate direction
+         *
+         * This variable is read from the parameter file through parameters called
+         * 'Radius repetitions', 'Longitude repetitions', and 'Latitude repetitions'.
          */
         std::array<unsigned int, dim> repetitions;
 

--- a/include/aspect/geometry_model/initial_topography_model/function.h
+++ b/include/aspect/geometry_model/initial_topography_model/function.h
@@ -70,6 +70,7 @@ namespace aspect
 
         /**
          * The maximum value the topography can take.
+         * This variable is read from the parameter file through a parameter called 'Maximum topography value'.
          */
         double max_topo;
 
@@ -81,6 +82,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/geometry_model/sphere.h
+++ b/include/aspect/geometry_model/sphere.h
@@ -151,7 +151,9 @@ namespace aspect
 
       private:
         /**
-         * Radius of the sphere
+         * Radius of the sphere.
+         *
+         * This variable is read from the parameter file through a parameter called 'Radius'.
          */
         double R;
     };

--- a/include/aspect/geometry_model/spherical_shell.h
+++ b/include/aspect/geometry_model/spherical_shell.h
@@ -371,6 +371,7 @@ namespace aspect
         /**
          * Specify the radial subdivision of the spherical shell
          * mesh.
+         * This variable is read from the parameter file through a parameter called 'Custom mesh subdivision'.
          */
         enum CustomMeshRadialSubdivision
         {
@@ -381,31 +382,42 @@ namespace aspect
 
         /**
          * Initial surface refinement for the custom mesh cases.
+         * This variable is read from the parameter file through a parameter called 'Initial lateral refinement'.
          */
         unsigned int initial_lateral_refinement;
 
         /**
          * Initial surface refinement for the custom mesh cases.
+         * This variable is read from the parameter file through a parameter called 'Number of slices'.
          */
         unsigned int n_slices;
 
         /**
          * List of radial values for the list custom mesh.
+         * This variable is read from the parameter file through a parameter called 'List of radial values'.
          */
         std::vector<double> R_values_list;
 
         /**
-         * Inner and outer radii of the spherical shell.
+         * Inner radius of the spherical shell.
+         * This variable is read from the parameter file through a parameter called 'Inner radius'.
          */
-        double R0, R1;
+        double R0;
+        /**
+         * Outer radius of the spherical shell.
+         * This variable is read from the parameter file through a parameter called 'Outer radius'.
+         */
+        double R1;
 
         /**
          * Opening angle of the section of the shell that we simulate.
+         * This variable is read from the parameter file through a parameter called 'Opening angle'.
          */
         double phi;
 
         /**
          * Number of tangential mesh cells in the initial, coarse mesh.
+         * This variable is read from the parameter file through a parameter called 'Cells along circumference'.
          */
         int n_cells_along_circumference;
 
@@ -417,6 +429,8 @@ namespace aspect
 
         /**
          * Flag whether the shell is periodic in phi.
+         *
+         * This variable is read from the parameter file through a parameter called 'Phi periodic'.
          */
         bool periodic;
 

--- a/include/aspect/geometry_model/two_merged_boxes.h
+++ b/include/aspect/geometry_model/two_merged_boxes.h
@@ -233,11 +233,14 @@ namespace aspect
          * is a safer option, since it forces the boundary conditions
          * to be always applied to the same depth, but one unified grid allows
          * for a more flexible usage of the adaptive refinement.
+         * This variable is read from the parameter file through a parameter called 'Use merged grids'.
          */
         bool use_merged_grids;
 
         /**
          * Extent of the whole model domain in x-, y-, and z-direction (in 3d).
+         * This variable is read from the parameter file through parameters called
+         * 'X extent', 'Y extent', and 'Z extent'.
          */
         Point<dim> extents;
 
@@ -248,6 +251,8 @@ namespace aspect
 
         /**
          * Origin of the lower box in x, y, and z (in 3d) coordinates.
+         * This variable is read from the parameter file through parameters called
+         * 'Box origin X coordinate', 'Box origin Y coordinate', and 'Box origin Z coordinate'.
          */
         Point<dim> lower_box_origin;
 
@@ -264,16 +269,24 @@ namespace aspect
         /**
          * Flag whether the whole domain is periodic in the x-, y-, and z-directions,
          * the x- and y- (in 3d) direction in the lithosphere.
+         * This variable is read from the parameter file through parameters called
+         * 'X periodic', 'X periodic lithosphere', 'Y periodic',
+         * 'Y periodic lithosphere', and 'Z periodic'.
          */
         bool periodic[dim+dim-1];
 
         /**
          * The number of cells in each coordinate direction for the lower box.
+         * This variable is read from the parameter file through parameters called
+         * 'X repetitions', 'Y repetitions', and 'Z repetitions'.
          */
         std::array<unsigned int, dim> lower_repetitions;
 
         /**
          * The number of cells in each coordinate direction for the upper box.
+         *
+         * This variable is read from the parameter file through parameters called
+         * 'Y repetitions lithosphere' and 'Z repetitions lithosphere'.
          */
         std::array<unsigned int, dim> upper_repetitions;
 

--- a/include/aspect/geometry_model/two_merged_chunks.h
+++ b/include/aspect/geometry_model/two_merged_chunks.h
@@ -253,6 +253,7 @@ namespace aspect
          * is a safer option, since it forces the boundary conditions
          * to be always applied to the same depth, but one unified grid allows
          * for a more flexible usage of the adaptive refinement.
+         * This variable is read from the parameter file through a parameter called 'Use merged grids'.
          */
         bool use_merged_grids;
 
@@ -260,6 +261,8 @@ namespace aspect
          * Minimum longitude-depth (2D) or
          * longitude-latitude-depth (3D) point
          * of the entire merged chunk.
+         * This variable is read from the parameter file through parameters called
+         * 'Chunk inner radius', 'Chunk minimum longitude', and 'Chunk minimum latitude'.
          */
         Point<dim> point1;
 
@@ -267,6 +270,8 @@ namespace aspect
          * Maximum longitude-depth (2D) or
          * longitude-latitude-depth (3D) point
          * of the entire merged chunk.
+         * This variable is read from the parameter file through parameters called
+         * 'Chunk outer radius', 'Chunk maximum longitude', and 'Chunk maximum latitude'.
          */
         Point<dim> point2;
 
@@ -274,6 +279,7 @@ namespace aspect
          * Minimum longitude-depth (2D) or
          * longitude-latitude-depth (3D) point
          * for the upper chunk.
+         * This variable is read from the parameter file through a parameter called 'Chunk middle boundary radius'.
          */
         Point<dim> point3;
 
@@ -286,9 +292,21 @@ namespace aspect
 
         /**
          * The number of cells in each coordinate direction
-         * for the lower and upper chunk.
+         * for the lower chunk.
+         * This variable is read from the parameter file through parameters called
+         * 'Inner chunk radius repetitions', 'Longitude repetitions', and
+         * 'Latitude repetitions'.
          */
         std::array<unsigned int, dim> lower_repetitions;
+
+        /**
+         * The number of cells in each coordinate direction
+         * for the upper chunk.
+         *
+         * This variable is read from the parameter file through parameters called
+         * 'Outer chunk radius repetitions', 'Longitude repetitions', and
+         * 'Latitude repetitions'.
+         */
         std::array<unsigned int, dim> upper_repetitions;
 
         /**

--- a/include/aspect/gravity_model/function.h
+++ b/include/aspect/gravity_model/function.h
@@ -82,6 +82,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/gravity_model/radial_constant.h
+++ b/include/aspect/gravity_model/radial_constant.h
@@ -60,6 +60,8 @@ namespace aspect
       private:
         /**
          * Magnitude of the gravity vector.
+         *
+         * This variable is read from the parameter file through a parameter called 'Magnitude'.
          */
         double magnitude;
     };

--- a/include/aspect/gravity_model/radial_linear.h
+++ b/include/aspect/gravity_model/radial_linear.h
@@ -60,6 +60,7 @@ namespace aspect
       private:
         /**
          * Magnitude of the gravity vector at the surface, m/s^2
+         * This variable is read from the parameter file through a parameter called 'Magnitude at surface'.
          */
         double magnitude_at_surface;
 
@@ -67,6 +68,8 @@ namespace aspect
          * Magnitude of the gravity vector at the bottom, m/s^2.
          * 'Bottom' means at the maximum depth of the provided geometry, for
          * a full sphere this means the center.
+         *
+         * This variable is read from the parameter file through a parameter called 'Magnitude at bottom'.
          */
         double magnitude_at_bottom;
 

--- a/include/aspect/gravity_model/vertical.h
+++ b/include/aspect/gravity_model/vertical.h
@@ -60,6 +60,8 @@ namespace aspect
       private:
         /**
          * Magnitude of the gravity vector.
+         *
+         * This variable is read from the parameter file through a parameter called 'Magnitude'.
          */
         double gravity_magnitude;
 

--- a/include/aspect/heating_model/adiabatic_heating.h
+++ b/include/aspect/heating_model/adiabatic_heating.h
@@ -100,6 +100,9 @@ namespace aspect
          */
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Use simplified adiabatic heating'.
+         */
         bool simplified_adiabatic_heating;
     };
   }

--- a/include/aspect/heating_model/adiabatic_heating_of_melt.h
+++ b/include/aspect/heating_model/adiabatic_heating_of_melt.h
@@ -104,6 +104,9 @@ namespace aspect
          */
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Use simplified adiabatic heating'.
+         */
         bool simplified_adiabatic_heating;
     };
   }

--- a/include/aspect/heating_model/compositional_heating.h
+++ b/include/aspect/heating_model/compositional_heating.h
@@ -72,6 +72,8 @@ namespace aspect
       private:
         /**
          * Magnitude of heat production for each compositional field
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional heating values'.
          */
         std::vector<double> heating_values;
 

--- a/include/aspect/heating_model/constant_heating.h
+++ b/include/aspect/heating_model/constant_heating.h
@@ -75,6 +75,9 @@ namespace aspect
          */
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Radiogenic heating rate'.
+         */
         double radiogenic_heating_rate;
     };
   }

--- a/include/aspect/heating_model/function.h
+++ b/include/aspect/heating_model/function.h
@@ -92,6 +92,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/heating_model/latent_heat_melt.h
+++ b/include/aspect/heating_model/latent_heat_melt.h
@@ -85,8 +85,16 @@ namespace aspect
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &outputs) const override;
 
       private:
-        // entropy change upon melting
+        /**
+         * Entropy change upon melting.
+         *
+         * This variable is read from the parameter file through a parameter called 'Melting entropy change'.
+         */
         double melting_entropy_change;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Retrieve entropy change from material model'.
+         */
         bool   retrieve_entropy_change_from_material_model;
     };
   }

--- a/include/aspect/heating_model/radioactive_decay.h
+++ b/include/aspect/heating_model/radioactive_decay.h
@@ -78,42 +78,51 @@ namespace aspect
       private:
 
         /**
-         * Number of radio active heating elements.
+         * Number of radioactive heating elements. This variable is read from
+         * the parameter file through the 'Number of elements' parameter.
          */
         unsigned int                   n_radio_heating_elements;
 
         /**
-         * Store the half life of different elements.
+         * Half-lives of different elements. This variable is read from the
+         * parameter file through the 'Half decay times' parameter.
          */
         std::vector<double>            half_decay_times;
 
         /**
-         * Store the unit heating rate of different elements.
+         * Unit heating rates of different elements. This variable is read from
+         * the parameter file through the 'Heating rates' parameter.
          */
         std::vector<double>            radioactive_heating_rates;
 
         /**
-         * Store the initial concentration in the crust.
+         * Initial concentrations in the crust. This variable is read from the
+         * parameter file through the 'Initial concentrations crust' parameter.
          */
         std::vector<double>            radioactive_initial_concentrations_crust;
 
         /**
-         * Store the initial concentration in the mantle.
+         * Initial concentrations in the mantle. This variable is read from the
+         * parameter file through the 'Initial concentrations mantle' parameter.
          */
         std::vector<double>            radioactive_initial_concentrations_mantle;
 
         /**
-         * Whether crust defined by composition or depth
+         * Whether the crust is defined by composition or depth. This variable
+         * is read from the parameter file through the 'Crust defined by
+         * composition' parameter.
          */
         bool                           is_crust_defined_by_composition;
 
         /**
-         * Depth of the crust.
+         * Depth of the crust. This variable is read from the parameter file
+         * through the 'Crust depth' parameter.
          */
         double                         crust_depth;
 
         /**
-         * Composition number of crust.
+         * Composition number of the crust. This variable is read from the
+         * parameter file through the 'Crust composition number' parameter.
          */
         unsigned int                   crust_composition_num;
     };

--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -88,9 +88,17 @@ namespace aspect
          * in the DruckerPrager rheology model can be used to define a
          * maximum stress computed from the given cohesion and friction
          * angle.
+         * This variable is read from the parameter file through the 'Limit
+         * stress contribution to shear heating' parameter.
          */
         bool limit_stress;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Cohesion for maximum shear stress'.
+         */
         double cohesion;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Friction angle for maximum shear stress'.
+         */
         double friction_angle;
         MaterialModel::Rheology::DruckerPrager<dim> drucker_prager_plasticity;
     };
@@ -142,7 +150,7 @@ namespace aspect
          * If this object is created and filled by the material model
          * it will replace the default viscous dissipation rate
          * computed by the shear heating model.
-        */
+         */
         std::vector<double> prescribed_shear_heating_rates;
     };
   }

--- a/include/aspect/heating_model/tidal_heating.h
+++ b/include/aspect/heating_model/tidal_heating.h
@@ -89,9 +89,17 @@ namespace aspect
          * If 'latitudinal variation', 'Maximum tidal strain rate' and 'Minimum tidal strain rate' are used.
          * Then, the equation follows as (maximum_tidal_strain_rate - minimum_tidal_strain_rate)*cos(theta/2)+(maximum_tidal_strain_rate+minimum_tidal_strain_rate)/2.
          * This is shown in Fig.3 of Nimmo et al. (2007) (https://doi.org/10.1016/j.icarus.2007.04.021).
+         * This variable is read from the parameter file through the 'Tidal
+         * frequency' parameter.
          */
         double tidal_frequency;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Elastic shear modulus'.
+         */
         double elastic_shear_modulus;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Constant tidal strain rate'.
+         */
         double constant_tidal_strain_rate;
 
         /**
@@ -103,7 +111,13 @@ namespace aspect
           latitudinal_variation
         } strain_rate_distribution;
 
+        /**
+         * This variable is read from the parameter file through a parameter called 'Maximum tidal strain rate'.
+         */
         double maximum_tidal_strain_rate;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Minimum tidal strain rate'.
+         */
         double minimum_tidal_strain_rate;
     };
   }

--- a/include/aspect/initial_composition/entropy_table_lookup.h
+++ b/include/aspect/initial_composition/entropy_table_lookup.h
@@ -71,9 +71,13 @@ namespace aspect
 
       private:
         /**
-         * Information about the location of data files.
+         * Location of data files. This variable is read from the parameter
+         * file through the 'Data directory' parameter.
          */
         std::string data_directory;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Material file name'.
+         */
         std::string material_file_name;
 
         /**

--- a/include/aspect/initial_composition/function.h
+++ b/include/aspect/initial_composition/function.h
@@ -71,6 +71,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/initial_temperature/S40RTS_perturbation.h
+++ b/include/aspect/initial_temperature/S40RTS_perturbation.h
@@ -140,9 +140,13 @@ namespace aspect
         VsToDensityMethod vs_to_density_method;
 
         /**
-         * File directory and names
+         * Directory and names of files. This variable is read from the
+         * parameter file through the 'Data directory' parameter.
          */
         std::string data_directory;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Spline knots depth file name'.
+         */
         std::string spline_depth_file_name;
 
         /**
@@ -151,6 +155,7 @@ namespace aspect
          * S40RTS there are different versions available that differ by the
          * degree of damping in the seismic inversion. These models could be
          * downloaded and used as well.
+         * This variable is read from the parameter file through a parameter called 'Initial condition file name'.
          */
         std::string harmonics_coeffs_file_name;
 
@@ -164,27 +169,37 @@ namespace aspect
          * 17,981-17,994.
          * The last parameter is a depth down to which heterogeneities are
          * zeroed out.
+         * This variable is read from the parameter file through a parameter called 'Vs to density scaling'.
          */
         double vs_to_density_constant;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient in initial temperature scaling'.
+         */
         double thermal_alpha;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Remove temperature heterogeneity down to specified depth'.
+         */
         double no_perturbation_depth;
 
         /**
          * This parameter allows to remove the degree 0 component of the shear
          * wave velocity perturbation, which guarantees that average
          * temperature at a certain depth is the background temperature.
+         * This variable is read from the parameter file through a parameter called 'Remove degree 0 from perturbation'.
          */
         bool zero_out_degree_0;
 
         /**
          * This parameter allows to use a lower maximum degree when reading
          * the spherical harmonic data file.
+         * This variable is read from the parameter file through a parameter called 'Specify a lower maximum degree'.
          */
         bool lower_max_degree;
 
         /**
          * The maximum degree the users specify, which is only valid when
          * "lower_max_degree" is set to true.
+         * This variable is read from the parameter file through a parameter called 'Maximum degree'.
          */
         unsigned int specified_max_degree;
 
@@ -192,6 +207,7 @@ namespace aspect
          * This parameter gives the reference temperature, which will be
          * perturbed. In the compressional case the background temperature
          * will be the adiabat.
+         * This variable is read from the parameter file through a parameter called 'Reference temperature'.
          */
         double reference_temperature;
 
@@ -219,6 +235,8 @@ namespace aspect
 
         /**
          * Whether to use the thermal expansion coefficient from the material model
+         *
+         * This variable is read from the parameter file through a parameter called 'Use thermal expansion coefficient from material model'.
          */
         bool use_material_model_thermal_alpha;
 

--- a/include/aspect/initial_temperature/SAVANI_perturbation.h
+++ b/include/aspect/initial_temperature/SAVANI_perturbation.h
@@ -107,14 +107,19 @@ namespace aspect
         VsToDensityMethod vs_to_density_method;
 
         /**
-         * File directory and names
+         * Directory and names of files. This variable is read from the
+         * parameter file through the 'Data directory' parameter.
          */
         std::string data_directory;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Spline knots depth file name'.
+         */
         std::string spline_depth_file_name;
 
         /**
          * This parameter allows setting the input file for the SAVANI global
          * shear-wave perturbation.
+         * This variable is read from the parameter file through a parameter called 'Initial condition file name'.
          */
         std::string harmonics_coeffs_file_name;
 
@@ -128,27 +133,37 @@ namespace aspect
          * 17,981-17,994.
          * The last parameter is a depth down to which heterogeneities are
          * zeroed out.
+         * This variable is read from the parameter file through a parameter called 'Vs to density scaling'.
          */
         double vs_to_density_constant;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient in initial temperature scaling'.
+         */
         double thermal_alpha;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Remove temperature heterogeneity down to specified depth'.
+         */
         double no_perturbation_depth;
 
         /**
          * This parameter allows to remove the degree 0 component of the shear
          * wave velocity perturbation, which guarantees that average
          * temperature at a certain depth is the background temperature.
+         * This variable is read from the parameter file through a parameter called 'Remove degree 0 from perturbation'.
          */
         bool zero_out_degree_0;
 
         /**
          * This parameter allows to use a lower maximum degree when reading
          * the spherical harmonic data file.
+         * This variable is read from the parameter file through a parameter called 'Specify a lower maximum degree'.
          */
         bool lower_max_degree;
 
         /**
          * The maximum degree the users specify, which is only valid when
          * "lower_max_degree" is set to true.
+         * This variable is read from the parameter file through a parameter called 'Maximum degree'.
          */
         unsigned int specified_max_degree;
 
@@ -156,6 +171,7 @@ namespace aspect
          * This parameter gives the reference temperature, which will be
          * perturbed. In the compressional case the background temperature
          * will be the adiabat.
+         * This variable is read from the parameter file through a parameter called 'Reference temperature'.
          */
         double reference_temperature;
 
@@ -183,6 +199,8 @@ namespace aspect
 
         /**
          * Whether to use the thermal expansion coefficient from the material model
+         *
+         * This variable is read from the parameter file through a parameter called 'Use thermal expansion coefficient from material model'.
          */
         bool use_material_model_thermal_alpha;
 

--- a/include/aspect/initial_temperature/adiabatic.h
+++ b/include/aspect/initial_temperature/adiabatic.h
@@ -110,32 +110,45 @@ namespace aspect
          * Age of the upper thermal boundary layer at the surface of the
          * model. If set to zero, no boundary layer will be present in the
          * model.
+         * This variable is read from the parameter file through the 'Age top
+         * boundary layer' parameter.
          */
         double age_top_boundary_layer;
 
-        /* Age of the lower thermal boundary layer. */
+        /**
+         * Age of the lower thermal boundary layer. This variable is read from
+         * the parameter file through the 'Age bottom boundary layer' parameter.
+         */
         double age_bottom_boundary_layer;
 
         /**
          * Radius (in m) of the initial temperature perturbation at the bottom
          * of the model domain.
+         * This variable is read from the parameter file through the 'Radius'
+         * parameter.
          */
         double radius;
         /**
          * Amplitude (in K) of the initial temperature perturbation at the
          * bottom of the model domain.
+         * This variable is read from the parameter file through the 'Amplitude'
+         * parameter.
          */
         double amplitude;
-        /*
+        /**
          * Position of the initial temperature perturbation (in the
          * center or at the boundary of the model domain).
+         * This variable is read from the parameter file through the 'Position'
+         * parameter.
          */
         std::string perturbation_position;
 
-        /*
+        /**
          * Deviation from adiabaticity in a subadiabatic mantle
          * temperature profile. 0 for an adiabatic temperature
          * profile.
+         * This variable is read from the parameter file through the
+         * 'Subadiabaticity' parameter.
          */
         double subadiabaticity;
 
@@ -144,14 +157,18 @@ namespace aspect
          */
         BoundaryLayerAgeModel::Kind top_boundary_layer_age_model;
 
-        /*
+        /**
          * Whether to use the half space cooling model, or the plate cooling
          * model
+         * This variable is read from the parameter file through the 'Cooling
+         * model' parameter.
          */
         std::string cooling_model;
 
-        /*
+        /**
          * Depth to the base of the lithosphere for plate cooling model, in m
+         * This variable is read from the parameter file through the
+         * 'Lithosphere thickness' parameter.
          */
         double lithosphere_thickness;
 
@@ -170,6 +187,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/initial_temperature/adiabatic_boundary.h
+++ b/include/aspect/initial_temperature/adiabatic_boundary.h
@@ -76,8 +76,17 @@ namespace aspect
 
       private:
 
+        /**
+         * This variable is read from the parameter file through a parameter called 'Isotherm temperature'.
+         */
         double isotherm_temperature;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Surface temperature'.
+         */
         double surface_temperature;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Adiabatic temperature gradient'.
+         */
         double temperature_gradient;
         types::boundary_id surface_boundary_id;
 

--- a/include/aspect/initial_temperature/box.h
+++ b/include/aspect/initial_temperature/box.h
@@ -105,13 +105,37 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Inclusion shape'.
+         */
         std::string inclusion_shape;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Inclusion gradient'.
+         */
         std::string inclusion_gradient;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Shape radius'.
+         */
         double radius;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Ambient temperature'.
+         */
         double ambient_temperature;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Inclusion temperature'.
+         */
         double inclusion_temperature;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Center X'.
+         */
         double center_x;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Center Y'.
+         */
         double center_y;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Center Z'.
+         */
         double center_z;
     };
   }

--- a/include/aspect/initial_temperature/continental_geotherm.h
+++ b/include/aspect/initial_temperature/continental_geotherm.h
@@ -74,18 +74,22 @@ namespace aspect
       private:
         /**
          * Surface temperature
+         * This variable is read from the parameter file through a parameter called 'Surface temperature'.
          */
         double T0;
 
         /**
          * Value of the isotherm defining the
          * Lithosphere-Asthenosphere boundary.
+         * This variable is read from the parameter file through a parameter called 'Lithosphere-Asthenosphere boundary isotherm'.
          */
         double LAB_isotherm;
 
         /**
          * Vector for the thicknesses of the compositional fields
          * representing the layers 'upper_crust', 'lower_crust' and 'lithospheric_mantle'.
+         *
+         * This variable is read from the parameter file through a parameter called 'Layer thicknesses'.
          */
         std::vector<double> thicknesses;
 

--- a/include/aspect/initial_temperature/function.h
+++ b/include/aspect/initial_temperature/function.h
@@ -74,6 +74,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/initial_temperature/harmonic_perturbation.h
+++ b/include/aspect/initial_temperature/harmonic_perturbation.h
@@ -69,6 +69,7 @@ namespace aspect
          * number variables are in fact twice the wave number in a
          * mathematical sense. This allows the user to prescribe a single
          * up-/downswing or half periods.
+         * This variable is read from the parameter file through a parameter called 'Vertical wave number'.
          */
         int vertical_wave_number;
 
@@ -76,6 +77,7 @@ namespace aspect
          * The lateral wave number  of the harmonic perturbation in the first
          * dimension. This is the only lateral wave number in 2D and equals
          * the degree of the spherical harmonics in a 3D spherical shell.
+         * This variable is read from the parameter file through a parameter called 'Lateral wave number one'.
          */
         int lateral_wave_number_1;
 
@@ -83,11 +85,13 @@ namespace aspect
          * The lateral wave number of the harmonic perturbation in the second
          * dimension. This is not used in 2D and equals the order of the
          * spherical harmonics in a 3D spherical shell.
+         * This variable is read from the parameter file through a parameter called 'Lateral wave number two'.
          */
         int lateral_wave_number_2;
 
         /**
          * The maximal magnitude of the harmonic perturbation.
+         * This variable is read from the parameter file through a parameter called 'Magnitude'.
          */
         double magnitude;
 
@@ -96,6 +100,8 @@ namespace aspect
          * in an incompressible material model. In case of a compressible
          * material model the perturbation is applied on top of an adiabatic
          * profile and this variable is not used at all.
+         *
+         * This variable is read from the parameter file through a parameter called 'Reference temperature'.
          */
         double reference_temperature;
     };

--- a/include/aspect/initial_temperature/lithosphere_mask.h
+++ b/include/aspect/initial_temperature/lithosphere_mask.h
@@ -79,11 +79,13 @@ namespace aspect
 
           /**
            * Directory in which the LAB depth file is present.
+           * This variable is read from the parameter file through a parameter called 'Data directory'.
            */
           std::string data_directory;
 
           /**
            * File name of the LAB depth file.
+           * This variable is read from the parameter file through a parameter called 'LAB depth filename'.
            */
           std::string LAB_file_name;
 
@@ -105,6 +107,7 @@ namespace aspect
            * This parameter gives the maximum depth of the lithosphere. The
            * model returns nans below this depth. This parameter is only used if LAB
            * depth source is set to 'Value'.
+           * This variable is read from the parameter file through a parameter called 'Maximum lithosphere depth'.
            */
           double max_depth;
       };
@@ -151,6 +154,8 @@ namespace aspect
       private:
         /**
          * This parameter gives the initial temperature set within the lithosphere.
+         *
+         * This variable is read from the parameter file through a parameter called 'Lithosphere temperature'.
          */
         double lithosphere_temperature;
 

--- a/include/aspect/initial_temperature/patch_on_S40RTS.h
+++ b/include/aspect/initial_temperature/patch_on_S40RTS.h
@@ -68,6 +68,7 @@ namespace aspect
         /**
          * This parameter gives the maximum depth of the Vs ascii grid. The
          * model will read in Vs from S40RTS below this depth.
+         * This variable is read from the parameter file through a parameter called 'Maximum grid depth'.
          */
         double max_grid_depth;
 
@@ -75,6 +76,7 @@ namespace aspect
          * This parameter gives the range (above maximum grid depth) over which to smooth.
          * Smoothing is done with a depth weighted combination of the values in the ascii grid and S40RTS
          * at each point.
+         * This variable is read from the parameter file through a parameter called 'Smoothing length scale'.
          */
         double smoothing_length_scale;
 
@@ -109,6 +111,8 @@ namespace aspect
         /**
          * This parameter is the depth down to which shear wave perturbations are
          * zeroed out.
+         *
+         * This variable is read from the parameter file through a parameter called 'Remove temperature heterogeneity down to specified depth'.
          */
         double no_perturbation_depth_patch;
 

--- a/include/aspect/initial_temperature/random_gaussian_perturbation.h
+++ b/include/aspect/initial_temperature/random_gaussian_perturbation.h
@@ -71,16 +71,20 @@ namespace aspect
 
         /**
          * The number of the random Gaussian perturbations.
+         * This variable is read from the parameter file through a parameter called 'Number of perturbations'.
          */
         unsigned int n_perturbations;
 
         /**
          * The maximal magnitude of the random Gaussian perturbations.
+         * This variable is read from the parameter file through a parameter called 'Maximum magnitude'.
          */
         double max_magnitude;
 
         /**
          * The width of the random Gaussian perturbations.
+         *
+         * This variable is read from the parameter file through a parameter called 'Width'.
          */
         double width;
 

--- a/include/aspect/initial_temperature/spherical_shell.h
+++ b/include/aspect/initial_temperature/spherical_shell.h
@@ -64,6 +64,7 @@ namespace aspect
          * spherical shell. Historically, this was permanently set to 6 (hence
          * the class name SphericalHexagonalPerturbation) The default is 6 in
          * order to provide backwards compatibility.
+         * This variable is read from the parameter file through a parameter called 'Angular mode'.
          */
         unsigned int angular_mode;
 
@@ -73,6 +74,7 @@ namespace aspect
          * will cause one of the perturbations to point north/up. Rotation
          * offset is set to -45 degrees by default in order to provide
          * backwards compatibility.
+         * This variable is read from the parameter file through a parameter called 'Rotation offset'.
          */
         double rotation_offset;
 
@@ -119,10 +121,25 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Angle'.
+         */
         double angle;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Non-dimensional depth'.
+         */
         double depth;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Amplitude'.
+         */
         double amplitude;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Sigma'.
+         */
         double sigma;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Sign'.
+         */
         double sign;
         unsigned int npoint;
 

--- a/include/aspect/material_model/ascii_reference_profile.h
+++ b/include/aspect/material_model/ascii_reference_profile.h
@@ -104,17 +104,20 @@ namespace aspect
       private:
         /**
          * Use truncated anelastic approximation?
+         * This variable is read from the parameter file through a parameter called 'Use TALA'.
          */
         bool tala;
 
         /**
          * The reference viscosity
+         * This variable is read from the parameter file through a parameter called 'Viscosity'.
          */
         double viscosity;
 
         /**
          * The constant $A$ in the temperature dependence of viscosity
          * $\exp\left(-A \frac{T - T_\text{adi}}{T_\text{adi}}\right).$
+         * This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
          */
         double thermal_viscosity_exponent;
 
@@ -123,6 +126,7 @@ namespace aspect
          * $\eta_r(z)$, which determines the depth dependence of viscosity,
          * and is multiplied with the reference viscosity and the
          * temperature dependence to compute the viscosity $\eta(z,T)$.
+         * This variable is read from the parameter file through a parameter called 'Viscosity prefactors'.
          */
         std::vector<double> viscosity_prefactors;
 
@@ -130,6 +134,8 @@ namespace aspect
          * A list of depths that determine the locations of the jumps in
          * the piece-wise constant function $\eta_r(z)$, which describes the
          * depth dependence of viscosity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Transition depths'.
          */
         std::vector<double> transition_depths;
 

--- a/include/aspect/material_model/averaging.h
+++ b/include/aspect/material_model/averaging.h
@@ -148,11 +148,14 @@ namespace aspect
         /**
          * The bell shape limit variable stores the maximum extend of the bell
          * shape for the Normalized Weighed Distance (NWD) averages.
+         * This variable is read from the parameter file through a parameter called 'Bell shape limit'.
          */
         double bell_shape_limit;
         /**
          * The averaging operation variable stores the chosen averaging
          * operation.
+         *
+         * This variable is read from the parameter file through a parameter called 'Averaging operation'.
          */
         AveragingOperation averaging_operation;
         /**

--- a/include/aspect/material_model/composition_reaction.h
+++ b/include/aspect/material_model/composition_reaction.h
@@ -97,14 +97,30 @@ namespace aspect
 
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Composition viscosity prefactor 1'.
+         */
         double composition_viscosity_prefactor_1;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Composition viscosity prefactor 2'.
+         */
         double composition_viscosity_prefactor_2;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
 
         /**
          * The thermal conductivity.
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 
@@ -113,6 +129,8 @@ namespace aspect
         /**
          * Above this depth the compositional fields react: The first field
          * gets converted to the second field.
+         *
+         * This variable is read from the parameter file through a parameter called 'Reaction depth'.
          */
         double reaction_depth;
     };

--- a/include/aspect/material_model/depth_dependent.h
+++ b/include/aspect/material_model/depth_dependent.h
@@ -99,11 +99,13 @@ namespace aspect
         /**
          * The viscosity that will be used as a reference for computing the depth-dependent
          * prefactor.
+         * This variable is read from the parameter file through a parameter called 'Reference viscosity'.
          */
         double reference_viscosity;
 
         /**
          * Currently chosen source for the viscosity.
+         * This variable is read from the parameter file through a parameter called 'Depth dependence method'.
          */
         ViscositySource viscosity_source;
 
@@ -122,8 +124,13 @@ namespace aspect
 
         /**
          * Values of depth specified by the user if using the depth dependence method 'list'
+         *
+         * This variable is read from the parameter file through a parameter called 'Depth list'.
          */
         std::vector<double> depth_values;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity list'.
+         */
         std::vector<double> viscosity_values;
 
         /**

--- a/include/aspect/material_model/diffusion_dislocation.h
+++ b/include/aspect/material_model/diffusion_dislocation.h
@@ -108,12 +108,27 @@ namespace aspect
          */
         Rheology::DiffusionDislocation<dim> diffusion_dislocation;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal diffusivity'.
+         */
         double thermal_diffusivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Heat capacity'.
+         */
         double heat_capacity;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Densities'.
+         */
         std::vector<double> densities;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansivities'.
+         */
         std::vector<double> thermal_expansivities;
 
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;

--- a/include/aspect/material_model/drucker_prager.h
+++ b/include/aspect/material_model/drucker_prager.h
@@ -130,7 +130,13 @@ namespace aspect
 
       private:
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
+         */
         double thermal_conductivities;
 
         EquationOfState::LinearizedIncompressible<dim> equation_of_state;
@@ -142,22 +148,30 @@ namespace aspect
 
         /**
          * The angle of internal friction
+         * This variable is read from the parameter file through a parameter called 'Angle of internal friction'.
          */
         double angle_of_internal_friction;
 
         /**
          * The cohesion
+         * This variable is read from the parameter file through a parameter called 'Cohesion'.
          */
         double cohesion;
 
         /**
          * The applied viscosity bounds
+         * This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
          */
         double minimum_viscosity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+         */
         double maximum_viscosity;
 
         /**
          * The reference strain rate used as a first estimate
+         *
+         * This variable is read from the parameter file through a parameter called 'Reference strain rate'.
          */
         double reference_strain_rate;
     };

--- a/include/aspect/material_model/entropy_model.h
+++ b/include/aspect/material_model/entropy_model.h
@@ -122,7 +122,13 @@ namespace aspect
 
       private:
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Angle of internal friction'.
+         */
         double angle_of_internal_friction;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Cohesion'.
+         */
         double cohesion;
 
         /**
@@ -131,15 +137,26 @@ namespace aspect
          * reach the tolerance value, which is the maximum temperature difference between the different components
          * when they are considered in equilibrium.
          * If the maximum iteration is reached but the temperature has not been equilibrated, the model will abort.
+         * This variable is read from the parameter file through a parameter called 'Maximum iteration for multicomponent equilibration'.
          */
         double multicomponent_max_iteration;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Multicomponent equilibration tolerance'.
+         */
         double multicomponent_tolerance;
 
         /**
          * Minimum/Maximum viscosity and lateral viscosity variations.
+         * This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
          */
         double min_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+         */
         double max_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum lateral viscosity variation'.
+         */
         double max_lateral_eta_variation;
 
         /**
@@ -162,9 +179,17 @@ namespace aspect
                                          std::vector<double> &composition_equilibrated_S) const;
         /**
          * Information about the location of data files.
+         *
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string data_directory;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Material file name'.
+         */
         std::vector<std::string> material_file_names;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Lateral viscosity file name'.
+         */
         std::string lateral_viscosity_file_name;
 
         /**

--- a/include/aspect/material_model/equation_of_state/linearized_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/linearized_incompressible.h
@@ -100,21 +100,25 @@ namespace aspect
         private:
           /**
            * The reference density $\rho_0$ used in the computation of the density.
+           * This variable is read from the parameter file through a parameter called 'Reference density'.
            */
           double reference_rho;
 
           /**
            * The reference temperature $T_0$ used in the computation of the density.
+           * This variable is read from the parameter file through a parameter called 'Reference temperature'.
            */
           double reference_T;
 
           /**
            * The constant thermal expansivity $\alpha$ used in the computation of the density.
+           * This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
            */
           double thermal_alpha;
 
           /**
            * The constant specific heat.
+           * This variable is read from the parameter file through a parameter called 'Reference specific heat'.
            */
           double reference_specific_heat;
 
@@ -128,6 +132,9 @@ namespace aspect
           /**
            * The density difference $\Delta\rho_i$ between each composition $\mathfrak c_i$
            * and the background.
+           *
+           * This variable is read from the parameter file through parameters called
+           * 'Density differential for compositional field 1' and 'Density differential for compositional field 2'.
            */
           std::vector<double> compositional_delta_rhos;
       };

--- a/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_compressible.h
@@ -114,6 +114,7 @@ namespace aspect
           /**
            * Vector of reference densities $\rho_0$ with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Reference densities'.
            */
           std::vector<double> reference_densities;
 
@@ -121,35 +122,42 @@ namespace aspect
           /**
            * Vector of reference temperatures $T_0$ with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Reference temperatures'.
            */
           std::vector<double> reference_temperatures;
 
           /**
            * Vector of reference compressibilities, with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Reference isothermal compressibilities'.
            */
           std::vector<double> reference_isothermal_compressibilities;
 
           /**
            * Vector of isothermal bulk modulus pressure derivatives with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Isothermal bulk modulus pressure derivatives'.
            */
           std::vector<double> isothermal_bulk_modulus_pressure_derivatives;
 
           /**
            * Vector of reference thermal expansivities, with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Reference thermal expansivities'.
            */
           std::vector<double> reference_thermal_expansivities;
 
           /**
            * Vector of isochoric specific heats, with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Isochoric specific heats'.
            */
           std::vector<double> isochoric_specific_heats;
 
           /**
            * Whether to enable the use of phase transitions, which currently breaks thermodynamic consistency
+           *
+           * This variable is read from the parameter file through a parameter called 'Enable phase transitions'.
            */
           bool enable_phase_transitions;
       };

--- a/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
+++ b/include/aspect/material_model/equation_of_state/multicomponent_incompressible.h
@@ -97,24 +97,29 @@ namespace aspect
           /**
            * Vector of reference densities $\rho_0$ with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Densities'.
            */
           std::vector<double> densities;
 
           /**
            * The reference temperature $T_0$ used in the computation of the density.
            * All components use the same reference temperature.
+           * This variable is read from the parameter file through a parameter called 'Reference temperature'.
            */
           double reference_T;
 
           /**
            * Vector of thermal expansivities with one entry per composition and phase plus one
            * for the background field.
+           * This variable is read from the parameter file through a parameter called 'Thermal expansivities'.
            */
           std::vector<double> thermal_expansivities;
 
           /**
            * Vector of specific heat capacities with one entry per composition and phase plus one
            * for the background field.
+           *
+           * This variable is read from the parameter file through a parameter called 'Heat capacities'.
            */
           std::vector<double> specific_heats;
       };

--- a/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
+++ b/include/aspect/material_model/equation_of_state/thermodynamic_table_lookup.h
@@ -102,19 +102,34 @@ namespace aspect
 
         private:
           unsigned int n_material_lookups;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Bilinear interpolation'.
+           */
           bool use_bilinear_interpolation;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Latent heat'.
+           */
           bool latent_heat;
 
           /**
            * Information about the location of data files.
+           * This variable is read from the parameter file through a parameter called 'Data directory'.
            */
           std::string data_directory;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Material file names'.
+           */
           std::vector<std::string> material_file_names;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Derivatives file names'.
+           */
           std::vector<std::string> derivatives_file_names;
 
           /**
            * The maximum number of substeps over the temperature pressure range
            * to calculate the averaged enthalpy gradient over a cell
+           *
+           * This variable is read from the parameter file through a parameter called 'Maximum latent heat substeps'.
            */
           unsigned int max_latent_heat_substeps;
 
@@ -126,7 +141,11 @@ namespace aspect
           {
             perplex,
             hefesto
-          } material_file_format;
+          };
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Material file format'.
+           */
+          formats material_file_format;
 
           /**
            * List of pointers to objects that read and process data we get from

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -162,50 +162,123 @@ namespace aspect
         enthalpy_derivative (const typename Interface<dim>::MaterialModelInputs &in) const;
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference density'.
+         */
         double reference_rho;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
+         */
         double thermal_alpha;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat'.
+         */
         double reference_specific_heat;
 
         /**
          * The constant compressibility.
+         * This variable is read from the parameter file through a parameter called 'Reference compressibility'.
          */
         double reference_compressibility;
 
         /**
          * The thermal conductivity.
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 
         /**
          * Parameters controlling the viscosity.
+         * This variable is read from the parameter file through a parameter called 'Dislocation viscosity iteration threshold'.
          */
         double dislocation_viscosity_iteration_threshold;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Dislocation viscosity iteration number'.
+         */
         unsigned int dislocation_viscosity_iteration_number;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Dislocation creep exponent'.
+         */
         std::vector<double> dislocation_creep_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Dislocation activation energy'.
+         */
         std::vector<double> dislocation_activation_energy;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Dislocation activation volume'.
+         */
         std::vector<double> dislocation_activation_volume;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Dislocation creep prefactor'.
+         */
         std::vector<double> dislocation_creep_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Diffusion creep exponent'.
+         */
         std::vector<double> diffusion_creep_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Diffusion activation energy'.
+         */
         std::vector<double> diffusion_activation_energy;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Diffusion activation volume'.
+         */
         std::vector<double> diffusion_activation_volume;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Diffusion creep prefactor'.
+         */
         std::vector<double> diffusion_creep_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Diffusion creep grain size exponent'.
+         */
         std::vector<double> diffusion_creep_grain_size_exponent;
 
         /**
          * Because of the nonlinear nature of this material model many
          * parameters need to be kept within bounds to ensure stability of the
          * solution. These bounds can be adjusted as input parameters.
+         * This variable is read from the parameter file through a parameter called 'Maximum temperature dependence of viscosity'.
          */
         double max_temperature_dependence_of_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
+         */
         double min_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+         */
         double max_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum specific heat'.
+         */
         double min_specific_heat;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum specific heat'.
+         */
         double max_specific_heat;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum thermal expansivity'.
+         */
         double min_thermal_expansivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum thermal expansivity'.
+         */
         double max_thermal_expansivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum latent heat substeps'.
+         */
         unsigned int max_latent_heat_substeps;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum grain size'.
+         */
         double minimum_grain_size;
 
         /**
@@ -308,13 +381,29 @@ namespace aspect
         /**
          * The following variables are properties of the material files
          * we read in.
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string datadirectory;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Material file names'.
+         */
         std::vector<std::string> material_file_names;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Derivatives file names'.
+         */
         std::vector<std::string> derivatives_file_names;
         unsigned int n_material_data;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Use table properties'.
+         */
         bool use_table_properties;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Use enthalpy for material properties'.
+         */
         bool use_enthalpy;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Bilinear interpolation'.
+         */
         bool use_bilinear_interpolation;
 
 
@@ -326,7 +415,11 @@ namespace aspect
         {
           perplex,
           hefesto
-        } material_file_format;
+        };
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Material file format'.
+         */
+        formats material_file_format;
 
         /**
          * List of pointers to objects that read and process data we get from
@@ -347,8 +440,13 @@ namespace aspect
         /*
          * Object for computing plastic stresses, viscosities, and additional outputs,
          * as well as an object for the required input parameters.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use Drucker-Prager rheology'.
          */
         bool enable_drucker_prager_rheology;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Use adiabatic pressure for yield stress'.
+         */
         bool use_adiabatic_pressure_for_yielding;
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
         Rheology::DruckerPragerParameters drucker_prager_parameters;

--- a/include/aspect/material_model/latent_heat.h
+++ b/include/aspect/material_model/latent_heat.h
@@ -92,27 +92,68 @@ namespace aspect
          */
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference density'.
+         */
         double reference_rho;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Composition viscosity prefactor'.
+         */
         double composition_viscosity_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
+         */
         double thermal_alpha;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat'.
+         */
         double reference_specific_heat;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Compressibility'.
+         */
         double reference_compressibility;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+         */
         double maximum_viscosity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
+         */
         double minimum_viscosity;
 
         /**
          * The thermal conductivity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Density differential for compositional field 1'.
+         */
         double compositional_delta_rho;
 
         // list of depth (or pressure), width and Clapeyron slopes
         // for the different phase transitions
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Phase transition density jumps'.
+         */
         std::vector<double> density_jumps;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Corresponding phase for density jump'.
+         */
         std::vector<int> transition_phases;
         std::vector<double> phase_prefactors;
 

--- a/include/aspect/material_model/latent_heat_melt.h
+++ b/include/aspect/material_model/latent_heat_melt.h
@@ -98,21 +98,53 @@ namespace aspect
          */
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference density'.
+         */
         double reference_rho;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Composition viscosity prefactor'.
+         */
         double composition_viscosity_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
+         */
         double thermal_alpha;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient of melt'.
+         */
         double melt_thermal_alpha;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat'.
+         */
         double reference_specific_heat;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Compressibility'.
+         */
         double reference_compressibility;
 
         /**
          * The thermal conductivity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Density differential for compositional field 1'.
+         */
         double compositional_delta_rho;
 
         /**
@@ -120,29 +152,71 @@ namespace aspect
          */
 
         // for the solidus temperature
+        /**
+         *  This variable is read from the parameter file through a parameter called 'A1'.
+         */
         double A1;   // °C
+        /**
+         *  This variable is read from the parameter file through a parameter called 'A2'.
+         */
         double A2; // °C/Pa
+        /**
+         *  This variable is read from the parameter file through a parameter called 'A3'.
+         */
         double A3; // °C/(Pa^2)
 
         // for the lherzolite liquidus temperature
+        /**
+         *  This variable is read from the parameter file through a parameter called 'B1'.
+         */
         double B1;   // °C
+        /**
+         *  This variable is read from the parameter file through a parameter called 'B2'.
+         */
         double B2;   // °C/Pa
+        /**
+         *  This variable is read from the parameter file through a parameter called 'B3'.
+         */
         double B3; // °C/(Pa^2)
 
         // for the liquidus temperature
+        /**
+         *  This variable is read from the parameter file through a parameter called 'C1'.
+         */
         double C1;   // °C
+        /**
+         *  This variable is read from the parameter file through a parameter called 'C2'.
+         */
         double C2;  // °C/Pa
+        /**
+         *  This variable is read from the parameter file through a parameter called 'C3'.
+         */
         double C3; // °C/(Pa^2)
 
         // for the reaction coefficient of pyroxene
+        /**
+         *  This variable is read from the parameter file through a parameter called 'r1'.
+         */
         double r1;     // cpx/melt
+        /**
+         *  This variable is read from the parameter file through a parameter called 'r2'.
+         */
         double r2;     // cpx/melt/GPa
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Mass fraction cpx'.
+         */
         double M_cpx;  // mass fraction of pyroxene
 
         // melt fraction exponent
+        /**
+         *  This variable is read from the parameter file through a parameter called 'beta'.
+         */
         double beta;
 
         // entropy change upon melting
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Peridotite melting entropy change'.
+         */
         double peridotite_melting_entropy_change;
 
         /**
@@ -150,19 +224,43 @@ namespace aspect
          */
 
         // for the melting temperature
+        /**
+         *  This variable is read from the parameter file through a parameter called 'D1'.
+         */
         double D1;    // °C
+        /**
+         *  This variable is read from the parameter file through a parameter called 'D2'.
+         */
         double D2;  // °C/Pa
+        /**
+         *  This variable is read from the parameter file through a parameter called 'D3'.
+         */
         double D3; // °C/(Pa^2)
         // for the melt-fraction dependence of productivity
+        /**
+         *  This variable is read from the parameter file through a parameter called 'E1'.
+         */
         double E1;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'E2'.
+         */
         double E2;
 
         // for the maximum melt fraction of pyroxenite
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum pyroxenite melt fraction'.
+         */
         double F_px_max;
 
         // the relative density of molten material (compared to solid)
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Relative density of melt'.
+         */
         double relative_melt_density;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Pyroxenite melting entropy change'.
+         */
         double pyroxenite_melting_entropy_change;
 
         /**

--- a/include/aspect/material_model/melt_boukare.h
+++ b/include/aspect/material_model/melt_boukare.h
@@ -137,20 +137,65 @@ namespace aspect
       private:
         // Thermodynamic parameters of the endmember components in the equation of state,
         // needed to compute their material properties.
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Endmember names'.
+         */
         std::vector<std::string> endmember_names;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Molar masses'.
+         */
         std::vector<double> molar_masses;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Number of atoms'.
+         */
         std::vector<double> number_of_atoms;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference volumes'.
+         */
         std::vector<double> reference_volumes;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference thermal expansivities'.
+         */
         std::vector<double> reference_thermal_expansivities;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference bulk moduli'.
+         */
         std::vector<double> reference_bulk_moduli;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'First derivatives of the bulk modulus'.
+         */
         std::vector<double> bulk_modulus_pressure_derivatives;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Second derivatives of the bulk modulus'.
+         */
         std::vector<double> bulk_modulus_second_pressure_derivatives;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Einstein temperatures'.
+         */
         std::vector<double> Einstein_temperatures;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference enthalpies'.
+         */
         std::vector<double> reference_enthalpies;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference entropies'.
+         */
         std::vector<double> reference_entropies;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat capacities'.
+         */
         std::vector<double> reference_specific_heats;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Linear coefficients for specific heat polynomial'.
+         */
         std::vector<double> specific_heat_linear_coefficients;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Second coefficients for specific heat polynomial'.
+         */
         std::vector<double> specific_heat_second_coefficients;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Third coefficients for specific heat polynomial'.
+         */
         std::vector<double> specific_heat_third_coefficients;
 
         std::vector<double> tait_parameters_a;
@@ -158,23 +203,56 @@ namespace aspect
         std::vector<double> tait_parameters_c;
 
         // Reference conditions for computing the material properties in the equation of state.
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_temperature;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference pressure'.
+         */
         double reference_pressure;
 
         // Rheological properties.
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference shear viscosity'.
+         */
         double eta_0;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference bulk viscosity'.
+         */
         double xi_0;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference melt viscosity'.
+         */
         double eta_f;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal bulk viscosity exponent'.
+         */
         double thermal_bulk_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Exponential melt weakening factor'.
+         */
         double alpha_phi;
 
         // Transport properties that are not computed from the equation of state.
         double thermal_conductivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference permeability'.
+         */
         double reference_permeability;
 
         // Parameters controlling melting and solidification of melt.
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Include melting and freezing'.
+         */
         bool include_melting_and_freezing;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Melting time scale for operator splitting'.
+         */
         double melting_time_scale;
 
         // Parameters defining the molar composition of the two endmember compositions we use
@@ -188,7 +266,13 @@ namespace aspect
         const double melting_reference_pressure = 120.e9;
 
         // reference melting temperature for Fe and Mg mantle endmember at the reference pressure
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Fe mantle melting temperature'.
+         */
         double Fe_mantle_melting_temperature;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Mg mantle melting temperature'.
+         */
         double Mg_mantle_melting_temperature;
 
         // molar entropy change of melting in J/mol K
@@ -200,7 +284,13 @@ namespace aspect
         const double Mg_mantle_melting_volume = 9.29e-08;
 
         // Number of moles of atoms mixing on pseudosite in mantle lattice (empirical model fitting the full Boukare model).
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Fe number of moles'.
+         */
         double Fe_number_of_moles;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Mg number of moles'.
+         */
         double Mg_number_of_moles;
 
         // Indices for the endmembers in the equation of state.

--- a/include/aspect/material_model/melt_global.h
+++ b/include/aspect/material_model/melt_global.h
@@ -112,28 +112,94 @@ namespace aspect
 
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference solid density'.
+         */
         double reference_rho_s;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference melt density'.
+         */
         double reference_rho_f;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference shear viscosity'.
+         */
         double eta_0;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference bulk viscosity'.
+         */
         double xi_0;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference melt viscosity'.
+         */
         double eta_f;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal bulk viscosity exponent'.
+         */
         double thermal_bulk_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
+         */
         double thermal_expansivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat'.
+         */
         double reference_specific_heat;
         double thermal_conductivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference permeability'.
+         */
         double reference_permeability;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Exponential melt weakening factor'.
+         */
         double alpha_phi;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Depletion density change'.
+         */
         double depletion_density_change;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Depletion solidus change'.
+         */
         double depletion_solidus_change;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Pressure solidus change'.
+         */
         double pressure_solidus_change;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Surface solidus'.
+         */
         double surface_solidus;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Solid compressibility'.
+         */
         double compressibility;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Melt compressibility'.
+         */
         double melt_compressibility;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Include melting and freezing'.
+         */
         bool include_melting_and_freezing;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Melting time scale for operator splitting'.
+         */
         double melting_time_scale;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Exponential depletion strengthening factor'.
+         */
         double alpha_depletion;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum Depletion viscosity change'.
+         */
         double delta_eta_depletion_max;
 
         // entropy change upon melting

--- a/include/aspect/material_model/melt_simple.h
+++ b/include/aspect/material_model/melt_simple.h
@@ -117,15 +117,42 @@ namespace aspect
 
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Use full compressibility'.
+         */
         bool model_is_compressible;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
+         */
         double thermal_expansivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference shear viscosity'.
+         */
         double eta_0;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference specific heat'.
+         */
         double reference_specific_heat;
         double thermal_conductivity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Solid compressibility'.
+         */
         double compressibility;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Depletion density change'.
+         */
         double depletion_density_change;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference solid density'.
+         */
         double reference_rho_solid;
 
 

--- a/include/aspect/material_model/modified_tait.h
+++ b/include/aspect/material_model/modified_tait.h
@@ -100,27 +100,32 @@ namespace aspect
 
         /**
          * The reference pressure
+         * This variable is read from the parameter file through a parameter called 'Reference pressure'.
          */
         double reference_pressure;
 
         /**
          * The reference temperature
+         * This variable is read from the parameter file through a parameter called 'Reference temperature'.
          */
         double reference_temperature;
 
         /**
          * The reference density
+         * This variable is read from the parameter file through a parameter called 'Reference density'.
          */
         double reference_rho;
 
         /**
          * The reference isothermal bulk modulus
+         * This variable is read from the parameter file through a parameter called 'Reference isothermal bulk modulus'.
          */
         double reference_isothermal_bulk_modulus;
 
         /**
          * The reference K'
          * (first pressure derivative of the isothermal bulk modulus)
+         * This variable is read from the parameter file through a parameter called 'Reference bulk modulus derivative'.
          */
         double reference_Kprime;
 
@@ -132,11 +137,13 @@ namespace aspect
 
         /**
          * The reference thermal expansivity
+         * This variable is read from the parameter file through a parameter called 'Reference thermal expansivity'.
          */
         double reference_thermal_expansivity;
 
         /**
          * The Einstein temperature
+         * This variable is read from the parameter file through a parameter called 'Einstein temperature'.
          */
         double einstein_temperature;
 
@@ -148,11 +155,14 @@ namespace aspect
 
         /**
          * The constant viscosity
+         * This variable is read from the parameter file through a parameter called 'Viscosity'.
          */
         double eta;
 
         /**
          * The constant thermal conductivity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 

--- a/include/aspect/material_model/multicomponent.h
+++ b/include/aspect/material_model/multicomponent.h
@@ -110,21 +110,26 @@ namespace aspect
         /**
          * Reference temperature for thermal expansion.  All components use
          * the same reference_T.
+         * This variable is read from the parameter file through a parameter called 'Reference temperature'.
          */
         double reference_T;
 
         /**
          * Enumeration for selecting which viscosity averaging scheme to use.
+         * This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
          */
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Vector for field viscosities, read from parameter file.
+         * This variable is read from the parameter file through a parameter called 'Viscosities'.
          */
         std::vector<double> viscosities;
 
         /**
          * Vector for field thermal conductivities, read from parameter file.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivities'.
          */
         std::vector<double> thermal_conductivities;
 

--- a/include/aspect/material_model/multicomponent_compressible.h
+++ b/include/aspect/material_model/multicomponent_compressible.h
@@ -118,16 +118,20 @@ namespace aspect
       private:
         /**
          * Enumeration for selecting which viscosity averaging scheme to use.
+         * This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
          */
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
         /**
          * Vector for field viscosities, read from parameter file.
+         * This variable is read from the parameter file through a parameter called 'Viscosities'.
          */
         std::vector<double> viscosities;
 
         /**
          * Vector for field thermal conductivities, read from parameter file.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivities'.
          */
         std::vector<double> thermal_conductivities;
 

--- a/include/aspect/material_model/nondimensional.h
+++ b/include/aspect/material_model/nondimensional.h
@@ -88,6 +88,7 @@ namespace aspect
       private:
         /**
          * Use truncated anelastic approximation?
+         * This variable is read from the parameter file through a parameter called 'Use TALA'.
          */
         bool tala;
 
@@ -98,27 +99,34 @@ namespace aspect
 
         /**
          * Parameter describing the temperature prefactor of viscosity.
+         * This variable is read from the parameter file through a parameter called 'Viscosity temperature prefactor'.
          */
         double exponential_viscosity_temperature_prefactor;
 
         /**
          * Parameter describing the depth prefactor of viscosity.
+         * This variable is read from the parameter file through a parameter called 'Viscosity depth prefactor'.
          */
         double exponential_viscosity_depth_prefactor;
 
         /**
          * The surface density.
+         * This variable is read from the parameter file through a parameter called 'Reference density'.
          */
         double reference_rho;
 
         /**
          * The nondimensional numbers (Dissipation number,
          * Rayleigh number, Grueneisen parameter).
+         * This variable is read from the parameter file through parameters called
+         * 'Di', 'Ra', and 'gamma'.
          */
         double Di, Ra, gamma;
 
         /**
          * The constant specific heat
+         *
+         * This variable is read from the parameter file through a parameter called 'Reference specific heat'.
          */
         double reference_specific_heat;
 

--- a/include/aspect/material_model/perplex_lookup.h
+++ b/include/aspect/material_model/perplex_lookup.h
@@ -96,12 +96,33 @@ namespace aspect
 
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'PerpleX input file name'.
+         */
         std::string perplex_file_name;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
+         */
         double k_value;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum material temperature'.
+         */
         double min_temperature;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum material temperature'.
+         */
         double max_temperature;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum material pressure'.
+         */
         double min_pressure;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum material pressure'.
+         */
         double max_pressure;
     };
 

--- a/include/aspect/material_model/reaction_model/crust_and_lithosphere_formation.h
+++ b/include/aspect/material_model/reaction_model/crust_and_lithosphere_formation.h
@@ -79,8 +79,13 @@ namespace aspect
            * occurs. Crust is generated above the crustal_thickness, and lithosphere
            * is generated below the crustal_thickness and down to a depth that is the
            * sum of crustal_thickness and lithosphere_thickness.
+           *
+           * This variable is read from the parameter file through a parameter called 'Crustal thickness'.
            */
           double crustal_thickness;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Lithosphere thickness'.
+           */
           double lithosphere_thickness;
 
           /**

--- a/include/aspect/material_model/reaction_model/grain_size_evolution.h
+++ b/include/aspect/material_model/reaction_model/grain_size_evolution.h
@@ -126,20 +126,46 @@ namespace aspect
         private:
           /**
            * Parameters controlling the grain size evolution.
+           * This variable is read from the parameter file through a parameter called 'Grain growth activation energy'.
            */
           std::vector<double> grain_growth_activation_energy;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Grain growth activation volume'.
+           */
           std::vector<double> grain_growth_activation_volume;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Grain growth rate constant'.
+           */
           std::vector<double> grain_growth_rate_constant;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Grain growth exponent'.
+           */
           std::vector<double> grain_growth_exponent;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Minimum grain size'.
+           */
           double              minimum_grain_size;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reciprocal required strain'.
+           */
           std::vector<double> reciprocal_required_strain;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Recrystallized grain size'.
+           */
           std::vector<double> recrystallized_grain_size;
 
           /**
            * Parameters controlling the dynamic grain recrystallization.
+           * This variable is read from the parameter file through a parameter called 'Average specific grain boundary energy'.
            */
           std::vector<double> grain_boundary_energy;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Work fraction for boundary area change'.
+           */
           std::vector<double> boundary_area_change_work_fraction;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Geometric constant'.
+           */
           std::vector<double> geometric_constant;
 
           /**
@@ -199,6 +225,7 @@ namespace aspect
           /**
            * A variable that records the formulation of how to evolve grain size.
            * See the type of this variable for a description of available options.
+           * This variable is read from the parameter file through a parameter called 'Grain size evolution formulation'.
            */
           typename Formulation::Kind grain_size_evolution_formulation;
 
@@ -213,9 +240,16 @@ namespace aspect
           /**
            * Parameters controlling the partitioning of energy
            * into grain damage in the pinned state.
+           * This variable is read from the parameter file through a parameter called 'Grain size reduction work fraction exponent'.
            */
           double grain_size_reduction_work_fraction_exponent;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Minimum grain size reduction work fraction'.
+           */
           double minimum_grain_size_reduction_work_fraction;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum grain size reduction work fraction'.
+           */
           double maximum_grain_size_reduction_work_fraction;
           double temperature_minimum_partitioning_power;
           double temperature_maximum_partitioning_power;
@@ -260,11 +294,14 @@ namespace aspect
 
           /**
            * The initial step size taken by the ARKode solver.
+           * This variable is read from the parameter file through a parameter called 'ARKode initial step size'.
            */
           double arkode_initial_step_size;
 
           /**
            * The minimum step size taken by the ARKode solver.
+           *
+           * This variable is read from the parameter file through a parameter called 'ARKode minimum step size'.
            */
           double arkode_minimum_step_size;
       };

--- a/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
+++ b/include/aspect/material_model/reaction_model/katz2003_mantle_melting.h
@@ -111,46 +111,126 @@ namespace aspect
         private:
           /**
            * Parameters for anhydrous melting of peridotite after Katz, 2003
+           *
+           * This variable is read from the parameter file through a parameter called 'Reference melt density'.
            */
 
           double reference_rho_fluid;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference bulk viscosity'.
+           */
           double xi_0;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference melt viscosity'.
+           */
           double viscosity_fluid;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Thermal bulk viscosity exponent'.
+           */
           double thermal_bulk_viscosity_exponent;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Exponential melt weakening factor'.
+           */
           double alpha_phi;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Melt extraction depth'.
+           */
           double extraction_depth;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Melt compressibility'.
+           */
           double melt_compressibility;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Melt bulk modulus derivative'.
+           */
           double melt_bulk_modulus_derivative;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Depletion solidus change'.
+           */
           double depletion_solidus_change;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Use fractional melting'.
+           */
           bool fractional_melting;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Freezing rate'.
+           */
           double freezing_rate;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Melting time scale for operator splitting'.
+           */
           double melting_time_scale;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference permeability'.
+           */
           double reference_permeability;
 
           // for the solidus temperature
+          /**
+           *  This variable is read from the parameter file through a parameter called 'A1'.
+           */
           double A1;   // °C
+          /**
+           *  This variable is read from the parameter file through a parameter called 'A2'.
+           */
           double A2; // °C/Pa
+          /**
+           *  This variable is read from the parameter file through a parameter called 'A3'.
+           */
           double A3; // °C/(Pa^2)
 
           // for the lherzolite liquidus temperature
+          /**
+           *  This variable is read from the parameter file through a parameter called 'B1'.
+           */
           double B1;   // °C
+          /**
+           *  This variable is read from the parameter file through a parameter called 'B2'.
+           */
           double B2;   // °C/Pa
+          /**
+           *  This variable is read from the parameter file through a parameter called 'B3'.
+           */
           double B3; // °C/(Pa^2)
 
           // for the liquidus temperature
+          /**
+           *  This variable is read from the parameter file through a parameter called 'C1'.
+           */
           double C1;   // °C
+          /**
+           *  This variable is read from the parameter file through a parameter called 'C2'.
+           */
           double C2;  // °C/Pa
+          /**
+           *  This variable is read from the parameter file through a parameter called 'C3'.
+           */
           double C3; // °C/(Pa^2)
 
           // for the reaction coefficient of pyroxene
+          /**
+           *  This variable is read from the parameter file through a parameter called 'r1'.
+           */
           double r1;     // cpx/melt
+          /**
+           *  This variable is read from the parameter file through a parameter called 'r2'.
+           */
           double r2;     // cpx/melt/GPa
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Mass fraction cpx'.
+           */
           double M_cpx;  // mass fraction of pyroxene
 
           // melt fraction exponent
+          /**
+           *  This variable is read from the parameter file through a parameter called 'beta'.
+           */
           double beta;
 
           // entropy change upon melting
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Peridotite melting entropy change'.
+           */
           double peridotite_melting_entropy_change;
       };
     }

--- a/include/aspect/material_model/reaction_model/tian2019_solubility.h
+++ b/include/aspect/material_model/reaction_model/tian2019_solubility.h
@@ -99,10 +99,20 @@ namespace aspect
            * The maximum water content for each of the 4 rock types in the tian approximation
            * method. These are important for keeping the polynomial bounded within reasonable
            * values.
+           * This variable is read from the parameter file through a parameter called 'Maximum weight percent water in peridotite'.
            */
           double tian_max_peridotite_water;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum weight percent water in gabbro'.
+           */
           double tian_max_gabbro_water;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum weight percent water in MORB'.
+           */
           double tian_max_MORB_water;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum weight percent water in sediment'.
+           */
           double tian_max_sediment_water;
 
           /**
@@ -110,6 +120,8 @@ namespace aspect
            * If false, the full pressure is used instead. When simulating fully coupled
            * fluid transport, setting this to true is recommended since the compaction
            * pressure can lead to numerical instabilities when determining reaction rates.
+           *
+           * This variable is read from the parameter file through a parameter called 'Use adiabatic pressure for reactions'.
            */
           bool use_adiabatic_pressure_for_reactions;
 

--- a/include/aspect/material_model/reactive_fluid_transport.h
+++ b/include/aspect/material_model/reactive_fluid_transport.h
@@ -150,9 +150,16 @@ namespace aspect
          * Variables that describe the properties of the fluid, i.e. its density,
          * viscosity, and compressibility.
          * Properties of the solid are defined in the base model.
+         * This variable is read from the parameter file through a parameter called 'Reference fluid density'.
          */
         double reference_rho_f;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference fluid viscosity'.
+         */
         double eta_f;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Fluid compressibility'.
+         */
         double fluid_compressibility;
 
         /**
@@ -160,16 +167,34 @@ namespace aspect
          * to the solid, i.e., the bulk viscosity (relative to the shear viscosity),
          * the permeability, and how much the solid viscosity changes in the presence
          * of fluids.
+         * This variable is read from the parameter file through a parameter called 'Shear to bulk viscosity ratio'.
          */
         double shear_to_bulk_viscosity_ratio;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum compaction viscosity'.
+         */
         double min_compaction_viscosity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum compaction viscosity'.
+         */
         double max_compaction_viscosity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference permeability'.
+         */
         double reference_permeability;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Exponential fluid weakening factor'.
+         */
         double alpha_phi;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
 
         /**
          * Time scale for fluid release and absorption.
+         *
+         * This variable is read from the parameter file through a parameter called 'Fluid reaction time scale for operator splitting'.
          */
         double fluid_reaction_time_scale;
 
@@ -231,8 +256,11 @@ namespace aspect
           zero_solubility,
           tian_approximation,
           katz2003
-        }
-        fluid_solid_reaction_scheme;
+        };
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Fluid-solid reaction scheme'.
+         */
+        ReactionScheme fluid_solid_reaction_scheme;
     };
   }
 }

--- a/include/aspect/material_model/replace_lithosphere_viscosity.h
+++ b/include/aspect/material_model/replace_lithosphere_viscosity.h
@@ -82,6 +82,8 @@ namespace aspect
 
         /**
          * This parameter gives the viscosity set within the lithosphere.
+         *
+         * This variable is read from the parameter file through a parameter called 'Lithosphere viscosity'.
          */
         double lithosphere_viscosity;
 

--- a/include/aspect/material_model/rheology/composite_visco_plastic.h
+++ b/include/aspect/material_model/rheology/composite_visco_plastic.h
@@ -185,15 +185,26 @@ namespace aspect
 
           /**
            * Enumeration for selecting which type of viscosity averaging to use.
+           * This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
            */
           ViscosityAveraging::Kind viscosity_averaging_scheme;
 
           /**
            * Whether to use different deformation mechanisms.
+           * This variable is read from the parameter file through a parameter called 'Include diffusion creep in composite rheology'.
            */
           bool use_diffusion_creep;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Include dislocation creep in composite rheology'.
+           */
           bool use_dislocation_creep;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Include Peierls creep in composite rheology'.
+           */
           bool use_peierls_creep;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Include Drucker Prager plasticity in composite rheology'.
+           */
           bool use_drucker_prager;
 
           /**
@@ -226,6 +237,7 @@ namespace aspect
           /**
            * The maximum viscosity, imposed via an isoviscous damper
            * in series with the composite viscoplastic element.
+           * This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
            */
           double maximum_viscosity;
 
@@ -251,6 +263,7 @@ namespace aspect
 
           /**
            * The minimum strain rate allowed by the rheology.
+           * This variable is read from the parameter file through a parameter called 'Minimum strain rate'.
            */
           double minimum_strain_rate;
 
@@ -258,12 +271,15 @@ namespace aspect
            * The log strain rate threshold which must be passed
            * before successful termination of the Newton iteration
            * to determine the creep stress.
+           * This variable is read from the parameter file through a parameter called 'Strain rate residual tolerance'.
            */
           double log_strain_rate_residual_threshold;
 
           /**
            * The maximum number of iterations allowed to determine
            * the creep stress.
+           *
+           * This variable is read from the parameter file through a parameter called 'Maximum creep strain rate iterations'.
            */
           unsigned int stress_max_iteration_number;
 

--- a/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/compositional_viscosity_prefactors.h
@@ -96,11 +96,24 @@ namespace aspect
           {
             none,
             hk04_olivine_hydration,
-          } viscosity_prefactor_scheme;
+          };
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Viscosity prefactor scheme'.
+           */
+          ViscosityPrefactorScheme viscosity_prefactor_scheme;
 
           // Initialize variables for the water fugacity calculation, from HK04
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Water fugacity exponents for diffusion creep'.
+           */
           std::vector<double> diffusion_water_fugacity_exponents;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Water fugacity exponents for dislocation creep'.
+           */
           std::vector<double> dislocation_water_fugacity_exponents;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Minimum mass fraction bound water content for fugacity'.
+           */
           std::vector<double> minimum_mass_fraction_water_for_dry_creep;
 
           // From Hirth & Kohlstedt 2004, equation 6

--- a/include/aspect/material_model/rheology/constant_viscosity.h
+++ b/include/aspect/material_model/rheology/constant_viscosity.h
@@ -63,6 +63,8 @@ namespace aspect
            * The constant viscosity that defines this rheology. It
            * is read from the input file by the parse_parameters()
            * function.
+           *
+           * This variable is read from the parameter file through a parameter called 'Viscosity'.
            */
           double viscosity;
       };

--- a/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
+++ b/include/aspect/material_model/rheology/constant_viscosity_prefactors.h
@@ -74,6 +74,8 @@ namespace aspect
            * for a given compositional field is multiplied with a
            * base_viscosity value provided by the material model, which
            * is then returned to the material model.
+           *
+           * This variable is read from the parameter file through a parameter called 'Constant viscosity prefactors'.
            */
           std::vector<double> constant_viscosity_prefactors;
       };

--- a/include/aspect/material_model/rheology/diffusion_creep.h
+++ b/include/aspect/material_model/rheology/diffusion_creep.h
@@ -172,26 +172,31 @@ namespace aspect
 
           /**
            * List of diffusion creep prefactors A.
+           * This variable is read from the parameter file through a parameter called 'Prefactors for diffusion creep'.
            */
           std::vector<double> prefactors;
 
           /**
            * List of diffusion creep stress exponents n (usually = 1).
+           * This variable is read from the parameter file through a parameter called 'Stress exponents for diffusion creep'.
            */
           std::vector<double> stress_exponents;
 
           /**
            * List of diffusion creep grain size exponents m.
+           * This variable is read from the parameter file through a parameter called 'Grain size exponents for diffusion creep'.
            */
           std::vector<double> grain_size_exponents;
 
           /**
            * List of diffusion creep activation energies E.
+           * This variable is read from the parameter file through a parameter called 'Activation energies for diffusion creep'.
            */
           std::vector<double> activation_energies;
 
           /**
            * List of diffusion creep activation volumes V.
+           * This variable is read from the parameter file through a parameter called 'Activation volumes for diffusion creep'.
            */
           std::vector<double> activation_volumes;
 
@@ -199,6 +204,8 @@ namespace aspect
            * Diffusion creep grain size d.  This is read from the
            * input file, and is only used by the functions that do
            * not take the grain size as additional argument.
+           *
+           * This variable is read from the parameter file through a parameter called 'Grain size'.
            */
           double fixed_grain_size;
       };

--- a/include/aspect/material_model/rheology/diffusion_dislocation.h
+++ b/include/aspect/material_model/rheology/diffusion_dislocation.h
@@ -116,17 +116,37 @@ namespace aspect
           /**
            * Defining a minimum strain rate stabilizes the viscosity calculation,
            * which involves a division by the strain rate. Units: 1/s.
+           *
+           * This variable is read from the parameter file through a parameter called 'Minimum strain rate'.
            */
           double min_strain_rate;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
+           */
           double minimum_viscosity;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+           */
           double maximum_viscosity;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Strain rate residual tolerance'.
+           */
           double log_strain_rate_residual_threshold;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum strain rate ratio iterations'.
+           */
           unsigned int stress_max_iteration_number;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Grain size'.
+           */
           double grain_size;
           unsigned int n_chemical_composition_fields;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
+           */
           MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
       };

--- a/include/aspect/material_model/rheology/dislocation_creep.h
+++ b/include/aspect/material_model/rheology/dislocation_creep.h
@@ -128,21 +128,26 @@ namespace aspect
 
           /**
            * List of dislocation creep prefactors A.
+           * This variable is read from the parameter file through a parameter called 'Prefactors for dislocation creep'.
            */
           std::vector<double> prefactors;
 
           /**
            * List of dislocation creep stress exponents n.
+           * This variable is read from the parameter file through a parameter called 'Stress exponents for dislocation creep'.
            */
           std::vector<double> stress_exponents;
 
           /**
            * List of dislocation creep activation energies E.
+           * This variable is read from the parameter file through a parameter called 'Activation energies for dislocation creep'.
            */
           std::vector<double> activation_energies;
 
           /**
            * List of dislocation creep activation volumes V.
+           *
+           * This variable is read from the parameter file through a parameter called 'Activation volumes for dislocation creep'.
            */
           std::vector<double> activation_volumes;
 

--- a/include/aspect/material_model/rheology/drucker_prager.h
+++ b/include/aspect/material_model/rheology/drucker_prager.h
@@ -204,6 +204,7 @@ namespace aspect
            * cohesion * cos_phi + pressure * sin_phi in 2D.
            * Phi is an angle of internal friction, that is
            * input by the user in degrees, but stored as radians.
+           * This variable is read from the parameter file through a parameter called 'Angles of internal friction'.
            */
           std::vector<double> angles_internal_friction;
 
@@ -215,32 +216,39 @@ namespace aspect
            * Psi is an angle of dilation, that is input by the user in degrees,
            * but stored as radians. Note that the dilation angle must not be larger
            * than the internal friction angle.
+           * This variable is read from the parameter file through a parameter called 'Angles of dilation'.
            */
           std::vector<double> angles_dilation;
 
           /**
            * The cohesion is provided and stored in Pa.
+           * This variable is read from the parameter file through a parameter called 'Cohesions'.
            */
           std::vector<double> cohesions;
 
           /**
            *The prefactors for the yield stress.
+           * This variable is read from the parameter file through a parameter called 'Prefactors for yield stress'.
            */
           std::vector<double> yield_stress_prefactors;
 
           /**
            * The yield stress is limited to a constant value, stored in Pa.
+           * This variable is read from the parameter file through a parameter called 'Maximum yield stress'.
            */
           std::vector<double> max_yield_stresses;
 
           /**
            * Whether to add a plastic damper in the computation
            * of the drucker prager plastic viscosity.
+           * This variable is read from the parameter file through a parameter called 'Use plastic damper'.
            */
           bool use_plastic_damper;
 
           /**
            * Viscosity of a damper used to stabilize plasticity
+           *
+           * This variable is read from the parameter file through a parameter called 'Plastic damper viscosity'.
            */
           double damper_viscosity;
       };

--- a/include/aspect/material_model/rheology/drucker_prager_power.h
+++ b/include/aspect/material_model/rheology/drucker_prager_power.h
@@ -128,22 +128,26 @@ namespace aspect
           /**
            * The angles of internal friction (phi) are input
            * by the user in degrees, but stored as radians.
+           * This variable is read from the parameter file through a parameter called 'Angles of internal friction'.
            */
           std::vector<double> angles_internal_friction;
 
           /**
            * The cohesion is provided and stored in Pa.
+           * This variable is read from the parameter file through a parameter called 'Cohesions'.
            */
           std::vector<double> cohesions;
 
           /**
            * The yield stress is limited to a constant value, stored in Pa.
+           * This variable is read from the parameter file through a parameter called 'Maximum yield stress'.
            */
           double max_yield_stress;
 
           /**
            * The reference strain rate at which the stress is equal to the
            * "yield stress".
+           * This variable is read from the parameter file through a parameter called 'Reference plastic strain rate'.
            */
           double drucker_prager_edot_ref;
 
@@ -155,6 +159,8 @@ namespace aspect
 
           /**
            * The stress exponent n of the pseudo-plastic element.
+           *
+           * This variable is read from the parameter file through a parameter called 'Plastic stress exponent'.
            */
           double drucker_prager_stress_exponent;
 

--- a/include/aspect/material_model/rheology/elasticity.h
+++ b/include/aspect/material_model/rheology/elasticity.h
@@ -48,6 +48,7 @@ namespace aspect
          * Elastic shear moduli at the evaluation points passed to
          * the instance of MaterialModel::Interface::evaluate() that fills
          * the current object.
+         * This variable is read from the parameter file through a parameter called 'Elastic shear moduli'.
          */
         std::vector<double> elastic_shear_moduli;
 
@@ -262,6 +263,7 @@ namespace aspect
           /**
            * Viscosity of a damper used to stabilize elasticity.
            * A value of 0 Pas is equivalent to not using a damper.
+           * This variable is read from the parameter file through a parameter called 'Elastic damper viscosity'.
            */
           double elastic_damper_viscosity;
 
@@ -275,11 +277,13 @@ namespace aspect
            * viscoelastic rheology for all time steps (if true) or to use the
            * actual (variable) advection time step of the model (if false). Read
            * from parameter file.
+           * This variable is read from the parameter file through a parameter called 'Use fixed elastic time step'.
            */
           bool use_fixed_elastic_time_step;
 
           /**
            * Double for fixed elastic time step value, read from parameter file.
+           * This variable is read from the parameter file through a parameter called 'Fixed elastic time step'.
            */
           double fixed_elastic_time_step;
 
@@ -289,6 +293,8 @@ namespace aspect
            * stabilization, and infinity is equivalent to not applying elastic
            * stresses at all. The factor is multiplied with the computational
            * time step to create a time scale.
+           *
+           * This variable is read from the parameter file through a parameter called 'Stabilization time scale factor'.
            */
           double stabilization_time_scale_factor;
 

--- a/include/aspect/material_model/rheology/frank_kamenetskii.h
+++ b/include/aspect/material_model/rheology/frank_kamenetskii.h
@@ -77,20 +77,30 @@ namespace aspect
         private:
           /**
            * List of Frank-Kamenetskii viscosity ratios (E).
+           * This variable is read from the parameter file through a parameter called 'Viscosity ratios for Frank Kamenetskii'.
            */
           std::vector<double> viscosity_ratios_frank_kamenetskii;
 
           /**
            * List of Frank-Kamenetskii prefactors (A).
+           * This variable is read from the parameter file through a parameter called 'Prefactors for Frank Kamenetskii'.
            */
           std::vector<double> prefactors_frank_kamenetskii;
 
           /**
            * List of Frank-Kamenetskii pressure prefactors (F).
+           *
+           * This variable is read from the parameter file through a parameter called 'Pressure prefactors for Frank Kamenetskii'.
            */
           std::vector<double> pressure_prefactors_frank_kamenetskii;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference temperatures for Frank Kamenetskii'.
+           */
           std::vector<double> reference_temperatures;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference pressures for Frank Kamenetskii'.
+           */
           std::vector<double> reference_pressures;
       };
     }

--- a/include/aspect/material_model/rheology/friction_models.h
+++ b/include/aspect/material_model/rheology/friction_models.h
@@ -89,6 +89,7 @@ namespace aspect
           /**
            * Select the mechanism to be used for the friction dependence.
            * Possible options: static friction | dynamic friction | function
+           * This variable is read from the parameter file through a parameter called 'Friction mechanism'.
            */
           FrictionMechanism friction_mechanism;
 
@@ -98,6 +99,7 @@ namespace aspect
 
           /**
            * Dynamic angles of internal friction that are used at high strain rates.
+           * This variable is read from the parameter file through a parameter called 'Dynamic angles of internal friction'.
            */
           std::vector<double> dynamic_angles_of_internal_friction;
 
@@ -106,6 +108,7 @@ namespace aspect
            * the mean of the dynamic and the static angle of friction. When the effective
            * strain rate in a cell is very high the dynamic angle of friction is taken, when
            * it is very low the static angle of internal friction is chosen.
+           * This variable is read from the parameter file through a parameter called 'Dynamic characteristic strain rate'.
            */
           double dynamic_characteristic_strain_rate;
 
@@ -113,6 +116,7 @@ namespace aspect
            * An exponential factor in the equation for the calculation of the friction angle
            * to make the transition between static and dynamic friction angle more smooth or
            * more step-like.
+           * This variable is read from the parameter file through a parameter called 'Dynamic friction smoothness exponent'.
            */
           double dynamic_friction_smoothness_exponent;
 
@@ -125,6 +129,8 @@ namespace aspect
           /**
            * The coordinate representation to evaluate the function for the friction angle.
            * Possible choices are depth, cartesian and spherical.
+           *
+           * This variable is read from the parameter file through a parameter called 'Coordinate system'.
            */
           Utilities::Coordinates::CoordinateSystem coordinate_system_friction_function;
       };

--- a/include/aspect/material_model/rheology/grain_boundary_sliding.h
+++ b/include/aspect/material_model/rheology/grain_boundary_sliding.h
@@ -129,26 +129,31 @@ namespace aspect
 
           /**
            * List of grain boundary sliding prefactors A.
+           * This variable is read from the parameter file through a parameter called 'Prefactors for grain boundary sliding'.
            */
           std::vector<double> prefactors;
 
           /**
            * List of grain boundary sliding stress exponents n (for ice = 1.8).
+           * This variable is read from the parameter file through a parameter called 'Stress exponents for grain boundary sliding'.
            */
           std::vector<double> stress_exponents;
 
           /**
            * List of grain boundary sliding grain size exponents m.
+           * This variable is read from the parameter file through a parameter called 'Grain size exponents for grain boundary sliding'.
            */
           std::vector<double> grain_size_exponents;
 
           /**
            * List of grain boundary sliding activation energies E.
+           * This variable is read from the parameter file through a parameter called 'Activation energies for grain boundary sliding'.
            */
           std::vector<double> activation_energies;
 
           /**
            * List of grain boundary sliding activation volumes V.
+           * This variable is read from the parameter file through a parameter called 'Activation volumes for grain boundary sliding'.
            */
           std::vector<double> activation_volumes;
 
@@ -156,6 +161,8 @@ namespace aspect
            * Grain boundary sliding grain size d.  This is read from the
            * input file, and is only used by the functions that do
            * not take the grain size as additional argument.
+           *
+           * This variable is read from the parameter file through a parameter called 'Grain size'.
            */
           double fixed_grain_size;
       };

--- a/include/aspect/material_model/rheology/peierls_creep.h
+++ b/include/aspect/material_model/rheology/peierls_creep.h
@@ -218,63 +218,84 @@ namespace aspect
           {
             viscosity_approximation,
             exact
-          } peierls_creep_flow_law;
+          };
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Peierls creep flow law'.
+           */
+          PeierlsCreepScheme peierls_creep_flow_law;
 
           /**
            * List of Peierls creep prefactors (A).
+           * This variable is read from the parameter file through a parameter called 'Prefactors for Peierls creep'.
            */
           std::vector<double> prefactors;
 
           /**
            * List of Peierls creep stress exponents (n).
+           * This variable is read from the parameter file through a parameter called 'Stress exponents for Peierls creep'.
            */
           std::vector<double> stress_exponents;
 
           /**
            * List of Peierls creep activation energies (E).
+           * This variable is read from the parameter file through a parameter called 'Activation energies for Peierls creep'.
            */
           std::vector<double> activation_energies;
 
           /**
            * List of Peierls creep activation volumes (V).
+           * This variable is read from the parameter file through a parameter called 'Activation volumes for Peierls creep'.
            */
           std::vector<double> activation_volumes;
 
           /**
            * List of Peierls stresses (sigma_p).
+           * This variable is read from the parameter file through a parameter called 'Peierls stresses'.
            */
           std::vector<double> peierls_stresses;
 
           /**
            * List of Peierls fitting parameters (gamma).
+           * This variable is read from the parameter file through a parameter called 'Peierls fitting parameters'.
            */
           std::vector<double> fitting_parameters;
 
           /**
            * List of the first Peierls parameter related
            * to dislocation glide (p).
+           * This variable is read from the parameter file through a parameter called 'Peierls glide parameters p'.
            */
           std::vector<double> glide_parameters_p;
 
           /**
            * List of the second Peierls parameter related
            * to dislocation glide (q).
+           * This variable is read from the parameter file through a parameter called 'Peierls glide parameters q'.
            */
           std::vector<double> glide_parameters_q;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Cutoff stresses for Peierls creep'.
+           */
           std::vector<double> stress_cutoffs;
 
           /**
            * A parameter determines whether a strict cutoff
            * on the stress is applied to the Peierls creep
+           * This variable is read from the parameter file through a parameter called 'Apply strict stress cutoff for Peierls creep'.
            */
           bool apply_strict_cutoff;
 
           /**
            * Parameters governing the iteration for the exact
            * Peierls viscosity.
+           *
+           * This variable is read from the parameter file through a parameter called 'Peierls strain rate residual tolerance'.
            */
           double strain_rate_residual_threshold;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum Peierls strain rate iterations'.
+           */
           unsigned int stress_max_iteration_number;
 
       };

--- a/include/aspect/material_model/rheology/strain_dependent.h
+++ b/include/aspect/material_model/rheology/strain_dependent.h
@@ -143,6 +143,7 @@ namespace aspect
 
           /**
            * Whether to use the temperature-activated viscous strain weakening.
+           * This variable is read from the parameter file through a parameter called 'Use temperature activated strain softening'.
            */
           bool use_temperature_activated_strain_softening;
 
@@ -184,25 +185,34 @@ namespace aspect
 
         private:
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Strain weakening mechanism'.
+           */
           WeakeningMechanism weakening_mechanism;
 
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Strain healing mechanism'.
+           */
           HealingMechanism healing_mechanism;
 
           /**
            * The start of the strain interval (plastic or total strain)
            * within which cohesion and angle of friction should be weakened.
+           * This variable is read from the parameter file through a parameter called 'Start plasticity strain weakening intervals'.
            */
           std::vector<double> start_plastic_strain_weakening_intervals;
 
           /**
            * The end of the strain interval (plastic or total strain)
            * within which cohesion and angle of friction should be weakened.
+           * This variable is read from the parameter file through a parameter called 'End plasticity strain weakening intervals'.
            */
           std::vector<double> end_plastic_strain_weakening_intervals;
 
           /**
            * The factor specifying the amount of weakening of the
            * cohesion over the prescribed strain interval (plastic or total strain).
+           * This variable is read from the parameter file through a parameter called 'Cohesion strain weakening factors'.
            */
           std::vector<double> cohesion_strain_weakening_factors;
 
@@ -210,24 +220,28 @@ namespace aspect
            * The factor specifying the amount of weakening of the
            * internal friction angles over the prescribed strain interval
            * (plastic or total strain).
+           * This variable is read from the parameter file through a parameter called 'Friction strain weakening factors'.
            */
           std::vector<double> friction_strain_weakening_factors;
 
           /**
            * The start of the strain interval (viscous or total strain)
            * within which cohesion and angle of friction should be weakened.
+           * This variable is read from the parameter file through a parameter called 'Start prefactor strain weakening intervals'.
            */
           std::vector<double> start_viscous_strain_weakening_intervals;
 
           /**
            * The end of the strain interval (viscous or total strain)
            * within which cohesion and angle of friction should be weakened.
+           * This variable is read from the parameter file through a parameter called 'End prefactor strain weakening intervals'.
            */
           std::vector<double> end_viscous_strain_weakening_intervals;
 
           /**
            * The factor specifying the amount of weakening over
            * the prescribed strain interval (viscous or total strain).
+           * This variable is read from the parameter file through a parameter called 'Prefactor strain weakening factors'.
            */
           std::vector<double> viscous_strain_weakening_factors;
 
@@ -241,19 +255,32 @@ namespace aspect
            *
            * ----------------------------> T
            *     T0  T1   T2  T3
+           * This variable is read from the parameter file through a parameter called 'Lower temperature for onset of strain weakening'.
            */
           std::vector<double> viscous_strain_weakening_T0;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Lower temperature for maximum strain weakening'.
+           */
           std::vector<double> viscous_strain_weakening_T1;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Upper temperature for maximum strain weakening'.
+           */
           std::vector<double> viscous_strain_weakening_T2;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Upper temperature for onset of strain weakening'.
+           */
           std::vector<double> viscous_strain_weakening_T3;
 
           /**
            * The healing rate used in the temperature dependent strain healing model.
+           * This variable is read from the parameter file through a parameter called 'Strain healing temperature dependent recovery rate'.
            */
           double strain_healing_temperature_dependent_recovery_rate;
 
           /**
            * A prefactor of viscosity used in the strain healing calculation.
+           *
+           * This variable is read from the parameter file through a parameter called 'Strain healing temperature dependent prefactor'.
            */
           double strain_healing_temperature_dependent_prefactor;
 

--- a/include/aspect/material_model/rheology/visco_plastic.h
+++ b/include/aspect/material_model/rheology/visco_plastic.h
@@ -212,11 +212,13 @@ namespace aspect
 
           /**
            * Minimum strain rate used to stabilize the strain rate dependent rheology.
+           * This variable is read from the parameter file through a parameter called 'Minimum strain rate'.
            */
           double min_strain_rate;
 
           /**
            * Enumeration for selecting which viscosity averaging scheme to use.
+           * This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
            */
           MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
@@ -241,6 +243,7 @@ namespace aspect
           /**
            * Reference strain rate for the first non-linear iteration
            * in the first time step.
+           * This variable is read from the parameter file through a parameter called 'Reference strain rate'.
            */
           double ref_strain_rate;
 
@@ -248,8 +251,12 @@ namespace aspect
            * Minimum and maximum viscosities used to improve the
            * stability of the rheology model.
            * These parameters contain one value per composition and phase (potentially the same value).
+           * This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
            */
           std::vector<double> minimum_viscosity;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+           */
           std::vector<double> maximum_viscosity;
 
           /**
@@ -264,7 +271,11 @@ namespace aspect
             frank_kamenetskii,
             composite,
             minimum_diffusion_dislocation
-          } viscous_flow_law;
+          };
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Viscous flow law'.
+           */
+          ViscosityScheme viscous_flow_law;
 
           /**
            * Enumeration for selecting which type of yield mechanism to use.
@@ -274,12 +285,17 @@ namespace aspect
           {
             stress_limiter,
             drucker_prager
-          } yield_mechanism;
+          };
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Yield mechanism'.
+           */
+          YieldScheme yield_mechanism;
 
           /**
            * Whether to allow negative pressures to be used in the computation
            * of plastic yield stresses and viscosities. If false, the minimum
            * pressure in the plasticity formulation will be set to zero.
+           * This variable is read from the parameter file through a parameter called 'Allow negative pressures in plasticity'.
            */
           bool allow_negative_pressures_in_plasticity;
 
@@ -290,6 +306,7 @@ namespace aspect
            * large negative value arising from large negative dynamic pressure,
            * resulting in solver convergence issue and in some cases a viscosity
            * of zero.
+           * This variable is read from the parameter file through a parameter called 'Use adiabatic pressure in creep viscosity'.
            */
           bool use_adiabatic_pressure_in_creep;
 
@@ -299,17 +316,20 @@ namespace aspect
            * This may be helpful in models where the full pressure has
            * large variations resulting in solver convergence issues.
            * Be aware that this setting will change the plastic shear band angle.
+           * This variable is read from the parameter file through a parameter called 'Use adiabatic pressure in plasticity'.
            */
           bool use_adiabatic_pressure_in_plasticity;
 
           /**
            * List of exponents controlling the behavior of the stress limiter
            * yielding mechanism.
+           * This variable is read from the parameter file through a parameter called 'Stress limiter exponents'.
            */
           std::vector<double> exponents_stress_limiter;
 
           /**
            * Temperature gradient added to temperature used in the flow law.
+           * This variable is read from the parameter file through a parameter called 'Adiabat temperature gradient for viscosity'.
            */
           double adiabatic_temperature_gradient_for_viscosity;
 
@@ -322,6 +342,7 @@ namespace aspect
 
           /**
            * Whether to include grain boundary sliding in the constitutive formulation.
+           * This variable is read from the parameter file through a parameter called 'Include Grain Boundary Sliding'.
            */
           bool use_grain_boundary_sliding;
 
@@ -332,6 +353,8 @@ namespace aspect
 
           /**
            * Whether to include Peierls creep in the constitutive formulation.
+           *
+           * This variable is read from the parameter file through a parameter called 'Include Peierls creep'.
            */
           bool use_peierls_creep;
 

--- a/include/aspect/material_model/simple.h
+++ b/include/aspect/material_model/simple.h
@@ -86,15 +86,35 @@ namespace aspect
          */
 
       private:
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Reference temperature'.
+         */
         double reference_T;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity'.
+         */
         double eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Composition viscosity prefactor'.
+         */
         double composition_viscosity_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal viscosity exponent'.
+         */
         double thermal_viscosity_exponent;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum thermal prefactor'.
+         */
         double maximum_thermal_prefactor;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Minimum thermal prefactor'.
+         */
         double minimum_thermal_prefactor;
 
         /**
          * The thermal conductivity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 

--- a/include/aspect/material_model/simple_compressible.h
+++ b/include/aspect/material_model/simple_compressible.h
@@ -100,26 +100,32 @@ namespace aspect
       private:
         /**
          * The reference density
+         * This variable is read from the parameter file through a parameter called 'Reference density'.
          */
         double reference_rho;
 
         /**
          * The constant thermal expansivity
+         * This variable is read from the parameter file through a parameter called 'Thermal expansion coefficient'.
          */
         double thermal_alpha;
 
         /**
          * The constant specific heat
+         * This variable is read from the parameter file through a parameter called 'Reference specific heat'.
          */
         double reference_specific_heat;
 
         /**
          * The constant compressibility.
+         * This variable is read from the parameter file through a parameter called 'Reference compressibility'.
          */
         double reference_compressibility;
 
         /**
          * The constant thermal conductivity.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
          */
         double k_value;
 

--- a/include/aspect/material_model/steinberger.h
+++ b/include/aspect/material_model/steinberger.h
@@ -234,6 +234,7 @@ namespace aspect
          * Boolean describing whether to use the lateral average temperature
          * for computing the viscosity, rather than the temperature
          * on the reference adiabat.
+         * This variable is read from the parameter file through a parameter called 'Use lateral average temperature for viscosity'.
          */
         bool use_lateral_average_temperature;
 
@@ -248,29 +249,51 @@ namespace aspect
          * Compositional prefactors with which to multiply the reference viscosity.
          * Volume fractions are used to weight the prefactors according to the
          * assigned viscosity averaging scheme.
+         * This variable is read from the parameter file through a parameter called 'Composition viscosity prefactors'.
          */
         std::vector<double> viscosity_prefactors;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
+         */
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging_scheme;
 
         /**
          * Information about lateral temperature averages.
          */
         std::vector<double> average_temperature;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Number lateral average bands'.
+         */
         unsigned int n_lateral_slices;
 
         /**
          * Minimum and maximum allowed viscosity, as well as the maximum allowed
          * viscosity variation compared to the average radial viscosity.
+         * This variable is read from the parameter file through a parameter called 'Minimum viscosity'.
          */
         double min_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum viscosity'.
+         */
         double max_eta;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Maximum lateral viscosity variation'.
+         */
         double max_lateral_eta_variation;
 
         /**
          * Information about the location of data files.
+         *
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string data_directory;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Radial viscosity file name'.
+         */
         std::string radial_viscosity_file_name;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Lateral viscosity file name'.
+         */
         std::string lateral_viscosity_file_name;
 
         /**
@@ -301,6 +324,9 @@ namespace aspect
          * Objects for computing plastic stresses, viscosities, and additional outputs
          */
         Rheology::DruckerPrager<dim> drucker_prager_plasticity;
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Use Drucker-Prager rheology'.
+         */
         bool enable_drucker_prager_rheology;
         Rheology::DruckerPragerParameters drucker_prager_parameters;
 

--- a/include/aspect/material_model/thermal_conductivity/constant.h
+++ b/include/aspect/material_model/thermal_conductivity/constant.h
@@ -62,6 +62,8 @@ namespace aspect
         private:
           /**
            * The thermal conductivity.
+           *
+           * This variable is read from the parameter file through a parameter called 'Thermal conductivity'.
            */
           double k;
       };

--- a/include/aspect/material_model/thermal_conductivity/tosi_stackhouse.h
+++ b/include/aspect/material_model/thermal_conductivity/tosi_stackhouse.h
@@ -94,16 +94,34 @@ namespace aspect
           /**
            * Parameters for the temperature and pressure dependence of the
            * thermal conductivity.
+           * This variable is read from the parameter file through a parameter called 'Thermal conductivity transition depths'.
            */
           std::vector<double> conductivity_transition_depths;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference thermal conductivities'.
+           */
           std::vector<double> reference_thermal_conductivities;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Pressure dependencies of thermal conductivity'.
+           */
           std::vector<double> conductivity_pressure_dependencies;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Reference temperatures for thermal conductivity'.
+           */
           std::vector<double> conductivity_reference_temperatures;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Thermal conductivity exponents'.
+           */
           std::vector<double> conductivity_exponents;
+          /**
+           *  This variable is read from the parameter file through a parameter called 'Saturation prefactors'.
+           */
           std::vector<double> saturation_scaling;
 
           /**
            * The maximum allowed thermal conductivity.
+           *
+           * This variable is read from the parameter file through a parameter called 'Maximum thermal conductivity'.
            */
           double maximum_conductivity;
       };

--- a/include/aspect/material_model/utilities.h
+++ b/include/aspect/material_model/utilities.h
@@ -664,13 +664,16 @@ namespace aspect
 
         private:
           /**
-          * Directory path where data files are stored.
-          */
+           * Directory path where data files are stored.
+           * This variable is read from the parameter file through a parameter called 'Data directory'.
+           */
           std::string data_directory;
 
           /**
            * List of file names containing material data for each composition.
-          */
+           *
+           * This variable is read from the parameter file through a parameter called 'Material file names'.
+           */
           std::vector<std::string> material_file_names;
 
           /**

--- a/include/aspect/material_model/visco_plastic.h
+++ b/include/aspect/material_model/visco_plastic.h
@@ -241,13 +241,20 @@ namespace aspect
          */
         std::unique_ptr<Rheology::ViscoPlastic<dim>> rheology;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal diffusivities'.
+         */
         std::vector<double> thermal_diffusivities;
 
         /**
          * Whether to use user-defined thermal conductivities instead of thermal diffusivities.
+         * This variable is read from the parameter file through a parameter called 'Define thermal conductivities'.
          */
         bool define_conductivities;
 
+        /**
+         *  This variable is read from the parameter file through a parameter called 'Thermal conductivities'.
+         */
         std::vector<double> thermal_conductivities;
 
         /**
@@ -272,6 +279,8 @@ namespace aspect
 
         /**
          * Determines whether to look up the dominant phases for each composition in its respective lookup table.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use dominant phase for viscosity'.
          */
         bool use_dominant_phase_for_viscosity;
 

--- a/include/aspect/material_model/viscoelastic.h
+++ b/include/aspect/material_model/viscoelastic.h
@@ -200,6 +200,7 @@ namespace aspect
       private:
         /**
          * Enumeration for selecting which viscosity averaging scheme to use.
+         * This variable is read from the parameter file through a parameter called 'Viscosity averaging scheme'.
          */
         MaterialUtilities::CompositionalAveragingOperation viscosity_averaging;
 
@@ -207,11 +208,14 @@ namespace aspect
 
         /**
          * Vector for field viscosities, read from parameter file.
+         * This variable is read from the parameter file through a parameter called 'Viscosities'.
          */
         std::vector<double> viscosities;
 
         /**
          * Vector for field thermal conductivities, read from parameter file.
+         *
+         * This variable is read from the parameter file through a parameter called 'Thermal conductivities'.
          */
         std::vector<double> thermal_conductivities;
 

--- a/include/aspect/mesh_deformation/diffusion.h
+++ b/include/aspect/mesh_deformation/diffusion.h
@@ -110,11 +110,14 @@ namespace aspect
          * The hillslope transport coefficient or diffusivity [m2/s]
          * used in the hillslope diffusion of the deformed
          * surface.
+         * This variable is read from the parameter file through a parameter called 'Hillslope transport coefficient'.
          */
         double diffusivity;
 
         /**
          * Maximum number of steps between the application of diffusion.
+         *
+         * This variable is read from the parameter file through a parameter called 'Time steps between diffusion'.
          */
         unsigned int timesteps_between_diffusion;
 

--- a/include/aspect/mesh_deformation/fastscape.h
+++ b/include/aspect/mesh_deformation/fastscape.h
@@ -198,12 +198,14 @@ namespace aspect
          * Suggestion for the number of FastScape steps to run for every ASPECT timestep,
          * where the FastScape timestep is determined by ASPECT_timestep_length divided by
          * this parameter.
+         * This variable is read from the parameter file through a parameter called 'Number of fastscape timesteps per aspect timestep'.
          */
         unsigned int fastscape_steps_per_aspect_step;
 
         /**
          * Maximum timestep allowed for FastScape, if the suggested timestep exceeds this
          * limit it is repeatedly divided by 2 until the final timestep is smaller than this parameter.
+         * This variable is read from the parameter file through a parameter called 'Maximum timestep length'.
          */
         double maximum_fastscape_timestep;
 
@@ -229,6 +231,7 @@ namespace aspect
 
         /**
          * User set FastScape Y extent for a 2D ASPECT model.
+         * This variable is read from the parameter file through a parameter called 'Y extent in 2d'.
          */
         double fastscape_y_extent_2d;
 
@@ -244,11 +247,13 @@ namespace aspect
 
         /**
          * Vertical exaggeration in FastScape visualization.
+         * This variable is read from the parameter file through a parameter called 'Vertical exaggeration'.
          */
         double vexp;
 
         /**
          * How many levels FastScape should be refined above the maximum ASPECT surface resolution.
+         * This variable is read from the parameter file through a parameter called 'Additional fastscape refinement'.
          */
         unsigned int additional_refinement_levels;
 
@@ -256,6 +261,7 @@ namespace aspect
          * Maximum expected refinement level at ASPECT's surface.
          * This and resolution_difference are required to properly transfer node data from
          * ASPECT to FastScape.
+         * This variable is read from the parameter file through a parameter called 'Maximum surface refinement level'.
          */
         unsigned int maximum_surface_refinement_level;
 
@@ -269,6 +275,7 @@ namespace aspect
          * of refinement at the surface, and we can subtract one within the code? Also,
          * it would be good to find a way to check these are correct, because they are a
          * common source of errors.
+         * This variable is read from the parameter file through a parameter called 'Surface refinement difference'.
          */
         unsigned int surface_refinement_difference;
 
@@ -276,11 +283,13 @@ namespace aspect
          * If set to true, the FastScape surface is averaged along Y and returned
          * to ASPECT. If set to false, the center slice of the FastScape model is
          * returned to ASPECT.
+         * This variable is read from the parameter file through a parameter called 'Average out of plane surface topography in 2d'.
          */
         bool average_out_of_plane_surface_topography;
 
         /**
          * Seed number for initial topography noise in FastScape.
+         * This variable is read from the parameter file through a parameter called 'Fastscape seed'.
          */
         int fastscape_seed;
 
@@ -296,6 +305,7 @@ namespace aspect
 
         /**
          * Whether or not to use the ghost nodes.
+         * This variable is read from the parameter file through a parameter called 'Use ghost nodes'.
          */
         bool use_ghost_nodes;
 
@@ -303,12 +313,14 @@ namespace aspect
          * Magnitude (m) of the initial noise applied to FastScape.
          * Applied as either a + or - value to the topography
          * such that the total difference can be up to 2*noise_elevation.
+         * This variable is read from the parameter file through a parameter called 'Initial noise magnitude'.
          */
         double noise_elevation;
 
         /**
          * Sediment rain in m/yr, added as a flat increase to the FastScape surface
          * in the marine domain every ASPECT timestep before running FastScape.
+         * This variable is read from the parameter file through a parameter called 'Sediment rain rates'.
          */
         std::vector<double> sediment_rain_rates;
 
@@ -316,6 +328,7 @@ namespace aspect
          * Time at which each interval of sediment_rain_rates is active. Should contain
          * one less value than sediment_rain_rates, assuming that sediment_rain_rates[0]
          * is applied from model time 0 until sediment_rain_times[0].
+         * This variable is read from the parameter file through a parameter called 'Sediment rain time intervals'.
          */
         std::vector<double> sediment_rain_times;
 
@@ -323,6 +336,7 @@ namespace aspect
          * Flag for having FastScape advect/uplift the surface. If the free surface is used
          * in conjunction with FastScape, this can be set to false, then FastScape will only
          * apply erosion/deposition to the surface and not advect or uplift it.
+         * This variable is read from the parameter file through a parameter called 'Uplift and advect with fastscape'.
          */
         bool fastscape_advection_uplift;
 
@@ -332,6 +346,7 @@ namespace aspect
          * and the free surface is used to advect the surface with a normal projection, or
          * if there is a surface refinement level difference leading to excess interpolation
          * points in areas of high ASPECT resolution.
+         * This variable is read from the parameter file through a parameter called 'Node tolerance'.
          */
         double node_tolerance;
 
@@ -339,6 +354,7 @@ namespace aspect
          * Interval between the generation of graphical output. This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
+         * This variable is read from the parameter file through a parameter called 'Time between graphical output'.
          */
         double output_interval;
 
@@ -358,6 +374,7 @@ namespace aspect
          * Where 1 represents a fixed height boundary (though this can still be uplifted through uplift velocities), and 0 a
          * reflective boundary. When two opposing boundaries are reflective (e.g., top and bottom are both zero), then the boundaries
          * become cyclic.
+         * This variable is read from the parameter file through a parameter called 'Front'.
          */
         unsigned int bottom;
 
@@ -366,6 +383,7 @@ namespace aspect
          * Where 1 represents a fixed height boundary (though this can still be uplifted through uplift velocities), and 0 a
          * reflective boundary. When two opposing boundaries are reflective (e.g., top and bottom are both zero), then the boundaries
          * become cyclic.
+         * This variable is read from the parameter file through a parameter called 'Back'.
          */
         unsigned int top;
 
@@ -374,6 +392,7 @@ namespace aspect
          * Where 1 represents a fixed height boundary (though this can still be uplifted through uplift velocities), and 0 a
          * reflective boundary. When two opposing boundaries are reflective (e.g., left and right are both zero), then the boundaries
          * become cyclic.
+         * This variable is read from the parameter file through a parameter called 'Right'.
          */
         unsigned int right;
 
@@ -382,13 +401,24 @@ namespace aspect
          * Where 1 represents a fixed height boundary (though this can still be uplifted through uplift velocities), and 0 a
          * reflective boundary. When two opposing boundaries are reflective (e.g., left and right are both zero), then the boundaries
          * become cyclic.
+         * This variable is read from the parameter file through a parameter called 'Left'.
          */
         unsigned int left;
 
         /**
-         * Parameters that set the FastScape boundaries periodic even though the ghost nodes are set 'fixed'
+         * Whether the FastScape front and back boundaries are periodic even
+         * though the ghost nodes are set to 'fixed'.
+         * This variable is read from the parameter file through a parameter called
+         * 'Back front ghost nodes periodic'.
          */
         bool topbottom_ghost_nodes_periodic;
+
+        /**
+         * Whether the FastScape left and right boundaries are periodic even
+         * though the ghost nodes are set to 'fixed'.
+         * This variable is read from the parameter file through a parameter called
+         * 'Left right ghost nodes periodic'.
+         */
         bool leftright_ghost_nodes_periodic;
 
         /**
@@ -398,21 +428,25 @@ namespace aspect
 
         /**
          * Prescribed flux per unit length into the model through the bottom boundary (m^2/yr).
+         * This variable is read from the parameter file through a parameter called 'Front mass flux'.
          */
         double bottom_flux;
 
         /**
          * Prescribed flux per unit length into the model through the top boundary (m^2/yr).
+         * This variable is read from the parameter file through a parameter called 'Back mass flux'.
          */
         double top_flux;
 
         /**
          * Prescribed flux per unit length into the model through the right boundary (m^2/yr).
+         * This variable is read from the parameter file through a parameter called 'Right mass flux'.
          */
         double right_flux;
 
         /**
          * Prescribed flux per unit length into the model through the left boundary (m^2/yr).
+         * This variable is read from the parameter file through a parameter called 'Left mass flux'.
          */
         double left_flux;
         /**
@@ -426,23 +460,27 @@ namespace aspect
 
         /**
          * Drainage area exponent for the stream power law. ($m$ variable in FastScape surface equation.)
+         * This variable is read from the parameter file through a parameter called 'Drainage area exponent'.
          */
         double drainage_area_exponent_m;
 
         /**
          * Slope exponent for the stream power law. ($n$ variable in FastScape surface equation.)
+         * This variable is read from the parameter file through a parameter called 'Slope exponent'.
          */
         double slope_exponent_n;
 
         /**
          * Slope exponent for multi-direction flow, where 0 is uniform, and 10 is steepest descent. (-1 varies with slope.)
          * ($p$ variable in FastScape surface equation.)
+         * This variable is read from the parameter file through a parameter called 'Multi-direction slope exponent'.
          */
         double slope_exponent_p;
 
         /**
          * Bedrock deposition coefficient. Higher values deposit more sediment
          * inside the domain. ($G$ variable in FastScape surface equation.)
+         * This variable is read from the parameter file through a parameter called 'Bedrock deposition coefficient'.
          */
         double bedrock_deposition_g;
 
@@ -450,6 +488,7 @@ namespace aspect
          * Sediment deposition coefficient. Higher values deposit more sediment inside the domain.
          * When set to -1 this is identical to the bedrock value.
          * ($G$ variable in FastScape surface equation applied to sediment.)
+         * This variable is read from the parameter file through a parameter called 'Sediment deposition coefficient'.
          */
         double sediment_deposition_g;
 
@@ -465,6 +504,7 @@ namespace aspect
 
         /**
          * Flag to choose if a function of river incision rate for the stream power law will be applied.
+         * This variable is read from the parameter file through a parameter called 'Use kf distribution function'.
          */
         bool use_kf_distribution_function;
 
@@ -474,6 +514,7 @@ namespace aspect
          * Units: ${m^(1-2drainage_area_exponent)/yr}$ if "Use years instead of seconds in output" is true;
          * otherwise, the units are ${m^(1-2drainage_area_exponent)/s}$. Then a time scale factor will be applied to
          * convert it into  ${m^(1-2drainage_area_exponent)/yr}$ for Fastscape.
+         * This variable is read from the parameter file through a parameter called 'Bedrock river incision rate'.
          */
         double constant_bedrock_river_incision_rate;
 
@@ -484,6 +525,7 @@ namespace aspect
          * convert it into  ${m^(1-2drainage_area_exponent)/yr}$ for Fastscape.
          * When set to -1 this is identical to the bedrock value.
          * ($kf$ variable in FastScape surface equation applied to sediment.)
+         * This variable is read from the parameter file through a parameter called 'Sediment river incision rate'.
          */
         double sediment_river_incision_rate;
 
@@ -499,6 +541,7 @@ namespace aspect
 
         /**
          * Flag for using parsed function vs constant
+         * This variable is read from the parameter file through a parameter called 'Use kd distribution function'.
          */
         bool use_kd_distribution_function;
 
@@ -508,6 +551,7 @@ namespace aspect
          * otherwise, the units are ${m^2/s}$. Then a time scale factor will be applied to
          * convert it into  ${m^2/yr}$ for Fastscape.
          * This function is only used only if use_kf_distribution_function is false.
+         * This variable is read from the parameter file through a parameter called 'Bedrock diffusivity'.
          */
         double constant_bedrock_transport_coefficient;
 
@@ -518,6 +562,7 @@ namespace aspect
          * convert it into  ${m^2/yr}$ for Fastscape.
          * When set to -1 this is identical to the bedrock value.
          * (kd in FastScape surface equation applied to sediment).
+         * This variable is read from the parameter file through a parameter called 'Sediment diffusivity'.
          */
         double sediment_transport_coefficient;
         /**
@@ -540,6 +585,7 @@ namespace aspect
 
         /**
          * User defined constant sea level value (m).
+         * This variable is read from the parameter file through a parameter called 'Sea level'.
          */
         double sea_level_constant_value;
 
@@ -550,62 +596,74 @@ namespace aspect
 
         /**
          * Whether to use a function to define sea level.
+         * This variable is read from the parameter file through a parameter called 'Use sea level function'.
          */
         bool use_sea_level_function;
 
         /**
          * Parameters to set an extra erosional base level
          * on the ghost nodes that differs from sea level.
+         * This variable is read from the parameter file through a parameter called 'Use a fixed erosional base level'.
          */
         bool use_fixed_erosional_base;
 
         /**
          * Height of the extra erosional base level.
+         * This variable is read from the parameter file through a parameter called 'Erosional base level'.
          */
         double h_erosional_base;
 
         /**
          * Surface porosity for sand.
+         * This variable is read from the parameter file through a parameter called 'Sand porosity'.
          */
         double sand_surface_porosity;
 
         /**
          * Surface porosity for silt.
+         * This variable is read from the parameter file through a parameter called 'Silt porosity'.
          */
         double silt_surface_porosity;
 
         /**
          * Sands e-folding depth for exponential porosity law (m).
+         * This variable is read from the parameter file through a parameter called 'Sand e-folding depth'.
          */
         double sand_efold_depth;
 
         /**
          * Silts e-folding depth for exponential porosity law (m).
+         * This variable is read from the parameter file through a parameter called 'Silt e-folding depth'.
          */
         double silt_efold_depth;
 
         /**
          * Silt fraction of material entering the marine domain.
+         * This variable is read from the parameter file through a parameter called 'Silt fraction'.
          */
         double incoming_silt_fraction;
 
         /**
          * Averaging depth/thickness for sand-silt equation (m).
+         * This variable is read from the parameter file through a parameter called 'Depth averaging thickness'.
          */
         double sand_silt_averaging_depth;
 
         /**
          * Sand marine transport coefficient. (marine diffusion, m^2/yr.)
+         * This variable is read from the parameter file through a parameter called 'Sand transport coefficient'.
          */
         double sand_transport_coefficient;
 
         /**
          * Silt marine transport coefficient. (marine diffusion, m^2/yr.)
+         * This variable is read from the parameter file through a parameter called 'Silt transport coefficient'.
          */
         double silt_transport_coefficient;
 
         /**
          * Flag to use the marine component of FastScape.
+         * This variable is read from the parameter file through a parameter called 'Use marine component'.
          */
         bool use_marine_component;
         /**
@@ -620,6 +678,7 @@ namespace aspect
         /**
          * Set a flat height (m) after which the flat_erosional_factor
          * is applied to the bedrock river incision rate and transport coefficient.
+         * This variable is read from the parameter file through a parameter called 'Orographic elevation control'.
          */
         int flat_elevation;
 
@@ -627,33 +686,40 @@ namespace aspect
          * Set the height (m) after which the model will track the ridge line
          * and based on the wind direction will apply the wind_barrier_erosional_factor
          * to the bedrock river incision rate and transport coefficient.
+         * This variable is read from the parameter file through a parameter called 'Orographic wind barrier height'.
          */
         int wind_barrier_elevation;
 
         /**
          * Wind direction for wind_barrier_erosional_factor.
+         * This variable is read from the parameter file through a parameter called 'Wind direction'.
          */
         unsigned int wind_direction;
 
         /**
          * Factor to multiply the bedrock river incision rate and transport coefficient by depending on them
          * flat_elevation.
+         * This variable is read from the parameter file through a parameter called 'Elevation factor'.
          */
         double flat_erosional_factor;
 
         /**
          * Factor to multiply the bedrock river incision rate and transport coefficient by depending on them
          * wind_barrier_elevation and wind direction.
+         * This variable is read from the parameter file through a parameter called 'Wind barrier factor'.
          */
         double wind_barrier_erosional_factor;
 
         /**
          * Flag to stack both orographic controls.
+         * This variable is read from the parameter file through a parameter called 'Stack orographic controls'.
          */
         bool stack_controls;
 
         /**
          * Flag to use orographic controls.
+         *
+         * This variable is read from the parameter file through a parameter called 'Flag to use orographic controls'.
          */
         bool use_orographic_controls;
         /**

--- a/include/aspect/mesh_deformation/interface.h
+++ b/include/aspect/mesh_deformation/interface.h
@@ -626,6 +626,8 @@ namespace aspect
          * Stabilization parameter for the free surface. Should be between
          * zero and one. A value of zero means no stabilization.  See Kaus
          * et. al. 2010 for more details.
+         *
+         * This variable is read from the parameter file through a parameter called 'Free surface stabilization theta'.
          */
         double surface_theta;
 

--- a/include/aspect/mesh_refinement/artificial_viscosity.h
+++ b/include/aspect/mesh_refinement/artificial_viscosity.h
@@ -64,11 +64,14 @@ namespace aspect
 
         /**
          * Scaling factor for the temperature indicator.
+         * This variable is read from the parameter file through a parameter called 'Temperature scaling factor'.
          */
         double temperature_scaling_factor;
 
         /**
          * The scaling factors for each compositional field.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional field scaling factors'.
          */
         std::vector<double> composition_scaling_factors;
     };

--- a/include/aspect/mesh_refinement/compaction_length.h
+++ b/include/aspect/mesh_refinement/compaction_length.h
@@ -70,6 +70,8 @@ namespace aspect
         /**
          * The desired ratio between compaction length and size of the mesh cells,
          * in other words, how many cells the mesh should have per compaction length.
+         *
+         * This variable is read from the parameter file through a parameter called 'Mesh cells per compaction length'.
          */
         double cells_per_compaction_length;
     };

--- a/include/aspect/mesh_refinement/composition.h
+++ b/include/aspect/mesh_refinement/composition.h
@@ -69,6 +69,8 @@ namespace aspect
         /**
          * The scaling factors that should be applied to the individual
          * refinement indicators before merging.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional field scaling factors'.
          */
         std::vector<double> composition_scaling_factors;
     };

--- a/include/aspect/mesh_refinement/composition_approximate_gradient.h
+++ b/include/aspect/mesh_refinement/composition_approximate_gradient.h
@@ -69,6 +69,8 @@ namespace aspect
         /**
          * The scaling factors that should be applied to the individual
          * refinement indicators before merging.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional field scaling factors'.
          */
         std::vector<double> composition_scaling_factors;
     };

--- a/include/aspect/mesh_refinement/composition_gradient.h
+++ b/include/aspect/mesh_refinement/composition_gradient.h
@@ -69,6 +69,8 @@ namespace aspect
         /**
          * The scaling factors that should be applied to the individual
          * refinement indicators before merging.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional field scaling factors'.
          */
         std::vector<double> composition_scaling_factors;
     };

--- a/include/aspect/mesh_refinement/composition_threshold.h
+++ b/include/aspect/mesh_refinement/composition_threshold.h
@@ -67,6 +67,8 @@ namespace aspect
         /**
          * The thresholds that should be used for the individual
          * compositional fields.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compositional field thresholds'.
          */
         std::vector<double> composition_thresholds;
     };

--- a/include/aspect/mesh_refinement/interface.h
+++ b/include/aspect/mesh_refinement/interface.h
@@ -247,18 +247,22 @@ namespace aspect
 
         /**
          * How to merge the results of multiple mesh refinement criteria.
+         * This variable is read from the parameter file through a parameter called 'Refinement criteria merge operation'.
          */
         MergeOperation merge_operation;
 
         /**
          * Whether to normalize the individual refinement indicators to the
          * range $[0,1]$ before merging.
+         * This variable is read from the parameter file through a parameter called 'Normalize individual refinement criteria'.
          */
         bool normalize_criteria;
 
         /**
          * The scaling factors that should be applied to the individual
          * refinement indicators before merging.
+         *
+         * This variable is read from the parameter file through a parameter called 'Refinement criteria scaling factors'.
          */
         std::vector<double> scaling_factors;
     };

--- a/include/aspect/mesh_refinement/maximum_refinement_function.h
+++ b/include/aspect/mesh_refinement/maximum_refinement_function.h
@@ -76,6 +76,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/mesh_refinement/minimum_refinement_function.h
+++ b/include/aspect/mesh_refinement/minimum_refinement_function.h
@@ -77,6 +77,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/mesh_refinement/nonadiabatic_temperature_threshold.h
+++ b/include/aspect/mesh_refinement/nonadiabatic_temperature_threshold.h
@@ -67,6 +67,7 @@ namespace aspect
         /**
          * The thresholds that should be used for the nonadiabatic
          * temperature.
+         * This variable is read from the parameter file through a parameter called 'Threshold'.
          */
         double threshold;
 
@@ -76,6 +77,8 @@ namespace aspect
          * (subadiabatic temperatures), only positive anomalies
          * (superadiabatic temperatures) or the absolute value of the
          * nonadiabatic temperature.
+         *
+         * This variable is read from the parameter file through a parameter called 'Temperature anomaly type'.
          */
         enum anomaly
         {

--- a/include/aspect/mesh_refinement/volume_of_fluid_interface.h
+++ b/include/aspect/mesh_refinement/volume_of_fluid_interface.h
@@ -64,6 +64,8 @@ namespace aspect
       private:
         /**
          * If true, flag cells for coarsening if they are not flagged for refinement
+         *
+         * This variable is read from the parameter file through a parameter called 'Strict coarsening'.
          */
         bool strict_coarsening;
     };

--- a/include/aspect/particle/generator/ascii_file.h
+++ b/include/aspect/particle/generator/ascii_file.h
@@ -63,7 +63,16 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * This variable is read from the parameter file through a parameter
+           * called 'Data directory'.
+           */
           std::string data_directory;
+
+          /**
+           * This variable is read from the parameter file through a parameter
+           * called 'Data file name'.
+           */
           std::string data_filename;
       };
 

--- a/include/aspect/particle/generator/probability_density_function.h
+++ b/include/aspect/particle/generator/probability_density_function.h
@@ -89,6 +89,8 @@ namespace aspect
         private:
           /**
            * Number of particles to create
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of particles'.
            */
           types::particle_index n_particles;
 
@@ -99,12 +101,17 @@ namespace aspect
            * on the integral of the density over each of the cells, and then
            * once we know how many particles we want on each cell, choose their
            * locations randomly within each cell.
+           * This variable is read from the parameter file through a parameter
+           * called 'Random cell selection'.
            */
           bool random_cell_selection;
 
           /**
            * The seed for the random number generator that controls the
            * particle generation.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Random number seed'.
            */
           unsigned int random_number_seed;
 

--- a/include/aspect/particle/generator/random_uniform.h
+++ b/include/aspect/particle/generator/random_uniform.h
@@ -65,6 +65,8 @@ namespace aspect
         private:
           /**
            * Number of particles to create
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of particles'.
            */
           types::particle_index n_particles;
 
@@ -75,12 +77,17 @@ namespace aspect
            * on the integral of the density over each of the cells, and then
            * once we know how many particles we want on each cell, choose their
            * locations randomly within each cell.
+           * This variable is read from the parameter file through a parameter
+           * called 'Random cell selection'.
            */
           bool random_cell_selection;
 
           /**
            * The seed for the random number generator that controls the
            * particle generation.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Random number seed'.
            */
           unsigned int random_number_seed;
       };

--- a/include/aspect/particle/generator/uniform_box.h
+++ b/include/aspect/particle/generator/uniform_box.h
@@ -69,12 +69,16 @@ namespace aspect
         private:
           /**
            * Number of initial particles to create.
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of particles'.
            */
           types::particle_index n_particles;
 
           /**
            * The minimum coordinates of the particle region, i.e. one corner of
            * the n-dimensional box region in which particles are generated.
+           * This variable is read from the parameter file through parameters
+           * called 'Minimum x', 'Minimum y', and 'Minimum z'.
            */
           Point<dim> P_min;
 
@@ -82,6 +86,9 @@ namespace aspect
            * The maximum coordinates of the particle region, i.e. the opposite
            * corner of the n-dimensional box region in which particles are
            * generated.
+           *
+           * This variable is read from the parameter file through parameters
+           * called 'Maximum x', 'Maximum y', and 'Maximum z'.
            */
           Point<dim> P_max;
       };

--- a/include/aspect/particle/generator/uniform_radial.h
+++ b/include/aspect/particle/generator/uniform_radial.h
@@ -78,6 +78,8 @@ namespace aspect
            * The minimum spherical coordinates of the particle region, i.e.
            * the first radius, colatitude and longitude from the given
            * center position P_center where particles are generated.
+           * This variable is read from the parameter file through parameters
+           * called 'Minimum radius', 'Minimum longitude', and 'Minimum latitude'.
            */
           std::array<double,dim> P_min;
 
@@ -85,11 +87,15 @@ namespace aspect
            * The maximum spherical coordinates of the particle region, i.e.
            * the last radius, colatitude and longitude from the given
            * center position P_center where particles are generated.
+           * This variable is read from the parameter file through parameters
+           * called 'Maximum radius', 'Maximum longitude', and 'Maximum latitude'.
            */
           std::array<double,dim> P_max;
 
           /**
            * The center of the particle region. Defaults to the origin.
+           * This variable is read from the parameter file through parameters
+           * called 'Center x', 'Center y', and 'Center z'.
            */
           Point<dim> P_center;
 
@@ -97,6 +103,8 @@ namespace aspect
            * The number of radial layers of particles that will be generated.
            * In particular this parameter determines the radial spacing between
            * particle layers as Pmax[0] - P_min[0] / radial_layers.
+           * This variable is read from the parameter file through a parameter
+           * called 'Radial layers'.
            */
           unsigned int radial_layers;
 
@@ -105,6 +113,9 @@ namespace aspect
            * spacing (in spherical coordinates) between particles, the number
            * of actually generated
            * particles can differ slightly from this number.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of particles'.
            */
           types::particle_index n_particles;
       };

--- a/include/aspect/particle/integrator/rk_2.h
+++ b/include/aspect/particle/integrator/rk_2.h
@@ -144,6 +144,9 @@ namespace aspect
           /**
            * Whether to evaluate old and current velocity to compute a solution
            * that is higher order accurate in time.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Higher order accurate in time'.
            */
           bool higher_order_in_time;
       };

--- a/include/aspect/particle/interpolator/cell_average.h
+++ b/include/aspect/particle/interpolator/cell_average.h
@@ -70,6 +70,9 @@ namespace aspect
            * By default, every cell needs to contain particles to use this interpolator
            * plugin. If this parameter is set to true, cells are allowed to have no particles,
            * in which case the interpolator will return 0 for the cell's properties.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Allow cells without particles'.
            */
           bool allow_cells_without_particles;
       };

--- a/include/aspect/particle/interpolator/harmonic_average.h
+++ b/include/aspect/particle/interpolator/harmonic_average.h
@@ -70,6 +70,9 @@ namespace aspect
            * By default, every cell needs to contain particles to use this interpolator
            * plugin. If this parameter is set to true, cells are allowed to have no particles,
            * in which case the interpolator will return 0 for the cell's properties.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Allow cells without particles'.
            */
           bool allow_cells_without_particles;
       };

--- a/include/aspect/particle/interpolator/nearest_neighbor.h
+++ b/include/aspect/particle/interpolator/nearest_neighbor.h
@@ -71,6 +71,9 @@ namespace aspect
            * By default, every cell needs to contain particles to use this interpolator
            * plugin. If this parameter is set to true, cells are allowed to have no particles,
            * in which case the interpolator will return 0 for the cell's properties.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Allow cells without particles'.
            */
           bool allow_cells_without_particles;
       };

--- a/include/aspect/particle/property/composition_reaction.h
+++ b/include/aspect/particle/property/composition_reaction.h
@@ -128,6 +128,8 @@ namespace aspect
           /**
            * The coordinate representation to evaluate the reaction_area
            * function. Possible choices are depth, cartesian and spherical.
+           * This variable is read from the parameter file through a parameter
+           * called 'Coordinate system'.
            */
           Utilities::Coordinates::CoordinateSystem coordinate_system;
 
@@ -149,6 +151,9 @@ namespace aspect
 
           /**
            * Vector of the times when each reaction should occur.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'List of reaction times'.
            */
           std::vector<double> reaction_times;
 

--- a/include/aspect/particle/property/cpo_bingham_average.h
+++ b/include/aspect/particle/property/cpo_bingham_average.h
@@ -178,7 +178,9 @@ namespace aspect
           mutable std::mt19937 random_number_generator;
 
           /**
-           * the random number generator seed used to initialize the random number generator.
+           * The random number generator seed used to initialize the random number generator.
+           * This variable is read from the parameter file through a parameter
+           * called 'Random number seed'.
            */
           unsigned int random_number_seed;
 
@@ -194,11 +196,16 @@ namespace aspect
 
           /**
            * when doing the random draw volume weighting, this sets how many samples are taken.
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of samples'.
            */
           unsigned int n_samples;
 
-          /*
-           this sets whether the orientations are represented by rotation matrix or Euler angles.
+          /**
+           * This variable determines whether the orientations are represented by rotation matrix or Euler angles.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Use rotation matrix'.
            */
           bool use_rotmat;
 

--- a/include/aspect/particle/property/cpo_elastic_tensor.h
+++ b/include/aspect/particle/property/cpo_elastic_tensor.h
@@ -164,11 +164,16 @@ namespace aspect
 
           /**
            * The number of grains per particle.
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of grains per particle'.
            */
           unsigned int n_grains;
 
           /**
            * The number of minerals per particle.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Minerals'.
            */
           unsigned int n_minerals;
 

--- a/include/aspect/particle/property/crystal_preferred_orientation.h
+++ b/include/aspect/particle/property/crystal_preferred_orientation.h
@@ -534,8 +534,17 @@ namespace aspect
            * Random number generator used for initialization of particles
            */
           mutable boost::mt19937 random_number_generator;
+
+          /**
+           * This variable is read from the parameter file through a parameter
+           * called 'Random number seed'.
+           */
           unsigned int random_number_seed;
 
+          /**
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of grains per particle'.
+           */
           unsigned int n_grains;
 
           unsigned int n_minerals;
@@ -555,28 +564,38 @@ namespace aspect
 
           /**
            * Store the volume fraction for each mineral.
+           * This variable is read from the parameter file through a parameter
+           * called 'Volume fractions minerals'.
            */
           std::vector<double> volume_fractions_minerals;
 
           /**
            * Advection method for particle properties
+           * This variable is read from the parameter file through a parameter
+           * called 'Property advection method'.
            */
           AdvectionMethod advection_method;
 
           /**
            * What algorithm to use to compute the derivatives
+           * This variable is read from the parameter file through a parameter
+           * called 'CPO derivatives algorithm'.
            */
           CPODerivativeAlgorithm cpo_derivative_algorithm;
 
           /**
            * This value determines the tolerance used for the Backward Euler and
            * Crank-Nicolson iterations.
+           * This variable is read from the parameter file through a parameter
+           * called 'Property advection tolerance'.
            */
           double property_advection_tolerance;
 
           /**
            * This value determines the the maximum number of iterations used for the
            * Backward Euler and Crank-Nicolson iterations.
+           * This variable is read from the parameter file through a parameter
+           * called 'Property advection max iterations'.
            */
           unsigned int property_advection_max_iterations;
 
@@ -586,17 +605,23 @@ namespace aspect
           /** @{ */
           /**
            * Stress exponent
+           * This variable is read from the parameter file through a parameter
+           * called 'Stress exponents'.
            */
           double stress_exponent;
 
           /**
            * efficiency of nucleation parameter.
            * lambda_m in equation 8 of Kaminski et al. (2004, Geophys. J. Int)
+           * This variable is read from the parameter file through a parameter
+           * called 'Nucleation efficiency'.
            */
           double nucleation_efficiency;
 
           /**
            * An exponent described in equation 10 of Kaminski and Ribe (2001, EPSL)
+           * This variable is read from the parameter file through a parameter
+           * called 'Exponents p'.
            */
           double exponent_p;
 
@@ -604,17 +629,23 @@ namespace aspect
            * The Dimensionless Grain Boundary Sliding (GBS) threshold.
            * This is a grain size threshold below which grain deform by GBS and
            * become strain-free grains.
+           * This variable is read from the parameter file through a parameter
+           * called 'Threshold GBS'.
            */
           double threshold_GBS;
 
           /**
            * Dimensionless grain boundary mobility as described by equation 14
            * in Kaminski and Ribe (2001, EPSL).
+           * This variable is read from the parameter file through a parameter
+           * called 'Mobility'.
            */
           double mobility;
 
           /**
            * Sets which type of initial grain model is used to create the gain sizes and orientations
+           * This variable is read from the parameter file through a parameter
+           * called 'Model name'.
            */
           CPOInitialGrainsModel initial_grains_model;
 
@@ -628,7 +659,9 @@ namespace aspect
            * but Bascou etal., 2002 JSG using VPSC provides a reference, which is
            * supported by experimental work from Zhang et al., 2006 EPSL
            * that agree with the three main slip systems
-          */
+           * This variable is read from the parameter file through a parameter
+           * called 'CPX RRSS'.
+           */
           std::vector<double> CPX_RRSS;
 
           /**
@@ -639,7 +672,10 @@ namespace aspect
            * The RRSS notation is defined in Kaminski etal., 2004 and
            * see Fraters and Billen 2021 for details;
            * Main slip systems from Karato 2008 and Bystricky et al., 2001
-          */
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'OlivineD RRSS'.
+           */
           std::vector<double> OlivineD_RRSS;
 
           /** @} */

--- a/include/aspect/particle/property/elastic_stress.h
+++ b/include/aspect/particle/property/elastic_stress.h
@@ -140,6 +140,9 @@ namespace aspect
            * weighted average with the stress values interpolated from the compositional
            * fields to the particle location. The default value of 1 is more accurate,
            * but can be less stable.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Particle stress value weight'.
            */
           double particle_weight;
       };

--- a/include/aspect/particle/property/function.h
+++ b/include/aspect/particle/property/function.h
@@ -91,6 +91,9 @@ namespace aspect
           /**
            * A private variable that stores the number of particle property
            * function components.
+           *
+           * This variable is read from the parameter file through a parameter
+           * called 'Number of components'.
            */
           unsigned int n_components;
       };

--- a/include/aspect/particle/property/melt_particle.h
+++ b/include/aspect/particle/property/melt_particle.h
@@ -102,6 +102,10 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * This variable is read from the parameter file through a parameter
+           * called 'Threshold for melt presence'.
+           */
           double threshold_for_melt_presence;
       };
     }

--- a/include/aspect/postprocess/boundary_strain_rate_residual_statistics.h
+++ b/include/aspect/postprocess/boundary_strain_rate_residual_statistics.h
@@ -83,11 +83,13 @@ namespace aspect
 
         /**
          * Directory in which the input data files are present.
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string data_directory;
 
         /**
          * Filename of the input ascii data file containing the surface strain rate components.
+         * This variable is read from the parameter file through a parameter called 'Data file name'.
          */
         std::string data_file_name;
 
@@ -96,6 +98,8 @@ namespace aspect
          * the unit of the data (if they are not specified in SI units (/s or
          * /yr depending on the "Use years instead of seconds"
          * parameter).
+         *
+         * This variable is read from the parameter file through a parameter called 'Scale factor'.
          */
         double scale_factor;
     };

--- a/include/aspect/postprocess/boundary_velocity_residual_statistics.h
+++ b/include/aspect/postprocess/boundary_velocity_residual_statistics.h
@@ -81,12 +81,14 @@ namespace aspect
          * Determines if the input ascii data file has velocity components in
          * spherical, i.e., (r, phi, theta) or in cartesian, i.e., (x, y, z)
          * coordinate system.
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
 
         /**
          * Determines if the model velocities are compared against ascii data
          * files, or a gplates model.
+         * This variable is read from the parameter file through a parameter called 'Use ascii data'.
          */
         bool use_ascii_data;
 
@@ -103,6 +105,7 @@ namespace aspect
         /**
          * Directory in which the input data files, i.e., GPlates model or ascii data
          * are present.
+         * This variable is read from the parameter file through a parameter called 'Data directory'.
          */
         std::string data_directory;
 
@@ -110,6 +113,7 @@ namespace aspect
          * Filename of the input Gplates model or ascii data file. For GPlates, the file names
          * can contain the specifiers %s and/or %c (in this order), meaning the name of the
          * boundary and the number of the data file time step.
+         * This variable is read from the parameter file through a parameter called 'Data file name'.
          */
         std::string data_file_name;
 
@@ -118,6 +122,8 @@ namespace aspect
          * the unit of the data (if they are not specified in SI units (m/s or
          * m/yr depending on the "Use years instead of seconds"
          * parameter).
+         *
+         * This variable is read from the parameter file through a parameter called 'Scale factor'.
          */
         double scale_factor;
     };

--- a/include/aspect/postprocess/command.h
+++ b/include/aspect/postprocess/command.h
@@ -61,8 +61,17 @@ namespace aspect
         execute (TableHandler &statistics) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Command'.
+         */
         std::string command;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Terminate on failure'.
+         */
         bool terminate_on_failure;
+        /**
+         * This variable is read from the parameter file through a parameter called 'Run on all processes'.
+         */
         bool on_all_processes;
     };
   }

--- a/include/aspect/postprocess/composition_velocity_statistics.h
+++ b/include/aspect/postprocess/composition_velocity_statistics.h
@@ -66,6 +66,9 @@ namespace aspect
          */
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Names of selected compositional fields'.
+         */
         std::vector<std::string> selected_fields;
     };
   }

--- a/include/aspect/postprocess/core_statistics.h
+++ b/include/aspect/postprocess/core_statistics.h
@@ -91,6 +91,8 @@ namespace aspect
          * Controls whether output the total excess entropy or the individual entropy terms
          * (i.e. entropy for specific heat, radioactive heating, gravitational contribution,
          * and adiabatic contribution).
+         *
+         * This variable is read from the parameter file through a parameter called 'Excess entropy only'.
          */
         bool   excess_entropy_only;
 

--- a/include/aspect/postprocess/crystal_preferred_orientation.h
+++ b/include/aspect/postprocess/crystal_preferred_orientation.h
@@ -136,12 +136,14 @@ namespace aspect
 
         /**
          * Random number generator seed used to initialize the random number generator.
+         * This variable is read from the parameter file through a parameter called 'Random number seed'.
          */
         unsigned int random_number_seed;
 
         /**
          * Interval between output (in years if appropriate simulation
          * parameter is set, otherwise seconds)
+         * This variable is read from the parameter file through a parameter called 'Time between data output'.
          */
         double output_interval;
 
@@ -217,6 +219,7 @@ namespace aspect
          * move this file to a network file system. If this variable is
          * set to a non-empty string it will be interpreted as a temporary
          * storage location.
+         * This variable is read from the parameter file through a parameter called 'Temporary output location'.
          */
         std::string temporary_output_location;
 
@@ -225,6 +228,7 @@ namespace aspect
          * progress of the rest of the model run. Setting this variable to
          * 'true' moves this process into a background thread, while the
          * rest of the model continues.
+         * This variable is read from the parameter file through a parameter called 'Write in background thread'.
          */
         bool write_in_background_thread;
 
@@ -270,6 +274,8 @@ namespace aspect
 
         /**
          * Whether to compress the raw and weighed cpo data output files with zlib.
+         *
+         * This variable is read from the parameter file through a parameter called 'Compress cpo data files'.
          */
         bool compress_cpo_data_files;
 

--- a/include/aspect/postprocess/depth_average.h
+++ b/include/aspect/postprocess/depth_average.h
@@ -89,6 +89,7 @@ namespace aspect
          * Interval between the generation of output in seconds. This parameter is read
          * from the input file and consequently is not part of the state that
          * needs to be saved and restored.
+         * This variable is read from the parameter file through a parameter called 'Time between graphical output'.
          */
         double output_interval;
 
@@ -100,12 +101,14 @@ namespace aspect
         /**
          * The formats in which to produce graphical output. This also
          * determines the extension of the file names to which to write.
+         * This variable is read from the parameter file through a parameter called 'Output format'.
          */
         std::vector<std::string> output_formats;
 
         /**
          * Number of zones in depth direction over which we are supposed to
          * average.
+         * This variable is read from the parameter file through a parameter called 'Number of zones'.
          */
         unsigned int n_depth_zones;
 
@@ -114,6 +117,8 @@ namespace aspect
          * This vector contains exactly n_depth_zones + 1 entries,
          * and entries i and i+1 represent the lower and upper depth bound
          * of zone i.
+         *
+         * This variable is read from the parameter file through a parameter called 'Depth boundaries of zones'.
          */
         std::vector<double> depth_bounds;
 

--- a/include/aspect/postprocess/dynamic_topography.h
+++ b/include/aspect/postprocess/dynamic_topography.h
@@ -110,22 +110,27 @@ namespace aspect
         /**
          * A parameter that allows users to set the density value
          * above the top surface.
+         * This variable is read from the parameter file through a parameter called 'Density above'.
          */
         double density_above;
 
         /**
          * A parameter that allows users to set the density value
          * below the bottom surface.
+         * This variable is read from the parameter file through a parameter called 'Density below'.
          */
         double density_below;
 
         /**
          * Whether to output the surface topography.
+         * This variable is read from the parameter file through a parameter called 'Output surface'.
          */
         bool output_surface;
 
         /**
          * Whether to output the bottom topography.
+         *
+         * This variable is read from the parameter file through a parameter called 'Output bottom'.
          */
         bool output_bottom;
     };

--- a/include/aspect/postprocess/geoid.h
+++ b/include/aspect/postprocess/geoid.h
@@ -80,55 +80,76 @@ namespace aspect
 
       private:
         /**
-         * Parameters to set the maximum and minimum degree when computing geoid from spherical harmonics
+         * Maximum degree when computing geoid from spherical harmonics.
+         * This variable is read from the parameter file through a parameter called 'Maximum degree'.
          */
         unsigned int max_degree;
+
+        /**
+         * Minimum degree when computing geoid from spherical harmonics.
+         * This variable is read from the parameter file through a parameter called 'Minimum degree'.
+         */
         unsigned int min_degree;
 
         /**
          * A parameter to control whether to output the data in geographical coordinates.
          * If true, output the data in longitudes and latitudes; if false, output data in x y z.
+         * This variable is read from the parameter file through a parameter called 'Output data in geographical coordinates'.
          */
         bool output_in_lat_lon;
 
         /**
          * A parameter to control whether to output the spherical harmonic coefficients of the geoid anomaly
+         * This variable is read from the parameter file through a parameter called 'Output geoid anomaly coefficients'.
          */
         bool output_geoid_anomaly_SH_coes;
 
         /**
          * A parameter to control whether to output the spherical harmonic coefficients of the surface topography contribution
+         * This variable is read from the parameter file through a parameter called 'Output surface topography contribution coefficients'.
          */
         bool output_surface_topo_contribution_SH_coes;
 
         /**
          * A parameter to control whether to output the spherical harmonic coefficients of the CMB topography contribution
+         * This variable is read from the parameter file through a parameter called 'Output CMB topography contribution coefficients'.
          */
         bool output_CMB_topo_contribution_SH_coes;
 
         /**
          * A parameter to control whether to output the spherical harmonic coefficients of the density anomaly
+         * This variable is read from the parameter file through a parameter called 'Output density anomaly contribution coefficients'.
          */
         bool output_density_anomaly_contribution_SH_coes;
 
         /**
          * A parameter to control whether to output the free-air gravity anomaly
+         * This variable is read from the parameter file through a parameter called 'Output gravity anomaly'.
          */
         bool output_gravity_anomaly;
 
         /**
-         * Parameters to set the density value out of the surface and CMB boundary
+         * Density value outside the surface boundary.
+         * This variable is read from the parameter file through a parameter called 'Density above'.
          */
         double density_above;
+
+        /**
+         * Density value outside the CMB boundary.
+         * This variable is read from the parameter file through a parameter called 'Density below'.
+         */
         double density_below;
 
         /**
          * A parameter to control whether to include the surface topography contribution on geoid
+         * This variable is read from the parameter file through a parameter called 'Include surface topography contribution'.
          */
         bool include_surface_topo_contribution;
 
         /**
          * A parameter to control whether to include the CMB topography contribution on geoid
+         *
+         * This variable is read from the parameter file through a parameter called 'Include CMB topography contribution'.
          */
         bool include_CMB_topo_contribution;
 

--- a/include/aspect/postprocess/global_statistics.h
+++ b/include/aspect/postprocess/global_statistics.h
@@ -143,6 +143,8 @@ namespace aspect
          * Whether to put every nonlinear iteration into a separate
          * line in the statistics file or to only output one line
          * per time step.
+         *
+         * This variable is read from the parameter file through a parameter called 'Write statistics for each nonlinear iteration'.
          */
         bool one_line_per_iteration;
     };

--- a/include/aspect/postprocess/gravity_point_values.h
+++ b/include/aspect/postprocess/gravity_point_values.h
@@ -105,6 +105,7 @@ namespace aspect
       private:
         /**
          * Interval between the generation of gravity output.
+         * This variable is read from the parameter file through a parameter called 'Time between gravity output'.
          */
         double output_interval;
 
@@ -116,6 +117,7 @@ namespace aspect
 
         /**
          * Maximum number of steps between the generation of gravity output.
+         * This variable is read from the parameter file through a parameter called 'Time steps between gravity output'.
          */
         unsigned int maximum_timesteps_between_outputs;
 
@@ -134,6 +136,7 @@ namespace aspect
         /**
          * end_time is taken from parameter file. It is used to tell the
          * postprocessor to write gravity output at the end time.
+         * This variable is read from the parameter file through a parameter called 'End time'.
          */
         double end_time;
 
@@ -150,6 +153,7 @@ namespace aspect
         /**
          * Set the precision of the gravity acceleration, potential and gradients
          * in the gravity output and statistics file.
+         * This variable is read from the parameter file through a parameter called 'Precision in gravity output'.
          */
         unsigned int precision;
 
@@ -158,11 +162,13 @@ namespace aspect
          * gravity is calculated near the surface or inside the model. An increase in the
          * quadrature element adds accuracy to the gravity solution from noise due to the
          * model grid.
+         * This variable is read from the parameter file through a parameter called 'Quadrature degree increase'.
          */
         unsigned int quadrature_degree_increase;
 
         /**
          * Parameter for the fibonacci spiral sampling scheme:
+         * This variable is read from the parameter file through a parameter called 'Number points fibonacci spiral'.
          */
         unsigned int n_points_spiral;
 
@@ -171,6 +177,7 @@ namespace aspect
          * Gravity may be calculated for a sets of points along the radius (e.g. depth
          * profile) between a minimum and maximum radius. Number of points along the radius
          * is specified with n_points_radius.
+         * This variable is read from the parameter file through a parameter called 'Number points radius'.
          */
         unsigned int n_points_radius;
 
@@ -179,6 +186,7 @@ namespace aspect
          * Gravity may be calculated for a sets of points along the longitude (e.g. satellite
          * mapping) between a minimum and maximum longitude. Number of points along the
          * longitude is specified with n_points_longitude.
+         * This variable is read from the parameter file through a parameter called 'Number points longitude'.
          */
         unsigned int n_points_longitude;
 
@@ -187,6 +195,7 @@ namespace aspect
          * Gravity may be calculated for a sets of points along the latitude (e.g. satellite
          * mapping) between a minimum and maximum latitude. Number of points along the
          * latitude is specified with n_points_latitude.
+         * This variable is read from the parameter file through a parameter called 'Number points latitude'.
          */
         unsigned int n_points_latitude;
 
@@ -194,6 +203,7 @@ namespace aspect
          * Parameter for the map and fibonacci spiral sampling scheme:
          * Prescribe a minimum radius for a sampling coverage at a specific height.
          * May be set in- or outside the model domain.
+         * This variable is read from the parameter file through a parameter called 'Minimum radius'.
          */
         double minimum_radius;
 
@@ -202,12 +212,14 @@ namespace aspect
          * Maximum radius for the radius range.
          * May be set in- or outside the model domain.
          * No need to specify maximum_radius if n_points_radius is 1.
+         * This variable is read from the parameter file through a parameter called 'Maximum radius'.
          */
         double maximum_radius;
 
         /**
          * Parameter for the map sampling scheme:
          * Minimum longitude for longitude range.
+         * This variable is read from the parameter file through a parameter called 'Minimum longitude'.
          */
         double minimum_colongitude;
 
@@ -215,12 +227,14 @@ namespace aspect
          * Parameter for the map sampling scheme:
          * Maximum longitude for the longitude range.
          * No need to specify maximum_longitude if n_points_longitude is 1.
+         * This variable is read from the parameter file through a parameter called 'Maximum longitude'.
          */
         double maximum_colongitude;
 
         /**
          * Parameter for the map sampling scheme:
          * Minimum latitude for the latitude range.
+         * This variable is read from the parameter file through a parameter called 'Minimum latitude'.
          */
         double minimum_colatitude;
 
@@ -228,6 +242,7 @@ namespace aspect
          * Parameter for the map sampling scheme:
          * Maximum latitude for the latitude range.
          * No need to specify maximum_latitude if n_points_latitude is 1.
+         * This variable is read from the parameter file through a parameter called 'Maximum latitude'.
          */
         double maximum_colatitude;
 
@@ -237,6 +252,7 @@ namespace aspect
          * acceleration and gradients in the domain filled with a constant density.
          * 2) calculate the density difference of the density given by the material
          * model and a constant density, in order to compute gravity anomalies.
+         * This variable is read from the parameter file through a parameter called 'Reference density'.
          */
         double reference_density;
 
@@ -254,6 +270,7 @@ namespace aspect
          * Parameter for the list of points sampling scheme:
          * List of radius coordinates for the list of points sampling scheme.
          * Must follow the same order as the lists of longitude and latitude.
+         * This variable is read from the parameter file through a parameter called 'List of radius'.
          */
         std::vector<double> radius_list;
 
@@ -261,6 +278,7 @@ namespace aspect
          * Parameter for the list of points sampling scheme:
          * List of longitude coordinates for the list of points sampling scheme.
          * Must follow the same order as the lists of radius and latitude.
+         * This variable is read from the parameter file through a parameter called 'List of longitude'.
          */
         std::vector<double> longitude_list;
 
@@ -268,6 +286,8 @@ namespace aspect
          * Parameter for the list of points sampling scheme:
          * List of latitude coordinates for the list of points sampling scheme.
          * Must follow the same order as the lists of longitude and longitude.
+         *
+         * This variable is read from the parameter file through a parameter called 'List of latitude'.
          */
         std::vector<double> latitude_list;
 

--- a/include/aspect/postprocess/memory_statistics.h
+++ b/include/aspect/postprocess/memory_statistics.h
@@ -59,6 +59,9 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter called 'Output peak virtual memory (VmPeak)'.
+         */
         bool output_vmpeak;
     };
   }

--- a/include/aspect/postprocess/particle_distribution_score.h
+++ b/include/aspect/postprocess/particle_distribution_score.h
@@ -77,6 +77,8 @@ namespace aspect
          * used in the histogram which computes the density
          * distribution score.  For example, a value of 2 means
          * $2\times 2=4$ buckets in 2D.
+         *
+         * This variable is read from the parameter file through a parameter called 'Granularity'.
          */
         unsigned int granularity;
 

--- a/include/aspect/postprocess/particle_distribution_statistics.h
+++ b/include/aspect/postprocess/particle_distribution_statistics.h
@@ -78,6 +78,7 @@ namespace aspect
          * If `KDE_per_particle` is true, the point-density function is defined
          * at the position of every particle in the cell. If it is false, the
          * point-density-function is defined on a regular grid throughout the cell.
+         * This variable is read from the parameter file through a parameter called 'Use KDE per particle'.
          */
         bool KDE_per_particle;
 
@@ -87,6 +88,7 @@ namespace aspect
          * a value of 2 means that the point-density function is defined at
          * $2\times 2=4$ points in 2D. This variable only applies if
          * `KDE_per_particle` is false.
+         * This variable is read from the parameter file through a parameter called 'KDE granularity'.
          */
         unsigned int granularity;
 
@@ -97,6 +99,8 @@ namespace aspect
          * in oversmoothing or undersmoothing of the point-density function.
          * Oversmoothing or undersmoothing results in a function which
          * represents the underlying data less accurately.
+         *
+         * This variable is read from the parameter file through a parameter called 'Kernel bandwidth'.
          */
         double bandwidth;
 

--- a/include/aspect/postprocess/particles.h
+++ b/include/aspect/postprocess/particles.h
@@ -183,6 +183,7 @@ namespace aspect
         /**
          * List of interval between output (in years if appropriate simulation
          * parameter is set, otherwise seconds) for each particle manager.
+         * This variable is read from the parameter file through a parameter called 'Time between data output'.
          */
         std::vector<double> output_interval;
 
@@ -251,6 +252,7 @@ namespace aspect
          * file using MPI I/O when writing on a parallel filesystem. 0 means
          * no grouping (and no parallel I/O). 1 will generate one big file
          * containing the whole solution.
+         * This variable is read from the parameter file through a parameter called 'Number of grouped files'.
          */
         unsigned int group_files;
 
@@ -260,6 +262,7 @@ namespace aspect
          * move this file to a network file system. If this variable is
          * set to a non-empty string it will be interpreted as a temporary
          * storage location.
+         * This variable is read from the parameter file through a parameter called 'Temporary output location'.
          */
         std::string temporary_output_location;
 
@@ -268,6 +271,7 @@ namespace aspect
          * progress of the rest of the model run. Setting this variable to
          * 'true' moves this process into a background thread, while the
          * rest of the model continues.
+         * This variable is read from the parameter file through a parameter called 'Write in background thread'.
          */
         bool write_in_background_thread;
 
@@ -280,6 +284,8 @@ namespace aspect
         /**
          * Stores the particle property fields which are excluded from output
          * to the visualization file for each particle manager.
+         *
+         * This variable is read from the parameter file through a parameter called 'Exclude output properties'.
          */
         std::vector<std::vector<std::string>> exclude_output_properties;
 

--- a/include/aspect/postprocess/point_values.h
+++ b/include/aspect/postprocess/point_values.h
@@ -98,6 +98,7 @@ namespace aspect
 
         /**
          * Interval between the generation of output in seconds.
+         * This variable is read from the parameter file through a parameter called 'Time between point values output'.
          */
         double output_interval;
 
@@ -120,6 +121,8 @@ namespace aspect
         /**
          * Whether or not to interpret the evaluation points in the input file
          * as natural coordinates or not.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use natural coordinates'.
          */
         bool use_natural_coordinates;
     };

--- a/include/aspect/postprocess/rotation_statistics.h
+++ b/include/aspect/postprocess/rotation_statistics.h
@@ -66,6 +66,7 @@ namespace aspect
          * that assumes that the 'volumetric' rotation is equal to the 'mass'
          * rotation. If this parameter is true this postprocessor computes
          * 'net rotation' instead of 'angular momentum'.
+         * This variable is read from the parameter file through a parameter called 'Use constant density of one'.
          */
         bool use_constant_density;
 
@@ -75,6 +76,8 @@ namespace aspect
          * axis. This is a second-order symmetric tensor with
          * 6 components in 3D. In 2D this option has no effect, because
          * the rotation axis is fixed and thus it is always a scalar.
+         *
+         * This variable is read from the parameter file through a parameter called 'Output full moment of inertia tensor'.
          */
         bool output_full_tensor;
     };

--- a/include/aspect/postprocess/sea_level.h
+++ b/include/aspect/postprocess/sea_level.h
@@ -121,14 +121,24 @@ namespace aspect
 
         /**
          * Information about the location of topography data files.
+         * This variable is read from the parameter file through a parameter called 'Data directory topography'.
          */
         std::string data_directory_topography;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Data file name topography'.
+         */
         std::string data_file_name_topography;
 
         /**
          * Information about the location of ice height data files.
+         * This variable is read from the parameter file through a parameter called 'Data directory ice height'.
          */
         std::string data_directory_ice_height;
+
+        /**
+         * This variable is read from the parameter file through a parameter called 'Data file name ice height'.
+         */
         std::string data_file_name_ice_height;
 
         /**
@@ -139,11 +149,13 @@ namespace aspect
 
         /**
          * The density of water.
+         * This variable is read from the parameter file through a parameter called 'Water density'.
          */
         double density_water;
 
         /**
          * The density of ice.
+         * This variable is read from the parameter file through a parameter called 'Ice density'.
          */
         double density_ice;
 
@@ -154,6 +166,7 @@ namespace aspect
 
         /**
          * Whether or not to produce text files with sea level values.
+         * This variable is read from the parameter file through a parameter called 'Output to file'.
          */
         bool write_to_file;
 
@@ -161,6 +174,8 @@ namespace aspect
          * Interval between the generation of text output. This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
+         *
+         * This variable is read from the parameter file through a parameter called 'Time between text output'.
          */
         double output_interval;
 

--- a/include/aspect/postprocess/topography.h
+++ b/include/aspect/postprocess/topography.h
@@ -85,6 +85,7 @@ namespace aspect
       private:
         /**
          * Whether or not to produce text files with topography values
+         * This variable is read from the parameter file through a parameter called 'Output to file'.
          */
         bool write_to_file;
 
@@ -92,6 +93,8 @@ namespace aspect
          * Interval between the generation of text output. This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
+         *
+         * This variable is read from the parameter file through a parameter called 'Time between text output'.
          */
         double output_interval;
 

--- a/include/aspect/postprocess/visualization.h
+++ b/include/aspect/postprocess/visualization.h
@@ -394,6 +394,7 @@ namespace aspect
          * Interval between the generation of graphical output. This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
+         * This variable is read from the parameter file through a parameter called 'Time between graphical output'.
          */
         double output_interval;
 
@@ -408,6 +409,7 @@ namespace aspect
          * This parameter
          * is read from the input file and consequently is not part of the
          * state that needs to be saved and restored.
+         * This variable is read from the parameter file through a parameter called 'Time steps between graphical output'.
          */
         unsigned int maximum_timesteps_between_outputs;
 
@@ -425,6 +427,7 @@ namespace aspect
 
         /**
          * Graphical output format.
+         * This variable is read from the parameter file through a parameter called 'Output format'.
          */
         std::string output_format;
 
@@ -433,6 +436,7 @@ namespace aspect
          * file using MPI I/O when writing on a parallel filesystem. 0 means
          * no grouping (and no parallel I/O). 1 will generate one big file
          * containing the whole solution.
+         * This variable is read from the parameter file through a parameter called 'Number of grouped files'.
          */
         unsigned int group_files;
 
@@ -442,6 +446,7 @@ namespace aspect
          * move this file to a network file system. If this variable is
          * set to a non-empty string it will be interpreted as a temporary
          * storage location.
+         * This variable is read from the parameter file through a parameter called 'Temporary output location'.
          */
         std::string temporary_output_location;
 
@@ -454,6 +459,7 @@ namespace aspect
          * field. Activating this option increases the spatial resolution in
          * each dimension by a factor equal to the polynomial degree used for
          * the velocity finite element (usually 2).
+         * This variable is read from the parameter file through a parameter called 'Interpolate output'.
          */
         bool interpolate_output;
 
@@ -463,6 +469,7 @@ namespace aspect
          * therefore saves disk space, but misrepresents discontinuous
          * output properties. Activating this function reduces the disk space
          * by about a factor of $2^{dim}$ for hdf5 output.
+         * This variable is read from the parameter file through a parameter called 'Filter output'.
          */
         bool filter_output;
 
@@ -470,6 +477,7 @@ namespace aspect
          * If true, return quantities related to stresses and strain with
          * point-wise values. Otherwise the values will be averaged on each
          * cell.
+         * This variable is read from the parameter file through a parameter called 'Point-wise stress and strain'.
          */
         bool pointwise_stress_and_strain;
 
@@ -483,6 +491,7 @@ namespace aspect
          * set to true, and (iii) you use a sufficiently new version of Paraview
          * or VisIt to read the files (Paraview version 5.5 or newer, and VisIt version
          * to be determined).
+         * This variable is read from the parameter file through a parameter called 'Write higher order output'.
          */
         bool write_higher_order_output;
 
@@ -491,6 +500,7 @@ namespace aspect
          * Arbitrary-Lagrangian-Eulerian formulation to handle deforming the
          * domain, so the mesh has its own velocity field. This may be
          * written as an output field by setting output_mesh_velocity to true.
+         * This variable is read from the parameter file through a parameter called 'Output mesh velocity'.
          */
         bool output_mesh_velocity;
 
@@ -500,6 +510,7 @@ namespace aspect
          * has a field that determines the displacement from the reference
          * configuration. This may be written as an output field by setting
          * this flag to true.
+         * This variable is read from the parameter file through a parameter called 'Output mesh displacement'.
          */
         bool output_mesh_displacement;
 
@@ -508,6 +519,7 @@ namespace aspect
          * Arbitrary-Lagrangian-Eulerian formulation to handle deforming the domain, and we output the
          * mesh in its deformed state by default. If this flag is set to true,
          * the mesh is written undeformed.
+         * This variable is read from the parameter file through a parameter called 'Output undeformed mesh'.
          */
         bool output_undeformed_mesh;
 
@@ -516,6 +528,7 @@ namespace aspect
          * velocity, (fluid pressure and velocity), pressure, temperature
          * and the compositional fields on the surface of the mesh.
          * The mesh surface includes all boundaries of the domain.
+         * This variable is read from the parameter file through a parameter called 'Output base variables on mesh surface'.
          */
         bool output_base_variables_on_mesh_surface;
 
@@ -524,6 +537,8 @@ namespace aspect
          * progress of the rest of the model run. Setting this variable to
          * 'true' moves this process into a background thread, while the
          * rest of the model continues.
+         *
+         * This variable is read from the parameter file through a parameter called 'Write in background thread'.
          */
         bool write_in_background_thread;
 

--- a/include/aspect/postprocess/visualization/compositional_vector.h
+++ b/include/aspect/postprocess/visualization/compositional_vector.h
@@ -70,6 +70,8 @@ namespace aspect
         private:
           /**
            * Names of vector fields.
+           *
+           * This variable is read from the parameter file through a parameter called 'Names of vectors'.
            */
           std::vector<std::string> vector_names;
 

--- a/include/aspect/postprocess/visualization/density_anomaly.h
+++ b/include/aspect/postprocess/visualization/density_anomaly.h
@@ -81,6 +81,8 @@ namespace aspect
 
           /**
            * Number of slices to use when computing depth average of temperature.
+           *
+           * This variable is read from the parameter file through a parameter called 'Number of depth slices'.
            */
           unsigned int n_slices;
 

--- a/include/aspect/postprocess/visualization/heat_flux_map.h
+++ b/include/aspect/postprocess/visualization/heat_flux_map.h
@@ -89,6 +89,8 @@ namespace aspect
           /**
            * A flag that determines whether to use the point-wise
            * heat flux calculation or the cell-wise averaged calculation.
+           *
+           * This variable is read from the parameter file through a parameter called 'Output point wise heat flux'.
            */
           bool output_point_wise_heat_flux;
 

--- a/include/aspect/postprocess/visualization/material_properties.h
+++ b/include/aspect/postprocess/visualization/material_properties.h
@@ -83,6 +83,9 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * This variable is read from the parameter file through a parameter called 'List of material properties'.
+           */
           std::vector<std::string> property_names;
       };
     }

--- a/include/aspect/postprocess/visualization/melt.h
+++ b/include/aspect/postprocess/visualization/melt.h
@@ -74,6 +74,9 @@ namespace aspect
           parse_parameters (ParameterHandler &prm) override;
 
         private:
+          /**
+           * This variable is read from the parameter file through a parameter called 'List of properties'.
+           */
           std::vector<std::string> property_names;
       };
 

--- a/include/aspect/postprocess/visualization/melt_fraction.h
+++ b/include/aspect/postprocess/visualization/melt_fraction.h
@@ -74,26 +74,65 @@ namespace aspect
            */
 
           // for the solidus temperature
+          /**
+           * This variable is read from the parameter file through a parameter called 'A1'.
+           */
           double A1;   // °C
+          /**
+           * This variable is read from the parameter file through a parameter called 'A2'.
+           */
           double A2; // °C/Pa
+          /**
+           * This variable is read from the parameter file through a parameter called 'A3'.
+           */
           double A3; // °C/(Pa^2)
 
           // for the lherzolite liquidus temperature
+          /**
+           * This variable is read from the parameter file through a parameter called 'B1'.
+           */
           double B1;   // °C
+          /**
+           * This variable is read from the parameter file through a parameter called 'B2'.
+           */
           double B2;   // °C/Pa
+          /**
+           * This variable is read from the parameter file through a parameter called 'B3'.
+           */
           double B3; // °C/(Pa^2)
 
           // for the liquidus temperature
+          /**
+           * This variable is read from the parameter file through a parameter called 'C1'.
+           */
           double C1;   // °C
+          /**
+           * This variable is read from the parameter file through a parameter called 'C2'.
+           */
           double C2;  // °C/Pa
+          /**
+           * This variable is read from the parameter file through a parameter called 'C3'.
+           */
           double C3; // °C/(Pa^2)
 
           // for the reaction coefficient of pyroxene
+          /**
+           * This variable is read from the parameter file through a parameter called 'r1'.
+           */
           double r1;     // cpx/melt
+          /**
+           * This variable is read from the parameter file through a parameter called 'r2'.
+           */
           double r2;     // cpx/melt/GPa
+          /**
+           * This variable is read from the parameter file through a parameter called 'Mass fraction cpx'.
+           */
           double M_cpx;  // mass fraction of pyroxenite
 
           // melt fraction exponent
+          /**
+           * This variable is read from the parameter file through a parameter called 'beta'.
+           */
           double beta;
 
           /**
@@ -101,12 +140,27 @@ namespace aspect
            */
 
           // for the melting temperature
+          /**
+           * This variable is read from the parameter file through a parameter called 'D1'.
+           */
           double D1;    // °C
+          /**
+           * This variable is read from the parameter file through a parameter called 'D2'.
+           */
           double D2;  // °C/Pa
+          /**
+           * This variable is read from the parameter file through a parameter called 'D3'.
+           */
           double D3; // °C/(Pa^2)
 
           // for the melt-fraction dependence of productivity
+          /**
+           * This variable is read from the parameter file through a parameter called 'E1'.
+           */
           double E1;
+          /**
+           * This variable is read from the parameter file through a parameter called 'E2'.
+           */
           double E2;
       };
     }

--- a/include/aspect/postprocess/visualization/principal_stress.h
+++ b/include/aspect/postprocess/visualization/principal_stress.h
@@ -72,6 +72,8 @@ namespace aspect
           /**
            * Whether to use the deviatoric stress tensor instead of the full stress
            * tensor to compute principal directions and values.
+           *
+           * This variable is read from the parameter file through a parameter called 'Use deviatoric stress'.
            */
           bool use_deviatoric_stress;
       };

--- a/include/aspect/postprocess/visualization/seismic_anomalies.h
+++ b/include/aspect/postprocess/visualization/seismic_anomalies.h
@@ -86,6 +86,7 @@ namespace aspect
            * Number of depth slices used to define average
            * seismic shear wave velocities from which anomalies
            * are calculated.
+           * This variable is read from the parameter file through a parameter called 'Number of depth slices'.
            */
           unsigned int n_slices;
       };
@@ -146,6 +147,8 @@ namespace aspect
            * Number of depth slices used to define average
            * seismic compressional wave velocities from which anomalies
            * are calculated.
+           *
+           * This variable is read from the parameter file through a parameter called 'Number of depth slices'.
            */
           unsigned int n_slices;
       };

--- a/include/aspect/postprocess/visualization/temperature_anomaly.h
+++ b/include/aspect/postprocess/visualization/temperature_anomaly.h
@@ -70,6 +70,7 @@ namespace aspect
         private:
           /**
            * Number of slices to use when computing depth average of temperature.
+           * This variable is read from the parameter file through a parameter called 'Number of depth slices'.
            */
           unsigned int n_slices;
 
@@ -77,8 +78,13 @@ namespace aspect
            * Whether to extrapolate temperatures above/below the first/last depth-average slice
            * or, alternatively, interpolate above the center of the first slice using the surface
            * temperature or below the last slice using the bottom temperature.
+           * This variable is read from the parameter file through a parameter called 'Use minimal temperature for surface'.
            */
           bool extrapolate_surface;
+
+          /**
+           * This variable is read from the parameter file through a parameter called 'Use maximal temperature for bottom'.
+           */
           bool extrapolate_bottom;
 
           /**

--- a/include/aspect/postprocess/visualization/volume_of_fluid_values.h
+++ b/include/aspect/postprocess/visualization/volume_of_fluid_values.h
@@ -101,11 +101,14 @@ namespace aspect
           /**
            * If true, the data output will include a field that has the
            * reconstructed fluid interface as the zero contour
+           * This variable is read from the parameter file through a parameter called 'Output interface reconstruction contour'.
            */
           bool include_contour;
 
           /**
            * If true, the data output will include the normal vector for the reconstructed interface
+           *
+           * This variable is read from the parameter file through a parameter called 'Output interface normals'.
            */
           bool include_normal;
       };

--- a/include/aspect/prescribed_solution/initial_composition.h
+++ b/include/aspect/prescribed_solution/initial_composition.h
@@ -83,7 +83,9 @@ namespace aspect
         Functions::ParsedFunction<dim> indicator_function;
 
         /**
-         * Coordinate system used for evaluating indicator.
+         * Coordinate system used for evaluating the indicator. This variable
+         * is read from the parameter file through the 'Coordinate system'
+         * parameter.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/prescribed_solution/initial_temperature.h
+++ b/include/aspect/prescribed_solution/initial_temperature.h
@@ -92,6 +92,8 @@ namespace aspect
         /**
          * The coordinate representation used to evaluate the indicator
          * function. Possible choices are cartesian, spherical, and depth.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 

--- a/include/aspect/prescribed_solution/temperature_function.h
+++ b/include/aspect/prescribed_solution/temperature_function.h
@@ -96,6 +96,8 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         *
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
     };

--- a/include/aspect/prescribed_solution/velocity_function.h
+++ b/include/aspect/prescribed_solution/velocity_function.h
@@ -97,12 +97,15 @@ namespace aspect
         /**
          * The coordinate representation to evaluate the function. Possible
          * choices are depth, cartesian and spherical.
+         * This variable is read from the parameter file through a parameter called 'Coordinate system'.
          */
         Utilities::Coordinates::CoordinateSystem coordinate_system;
 
         /**
          * Whether to specify velocity in x, y, z components, or
          * r, phi, theta components.
+         *
+         * This variable is read from the parameter file through a parameter called 'Use spherical unit vectors'.
          */
         bool use_spherical_unit_vectors;
     };

--- a/include/aspect/termination_criteria/end_step.h
+++ b/include/aspect/termination_criteria/end_step.h
@@ -62,6 +62,10 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'End step'.
+         */
         unsigned int end_step;
     };
   }

--- a/include/aspect/termination_criteria/end_time.h
+++ b/include/aspect/termination_criteria/end_time.h
@@ -69,6 +69,10 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'End time'.
+         */
         double end_time;
     };
   }

--- a/include/aspect/termination_criteria/end_walltime.h
+++ b/include/aspect/termination_criteria/end_walltime.h
@@ -67,6 +67,9 @@ namespace aspect
         /**
          * The maximum walltime duration in seconds. The program will be terminated
          * once this value is reached.
+         *
+         * This variable is read from the parameter file through a parameter
+         * called 'Wall time'.
          */
         unsigned int walltime_duration;
 

--- a/include/aspect/termination_criteria/steady_heat_flux.h
+++ b/include/aspect/termination_criteria/steady_heat_flux.h
@@ -66,18 +66,25 @@ namespace aspect
         /**
          * The minimum length of simulation time that the system
          * should be in steady state before termination.
+         * This variable is read from the parameter file through a parameter
+         * called 'Time in steady state'.
          */
         double necessary_time_in_steady_state;
 
         /**
          * The maximum relative deviation of the heat flux in recent
          * simulation time for the system to be considered in steady state.
+         * This variable is read from the parameter file through a parameter
+         * called 'Maximum relative deviation'.
          */
         double allowed_relative_deviation;
 
         /**
          * A set of boundary ids on which the average heat flux will be
          * computed.
+         *
+         * This variable is read from the parameter file through a parameter
+         * called 'Boundary indicators'.
          */
         std::set<types::boundary_id> boundary_indicators;
 

--- a/include/aspect/termination_criteria/steady_rms_velocity.h
+++ b/include/aspect/termination_criteria/steady_rms_velocity.h
@@ -63,7 +63,16 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'Time in steady state'.
+         */
         double                                  time_length;
+
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'Maximum relative deviation'.
+         */
         double                                  relative_deviation;
 
         /**

--- a/include/aspect/termination_criteria/steady_temperature.h
+++ b/include/aspect/termination_criteria/steady_temperature.h
@@ -62,7 +62,16 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'Time in steady state'.
+         */
         double                                  necessary_time_in_steady_state;
+
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'Maximum relative deviation'.
+         */
         double                                  allowed_relative_deviation;
 
         /**

--- a/include/aspect/termination_criteria/user_request.h
+++ b/include/aspect/termination_criteria/user_request.h
@@ -64,6 +64,10 @@ namespace aspect
         parse_parameters (ParameterHandler &prm) override;
 
       private:
+        /**
+         * This variable is read from the parameter file through a parameter
+         * called 'File name'.
+         */
         std::string             filename_to_test;
     };
   }

--- a/include/aspect/time_stepping/interface.h
+++ b/include/aspect/time_stepping/interface.h
@@ -247,12 +247,17 @@ namespace aspect
 
         /**
          * The minimum time step size specified by the user (in seconds).
+         * This variable is read from the parameter file through a parameter
+         * called 'Minimum time step size'.
          */
         double minimum_time_step_size;
 
         /**
          * Whether to do a final checkpoint before termination. This is
          * specified in the parameters.
+         *
+         * This variable is read from the parameter file through a parameter
+         * called 'Checkpoint on termination'.
          */
         bool do_checkpoint_on_terminate;
 

--- a/include/aspect/time_stepping/repeat_on_cutback.h
+++ b/include/aspect/time_stepping/repeat_on_cutback.h
@@ -66,6 +66,8 @@ namespace aspect
         /**
          * Parameter to determine how much smaller the time step should be
          * repeated as.
+         * This variable is read from the parameter file through a parameter
+         * called 'Cut back amount'.
          */
         double cut_back_amount;
 
@@ -73,6 +75,9 @@ namespace aspect
          * Parameter that controls when to repeat a time step. If the newly
          * computed step size is smaller than the last step size multiplied by
          * this factor, the step is repeated.
+         *
+         * This variable is read from the parameter file through a parameter
+         * called 'Relative repeat threshold'.
          */
         double repeat_threshold;
     };

--- a/include/aspect/time_stepping/repeat_on_nonlinear_fail.h
+++ b/include/aspect/time_stepping/repeat_on_nonlinear_fail.h
@@ -78,6 +78,9 @@ namespace aspect
         /**
          * Parameter to determine how much smaller the time step should be
          * repeated as.
+         *
+         * This variable is read from the parameter file through a parameter
+         * called 'Cut back factor'.
          */
         double cut_back_factor;
 


### PR DESCRIPTION
A lot of member variables of plugins are read directly from input file parameters. This patch annotates all of these variables with the parameter they're read in from.

This patch burned a fairly sizable hole into my Copilot token budget, but then also took the better part of 2 or 3 hours of work to actually get right -- Copilot had real trouble being consistent, aligning asterisks, inserting the documentation into the pre-existing comment, and other issues. 

I looked through the whole patch and it looks ok now. I can't vouch that all of the annotations are factually correct -- the ones I checked really did reference the right parameter, but I have not looked through all 914 annotations whether the parameter name as now provided in the documentation indeed matches what we read from in the .cc file -- that is just not a humanly feasible task. But if it is even just 90% correct, that would already be useful.

I think this sort of annotation will also be useful to AIs to train on because they can make that connection between parameter and variable more easily.

*Describe what you did in this PR and why you did it.*

### Before your first pull request:

* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](https://aspect-documentation.readthedocs.io/en/latest/user/extending/testing/writing-tests.html) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
